### PR TITLE
docs(chatbot): add TypeScript SDK to supported languages

### DIFF
--- a/examples/python_agent_nodes/documentation_chatbot/product_context.py
+++ b/examples/python_agent_nodes/documentation_chatbot/product_context.py
@@ -70,7 +70,7 @@ deploying and managing distributed multi-agent systems in production (like Kuber
 - **Failure Isolation**: Agent failures don't cascade; control plane handles routing around issues
 
 **CLI Commands:**
-- `af init`: Create new agent (Python or Go)
+- `af init`: Create new agent (Python, Go, or TypeScript)
 - `af server`: Start control plane
 - `af run`: Run agent locally
 - `af dev`: Development mode with hot reload
@@ -85,7 +85,7 @@ deploying and managing distributed multi-agent systems in production (like Kuber
 
 **Getting Started:**
 - Installation and setup (af init, af server)
-- Creating first agent (Python vs Go choice)
+- Creating first agent (Python, Go, or TypeScript choice)
 - Understanding reasoners vs skills
 - Basic agent structure and configuration
 
@@ -126,7 +126,7 @@ The documentation is organized by:
 - **Getting Started**: Quick start, installation, first agent
 - **Core Concepts**: Reasoners, skills, memory, identity, cross-agent communication
 - **Guides**: Deployment, testing, multi-agent patterns, examples
-- **API Reference**: Python SDK, Go SDK, CLI commands, REST APIs
+- **API Reference**: Python SDK, Go SDK, TypeScript SDK, CLI commands, REST APIs
 - **Examples**: Customer support, research assistant, terminal assistant
 
 ## Search Term Relationships


### PR DESCRIPTION
## Summary

- Update product context to include TypeScript alongside Python and Go
- CLI commands now mention all three language options  
- Getting started section references TypeScript
- API Reference includes TypeScript SDK

This fixes the RAG chatbot returning only Python/Go when asked about supported languages.

**Note:** Vector DB still needs to be re-indexed to include TypeScript SDK documentation content.

## Test plan

- [ ] Deploy docs chatbot and ask "what languages are supported?"
- [ ] Verify response includes Python, Go, and TypeScript

🤖 Generated with [Claude Code](https://claude.com/claude-code)