### PR TITLE
Document callback URL and compose storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ cd agentfield && docker compose up
 
 Your control plane is running at `http://localhost:8080`
 
+<details>
+<summary><code>export AGENT_CALLBACK_URL="http://host.docker.internal:8001"</code></summary>
+
+**Heads-up:** When your agent nodes run outside the Docker network (local shell, another VM, etc.) they can't be reached through `localhost`. Before starting any agent, set a callback URL that the control plane can dial:
+
+```bash
+export AGENT_CALLBACK_URL="http://host.docker.internal:8001"
+```
+
+Replace `host.docker.internal` with whatever host/IP the control plane can reach if you're on Linux or a remote machine.
+
+</details>
+
 **[📚 Full quickstart guide →](https://agentfield.ai/docs/quick-start)**
 
 ```python

--- a/deployments/docker/docker-compose.yml
+++ b/deployments/docker/docker-compose.yml
@@ -17,6 +17,9 @@ services:
       context: ../..
       dockerfile: deployments/docker/Dockerfile.control-plane
     environment:
+      AGENTFIELD_STORAGE_MODE: postgres
+      AGENTFIELD_POSTGRES_URL: postgres://agentfield:agentfield@postgres:5432/agentfield?sslmode=disable
+      AGENTFIELD_STORAGE_POSTGRES_URL: postgres://agentfield:agentfield@postgres:5432/agentfield?sslmode=disable
       AGENTFIELD_DATABASE_URL: postgres://agentfield:agentfield@postgres:5432/agentfield?sslmode=disable
       AGENTFIELD_HTTP_ADDR: 0.0.0.0:8080
     ports:


### PR DESCRIPTION
## Summary
- configure the docker control-plane service to export the PostgreSQL storage provider env vars
- document how to set AGENT_CALLBACK_URL when agents run outside the compose network

## Testing
- not run (not requested)
