### PR TITLE
Fix Go SDK module path for proper package importing

### DIFF
--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -5,7 +5,7 @@ The Haxen Go SDK provides idiomatic Go bindings for interacting with the Haxen c
 ## Installation
 
 ```bash
-go get github.com/your-org/haxen/sdk/go
+go get github.com/agentfield/haxen/sdk/go
 ```
 
 ## Quick Start
@@ -17,7 +17,7 @@ import (
     "context"
     "log"
 
-    haxenagent "github.com/your-org/haxen/sdk/go/agent"
+    haxenagent "github.com/agentfield/haxen/sdk/go/agent"
 )
 
 func main() {

--- a/sdk/go/agent/agent.go
+++ b/sdk/go/agent/agent.go
@@ -17,9 +17,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/your-org/haxen/sdk/go/ai"
-	"github.com/your-org/haxen/sdk/go/client"
-	"github.com/your-org/haxen/sdk/go/types"
+	"github.com/agentfield/haxen/sdk/go/ai"
+	"github.com/agentfield/haxen/sdk/go/client"
+	"github.com/agentfield/haxen/sdk/go/types"
 )
 
 type executionContextKey struct{}

--- a/sdk/go/ai/README.md
+++ b/sdk/go/ai/README.md
@@ -18,8 +18,8 @@ This package provides AI/LLM capabilities for the Haxen Go SDK, supporting both 
 ```go
 import (
     "context"
-    "github.com/your-org/haxen/sdk/go/agent"
-    "github.com/your-org/haxen/sdk/go/ai"
+    "github.com/agentfield/haxen/sdk/go/agent"
+    "github.com/agentfield/haxen/sdk/go/ai"
 )
 
 // Create agent with AI configured

--- a/sdk/go/client/client.go
+++ b/sdk/go/client/client.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/your-org/haxen/sdk/go/types"
+	"github.com/agentfield/haxen/sdk/go/types"
 )
 
 // Client provides a thin wrapper over the Haxen control plane REST API.

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -1,3 +1,3 @@
-module github.com/your-org/haxen/sdk/go
+module github.com/agentfield/haxen/sdk/go
 
 go 1.21


### PR DESCRIPTION
Updated the Go SDK to use the correct module path for importing
as a GitHub-hosted Go package. This enables developers to use the
SDK with standard Go tooling.

Changes:
- Updated go.mod module path from placeholder to github.com/agentfield/haxen/sdk/go
- Fixed all internal import statements in agent, client, and other packages
- Updated SDK documentation with correct import examples
- Verified module structure with go mod tidy

Developers can now import the SDK with:
go get github.com/agentfield/haxen/sdk/go