### PR TITLE
Harden node registration callback validation

### DIFF
--- a/tests/functional/tests/test_callback_ssrf.py
+++ b/tests/functional/tests/test_callback_ssrf.py
@@ -1,0 +1,46 @@
+import asyncio
+import os
+
+import pytest
+
+from utils import unique_node_id
+
+
+@pytest.mark.functional
+@pytest.mark.asyncio
+async def test_node_registration_does_not_probe_callback(async_http_client):
+    """
+    Registration should not reach out to the provided callback URL (prevents SSRF).
+    """
+    hits = 0
+
+    async def handle(reader, writer):
+        nonlocal hits
+        hits += 1
+        writer.write(b"HTTP/1.1 200 OK\r\nContent-Length:2\r\n\r\nOK")
+        await writer.drain()
+        writer.close()
+
+    server = await asyncio.start_server(handle, host="0.0.0.0", port=0)
+    port = server.sockets[0].getsockname()[1]
+    callback_host = os.environ.get("TEST_AGENT_CALLBACK_HOST", "test-runner")
+    base_url = f"http://{callback_host}:{port}"
+    node_id = unique_node_id("ssrf")
+
+    try:
+        resp = await async_http_client.post(
+            "/api/v1/nodes",
+            json={"id": node_id, "base_url": base_url},
+            timeout=10.0,
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["success"] is True
+        assert body.get("resolved_base_url") == base_url
+
+        # Allow a brief window for any unexpected probes to surface
+        await asyncio.sleep(0.5)
+        assert hits == 0, f"control plane probed callback URL during registration ({hits} requests)"
+    finally:
+        server.close()
+        await server.wait_closed()


### PR DESCRIPTION
## Summary
- stop node registration from issuing callback URL health probes and gate auto-discovery probes behind AGENTFIELD_ENABLE_CALLBACK_PROBES
- keep callback candidate normalization while avoiding outbound requests to untrusted URLs
- add unit + functional coverage to prevent SSRF regressions on registration

## Testing
- go test ./control-plane/internal/handlers
- OPENROUTER_API_KEY=*** docker compose -f docker/docker-compose.local.yml up --build --abort-on-container-exit --exit-code-from test-runner (ran with host port override locally because 8080 was already in use)