### PR TITLE
fix(docs-chatbot): override install phase for PyPI wait

### DIFF
--- a/examples/python_agent_nodes/documentation_chatbot/install.sh
+++ b/examples/python_agent_nodes/documentation_chatbot/install.sh
@@ -4,6 +4,10 @@
 
 set -e
 
+# Set up virtual environment (replaces Nixpacks default install phase)
+python -m venv --copies /opt/venv
+. /opt/venv/bin/activate
+
 # Extract agentfield version requirement from requirements.txt
 AGENTFIELD_REQ=$(grep -E "^agentfield" requirements.txt || echo "")
 

--- a/examples/python_agent_nodes/documentation_chatbot/nixpacks.toml
+++ b/examples/python_agent_nodes/documentation_chatbot/nixpacks.toml
@@ -1,0 +1,5 @@
+[phases.install]
+cmds = ["./install.sh"]
+
+[start]
+cmd = "python -m agentfield.run"

--- a/examples/python_agent_nodes/documentation_chatbot/railway.json
+++ b/examples/python_agent_nodes/documentation_chatbot/railway.json
@@ -2,7 +2,7 @@
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
     "builder": "NIXPACKS",
-    "buildCommand": "./install.sh"
+    "nixpacksConfigPath": "nixpacks.toml"
   },
   "deploy": {
     "startCommand": "python -m agentfield.run"


### PR DESCRIPTION
## Summary

Follow-up fix for #37 - the previous fix used `buildCommand` which runs **after** the default `pip install`, so pip had already failed before our script ran.

This fix overrides the **install phase** itself:

- Add `nixpacks.toml` with `[phases.install]` to run `install.sh` 
- Update `railway.json` to use `nixpacksConfigPath`
- Update `install.sh` to create venv before waiting for PyPI

## What was happening

```
║ install    │ pip install -r requirements.txt   ← FAILS HERE (race condition)
║ build      │ ./install.sh                      ← Our script ran too late
```

## What this fixes

```
║ install    │ ./install.sh   ← Now runs our script which waits for PyPI
```

## Test plan

- [ ] Merge and verify Railway deployment succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)