### PR TITLE
feat: add delete-namespace endpoint for RAG reindexing

### DIFF
--- a/control-plane/internal/handlers/memory.go
+++ b/control-plane/internal/handlers/memory.go
@@ -22,6 +22,7 @@ type MemoryStorage interface {
 	PublishMemoryChange(ctx context.Context, event types.MemoryChangeEvent) error
 	SetVector(ctx context.Context, record *types.VectorRecord) error
 	DeleteVector(ctx context.Context, scope, scopeID, key string) error
+	DeleteVectorsByPrefix(ctx context.Context, scope, scopeID, prefix string) (int, error)
 	SimilaritySearch(ctx context.Context, scope, scopeID string, queryEmbedding []float32, topK int, filters map[string]interface{}) ([]*types.VectorSearchResult, error)
 }
 

--- a/control-plane/internal/handlers/memory_handler_test.go
+++ b/control-plane/internal/handlers/memory_handler_test.go
@@ -104,6 +104,10 @@ func (m *memoryStorageStub) DeleteVector(ctx context.Context, scope, scopeID, ke
 	return nil
 }
 
+func (m *memoryStorageStub) DeleteVectorsByPrefix(ctx context.Context, scope, scopeID, prefix string) (int, error) {
+	return 0, nil
+}
+
 func (m *memoryStorageStub) SimilaritySearch(ctx context.Context, scope, scopeID string, queryEmbedding []float32, topK int, filters map[string]interface{}) ([]*types.VectorSearchResult, error) {
 	return []*types.VectorSearchResult{}, nil
 }

