### PR TITLE
feat(go-sdk): add Memory and Note APIs for agent state and progress tracking

### DIFF
--- a/sdk/go/agent/memory.go
+++ b/sdk/go/agent/memory.go
@@ -1,0 +1,332 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+)
+
+// MemoryScope represents different memory isolation levels.
+type MemoryScope string
+
+const (
+	// ScopeWorkflow isolates memory to the current workflow execution.
+	ScopeWorkflow MemoryScope = "workflow"
+	// ScopeSession isolates memory to the current session.
+	ScopeSession MemoryScope = "session"
+	// ScopeUser isolates memory to the current user/actor.
+	ScopeUser MemoryScope = "user"
+	// ScopeGlobal provides cross-session, cross-workflow storage.
+	ScopeGlobal MemoryScope = "global"
+)
+
+// MemoryBackend is the pluggable storage interface for memory operations.
+// Implementations can use in-memory storage, Redis, databases, or external APIs.
+type MemoryBackend interface {
+	// Set stores a value at the given scope and key.
+	Set(scope MemoryScope, scopeID, key string, value any) error
+	// Get retrieves a value; returns (value, found, error).
+	Get(scope MemoryScope, scopeID, key string) (any, bool, error)
+	// Delete removes a key from storage.
+	Delete(scope MemoryScope, scopeID, key string) error
+	// List returns all keys in a scope.
+	List(scope MemoryScope, scopeID string) ([]string, error)
+}
+
+// Memory provides hierarchical state management for agent handlers.
+// It supports multiple isolation scopes (workflow, session, user, global)
+// with automatic scope ID resolution from execution context.
+type Memory struct {
+	backend MemoryBackend
+}
+
+// NewMemory creates a Memory instance with the given backend.
+// If backend is nil, an in-memory backend is used.
+func NewMemory(backend MemoryBackend) *Memory {
+	if backend == nil {
+		backend = NewInMemoryBackend()
+	}
+	return &Memory{backend: backend}
+}
+
+// Set stores a value in the session scope (default scope).
+func (m *Memory) Set(ctx context.Context, key string, value any) error {
+	execCtx := ExecutionContextFrom(ctx)
+	scopeID := execCtx.SessionID
+	if scopeID == "" {
+		scopeID = execCtx.RunID
+	}
+	return m.backend.Set(ScopeSession, scopeID, key, value)
+}
+
+// Get retrieves a value from the session scope (default scope).
+// Returns nil if the key does not exist.
+func (m *Memory) Get(ctx context.Context, key string) (any, error) {
+	execCtx := ExecutionContextFrom(ctx)
+	scopeID := execCtx.SessionID
+	if scopeID == "" {
+		scopeID = execCtx.RunID
+	}
+	val, _, err := m.backend.Get(ScopeSession, scopeID, key)
+	return val, err
+}
+
+// GetWithDefault retrieves a value from the session scope,
+// returning the default if the key does not exist.
+func (m *Memory) GetWithDefault(ctx context.Context, key string, defaultVal any) (any, error) {
+	execCtx := ExecutionContextFrom(ctx)
+	scopeID := execCtx.SessionID
+	if scopeID == "" {
+		scopeID = execCtx.RunID
+	}
+	val, found, err := m.backend.Get(ScopeSession, scopeID, key)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return defaultVal, nil
+	}
+	return val, nil
+}
+
+// Delete removes a key from the session scope.
+func (m *Memory) Delete(ctx context.Context, key string) error {
+	execCtx := ExecutionContextFrom(ctx)
+	scopeID := execCtx.SessionID
+	if scopeID == "" {
+		scopeID = execCtx.RunID
+	}
+	return m.backend.Delete(ScopeSession, scopeID, key)
+}
+
+// List returns all keys in the session scope.
+func (m *Memory) List(ctx context.Context) ([]string, error) {
+	execCtx := ExecutionContextFrom(ctx)
+	scopeID := execCtx.SessionID
+	if scopeID == "" {
+		scopeID = execCtx.RunID
+	}
+	return m.backend.List(ScopeSession, scopeID)
+}
+
+// WorkflowScope returns a ScopedMemory for workflow-level storage.
+// Data is isolated to the current workflow execution.
+func (m *Memory) WorkflowScope() *ScopedMemory {
+	return &ScopedMemory{
+		backend: m.backend,
+		scope:   ScopeWorkflow,
+		getID: func(ctx context.Context) string {
+			execCtx := ExecutionContextFrom(ctx)
+			if execCtx.WorkflowID != "" {
+				return execCtx.WorkflowID
+			}
+			return execCtx.RunID
+		},
+	}
+}
+
+// SessionScope returns a ScopedMemory for session-level storage.
+// Data persists across workflow executions within the same session.
+func (m *Memory) SessionScope() *ScopedMemory {
+	return &ScopedMemory{
+		backend: m.backend,
+		scope:   ScopeSession,
+		getID: func(ctx context.Context) string {
+			execCtx := ExecutionContextFrom(ctx)
+			if execCtx.SessionID != "" {
+				return execCtx.SessionID
+			}
+			return execCtx.RunID
+		},
+	}
+}
+
+// UserScope returns a ScopedMemory for user/actor-level storage.
+// Data persists across sessions for the same user.
+func (m *Memory) UserScope() *ScopedMemory {
+	return &ScopedMemory{
+		backend: m.backend,
+		scope:   ScopeUser,
+		getID: func(ctx context.Context) string {
+			execCtx := ExecutionContextFrom(ctx)
+			if execCtx.ActorID != "" {
+				return execCtx.ActorID
+			}
+			// Fall back to session if no actor
+			if execCtx.SessionID != "" {
+				return execCtx.SessionID
+			}
+			return execCtx.RunID
+		},
+	}
+}
+
+// GlobalScope returns a ScopedMemory for global storage.
+// Data is shared across all sessions, users, and workflows.
+func (m *Memory) GlobalScope() *ScopedMemory {
+	return &ScopedMemory{
+		backend: m.backend,
+		scope:   ScopeGlobal,
+		getID: func(ctx context.Context) string {
+			return "global"
+		},
+	}
+}
+
+// ScopedMemory provides memory operations within a specific scope.
+type ScopedMemory struct {
+	backend MemoryBackend
+	scope   MemoryScope
+	getID   func(context.Context) string
+}
+
+// Set stores a value in this scope.
+func (s *ScopedMemory) Set(ctx context.Context, key string, value any) error {
+	return s.backend.Set(s.scope, s.getID(ctx), key, value)
+}
+
+// Get retrieves a value from this scope.
+// Returns nil if the key does not exist.
+func (s *ScopedMemory) Get(ctx context.Context, key string) (any, error) {
+	val, _, err := s.backend.Get(s.scope, s.getID(ctx), key)
+	return val, err
+}
+
+// GetWithDefault retrieves a value from this scope,
+// returning the default if the key does not exist.
+func (s *ScopedMemory) GetWithDefault(ctx context.Context, key string, defaultVal any) (any, error) {
+	val, found, err := s.backend.Get(s.scope, s.getID(ctx), key)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return defaultVal, nil
+	}
+	return val, nil
+}
+
+// Delete removes a key from this scope.
+func (s *ScopedMemory) Delete(ctx context.Context, key string) error {
+	return s.backend.Delete(s.scope, s.getID(ctx), key)
+}
+
+// List returns all keys in this scope.
+func (s *ScopedMemory) List(ctx context.Context) ([]string, error) {
+	return s.backend.List(s.scope, s.getID(ctx))
+}
+
+// GetTyped retrieves a value and unmarshals it into the provided type.
+// This is useful when storing complex objects as JSON.
+func (s *ScopedMemory) GetTyped(ctx context.Context, key string, dest any) error {
+	val, found, err := s.backend.Get(s.scope, s.getID(ctx), key)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return nil
+	}
+
+	// If it's already the right type, try direct assignment
+	// Otherwise, marshal/unmarshal through JSON for complex types
+	switch v := val.(type) {
+	case []byte:
+		return json.Unmarshal(v, dest)
+	case string:
+		return json.Unmarshal([]byte(v), dest)
+	default:
+		// Round-trip through JSON for type conversion
+		data, err := json.Marshal(val)
+		if err != nil {
+			return err
+		}
+		return json.Unmarshal(data, dest)
+	}
+}
+
+// InMemoryBackend provides a thread-safe in-memory implementation of MemoryBackend.
+// Data is lost when the process exits.
+type InMemoryBackend struct {
+	mu   sync.RWMutex
+	data map[string]map[string]any // "scope:scopeID" -> key -> value
+}
+
+// NewInMemoryBackend creates a new in-memory storage backend.
+func NewInMemoryBackend() *InMemoryBackend {
+	return &InMemoryBackend{
+		data: make(map[string]map[string]any),
+	}
+}
+
+func (b *InMemoryBackend) compositeKey(scope MemoryScope, scopeID string) string {
+	return string(scope) + ":" + scopeID
+}
+
+// Set stores a value.
+func (b *InMemoryBackend) Set(scope MemoryScope, scopeID, key string, value any) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	ck := b.compositeKey(scope, scopeID)
+	if b.data[ck] == nil {
+		b.data[ck] = make(map[string]any)
+	}
+	b.data[ck][key] = value
+	return nil
+}
+
+// Get retrieves a value.
+func (b *InMemoryBackend) Get(scope MemoryScope, scopeID, key string) (any, bool, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	ck := b.compositeKey(scope, scopeID)
+	if b.data[ck] == nil {
+		return nil, false, nil
+	}
+	val, found := b.data[ck][key]
+	return val, found, nil
+}
+
+// Delete removes a key.
+func (b *InMemoryBackend) Delete(scope MemoryScope, scopeID, key string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	ck := b.compositeKey(scope, scopeID)
+	if b.data[ck] != nil {
+		delete(b.data[ck], key)
+	}
+	return nil
+}
+
+// List returns all keys in a scope.
+func (b *InMemoryBackend) List(scope MemoryScope, scopeID string) ([]string, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	ck := b.compositeKey(scope, scopeID)
+	if b.data[ck] == nil {
+		return nil, nil
+	}
+	keys := make([]string, 0, len(b.data[ck]))
+	for key := range b.data[ck] {
+		keys = append(keys, key)
+	}
+	return keys, nil
+}
+
+// Clear removes all data from the backend.
+// Useful for testing.
+func (b *InMemoryBackend) Clear() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.data = make(map[string]map[string]any)
+}
+
+// ClearScope removes all data for a specific scope and scopeID.
+func (b *InMemoryBackend) ClearScope(scope MemoryScope, scopeID string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	ck := b.compositeKey(scope, scopeID)
+	delete(b.data, ck)
+}

