### PR TITLE
fix(docs-chatbot): use railway.json for Railpack PyPI wait

### DIFF
--- a/examples/python_agent_nodes/documentation_chatbot/install.sh
+++ b/examples/python_agent_nodes/documentation_chatbot/install.sh
@@ -16,19 +16,15 @@ fi
 # Parse minimum version from requirement (handles >=X.Y.Z format)
 MIN_VERSION=$(echo "$AGENTFIELD_REQ" | sed -E 's/agentfield[>=<]+//' | tr -d ' ')
 
-echo "Waiting for agentfield>=$MIN_VERSION to be available on PyPI..."
+echo "Checking for agentfield>=$MIN_VERSION on PyPI..."
 
 MAX_RETRIES=30
 RETRY_INTERVAL=10
 
 for i in $(seq 1 $MAX_RETRIES); do
-    # Check if the version is available on PyPI
-    AVAILABLE=$(pip index versions agentfield 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -20 || echo "")
-
-    if echo "$AVAILABLE" | grep -qE "^${MIN_VERSION}$|^[0-9]+\.[0-9]+\.[1-9][0-9]*$"; then
-        # Version found or a higher version exists
-        LATEST=$(echo "$AVAILABLE" | head -1)
-        echo "Found agentfield $LATEST on PyPI"
+    # Try to install the specific version to check if it exists
+    if pip install --dry-run "agentfield>=$MIN_VERSION" >/dev/null 2>&1; then
+        echo "agentfield>=$MIN_VERSION is available on PyPI"
         break
     fi
 
@@ -38,7 +34,7 @@ for i in $(seq 1 $MAX_RETRIES); do
         break
     fi
 
-    echo "Attempt $i/$MAX_RETRIES: agentfield $MIN_VERSION not yet available, waiting ${RETRY_INTERVAL}s..."
+    echo "Attempt $i/$MAX_RETRIES: agentfield>=$MIN_VERSION not yet available, waiting ${RETRY_INTERVAL}s..."
     sleep $RETRY_INTERVAL
 done
 

--- a/examples/python_agent_nodes/documentation_chatbot/nixpacks.toml
+++ b/examples/python_agent_nodes/documentation_chatbot/nixpacks.toml
@@ -1,8 +1,0 @@
-[phases.setup]
-nixPkgs = ["python311"]
-
-[phases.install]
-cmds = ["./install.sh"]
-
-[start]
-cmd = "python -m agentfield.run"

--- a/examples/python_agent_nodes/documentation_chatbot/railway.json
+++ b/examples/python_agent_nodes/documentation_chatbot/railway.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS",
+    "buildCommand": "./install.sh"
+  },
+  "deploy": {
+    "startCommand": "python -m agentfield.run"
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #36 - Railway now uses Railpack instead of Nixpacks, so the `nixpacks.toml` config wasn't being used.

Changes:
- Replace `nixpacks.toml` with `railway.json` config
- Force `NIXPACKS` builder with custom `buildCommand` pointing to `install.sh`
- Fix version check in `install.sh` using `pip install --dry-run` for reliability

## Context

The v0.1.11 release failed on Railway because:
1. Release workflow bumped requirements.txt to `agentfield>=0.1.11`
2. Railway triggered a deploy before PyPI upload completed
3. Build failed with: `Could not find a version that satisfies the requirement agentfield>=0.1.11`

This fix makes Railway wait up to 5 minutes for the package to appear on PyPI before installing.

## Test plan

- [ ] Merge and trigger a release
- [ ] Verify Railway waits for PyPI and deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)