### PR TITLE
fix(vector-store): fix PostgreSQL DeleteByPrefix and update namespace defaults

### DIFF
--- a/control-plane/internal/storage/vector_store_postgres.go
+++ b/control-plane/internal/storage/vector_store_postgres.go
@@ -79,10 +79,11 @@ func (s *postgresVectorStore) DeleteByPrefix(ctx context.Context, scope, scopeID
 		return 0, err
 	}
 
+	// Use || operator to build the LIKE pattern in PostgreSQL
 	result, err := s.db.ExecContext(ctx, `
 		DELETE FROM memory_vectors
-		WHERE scope = ? AND scope_id = ? AND key LIKE ?
-	`, scope, scopeID, prefix+"%")
+		WHERE scope = ? AND scope_id = ? AND key LIKE ? || '%'
+	`, scope, scopeID, prefix)
 	if err != nil {
 		return 0, err
 	}

--- a/examples/python_agent_nodes/documentation_chatbot/routers/ingestion.py
+++ b/examples/python_agent_nodes/documentation_chatbot/routers/ingestion.py
@@ -37,13 +37,13 @@ async def _clear_namespace_via_api(namespace: str) -> dict:
 
     url = f"{base_url}/api/v1/memory/vector/namespace"
     async with httpx.AsyncClient(timeout=30) as client:
-        resp = await client.delete(url, json={"namespace": namespace}, headers=headers)
+        resp = await client.delete(url, json={"namespace": namespace, "scope": "global"}, headers=headers)
         resp.raise_for_status()
         return resp.json()
 
 
 @ingestion_router.skill()
-async def clear_namespace(namespace: str = "documentation") -> dict:
+async def clear_namespace(namespace: str = "website-docs") -> dict:
     """Wipe all vectors for a namespace before re-indexing."""
     result = await _clear_namespace_via_api(namespace)
     deleted = result.get("deleted", 0)
@@ -54,7 +54,7 @@ async def clear_namespace(namespace: str = "documentation") -> dict:
 @ingestion_router.reasoner()
 async def ingest_folder(
     folder_path: str,
-    namespace: str = "documentation",
+    namespace: str = "website-docs",
     glob_pattern: str = "**/*",
     chunk_size: int = 1200,
     chunk_overlap: int = 250,

--- a/examples/python_agent_nodes/documentation_chatbot/routers/qa.py
+++ b/examples/python_agent_nodes/documentation_chatbot/routers/qa.py
@@ -163,7 +163,7 @@ Then self-assess and set confidence, needs_more, and missing_topics accordingly.
 @qa_router.reasoner()
 async def qa_answer(
     question: str,
-    namespace: str = "documentation",
+    namespace: str = "website-docs",
     top_k: int = 6,
     min_score: float = 0.35,
 ) -> DocAnswer:
@@ -228,7 +228,7 @@ async def qa_answer(
 @qa_router.reasoner()
 async def qa_answer_with_documents(
     question: str,
-    namespace: str = "documentation",
+    namespace: str = "website-docs",
     top_k: int = 6,
     min_score: float = 0.35,
     top_documents: int = 5,

--- a/examples/python_agent_nodes/documentation_chatbot/routers/retrieval.py
+++ b/examples/python_agent_nodes/documentation_chatbot/routers/retrieval.py
@@ -59,7 +59,7 @@ async def _retrieve_for_query(
 @retrieval_router.reasoner()
 async def parallel_retrieve(
     queries: List[str],
-    namespace: str = "documentation",
+    namespace: str = "website-docs",
     top_k: int = 6,
     min_score: float = 0.35,
 ) -> List[RetrievalResult]:


### PR DESCRIPTION
## Summary

- Fix `DeleteByPrefix` to use PostgreSQL `||` operator for LIKE pattern - the previous approach with `prefix+"%"` in Go wasn't working correctly with parameter binding
- Change default namespace from `"documentation"` to `"website-docs"` to match the frontend chat API expectations
- Add `scope: "global"` to `clear_namespace` API call to ensure proper scope matching

## Root Cause

The delete namespace API was returning `deleted: 0` even when vectors existed because:
1. The PostgreSQL LIKE pattern wasn't being constructed correctly through parameter binding
2. The scope wasn't being explicitly passed, causing a mismatch

## Test plan

- [ ] Deploy control plane with the fix
- [ ] Run `curl -X DELETE .../api/v1/memory/vector/namespace -d '{"namespace":"website-docs", "scope":"global"}'` and verify it deletes vectors
- [ ] Re-run reindex script and verify vectors are created
- [ ] Test chat functionality returns TypeScript examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)