### PR TITLE
Add Go SDK CallLocal workflow tracking

### DIFF
--- a/sdk/go/types/types.go
+++ b/sdk/go/types/types.go
@@ -85,3 +85,22 @@ type ShutdownRequest struct {
 	Reason          string `json:"reason,omitempty"`
 	ExpectedRestart string `json:"expected_restart,omitempty"`
 }
+
+// WorkflowExecutionEvent mirrors the control plane's event ingestion payload.
+// It allows agents to emit parent/child execution details without routing work
+// through the control plane.
+type WorkflowExecutionEvent struct {
+	ExecutionID       string                 `json:"execution_id"`
+	WorkflowID        string                 `json:"workflow_id,omitempty"`
+	RunID             string                 `json:"run_id,omitempty"`
+	ReasonerID        string                 `json:"reasoner_id,omitempty"`
+	Type              string                 `json:"type,omitempty"`
+	AgentNodeID       string                 `json:"agent_node_id,omitempty"`
+	Status            string                 `json:"status"`
+	ParentExecutionID *string                `json:"parent_execution_id,omitempty"`
+	ParentWorkflowID  *string                `json:"parent_workflow_id,omitempty"`
+	InputData         map[string]interface{} `json:"input_data,omitempty"`
+	Result            interface{}            `json:"result,omitempty"`
+	Error             string                 `json:"error,omitempty"`
+	DurationMS        *int64                 `json:"duration_ms,omitempty"`
+}


### PR DESCRIPTION
# Summary
- add CallLocal support to run Go reasoners locally while emitting workflow DAG events and tracking execution lineage
- extend execution context + workflow event payloads so parent/child relationships show up in control plane
- update hello agent and add unit/functional coverage to ensure local calls still build DAGs

## Testing
- [ ] `./scripts/test-all.sh`
- [x] Additional verification (please describe): `cd sdk/go && go test ./...`; `OPENROUTER_API_KEY=<provided> make test-functional-local`

## Checklist
- [ ] I updated documentation where applicable.
- [x] I added or updated tests (or none were needed).
- [ ] I updated `CHANGELOG.md` (or this change does not warrant a changelog entry).

## Screenshots (if UI-related)
- N/A

## Related issues
- N/A
