### PR TITLE
fix(control-plane): remove redundant WebSocket origin check

### DIFF
--- a/control-plane/internal/server/server.go
+++ b/control-plane/internal/server/server.go
@@ -937,11 +937,7 @@ func (s *AgentFieldServer) setupRoutes() {
 		agentAPI.DELETE("/memory/vector/namespace", handlers.DeleteNamespaceVectorsHandler(s.storage))
 
 		// Memory events endpoints
-		memoryEventsHandler := handlers.NewMemoryEventsHandler(
-			s.storage,
-			corsConfig.AllowOrigins,
-			s.config.API.Auth.APIKey != "",
-		)
+		memoryEventsHandler := handlers.NewMemoryEventsHandler(s.storage)
 		agentAPI.GET("/memory/events/ws", memoryEventsHandler.WebSocketHandler)
 		agentAPI.GET("/memory/events/sse", memoryEventsHandler.SSEHandler)
 		agentAPI.GET("/memory/events/history", handlers.GetEventHistoryHandler(s.storage))


### PR DESCRIPTION
## Summary

- Remove redundant origin checking from WebSocket upgrader for memory events
- The origin check was causing 403 errors for server-to-server connections (Python SDK agents) that don't send Origin headers
- Auth middleware already validates API keys before requests reach the handler, making the origin check unnecessary

## Context

When auth is enabled, agents connecting to `/api/v1/memory/events/ws` were getting HTTP 403 because:
1. Server-to-server WebSocket connections don't include an `Origin` header
2. The `CheckOrigin` function was returning `false` when no Origin was present

This was redundant because the auth middleware already validates API keys before requests reach this handler.

## Test plan

- [ ] Deploy to staging and verify memory events WebSocket connection works with auth enabled
- [ ] Verify browser WebSocket connections still work (they pass through auth middleware too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)