### PR TITLE
Remove unused configuration variables

### DIFF
--- a/control-plane/config/agentfield.yaml
+++ b/control-plane/config/agentfield.yaml
@@ -1,9 +1,5 @@
 agentfield:
   port: 8080
-  mode: "local"
-  max_concurrent_requests: 1024
-  request_timeout: 180s
-  circuit_breaker_threshold: 20
   execution_cleanup:
     enabled: true
     retention_period: 72h
@@ -11,17 +7,7 @@ agentfield:
     batch_size: 200
     preserve_recent_duration: 1h
   execution_queue:
-    worker_count: 32
-    request_timeout: 180s    # Set to 0s or -1s to disable the queue-level request timeout
-    agent_call_timeout: 1800s  # Set to 0s or -1s to disable the agent HTTP timeout
-    lease_duration: 180s     # Set to 0s or -1s to keep leases active indefinitely
-    max_attempts: 4
-    failure_backoff: 500ms
-    max_failure_backoff: 30s
-    poll_interval: 100ms
-    result_preview_bytes: 4096
-    queue_soft_limit: 20000
-    waiter_map_limit: 4000
+    agent_call_timeout: 1800s  # Timeout for agent HTTP calls (0s or -1s to disable)
     webhook_timeout: 10s          # Per-attempt timeout for webhook deliveries
     webhook_max_attempts: 3       # Number of attempts before marking the webhook as failed
     webhook_retry_backoff: 1s     # Initial backoff between webhook retries (exponential)
@@ -31,7 +17,6 @@ ui:
   enabled: true
   mode: "embedded"
   dev_port: 5173
-  backend_url: ""
 
 api:
   cors:
@@ -61,13 +46,9 @@ storage:
   local:
     database_path: ""
     kv_store_path: ""
-    cache_size: 1000
-    retention_days: 30
-    auto_vacuum: true
   vector:
     enabled: true
     distance: "cosine"
-  config: {}
 
 features:
   did:
@@ -90,12 +71,3 @@ features:
       encryption: "AES-256-GCM"
       backup_enabled: true
       backup_interval: "24h"
-
-agents:
-  discovery:
-    scan_interval: "30s"
-    health_check_interval: "10s"
-  scaling:
-    auto_scale: false
-    min_replicas: 1
-    max_replicas: 10