--- a/sdk/go/agent/memory_test.go
+++ b/sdk/go/agent/memory_test.go
@@ -1,0 +1,434 @@
+package agent
+
+import (
+	"context"
+	"io"
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInMemoryBackend(t *testing.T) {
+	backend := NewInMemoryBackend()
+
+	t.Run("Set and Get", func(t *testing.T) {
+		err := backend.Set(ScopeSession, "session-1", "key1", "value1")
+		require.NoError(t, err)
+
+		val, found, err := backend.Get(ScopeSession, "session-1", "key1")
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, "value1", val)
+	})
+
+	t.Run("Get non-existent key", func(t *testing.T) {
+		val, found, err := backend.Get(ScopeSession, "session-1", "nonexistent")
+		require.NoError(t, err)
+		assert.False(t, found)
+		assert.Nil(t, val)
+	})
+
+	t.Run("Get from non-existent scope", func(t *testing.T) {
+		val, found, err := backend.Get(ScopeSession, "nonexistent-session", "key1")
+		require.NoError(t, err)
+		assert.False(t, found)
+		assert.Nil(t, val)
+	})
+
+	t.Run("Delete key", func(t *testing.T) {
+		err := backend.Set(ScopeSession, "session-1", "to-delete", "value")
+		require.NoError(t, err)
+
+		err = backend.Delete(ScopeSession, "session-1", "to-delete")
+		require.NoError(t, err)
+
+		val, found, err := backend.Get(ScopeSession, "session-1", "to-delete")
+		require.NoError(t, err)
+		assert.False(t, found)
+		assert.Nil(t, val)
+	})
+
+	t.Run("Delete non-existent key (no error)", func(t *testing.T) {
+		err := backend.Delete(ScopeSession, "session-1", "nonexistent")
+		require.NoError(t, err)
+	})
+
+	t.Run("List keys", func(t *testing.T) {
+		// Clear and set up fresh data
+		backend.ClearScope(ScopeWorkflow, "workflow-1")
+		err := backend.Set(ScopeWorkflow, "workflow-1", "key-a", "value-a")
+		require.NoError(t, err)
+		err = backend.Set(ScopeWorkflow, "workflow-1", "key-b", "value-b")
+		require.NoError(t, err)
+
+		keys, err := backend.List(ScopeWorkflow, "workflow-1")
+		require.NoError(t, err)
+		assert.Len(t, keys, 2)
+		assert.Contains(t, keys, "key-a")
+		assert.Contains(t, keys, "key-b")
+	})
+
+	t.Run("List empty scope", func(t *testing.T) {
+		keys, err := backend.List(ScopeGlobal, "nonexistent")
+		require.NoError(t, err)
+		assert.Nil(t, keys)
+	})
+
+	t.Run("Scope isolation", func(t *testing.T) {
+		// Set same key in different scopes
+		err := backend.Set(ScopeSession, "id-1", "shared-key", "session-value")
+		require.NoError(t, err)
+		err = backend.Set(ScopeWorkflow, "id-1", "shared-key", "workflow-value")
+		require.NoError(t, err)
+
+		sessionVal, _, _ := backend.Get(ScopeSession, "id-1", "shared-key")
+		workflowVal, _, _ := backend.Get(ScopeWorkflow, "id-1", "shared-key")
+
+		assert.Equal(t, "session-value", sessionVal)
+		assert.Equal(t, "workflow-value", workflowVal)
+	})
+
+	t.Run("ScopeID isolation", func(t *testing.T) {
+		// Same scope, different IDs
+		err := backend.Set(ScopeSession, "session-a", "key", "value-a")
+		require.NoError(t, err)
+		err = backend.Set(ScopeSession, "session-b", "key", "value-b")
+		require.NoError(t, err)
+
+		valA, _, _ := backend.Get(ScopeSession, "session-a", "key")
+		valB, _, _ := backend.Get(ScopeSession, "session-b", "key")
+
+		assert.Equal(t, "value-a", valA)
+		assert.Equal(t, "value-b", valB)
+	})
+
+	t.Run("Clear all data", func(t *testing.T) {
+		err := backend.Set(ScopeGlobal, "global", "test", "value")
+		require.NoError(t, err)
+
+		backend.Clear()
+
+		val, found, _ := backend.Get(ScopeGlobal, "global", "test")
+		assert.False(t, found)
+		assert.Nil(t, val)
+	})
+
+	t.Run("Store complex types", func(t *testing.T) {
+		complexData := map[string]any{
+			"name":   "test",
+			"count":  42,
+			"nested": map[string]any{"key": "value"},
+		}
+		err := backend.Set(ScopeSession, "session-1", "complex", complexData)
+		require.NoError(t, err)
+
+		val, found, err := backend.Get(ScopeSession, "session-1", "complex")
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, complexData, val)
+	})
+}
+
+func TestMemory_DefaultScope(t *testing.T) {
+	backend := NewInMemoryBackend()
+	memory := NewMemory(backend)
+
+	// Create a context with execution context
+	execCtx := ExecutionContext{
+		SessionID:  "test-session",
+		WorkflowID: "test-workflow",
+		RunID:      "test-run",
+	}
+	ctx := contextWithExecution(context.Background(), execCtx)
+
+	t.Run("Set and Get", func(t *testing.T) {
+		err := memory.Set(ctx, "key1", "value1")
+		require.NoError(t, err)
+
+		val, err := memory.Get(ctx, "key1")
+		require.NoError(t, err)
+		assert.Equal(t, "value1", val)
+	})
+
+	t.Run("GetWithDefault - key exists", func(t *testing.T) {
+		err := memory.Set(ctx, "existing", "real-value")
+		require.NoError(t, err)
+
+		val, err := memory.GetWithDefault(ctx, "existing", "default")
+		require.NoError(t, err)
+		assert.Equal(t, "real-value", val)
+	})
+
+	t.Run("GetWithDefault - key missing", func(t *testing.T) {
+		val, err := memory.GetWithDefault(ctx, "missing", "default-value")
+		require.NoError(t, err)
+		assert.Equal(t, "default-value", val)
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		err := memory.Set(ctx, "to-delete", "value")
+		require.NoError(t, err)
+
+		err = memory.Delete(ctx, "to-delete")
+		require.NoError(t, err)
+
+		val, err := memory.Get(ctx, "to-delete")
+		require.NoError(t, err)
+		assert.Nil(t, val)
+	})
+
+	t.Run("List", func(t *testing.T) {
+		// Clear the session scope
+		backend.ClearScope(ScopeSession, "test-session")
+
+		err := memory.Set(ctx, "list-key-1", "v1")
+		require.NoError(t, err)
+		err = memory.Set(ctx, "list-key-2", "v2")
+		require.NoError(t, err)
+
+		keys, err := memory.List(ctx)
+		require.NoError(t, err)
+		assert.Len(t, keys, 2)
+		assert.Contains(t, keys, "list-key-1")
+		assert.Contains(t, keys, "list-key-2")
+	})
+}
+
+func TestMemory_WorkflowScope(t *testing.T) {
+	backend := NewInMemoryBackend()
+	memory := NewMemory(backend)
+
+	execCtx := ExecutionContext{
+		SessionID:  "test-session",
+		WorkflowID: "test-workflow",
+		RunID:      "test-run",
+	}
+	ctx := contextWithExecution(context.Background(), execCtx)
+
+	t.Run("Set and Get", func(t *testing.T) {
+		err := memory.WorkflowScope().Set(ctx, "wf-key", "wf-value")
+		require.NoError(t, err)
+
+		val, err := memory.WorkflowScope().Get(ctx, "wf-key")
+		require.NoError(t, err)
+		assert.Equal(t, "wf-value", val)
+	})
+
+	t.Run("Isolation from session scope", func(t *testing.T) {
+		err := memory.Set(ctx, "shared-key", "session-val")
+		require.NoError(t, err)
+		err = memory.WorkflowScope().Set(ctx, "shared-key", "workflow-val")
+		require.NoError(t, err)
+
+		sessionVal, _ := memory.Get(ctx, "shared-key")
+		workflowVal, _ := memory.WorkflowScope().Get(ctx, "shared-key")
+
+		assert.Equal(t, "session-val", sessionVal)
+		assert.Equal(t, "workflow-val", workflowVal)
+	})
+}
+
+func TestMemory_GlobalScope(t *testing.T) {
+	backend := NewInMemoryBackend()
+	memory := NewMemory(backend)
+
+	// Two different execution contexts
+	ctx1 := contextWithExecution(context.Background(), ExecutionContext{
+		SessionID: "session-1",
+	})
+	ctx2 := contextWithExecution(context.Background(), ExecutionContext{
+		SessionID: "session-2",
+	})
+
+	t.Run("Global data shared across sessions", func(t *testing.T) {
+		err := memory.GlobalScope().Set(ctx1, "global-key", "global-value")
+		require.NoError(t, err)
+
+		// Access from different session
+		val, err := memory.GlobalScope().Get(ctx2, "global-key")
+		require.NoError(t, err)
+		assert.Equal(t, "global-value", val)
+	})
+
+	t.Run("Session data isolated", func(t *testing.T) {
+		err := memory.Set(ctx1, "session-key", "session-1-value")
+		require.NoError(t, err)
+
+		// Should not see session-1's data from session-2
+		val, err := memory.Get(ctx2, "session-key")
+		require.NoError(t, err)
+		assert.Nil(t, val) // Not found
+	})
+}
+
+func TestMemory_UserScope(t *testing.T) {
+	backend := NewInMemoryBackend()
+	memory := NewMemory(backend)
+
+	// Same actor, different sessions
+	ctx1 := contextWithExecution(context.Background(), ExecutionContext{
+		SessionID: "session-1",
+		ActorID:   "user-123",
+	})
+	ctx2 := contextWithExecution(context.Background(), ExecutionContext{
+		SessionID: "session-2",
+		ActorID:   "user-123",
+	})
+
+	t.Run("User data persists across sessions", func(t *testing.T) {
+		err := memory.UserScope().Set(ctx1, "user-pref", "dark-mode")
+		require.NoError(t, err)
+
+		// Access from different session, same user
+		val, err := memory.UserScope().Get(ctx2, "user-pref")
+		require.NoError(t, err)
+		assert.Equal(t, "dark-mode", val)
+	})
+}
+
+func TestMemory_ScopedGetTyped(t *testing.T) {
+	backend := NewInMemoryBackend()
+	memory := NewMemory(backend)
+
+	ctx := contextWithExecution(context.Background(), ExecutionContext{
+		SessionID: "test-session",
+	})
+
+	t.Run("GetTyped with struct", func(t *testing.T) {
+		type TestData struct {
+			Name  string `json:"name"`
+			Count int    `json:"count"`
+		}
+
+		original := TestData{Name: "test", Count: 42}
+		err := memory.SessionScope().Set(ctx, "typed-data", original)
+		require.NoError(t, err)
+
+		var retrieved TestData
+		err = memory.SessionScope().GetTyped(ctx, "typed-data", &retrieved)
+		require.NoError(t, err)
+		assert.Equal(t, original.Name, retrieved.Name)
+		assert.Equal(t, original.Count, retrieved.Count)
+	})
+
+	t.Run("GetTyped with slice", func(t *testing.T) {
+		original := []string{"a", "b", "c"}
+		err := memory.SessionScope().Set(ctx, "slice-data", original)
+		require.NoError(t, err)
+
+		var retrieved []string
+		err = memory.SessionScope().GetTyped(ctx, "slice-data", &retrieved)
+		require.NoError(t, err)
+		assert.Equal(t, original, retrieved)
+	})
+
+	t.Run("GetTyped with non-existent key", func(t *testing.T) {
+		var retrieved string
+		err := memory.SessionScope().GetTyped(ctx, "nonexistent", &retrieved)
+		require.NoError(t, err)
+		assert.Equal(t, "", retrieved) // zero value
+	})
+}
+
+func TestMemory_FallbackToRunID(t *testing.T) {
+	backend := NewInMemoryBackend()
+	memory := NewMemory(backend)
+
+	// Context with only RunID (no SessionID, WorkflowID, ActorID)
+	ctx := contextWithExecution(context.Background(), ExecutionContext{
+		RunID: "run-123",
+	})
+
+	t.Run("Session scope falls back to RunID", func(t *testing.T) {
+		err := memory.Set(ctx, "key", "value")
+		require.NoError(t, err)
+
+		// Verify it was stored under RunID
+		val, found, _ := backend.Get(ScopeSession, "run-123", "key")
+		assert.True(t, found)
+		assert.Equal(t, "value", val)
+	})
+
+	t.Run("Workflow scope falls back to RunID", func(t *testing.T) {
+		err := memory.WorkflowScope().Set(ctx, "wf-key", "wf-value")
+		require.NoError(t, err)
+
+		val, found, _ := backend.Get(ScopeWorkflow, "run-123", "wf-key")
+		assert.True(t, found)
+		assert.Equal(t, "wf-value", val)
+	})
+}
+
+func TestMemory_NilBackend(t *testing.T) {
+	// NewMemory should create InMemoryBackend if nil is passed
+	memory := NewMemory(nil)
+
+	ctx := contextWithExecution(context.Background(), ExecutionContext{
+		SessionID: "test",
+	})
+
+	err := memory.Set(ctx, "key", "value")
+	require.NoError(t, err)
+
+	val, err := memory.Get(ctx, "key")
+	require.NoError(t, err)
+	assert.Equal(t, "value", val)
+}
+
+func TestAgentMemory(t *testing.T) {
+	cfg := Config{
+		NodeID:  "test-node",
+		Version: "1.0.0",
+		Logger:  log.New(io.Discard, "", 0),
+	}
+
+	agent, err := New(cfg)
+	require.NoError(t, err)
+
+	ctx := contextWithExecution(context.Background(), ExecutionContext{
+		SessionID: "test-session",
+	})
+
+	t.Run("Agent has memory", func(t *testing.T) {
+		assert.NotNil(t, agent.Memory())
+	})
+
+	t.Run("Agent memory works", func(t *testing.T) {
+		err := agent.Memory().Set(ctx, "agent-key", "agent-value")
+		require.NoError(t, err)
+
+		val, err := agent.Memory().Get(ctx, "agent-key")
+		require.NoError(t, err)
+		assert.Equal(t, "agent-value", val)
+	})
+}
+
+func TestAgentWithCustomMemoryBackend(t *testing.T) {
+	// Create a custom backend
+	customBackend := NewInMemoryBackend()
+
+	cfg := Config{
+		NodeID:        "test-node",
+		Version:       "1.0.0",
+		Logger:        log.New(io.Discard, "", 0),
+		MemoryBackend: customBackend,
+	}
+
+	agent, err := New(cfg)
+	require.NoError(t, err)
+
+	ctx := contextWithExecution(context.Background(), ExecutionContext{
+		SessionID: "test-session",
+	})
+
+	// Set via agent
+	err = agent.Memory().Set(ctx, "custom-key", "custom-value")
+	require.NoError(t, err)
+
+	// Verify directly on backend
+	val, found, _ := customBackend.Get(ScopeSession, "test-session", "custom-key")
+	assert.True(t, found)
+	assert.Equal(t, "custom-value", val)
+}

