### PR TITLE
docs(chatbot): add SDK search term relationship

### DIFF
--- a/examples/python_agent_nodes/documentation_chatbot/product_context.py
+++ b/examples/python_agent_nodes/documentation_chatbot/product_context.py
@@ -142,4 +142,5 @@ When users ask about:
 - "Differences" or "comparison" or "vs" → Look for: infrastructure vs framework, control plane vs embedded library, multi-team vs single app, production features
 - "Scale" or "scalability" → Look for: stateless control plane, independent scaling, billions of requests, horizontal scaling
 - "Architecture" → Look for: distributed architecture, control plane, agent nodes, microservices, stateless design
+- "SDK" or "language" or "languages" or "supported" → Look for: Python SDK, Go SDK, TypeScript SDK, npm install @agentfield/sdk, pip install agentfield
 """


### PR DESCRIPTION
## Summary

- Add search term mapping for SDK/language queries
- Maps "SDK", "language", "languages", "supported" → Python SDK, Go SDK, TypeScript SDK

This improves RAG retrieval when users ask about supported languages or SDKs.

## Test plan

- [ ] Ask chatbot "what SDKs are supported?"
- [ ] Verify it retrieves relevant SDK documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)