### PR TITLE
fix(sdk): inject API key into all HTTP requests

### DIFF
--- a/sdk/python/agentfield/client.py
+++ b/sdk/python/agentfield/client.py
@@ -357,6 +357,13 @@ class AgentFieldClient:
 
     async def _async_request(self, method: str, url: str, **kwargs):
         """Perform an HTTP request using the shared async client with sync fallback."""
+        # Inject API key into headers if available
+        if self.api_key:
+            if "headers" not in kwargs:
+                kwargs["headers"] = {}
+            if "X-API-Key" not in kwargs["headers"]:
+                kwargs["headers"]["X-API-Key"] = self.api_key
+
         try:
             client = await self.get_async_http_client()
         except RuntimeError:


### PR DESCRIPTION
## Summary

- Automatically inject `X-API-Key` header in `AgentFieldClient._async_request()` when `api_key` is configured
- Only injects if header not already present (won't overwrite explicit headers)
- Fixes 401 errors when control plane has authentication enabled

## Problem

When authentication is enabled on the control plane, the Python SDK was failing with 401 errors on:
- Async status updates (`_post_execution_status`)
- Memory operations (vector search, set, get, etc.)

The SDK had `api_key` configured but wasn't including it in the `X-API-Key` header for HTTP requests.

## Solution

Central fix at `AgentFieldClient._async_request()` that automatically injects the API key into all outbound requests. This covers both async (httpx) and sync fallback (requests) paths.

## Test plan

- [ ] Deploy to staging with auth-enabled control plane
- [ ] Verify async status updates succeed (no more 401 errors)
- [ ] Verify memory vector search works
- [ ] Verify other memory operations (set, get, delete) work

🤖 Generated with [Claude Code](https://claude.com/claude-code)