--- a/sdk/go/agent/note.go
+++ b/sdk/go/agent/note.go
@@ -1,0 +1,133 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// notePayload represents the JSON payload sent to the AgentField server.
+type notePayload struct {
+	Message     string   `json:"message"`
+	Tags        []string `json:"tags"`
+	Timestamp   float64  `json:"timestamp"`
+	AgentNodeID string   `json:"agent_node_id"`
+}
+
+// Note sends a progress/status message to the AgentField server.
+// This is useful for debugging and tracking agent execution progress
+// in the AgentField UI.
+//
+// Notes are sent asynchronously (fire-and-forget) and will not block
+// the handler or raise errors that interrupt the workflow.
+//
+// Example usage:
+//
+//	agent.Note(ctx, "Starting data processing", "debug", "processing")
+//	// ... do work ...
+//	agent.Note(ctx, "Processing completed", "info")
+func (a *Agent) Note(ctx context.Context, message string, tags ...string) {
+	if tags == nil {
+		tags = []string{}
+	}
+
+	// Fire-and-forget: send note in a goroutine
+	go a.sendNote(ctx, message, tags)
+}
+
+// Notef sends a formatted progress/status message to the AgentField server.
+// This is a convenience method that formats the message using fmt.Sprintf.
+//
+// Example usage:
+//
+//	agent.Notef(ctx, "Processing %d items...", len(items))
+func (a *Agent) Notef(ctx context.Context, format string, args ...any) {
+	a.Note(ctx, fmt.Sprintf(format, args...))
+}
+
+// sendNote performs the actual HTTP request to send the note.
+func (a *Agent) sendNote(ctx context.Context, message string, tags []string) {
+	// Check if AgentField URL is configured
+	baseURL := strings.TrimSpace(a.cfg.AgentFieldURL)
+	if baseURL == "" {
+		// No server configured, silently skip
+		return
+	}
+
+	// Get execution context from the provided context
+	execCtx := ExecutionContextFrom(ctx)
+
+	// Build UI API URL (notes go to /api/ui/v1, not /api/v1)
+	uiAPIURL := strings.Replace(baseURL, "/api/v1", "/api/ui/v1", 1)
+	if !strings.Contains(uiAPIURL, "/api/ui/v1") {
+		// If no /api/v1 was found, append /api/ui/v1
+		uiAPIURL = strings.TrimSuffix(baseURL, "/") + "/api/ui/v1"
+	}
+	noteURL := uiAPIURL + "/executions/note"
+
+	// Build payload
+	payload := notePayload{
+		Message:     message,
+		Tags:        tags,
+		Timestamp:   float64(time.Now().UnixNano()) / 1e9, // Unix timestamp as float
+		AgentNodeID: a.cfg.NodeID,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		a.logger.Printf("note: failed to marshal payload: %v", err)
+		return
+	}
+
+	// Build request with execution context headers
+	reqCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, noteURL, bytes.NewReader(body))
+	if err != nil {
+		a.logger.Printf("note: failed to create request: %v", err)
+		return
+	}
+
+	// Set headers
+	req.Header.Set("Content-Type", "application/json")
+	if a.cfg.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+a.cfg.Token)
+	}
+
+	// Add execution context headers
+	if execCtx.RunID != "" {
+		req.Header.Set("X-Run-ID", execCtx.RunID)
+	}
+	if execCtx.ExecutionID != "" {
+		req.Header.Set("X-Execution-ID", execCtx.ExecutionID)
+	}
+	if execCtx.SessionID != "" {
+		req.Header.Set("X-Session-ID", execCtx.SessionID)
+	}
+	if execCtx.ActorID != "" {
+		req.Header.Set("X-Actor-ID", execCtx.ActorID)
+	}
+	if execCtx.WorkflowID != "" {
+		req.Header.Set("X-Workflow-ID", execCtx.WorkflowID)
+	}
+	req.Header.Set("X-Agent-Node-ID", a.cfg.NodeID)
+
+	// Send request
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		// Silently fail - notes should not interrupt workflow
+		return
+	}
+	defer resp.Body.Close()
+
+	// We don't care about the response for fire-and-forget notes
+	// but we could log errors for debugging
+	if resp.StatusCode >= 400 {
+		a.logger.Printf("note: server returned status %d", resp.StatusCode)
+	}
+}

