### PR TITLE
Automate changelog generation with git-cliff

### DIFF
--- a/.cliff.toml
+++ b/.cliff.toml
@@ -1,0 +1,43 @@
+[changelog]
+header = ""
+body = """
+{% if version %}## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}## [Unreleased]{% endif %}
+{% for group, commits in commits | group_by(attribute="group") %}
+{% if commits | length != 0 -%}
+### {{ group }}
+{% for commit in commits %}
+- {{ commit.message | upper_first }} ({{ commit.id | truncate(length=7, end="") }})
+{% endfor %}
+{% endif %}
+{% endfor %}
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = false
+filter_unconventional = false
+split_commits = false
+protect_breaking_commits = true
+filter_commits = false
+tag_pattern = "v?\\d+\\.\\d+\\.\\d+.*"
+topo_order = false
+sort_commits = "newest"
+commit_parsers = [
+  { message = "^feat", group = "Added" },
+  { message = "^fix", group = "Fixed" },
+  { message = "^docs?", group = "Documentation" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Changed" },
+  { message = "^style", group = "Styling" },
+  { message = "^test", group = "Testing" },
+  { message = "^build", group = "Build" },
+  { message = "^ci", group = "CI" },
+  { message = "^chore\\(release\\)", skip = true },
+  { message = "^chore", group = "Chores" },
+  { message = "^revert", group = "Reverted" },
+  { message = "^Merge", skip = true },
+  { body = ".*security", group = "Security" },
+  { message = ".*", group = "Other" },
+]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,11 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Install git-cliff
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff
+
       - name: Determine publish flags
         id: flags
         run: |
@@ -106,6 +111,7 @@ jobs:
             fi
             version="$("${cmd[@]}")"
             tag="v${version}"
+            python scripts/update_changelog.py --version "${version}"
             git status --short
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+<!-- changelog:entries -->
+
 ## [0.1.2] - 2025-11-12
 ### Fixed
 - Control-plane Docker image now builds with CGO enabled so SQLite works in containers like Railway.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -58,12 +58,25 @@ When opening a PR:
 
 ## Release Workflow
 
-Releases are automated via GitHub Actions:
+Releases are automated via GitHub Actions. The workflow now uses
+[git-cliff](https://github.com/orhun/git-cliff) to render changelog entries from the
+commit history as part of the version bump step. Maintainers typically only need to:
 
-1. Update `CHANGELOG.md` with notable changes.
-2. Bump versions (Go modules, Python package) as needed.
-3. Tag the release following `vMAJOR.MINOR.PATCH`.
-4. The `release.yml` workflow builds artifacts and publishes SDKs.
+1. Ensure commits follow the conventional prefixes (`feat:`, `fix:`, etc.) so they are
+   categorized correctly.
+2. Trigger the `Release` workflow with the desired SemVer component/channel.
+3. Let the workflow bump versions, rebuild SDKs, update `CHANGELOG.md`, and publish
+   artifacts automatically.
+
+To preview the generated changelog locally install `git-cliff`
+(`cargo install git-cliff` or grab a release binary) and run:
+
+```bash
+python scripts/update_changelog.py --version 0.1.8 --dry-run
+```
+
+If you install via Cargo make sure `~/.cargo/bin` is on your `PATH` so `git cliff`
+invokes the plugin binary correctly.
 
 ## Questions?
 

--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Generate and insert release notes produced by git-cliff."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+CLIFF_CONFIG = REPO_ROOT / ".cliff.toml"
+MARKER = "<!-- changelog:entries -->"
+
+
+def run_git_cliff(version: str) -> str:
+    """Invoke git-cliff and return the rendered release entry."""
+    cmd = [
+        "git",
+        "cliff",
+        "--config",
+        str(CLIFF_CONFIG),
+        "--unreleased",
+        "--tag",
+        version,
+    ]
+    result = subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        msg = result.stderr.strip() or result.stdout.strip()
+        raise SystemExit(
+            f"git-cliff failed with exit code {result.returncode}: {msg}"
+        )
+    return result.stdout.strip()
+
+
+def ensure_marker(text: str) -> tuple[str, str]:
+    if MARKER not in text:
+        raise SystemExit(
+            f"Missing changelog marker '{MARKER}'. "
+            "Make sure CHANGELOG.md follows the expected template."
+        )
+    before, after = text.split(MARKER, 1)
+    return before, after
+
+
+def remove_existing_entry(body: str, version: str) -> str:
+    pattern = re.compile(
+        rf"^## \[{re.escape(version)}].*?(?=^## \[|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    updated, count = pattern.subn("", body, count=1)
+    if count:
+        return updated.lstrip("\n")
+    return body
+
+
+def build_changelog(prefix: str, entry: str, suffix: str) -> str:
+    suffix = suffix.lstrip("\n")
+    parts = [
+        prefix.rstrip(),
+        "",
+        MARKER,
+        "",
+        entry.strip(),
+    ]
+    if suffix:
+        parts.extend(["", suffix.rstrip()])
+    return "\n".join(part for part in parts if part is not None) + "\n"
+
+
+def update_changelog(version: str, entry: str, dry_run: bool) -> None:
+    current = CHANGELOG.read_text(encoding="utf-8")
+    before, after = ensure_marker(current)
+    cleaned_after = remove_existing_entry(after, version)
+    next_text = build_changelog(before, entry, cleaned_after)
+    if dry_run:
+        sys.stdout.write(next_text)
+        return
+    CHANGELOG.write_text(next_text, encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Render the latest git history into CHANGELOG.md."
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Semantic version (without leading 'v') for the release entry.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the would-be changelog instead of updating the file.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        rendered = run_git_cliff(args.version)
+    except FileNotFoundError as exc:
+        raise SystemExit(
+            "git-cliff is not installed. Install it via "
+            "`cargo install git-cliff` or download a release binary."
+        ) from exc
+
+    if not rendered:
+        today = datetime.utcnow().strftime("%Y-%m-%d")
+        rendered = (
+            f"## [{args.version}] - {today}\n\n"
+            "- No notable changes were recorded for this release.\n"
+        )
+
+    update_changelog(args.version, rendered, args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Integrates git-cliff into the release workflow to automatically generate changelog entries from commit history. This streamlines the release process by eliminating manual changelog updates.

The CONTRIBUTING.md file has been updated to reflect this new process and guide contributors on how to structure their commits for effective changelog generation. A new script, `scripts/update_changelog.py`, is called to perform the changelog update during the release process.

# Summary

<!-- Provide a brief summary of the change. -->

## Testing

- [ ] `./scripts/test-all.sh`
- [ ] Additional verification (please describe):

## Checklist

- [ ] I updated documentation where applicable.
- [ ] I added or updated tests (or none were needed).
- [ ] I updated `CHANGELOG.md` (or this change does not warrant a changelog entry).

## Screenshots (if UI-related)

<!-- Drag and drop images here. -->

## Related issues

<!-- e.g., Fixes #123 -->
