### PR TITLE
fix(examples): revert to stable agentfield version (0.1.19)

### DIFF
--- a/examples/python_agent_nodes/agentic_rag/requirements.txt
+++ b/examples/python_agent_nodes/agentic_rag/requirements.txt
@@ -1,3 +1,3 @@
-agentfield>=0.1.20-rc.1
+agentfield>=0.1.19
 fastembed>=0.2.0
 numpy>=1.24.0

--- a/examples/python_agent_nodes/documentation_chatbot/requirements.txt
+++ b/examples/python_agent_nodes/documentation_chatbot/requirements.txt
@@ -1,4 +1,4 @@
 fastembed>=0.3.4
 pydantic>=2.7.4
-agentfield>=0.1.20-rc.1
+agentfield>=0.1.19
 httpx>=0.27.0

--- a/examples/python_agent_nodes/hello_world_rag/requirements.txt
+++ b/examples/python_agent_nodes/hello_world_rag/requirements.txt
@@ -1,2 +1,2 @@
-agentfield>=0.1.20-rc.1
+agentfield>=0.1.19
 fastembed>=0.2.0


### PR DESCRIPTION
## Summary

- Reverts example requirements from `agentfield>=0.1.20-rc.1` to `agentfield>=0.1.19`
- Fixes Railway deployment failures for RAG QA and other examples

## Problem

The staging release workflow bumped example `requirements.txt` files to require `agentfield>=0.1.20-rc.1`. However, RC versions are published to **TestPyPI**, not PyPI. When Railway triggered a deployment, pip couldn't find the package on PyPI and the build failed after 30 retry attempts.

## Fix

Revert to the last stable version (`0.1.19`) which exists on PyPI.

## Test plan

- [ ] Merge this PR
- [ ] Verify Railway RAG QA deployment succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)