--- a/sdk/go/agent/note_test.go
+++ b/sdk/go/agent/note_test.go
@@ -1,0 +1,375 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNote_Basic(t *testing.T) {
+	var receivedPayload notePayload
+	var receivedHeaders http.Header
+	var mu sync.Mutex
+	requestReceived := make(chan struct{})
+
+	// Create a test server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		// Parse the payload
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedPayload)
+		receivedHeaders = r.Header.Clone()
+
+		w.WriteHeader(http.StatusOK)
+		close(requestReceived)
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		NodeID:        "test-node",
+		Version:       "1.0.0",
+		AgentFieldURL: server.URL + "/api/v1", // Will be converted to /api/ui/v1
+		Logger:        log.New(io.Discard, "", 0),
+	}
+
+	agent, err := New(cfg)
+	require.NoError(t, err)
+
+	ctx := contextWithExecution(context.Background(), ExecutionContext{
+		RunID:       "run-123",
+		ExecutionID: "exec-456",
+		SessionID:   "session-789",
+		ActorID:     "actor-abc",
+		WorkflowID:  "workflow-xyz",
+	})
+
+	agent.Note(ctx, "Test message", "tag1", "tag2")
+
+	// Wait for the note to be sent
+	select {
+	case <-requestReceived:
+		// Success
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for note request")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Verify payload
+	assert.Equal(t, "Test message", receivedPayload.Message)
+	assert.Equal(t, []string{"tag1", "tag2"}, receivedPayload.Tags)
+	assert.Equal(t, "test-node", receivedPayload.AgentNodeID)
+	assert.Greater(t, receivedPayload.Timestamp, float64(0))
+
+	// Verify headers
+	assert.Equal(t, "run-123", receivedHeaders.Get("X-Run-ID"))
+	assert.Equal(t, "exec-456", receivedHeaders.Get("X-Execution-ID"))
+	assert.Equal(t, "session-789", receivedHeaders.Get("X-Session-ID"))
+	assert.Equal(t, "actor-abc", receivedHeaders.Get("X-Actor-ID"))
+	assert.Equal(t, "workflow-xyz", receivedHeaders.Get("X-Workflow-ID"))
+	assert.Equal(t, "test-node", receivedHeaders.Get("X-Agent-Node-ID"))
+}
+
+func TestNotef_Formatted(t *testing.T) {
+	var receivedPayload notePayload
+	requestReceived := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedPayload)
+		w.WriteHeader(http.StatusOK)
+		close(requestReceived)
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		NodeID:        "test-node",
+		Version:       "1.0.0",
+		AgentFieldURL: server.URL + "/api/v1",
+		Logger:        log.New(io.Discard, "", 0),
+	}
+
+	agent, err := New(cfg)
+	require.NoError(t, err)
+
+	ctx := contextWithExecution(context.Background(), ExecutionContext{
+		RunID: "run-123",
+	})
+
+	agent.Notef(ctx, "Processing %d items with status %s", 42, "active")
+
+	select {
+	case <-requestReceived:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for note request")
+	}
+
+	assert.Equal(t, "Processing 42 items with status active", receivedPayload.Message)
+}
+
+func TestNote_NoTags(t *testing.T) {
+	var receivedPayload notePayload
+	requestReceived := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedPayload)
+		w.WriteHeader(http.StatusOK)
+		close(requestReceived)
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		NodeID:        "test-node",
+		Version:       "1.0.0",
+		AgentFieldURL: server.URL + "/api/v1",
+		Logger:        log.New(io.Discard, "", 0),
+	}
+
+	agent, err := New(cfg)
+	require.NoError(t, err)
+
+	ctx := contextWithExecution(context.Background(), ExecutionContext{
+		RunID: "run-123",
+	})
+
+	// Call Note without tags
+	agent.Note(ctx, "No tags message")
+
+	select {
+	case <-requestReceived:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for note request")
+	}
+
+	assert.Equal(t, "No tags message", receivedPayload.Message)
+	assert.Equal(t, []string{}, receivedPayload.Tags)
+}
+
+func TestNote_NoAgentFieldURL(t *testing.T) {
+	// Agent without AgentFieldURL should not send notes
+	cfg := Config{
+		NodeID:  "test-node",
+		Version: "1.0.0",
+		Logger:  log.New(io.Discard, "", 0),
+		// No AgentFieldURL
+	}
+
+	agent, err := New(cfg)
+	require.NoError(t, err)
+
+	ctx := contextWithExecution(context.Background(), ExecutionContext{
+		RunID: "run-123",
+	})
+
+	// This should not panic or block
+	agent.Note(ctx, "This note goes nowhere")
+
+	// Give it a moment to ensure no panic
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestNote_ServerError(t *testing.T) {
+	// Server that returns an error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		NodeID:        "test-node",
+		Version:       "1.0.0",
+		AgentFieldURL: server.URL + "/api/v1",
+		Logger:        log.New(io.Discard, "", 0),
+	}
+
+	agent, err := New(cfg)
+	require.NoError(t, err)
+
+	ctx := contextWithExecution(context.Background(), ExecutionContext{
+		RunID: "run-123",
+	})
+
+	// Should not panic even with server error
+	agent.Note(ctx, "Test message")
+
+	// Give it time to complete
+	time.Sleep(200 * time.Millisecond)
+}
+
+func TestNote_URLConversion(t *testing.T) {
+	var requestPath string
+	requestReceived := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		close(requestReceived)
+	}))
+	defer server.Close()
+
+	tests := []struct {
+		name           string
+		agentFieldURL  string
+		expectedPath   string
+	}{
+		{
+			name:          "Standard /api/v1 URL",
+			agentFieldURL: server.URL + "/api/v1",
+			expectedPath:  "/api/ui/v1/executions/note",
+		},
+		{
+			name:          "URL without /api/v1",
+			agentFieldURL: server.URL,
+			expectedPath:  "/api/ui/v1/executions/note",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requestReceived = make(chan struct{})
+			requestPath = ""
+
+			cfg := Config{
+				NodeID:        "test-node",
+				Version:       "1.0.0",
+				AgentFieldURL: tt.agentFieldURL,
+				Logger:        log.New(io.Discard, "", 0),
+			}
+
+			agent, err := New(cfg)
+			require.NoError(t, err)
+
+			ctx := contextWithExecution(context.Background(), ExecutionContext{
+				RunID: "run-123",
+			})
+
+			agent.Note(ctx, "Test")
+
+			select {
+			case <-requestReceived:
+				assert.Equal(t, tt.expectedPath, requestPath)
+			case <-time.After(2 * time.Second):
+				t.Fatal("Timeout waiting for note request")
+			}
+		})
+	}
+}
+
+func TestNote_WithToken(t *testing.T) {
+	var receivedAuthHeader string
+	requestReceived := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuthHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		close(requestReceived)
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		NodeID:        "test-node",
+		Version:       "1.0.0",
+		AgentFieldURL: server.URL + "/api/v1",
+		Token:         "test-token-123",
+		Logger:        log.New(io.Discard, "", 0),
+	}
+
+	agent, err := New(cfg)
+	require.NoError(t, err)
+
+	ctx := contextWithExecution(context.Background(), ExecutionContext{
+		RunID: "run-123",
+	})
+
+	agent.Note(ctx, "Test message")
+
+	select {
+	case <-requestReceived:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for note request")
+	}
+
+	assert.Equal(t, "Bearer test-token-123", receivedAuthHeader)
+}
+
+func TestNote_FireAndForget(t *testing.T) {
+	// Test that Note doesn't block even if server is slow
+	slowServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(5 * time.Second) // Slow response
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer slowServer.Close()
+
+	cfg := Config{
+		NodeID:        "test-node",
+		Version:       "1.0.0",
+		AgentFieldURL: slowServer.URL + "/api/v1",
+		Logger:        log.New(io.Discard, "", 0),
+	}
+
+	agent, err := New(cfg)
+	require.NoError(t, err)
+
+	ctx := contextWithExecution(context.Background(), ExecutionContext{
+		RunID: "run-123",
+	})
+
+	start := time.Now()
+	agent.Note(ctx, "Test message")
+	elapsed := time.Since(start)
+
+	// Note should return immediately (< 100ms), not wait for server
+	assert.Less(t, elapsed, 100*time.Millisecond, "Note should not block")
+}
+
+func TestNote_MultipleNotes(t *testing.T) {
+	var mu sync.Mutex
+	noteCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		noteCount++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		NodeID:        "test-node",
+		Version:       "1.0.0",
+		AgentFieldURL: server.URL + "/api/v1",
+		Logger:        log.New(io.Discard, "", 0),
+	}
+
+	agent, err := New(cfg)
+	require.NoError(t, err)
+
+	ctx := contextWithExecution(context.Background(), ExecutionContext{
+		RunID: "run-123",
+	})
+
+	// Send multiple notes
+	for i := 0; i < 5; i++ {
+		agent.Notef(ctx, "Note %d", i)
+	}
+
+	// Wait for all notes to be sent
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 5, noteCount)
+}


