### PR TITLE
fix(release): add [skip ci] to prevent infinite release loop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add -A
-            git commit -m "chore(release): ${tag}"
+            git commit -m "chore(release): ${tag} [skip ci]"
             git tag -a "${tag}" -m "Release ${tag}"
             git push origin "HEAD:${REF_NAME}"
             git push origin "${tag}"


### PR DESCRIPTION
## Summary

Adds `[skip ci]` to the release commit message to explicitly prevent infinite release loops.

## Problem

The release workflow:
1. Bumps version files (`VERSION`, `sdk/python/*`, `sdk/typescript/*`, `control-plane/*`)
2. Commits with `chore(release): vX.Y.Z`
3. Pushes to main

These files match the workflow's trigger paths, which could theoretically cause an infinite loop.

## Current Protection

GitHub Actions already prevents `GITHUB_TOKEN` pushes from triggering workflows. However, this is implicit behavior.

## This Fix

Adding `[skip ci]` makes the protection explicit and guards against:
- Future changes that might use a PAT instead of GITHUB_TOKEN
- Any edge cases where the implicit protection might not apply

## Test plan

- [ ] Merge this PR
- [ ] Next staging release should NOT trigger another release
- [ ] Verify release commit contains `[skip ci]` suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)