--- a/control-plane/internal/server/server.go
+++ b/control-plane/internal/server/server.go
@@ -918,6 +918,7 @@ func (s *AgentFieldServer) setupRoutes() {
 		agentAPI.POST("/memory/vector/set", handlers.SetVectorHandler(s.storage))
 		agentAPI.POST("/memory/vector/search", handlers.SimilaritySearchHandler(s.storage))
 		agentAPI.POST("/memory/vector/delete", handlers.DeleteVectorHandler(s.storage))
+		agentAPI.DELETE("/memory/vector/namespace", handlers.DeleteNamespaceVectorsHandler(s.storage))
 
 		// Memory events endpoints
 		memoryEventsHandler := handlers.NewMemoryEventsHandler(s.storage)

--- a/control-plane/internal/server/server_routes_test.go
+++ b/control-plane/internal/server/server_routes_test.go
@@ -155,6 +155,9 @@ func (s *stubStorage) ListMemory(ctx context.Context, scope, scopeID string) ([]
 }
 func (s *stubStorage) SetVector(ctx context.Context, record *types.VectorRecord) error    { return nil }
 func (s *stubStorage) DeleteVector(ctx context.Context, scope, scopeID, key string) error { return nil }
+func (s *stubStorage) DeleteVectorsByPrefix(ctx context.Context, scope, scopeID, prefix string) (int, error) {
+	return 0, nil
+}
 func (s *stubStorage) SimilaritySearch(ctx context.Context, scope, scopeID string, queryEmbedding []float32, topK int, filters map[string]interface{}) ([]*types.VectorSearchResult, error) {
 	return nil, nil
 }

--- a/control-plane/internal/storage/local.go
+++ b/control-plane/internal/storage/local.go
@@ -3792,6 +3792,17 @@ func (ls *LocalStorage) DeleteVector(ctx context.Context, scope, scopeID, key st
 	return ls.vectorStore.Delete(ctx, scope, scopeID, key)
 }
 
+// DeleteVectorsByPrefix deletes all vectors whose key starts with the given prefix.
+func (ls *LocalStorage) DeleteVectorsByPrefix(ctx context.Context, scope, scopeID, prefix string) (int, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	if err := ls.requireVectorStore(); err != nil {
+		return 0, err
+	}
+	return ls.vectorStore.DeleteByPrefix(ctx, scope, scopeID, prefix)
+}
+
 // SimilaritySearch performs a similarity search within a scope using the configured vector backend.
 func (ls *LocalStorage) SimilaritySearch(ctx context.Context, scope, scopeID string, queryEmbedding []float32, topK int, filters map[string]interface{}) ([]*types.VectorSearchResult, error) {
 	if err := ctx.Err(); err != nil {

--- a/control-plane/internal/storage/storage.go
+++ b/control-plane/internal/storage/storage.go
@@ -88,6 +88,7 @@ type StorageProvider interface {
 	ListMemory(ctx context.Context, scope, scopeID string) ([]*types.Memory, error)
 	SetVector(ctx context.Context, record *types.VectorRecord) error
 	DeleteVector(ctx context.Context, scope, scopeID, key string) error
+	DeleteVectorsByPrefix(ctx context.Context, scope, scopeID, prefix string) (int, error)
 	SimilaritySearch(ctx context.Context, scope, scopeID string, queryEmbedding []float32, topK int, filters map[string]interface{}) ([]*types.VectorSearchResult, error)
 
 	// Event operations

--- a/control-plane/internal/storage/vector_store.go
+++ b/control-plane/internal/storage/vector_store.go
@@ -16,6 +16,7 @@ import (
 type vectorStore interface {
 	Set(ctx context.Context, record *types.VectorRecord) error
 	Delete(ctx context.Context, scope, scopeID, key string) error
+	DeleteByPrefix(ctx context.Context, scope, scopeID, prefix string) (int, error)
 	Search(ctx context.Context, scope, scopeID string, query []float32, topK int, filters map[string]interface{}) ([]*types.VectorSearchResult, error)
 }
 

--- a/control-plane/internal/storage/vector_store_postgres.go
+++ b/control-plane/internal/storage/vector_store_postgres.go
@@ -74,6 +74,26 @@ func (s *postgresVectorStore) Delete(ctx context.Context, scope, scopeID, key st
 	return err
 }
 
+func (s *postgresVectorStore) DeleteByPrefix(ctx context.Context, scope, scopeID, prefix string) (int, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	result, err := s.db.ExecContext(ctx, `
+		DELETE FROM memory_vectors
+		WHERE scope = ? AND scope_id = ? AND key LIKE ?
+	`, scope, scopeID, prefix+"%")
+	if err != nil {
+		return 0, err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return int(rows), nil
+}
+
 func (s *postgresVectorStore) Search(ctx context.Context, scope, scopeID string, query []float32, topK int, filters map[string]interface{}) ([]*types.VectorSearchResult, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/control-plane/internal/storage/vector_store_sqlite.go
+++ b/control-plane/internal/storage/vector_store_sqlite.go
@@ -76,6 +76,26 @@ func (s *sqliteVectorStore) Delete(ctx context.Context, scope, scopeID, key stri
 	return err
 }
 
+func (s *sqliteVectorStore) DeleteByPrefix(ctx context.Context, scope, scopeID, prefix string) (int, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	result, err := s.db.ExecContext(ctx, `
+		DELETE FROM memory_vectors
+		WHERE scope = ? AND scope_id = ? AND key LIKE ?
+	`, scope, scopeID, prefix+"%")
+	if err != nil {
+		return 0, err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return int(rows), nil
+}
+
 func (s *sqliteVectorStore) Search(ctx context.Context, scope, scopeID string, query []float32, topK int, filters map[string]interface{}) ([]*types.VectorSearchResult, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/examples/python_agent_nodes/documentation_chatbot/requirements.txt
+++ b/examples/python_agent_nodes/documentation_chatbot/requirements.txt
@@ -1,3 +1,4 @@
 fastembed>=0.3.4
 pydantic>=2.7.4
 agentfield>=0.1.9
+httpx>=0.27.0


### PR DESCRIPTION
## Summary

- Add `DELETE /api/v1/memory/vector/namespace` endpoint to clear all vectors with a given namespace prefix
- Add `DeleteVectorsByPrefix` method to `StorageProvider` interface
- Implement `DeleteByPrefix` for both SQLite and Postgres vector stores
- Add `clear_namespace` skill to documentation chatbot for programmatic namespace clearing

This enables the documentation chatbot to wipe and reindex its RAG data when documentation content changes, supporting automated reindexing workflows.

## Test plan

- [ ] Verify endpoint returns correct count of deleted vectors
- [ ] Test with SQLite backend
- [ ] Test with Postgres backend  
- [ ] Verify namespace prefix matching works correctly (e.g., `documentation` matches `documentation|...` keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)