### PR TITLE
fix(release): skip example requirements bump for prerelease versions

### DIFF
--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -190,7 +190,10 @@ def apply_version(version: SemVer) -> None:
     update_pyproject(version)
     update_init(version)
     update_pkg_info(version)
-    update_requirements(version)
+    # Only update example requirements for stable releases.
+    # Prereleases go to TestPyPI, not PyPI, so examples would fail to install.
+    if not version.prerelease:
+        update_requirements(version)
     update_go_template(version)
     update_ts_package_json(version)
 


### PR DESCRIPTION
## Summary

- Modifies `bump_version.py` to skip updating example `requirements.txt` files for prerelease versions
- Prevents future Railway deployment failures caused by examples requiring RC versions

## Problem

When the staging release workflow runs, `bump_version.py` updates all version files including example `requirements.txt` files. Since RC versions are published to TestPyPI (not PyPI), Railway deployments fail because pip can't find the package.

## Solution

Check if the version has a prerelease component before updating example requirements:

```python
# Only update example requirements for stable releases.
# Prereleases go to TestPyPI, not PyPI, so examples would fail to install.
if not version.prerelease:
    update_requirements(version)
```

## Test plan

- [ ] Merge PR #54 first (fixes current broken state)
- [ ] Merge this PR
- [ ] Next staging release should NOT bump example requirements
- [ ] Next production release SHOULD bump example requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)