### PR TITLE
fix(release): skip example requirements for prereleases

### DIFF
--- a/examples/python_agent_nodes/agentic_rag/requirements.txt
+++ b/examples/python_agent_nodes/agentic_rag/requirements.txt
@@ -1,3 +1,3 @@
-agentfield>=0.1.20-rc.2
+agentfield>=0.1.19
 fastembed>=0.2.0
 numpy>=1.24.0

--- a/examples/python_agent_nodes/documentation_chatbot/requirements.txt
+++ b/examples/python_agent_nodes/documentation_chatbot/requirements.txt
@@ -1,4 +1,4 @@
 fastembed>=0.3.4
 pydantic>=2.7.4
-agentfield>=0.1.20-rc.2
+agentfield>=0.1.19
 httpx>=0.27.0

--- a/examples/python_agent_nodes/hello_world_rag/requirements.txt
+++ b/examples/python_agent_nodes/hello_world_rag/requirements.txt
@@ -1,2 +1,2 @@
-agentfield>=0.1.20-rc.2
+agentfield>=0.1.19
 fastembed>=0.2.0

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -190,7 +190,11 @@ def apply_version(version: SemVer) -> None:
     update_pyproject(version)
     update_init(version)
     update_pkg_info(version)
-    update_requirements(version)
+    # Only update example requirements for stable releases.
+    # Prereleases are excluded by pip install by default (PEP 440),
+    # so examples would fail to install without --pre flag.
+    if not version.prerelease:
+        update_requirements(version)
     update_go_template(version)
     update_ts_package_json(version)
 


### PR DESCRIPTION
## Summary

Fixes the regression from PR #58 where example requirements were being updated to prerelease versions.

Even though prereleases are now published to PyPI (not TestPyPI), `pip install` still excludes them by default per [PEP 440](https://peps.python.org/pep-0440/). Users running `pip install -r requirements.txt` would fail without the `--pre` flag.

### Changes

- Restore the prerelease check in `bump_version.py` to skip example requirements
- Revert example requirements back to `>=0.1.19` (last stable version)

### Root cause

In PR #58, I incorrectly removed the prerelease skip thinking that since we publish to regular PyPI, users could install prereleases. But pip's default behavior excludes prereleases regardless of which registry they're on.

## Test plan

- [ ] Merge and verify next staging release doesn't update example requirements
- [ ] Verify `pip install -r requirements.txt` works in example directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)