### PR DESCRIPTION
## Summary

This PR adds two major new capabilities to the Go SDK to support stateful agents and real-time progress tracking:

### Memory System
- **Hierarchical scoped storage** with four isolation levels: `workflow`, `session`, `user`, and `global`
- **Pluggable `MemoryBackend` interface** - implement your own storage (Redis, database, etc.)
- **Default in-memory backend** included for development and testing
- **Automatic scope ID resolution** from execution context (RunID, SessionID, ActorID, WorkflowID)
- **Type-safe retrieval** with `GetTyped()` method for structured data

### Note API
- **`Note(ctx, message, tags...)`** - send progress/status messages to the AgentField UI
- **`Notef(ctx, format, args...)`** - convenience method with printf-style formatting
- **Fire-and-forget delivery** - async HTTP requests that won't block handlers
- **Silent failure mode** - notes never interrupt workflow execution
- **Execution context propagation** - includes RunID, SessionID, WorkflowID headers

### Usage Examples

```go
// Memory - store state in session scope (default)
agent.Memory().Set(ctx, "search_results", results)
val, _ := agent.Memory().Get(ctx, "search_results")

// Memory - use global scope for cross-session data
agent.Memory().GlobalScope().Set(ctx, "cache_key", data)

// Note - report progress
agent.Note(ctx, "Processing batch 1/5", "progress")
agent.Notef(ctx, "Found %d results", len(results))
```

### Files Changed
- `sdk/go/agent/agent.go` - Add `Memory()` method and `MemoryBackend` config field
- `sdk/go/agent/memory.go` - Memory system implementation (333 lines)
- `sdk/go/agent/memory_test.go` - Comprehensive test coverage (434 lines)
- `sdk/go/agent/note.go` - Note API implementation (133 lines)
- `sdk/go/agent/note_test.go` - Test coverage for note system (375 lines)

## Test plan

- [x] Unit tests pass for Memory system
- [x] Unit tests pass for Note API
- [x] Tested with Brain Deep Research Go port locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)