--- a/control-plane/internal/config/config.go
+++ b/control-plane/internal/config/config.go
@@ -13,13 +13,11 @@ import (
 
 // Config holds the entire configuration for the AgentField server.
 type Config struct {
-	AgentField      AgentFieldConfig      `yaml:"agentfield" mapstructure:"agentfield"`
-	Agents          AgentsConfig          `yaml:"agents" mapstructure:"agents"`
-	Features        FeatureConfig         `yaml:"features" mapstructure:"features"`
-	Storage         StorageConfig         `yaml:"storage" mapstructure:"storage"`                   // Added storage config
-	UI              UIConfig              `yaml:"ui" mapstructure:"ui"`                             // Added UI config
-	API             APIConfig             `yaml:"api" mapstructure:"api"`                           // Added API config
-	DataDirectories DataDirectoriesConfig `yaml:"data_directories" mapstructure:"data_directories"` // Added data directories config
+	AgentField AgentFieldConfig `yaml:"agentfield" mapstructure:"agentfield"`
+	Features   FeatureConfig    `yaml:"features" mapstructure:"features"`
+	Storage    StorageConfig    `yaml:"storage" mapstructure:"storage"`
+	UI         UIConfig         `yaml:"ui" mapstructure:"ui"`
+	API        APIConfig        `yaml:"api" mapstructure:"api"`
 }
 
 // UIConfig holds configuration for the web UI.
@@ -29,19 +27,13 @@ type UIConfig struct {
 	SourcePath string `yaml:"source_path" mapstructure:"source_path"` // Path to UI source for building
 	DistPath   string `yaml:"dist_path" mapstructure:"dist_path"`     // Path to built UI assets for serving
 	DevPort    int    `yaml:"dev_port" mapstructure:"dev_port"`       // Port for UI dev server
-	BackendURL string `yaml:"backend_url" mapstructure:"backend_url"` // URL of the backend if UI is separate
 }
 
 // AgentFieldConfig holds the core AgentField server configuration.
 type AgentFieldConfig struct {
-	Port                    int                    `yaml:"port"`
-	DatabaseURL             string                 `yaml:"database_url"`
-	MaxConcurrentRequests   int                    `yaml:"max_concurrent_requests"`
-	RequestTimeout          time.Duration          `yaml:"request_timeout"`
-	CircuitBreakerThreshold int                    `yaml:"circuit_breaker_threshold"`
-	Mode                    string                 `yaml:"mode"`
-	ExecutionCleanup        ExecutionCleanupConfig `yaml:"execution_cleanup" mapstructure:"execution_cleanup"`
-	ExecutionQueue          ExecutionQueueConfig   `yaml:"execution_queue" mapstructure:"execution_queue"`
+	Port             int                    `yaml:"port"`
+	ExecutionCleanup ExecutionCleanupConfig `yaml:"execution_cleanup" mapstructure:"execution_cleanup"`
+	ExecutionQueue   ExecutionQueueConfig   `yaml:"execution_queue" mapstructure:"execution_queue"`
 }
 
 // ExecutionCleanupConfig holds configuration for execution cleanup and garbage collection
@@ -54,66 +46,18 @@ type ExecutionCleanupConfig struct {
 	StaleExecutionTimeout  time.Duration `yaml:"stale_execution_timeout" mapstructure:"stale_execution_timeout" default:"30m"`
 }
 
-// ExecutionQueueConfig configures the durable execution worker pool.
+// ExecutionQueueConfig configures execution and webhook settings.
 type ExecutionQueueConfig struct {
-	WorkerCount            int           `yaml:"worker_count" mapstructure:"worker_count"`
-	RequestTimeout         time.Duration `yaml:"request_timeout" mapstructure:"request_timeout"`
 	AgentCallTimeout       time.Duration `yaml:"agent_call_timeout" mapstructure:"agent_call_timeout"`
-	LeaseDuration          time.Duration `yaml:"lease_duration" mapstructure:"lease_duration"`
-	MaxAttempts            int           `yaml:"max_attempts" mapstructure:"max_attempts"`
-	FailureBackoff         time.Duration `yaml:"failure_backoff" mapstructure:"failure_backoff"`
-	MaxFailureBackoff      time.Duration `yaml:"max_failure_backoff" mapstructure:"max_failure_backoff"`
-	PollInterval           time.Duration `yaml:"poll_interval" mapstructure:"poll_interval"`
-	ResultPreviewBytes     int           `yaml:"result_preview_bytes" mapstructure:"result_preview_bytes"`
-	QueueSoftLimit         int           `yaml:"queue_soft_limit" mapstructure:"queue_soft_limit"`
-	WaiterMapLimit         int           `yaml:"waiter_map_limit" mapstructure:"waiter_map_limit"`
 	WebhookTimeout         time.Duration `yaml:"webhook_timeout" mapstructure:"webhook_timeout"`
 	WebhookMaxAttempts     int           `yaml:"webhook_max_attempts" mapstructure:"webhook_max_attempts"`
 	WebhookRetryBackoff    time.Duration `yaml:"webhook_retry_backoff" mapstructure:"webhook_retry_backoff"`
 	WebhookMaxRetryBackoff time.Duration `yaml:"webhook_max_retry_backoff" mapstructure:"webhook_max_retry_backoff"`
 }
 
-// AgentsConfig holds configuration related to agent management.
-type AgentsConfig struct {
-	Discovery DiscoveryConfig `yaml:"discovery"`
-	Scaling   ScalingConfig   `yaml:"scaling"`
-}
-
-// DiscoveryConfig holds configuration for agent discovery.
-type DiscoveryConfig struct {
-	ScanInterval        time.Duration `yaml:"scan_interval"`
-	HealthCheckInterval time.Duration `yaml:"health_check_interval"`
-}
-
-// ScalingConfig holds configuration for agent scaling.
-type ScalingConfig struct {
-	AutoScale   bool `yaml:"auto_scale"`
-	MinReplicas int  `yaml:"min_replicas"`
-	MaxReplicas int  `yaml:"max_replicas"`
-}
-
 // FeatureConfig holds configuration for enabling/disabling features.
 type FeatureConfig struct {
-	Core       CoreFeatures       `yaml:"core"`
-	Enterprise EnterpriseFeatures `yaml:"enterprise"`
-	DID        DIDConfig          `yaml:"did"`
-}
-
-// CoreFeatures holds configuration for core features.
-type CoreFeatures struct {
-	MemoryManagement bool `yaml:"memory_management" default:"true"`
-	ExecutionLogging bool `yaml:"execution_logging" default:"true"`
-	BasicMetrics     bool `yaml:"basic_metrics" default:"true"`
-	WebSocketSupport bool `yaml:"websocket_support" default:"true"`
-}
-
-// EnterpriseFeatures holds configuration for enterprise features.
-type EnterpriseFeatures struct {
-	Enabled         bool `yaml:"enabled" default:"false"`
-	ComplianceMode  bool `yaml:"compliance_mode" default:"false"`
-	AuditLogging    bool `yaml:"audit_logging" default:"false"`
-	RoleBasedAccess bool `yaml:"role_based_access" default:"false"`
-	DataEncryption  bool `yaml:"data_encryption" default:"false"`
+	DID DIDConfig `yaml:"did"`
 }
 
 // DIDConfig holds configuration for DID identity system.
@@ -165,19 +109,6 @@ type CORSConfig struct {
 // work with a single definition while keeping the canonical struct colocated
 // with the implementation in the storage package.
 type StorageConfig = storage.StorageConfig
-
-// DataDirectoriesConfig holds configuration for AgentField data directory paths
-type DataDirectoriesConfig struct {
-	AgentFieldHome   string `yaml:"agentfield_home" mapstructure:"agentfield_home"`       // Can be overridden by AGENTFIELD_HOME env var
-	DatabaseDir      string `yaml:"database_dir" mapstructure:"database_dir"`             // Relative to agentfield_home
-	KeysDir          string `yaml:"keys_dir" mapstructure:"keys_dir"`                     // Relative to agentfield_home
-	DIDRegistriesDir string `yaml:"did_registries_dir" mapstructure:"did_registries_dir"` // Relative to agentfield_home
-	VCsDir           string `yaml:"vcs_dir" mapstructure:"vcs_dir"`                       // Relative to agentfield_home
-	AgentsDir        string `yaml:"agents_dir" mapstructure:"agents_dir"`                 // Relative to agentfield_home
-	LogsDir          string `yaml:"logs_dir" mapstructure:"logs_dir"`                     // Relative to agentfield_home
-	ConfigDir        string `yaml:"config_dir" mapstructure:"config_dir"`                 // Relative to agentfield_home
-	TempDir          string `yaml:"temp_dir" mapstructure:"temp_dir"`                     // Relative to agentfield_home
-}
 
 // DefaultConfigPath is the default path for the af configuration file.
 const DefaultConfigPath = "agentfield.yaml" // Or "./agentfield.yaml", "config/agentfield.yaml" depending on convention

--- a/control-plane/internal/storage/storage.go
+++ b/control-plane/internal/storage/storage.go
@@ -209,7 +209,6 @@ type StorageConfig struct {
 	Local    LocalStorageConfig    `yaml:"local" mapstructure:"local"`
 	Postgres PostgresStorageConfig `yaml:"postgres" mapstructure:"postgres"`
 	Vector   VectorStoreConfig     `yaml:"vector" mapstructure:"vector"`
-	Config   interface{}           `yaml:"config" mapstructure:"config"`
 }
 
 // PostgresStorageConfig holds configuration for the PostgreSQL storage provider.
@@ -230,11 +229,8 @@ type PostgresStorageConfig struct {
 
 // LocalStorageConfig holds configuration for the local storage provider.
 type LocalStorageConfig struct {
-	DatabasePath  string `yaml:"database_path" mapstructure:"database_path"`
-	KVStorePath   string `yaml:"kv_store_path" mapstructure:"kv_store_path"`
-	CacheSize     int    `yaml:"cache_size" mapstructure:"cache_size"`
-	RetentionDays int    `yaml:"retention_days" mapstructure:"retention_days"`
-	AutoVacuum    bool   `yaml:"auto_vacuum" mapstructure:"auto_vacuum"`
+	DatabasePath string `yaml:"database_path" mapstructure:"database_path"`
+	KVStorePath  string `yaml:"kv_store_path" mapstructure:"kv_store_path"`
 }
 
 // VectorStoreConfig controls vector storage behavior.
@@ -286,7 +282,6 @@ func (sf *StorageFactory) CreateStorage(config StorageConfig) (StorageProvider, 
 			Local:    config.Local,
 			Postgres: config.Postgres,
 			Vector:   config.Vector,
-			Config:   config.Config,
 		}); err != nil {
 			return nil, nil, fmt.Errorf("failed to initialize local storage: %w", err)
 		}
@@ -300,7 +295,6 @@ func (sf *StorageFactory) CreateStorage(config StorageConfig) (StorageProvider, 
 			Local:    config.Local,
 			Postgres: config.Postgres,
 			Vector:   config.Vector,
-			Config:   config.Config,
 		}); err != nil {
 			return nil, nil, fmt.Errorf("failed to initialize postgres storage: %w", err)
 		}


### PR DESCRIPTION
## Summary

Audited `control-plane/config/agentfield.yaml` and found many config options that were defined but never actually used by the codebase. This creates confusion for users who set these values expecting them to have an effect.

**Removed 103 lines of dead config/struct definitions.**

## What Was Removed

### From YAML config:
| Section | Removed Fields | Reason |
|---------|---------------|--------|
| `agentfield` | `mode`, `max_concurrent_requests`, `request_timeout`, `circuit_breaker_threshold` | Never wired to any implementation |
| `execution_queue` | `worker_count`, `request_timeout`, `lease_duration`, `max_attempts`, `failure_backoff`, `max_failure_backoff`, `poll_interval`, `result_preview_bytes`, `queue_soft_limit`, `waiter_map_limit` | Defined but never accessed |
| `ui` | `backend_url` | Never used |
| `storage.local` | `cache_size`, `retention_days`, `auto_vacuum` | SQLite uses hardcoded values |
| `storage` | `config: {}` | Generic field never accessed |
| `agents` | Entire section | Discovery/scaling never implemented |

### From Go structs:
- `AgentsConfig`, `DiscoveryConfig`, `ScalingConfig`
- `CoreFeatures`, `EnterpriseFeatures`
- `DataDirectoriesConfig`
- Various unused fields in `AgentFieldConfig`, `ExecutionQueueConfig`, `LocalStorageConfig`, `StorageConfig`, `UIConfig`

## What Remains (All Actively Used)

```yaml
agentfield:
  port                          # HTTP server port
  execution_cleanup: ...        # All fields used by cleanup service
  execution_queue:
    agent_call_timeout          # Used in ExecuteHandler
    webhook_*                   # Used by WebhookDispatcher

ui:
  enabled, mode, dev_port       # All used for UI serving

api:
  cors: ...                     # All fields passed to Gin CORS middleware

storage:
  mode                          # Used by StorageFactory
  local:
    database_path, kv_store_path  # Used by LocalStorage
  vector:
    enabled, distance           # Used by vector store

features:
  did: ...                      # All fields used by DID/VC services
```

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./internal/config/...` passes
- [x] `go test ./internal/storage/...` passes
- [x] `go test ./cmd/...` passes
- [x] `go test ./internal/application/...` passes
- [x] `go test ./internal/server/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)