### PR TITLE
fix(docs-chatbot): use correct start command

### DIFF
--- a/examples/python_agent_nodes/documentation_chatbot/nixpacks.toml
+++ b/examples/python_agent_nodes/documentation_chatbot/nixpacks.toml
@@ -2,4 +2,4 @@
 cmds = ["./install.sh"]
 
 [start]
-cmd = "python -m agentfield.run"
+cmd = "python main.py"

--- a/examples/python_agent_nodes/documentation_chatbot/railway.json
+++ b/examples/python_agent_nodes/documentation_chatbot/railway.json
@@ -5,6 +5,6 @@
     "nixpacksConfigPath": "nixpacks.toml"
   },
   "deploy": {
-    "startCommand": "python -m agentfield.run"
+    "startCommand": "python main.py"
   }
 }


### PR DESCRIPTION
## Summary

Fix the start command from `python -m agentfield.run` (doesn't exist) to `python main.py`.

The previous PRs introduced an incorrect start command that caused the app to crash with:
```
/opt/venv/bin/python: No module named agentfield.run
```

## Changes

- `railway.json`: `startCommand` → `python main.py`
- `nixpacks.toml`: `cmd` → `python main.py`

## Test plan

- [ ] Merge and verify Railway deployment starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)