### PR TITLE
fix: correct parent execution ID for sub-calls in app.call()

### DIFF
--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -2708,6 +2708,10 @@ class Agent(FastAPI):
         # Prepare headers with proper workflow tracking
         headers = current_context.to_headers()
 
+        # Ensure the current execution is the parent for sub-calls (not the inherited parent)
+        # This fixes workflow graph attribution for local skill calls
+        headers["X-Parent-Execution-ID"] = current_context.execution_id
+
         # DISABLED: Same-agent call detection - Force all calls through AgentField server
         # This ensures all app.call() requests go through the AgentField server for proper
         # workflow tracking, execution context, and distributed processing


### PR DESCRIPTION
## Problem

When an agent's reasoner calls a skill (or another reasoner) via app.call(), the X-Parent-Execution-ID header is incorrectly set to the inherited parent from the incoming request, rather than the current execution's ID.

This causes the control plane to record incorrect parent-child relationships in the workflow graph. Sub-calls appear as siblings of the calling execution instead of children.

## Example Scenario

1. Agent A calls Agent B's reasoner
2. Agent B's reasoner calls a local skill via app.call()
3. Expected: The skill execution is recorded as a child of Agent B's reasoner
4. Actual: The skill execution is recorded as a child of Agent A (the inherited parent)

## Root Cause

In agent.py, the call() method uses current_context.to_headers() which propagates the inherited parent_execution_id rather than using the current execution as the parent for sub-calls.

## Fix

After calling to_headers(), override X-Parent-Execution-ID to use current_context.execution_id, ensuring sub-calls are correctly attributed as children of the current execution.