### PR TITLE
feat(release): unify PyPI publishing for all releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
     inputs:
       release_environment:
-        description: 'Target environment (staging=TestPyPI/npm@next, production=PyPI/npm@latest)'
+        description: 'Target environment (staging=prerelease, production=stable release)'
         type: choice
         options:
           - staging
@@ -38,7 +38,7 @@ on:
         type: string
         required: false
       publish_pypi:
-        description: 'Publish Python SDK (staging=TestPyPI, production=PyPI)'
+        description: 'Publish Python SDK to PyPI'
         type: boolean
         default: true
       publish_npm:
@@ -363,8 +363,8 @@ jobs:
             # Staging binary (use --staging flag)
             curl -fsSL https://agentfield.ai/install.sh | bash -s -- --staging
 
-            # Python SDK (from TestPyPI)
-            pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ agentfield
+            # Python SDK (prerelease - requires --pre flag)
+            pip install --pre agentfield
 
             # TypeScript SDK
             npm install @agentfield/sdk@next
@@ -410,22 +410,8 @@ jobs:
           name: python-sdk-dist
           path: sdk/python/dist
 
-      - name: Publish to TestPyPI (staging)
-        if: |
-          needs.prepare.outputs.environment == 'staging' &&
-          needs.prepare.outputs.publish_pypi == 'true'
-        working-directory: sdk/python
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        run: |
-          python -m pip install --upgrade twine
-          twine upload --repository-url https://test.pypi.org/legacy/ dist/*
-
-      - name: Publish to PyPI (production)
-        if: |
-          needs.prepare.outputs.environment == 'production' &&
-          needs.prepare.outputs.publish_pypi == 'true'
+      - name: Publish to PyPI
+        if: needs.prepare.outputs.publish_pypi == 'true'
         working-directory: sdk/python
         env:
           TWINE_USERNAME: __token__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 Implement automatic staging releases and manual production releases:
 
-- Staging: Automatic on push to main (TestPyPI, npm @next, staging-* Docker)
+- Staging: Automatic on push to main (PyPI prerelease, npm @next, staging-* Docker)
 - Production: Manual workflow dispatch (PyPI, npm @latest, vX.Y.Z + latest Docker)
 
 Changes:
 - Add push trigger with path filters for automatic staging
 - Replace release_channel with release_environment input
-- Split PyPI publishing: TestPyPI (staging) vs PyPI (production)
+- Unified PyPI publishing for both staging (prerelease) and production
 - Split npm publishing: @next tag (staging) vs @latest (production)
 - Conditional Docker tagging: staging-X.Y.Z vs vX.Y.Z + latest
 - Add install-staging.sh for testing prerelease binaries

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -190,10 +190,7 @@ def apply_version(version: SemVer) -> None:
     update_pyproject(version)
     update_init(version)
     update_pkg_info(version)
-    # Only update example requirements for stable releases.
-    # Prereleases go to TestPyPI, not PyPI, so examples would fail to install.
-    if not version.prerelease:
-        update_requirements(version)
+    update_requirements(version)
     update_go_template(version)
     update_ts_package_json(version)
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -531,8 +531,8 @@ print_success_message() {
 
   if [[ "$STAGING" == "1" ]]; then
     printf "${BOLD}Testing SDKs:${NC}\n"
-    printf "  Python (TestPyPI):\n"
-    printf "     ${CYAN}pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ agentfield${NC}\n"
+    printf "  Python (prerelease):\n"
+    printf "     ${CYAN}pip install --pre agentfield${NC}\n"
     printf "\n"
     printf "  TypeScript:\n"
     printf "     ${CYAN}npm install @agentfield/sdk@next${NC}\n"


### PR DESCRIPTION
## Summary

Publish all Python SDK releases (both prerelease and stable) to PyPI instead of using TestPyPI for prereleases.

Per [PEP 440](https://peps.python.org/pep-0440/), prerelease versions (e.g., `0.1.20rc1`) are excluded by default from `pip install` - users must explicitly use `--pre` flag. This simplifies the release process.

### Changes

- Merge TestPyPI and PyPI publish steps into single PyPI step
- Update release notes to show `pip install --pre` for staging
- Update `install.sh` staging output
- Re-enable example requirements updates for prereleases (since they'll be on PyPI now)
- Update `RELEASE.md` documentation

### After merging

You can remove the `TEST_PYPI_API_TOKEN` secret from the repository settings - it's no longer needed.

## Test plan

- [ ] Verify the workflow YAML is valid
- [ ] Merge and confirm staging release publishes to PyPI with prerelease version
- [ ] Verify `pip install --pre agentfield` installs the prerelease

🤖 Generated with [Claude Code](https://claude.com/claude-code)