### PR TITLE
fix(python-sdk): move conditional imports to module level

### DIFF
--- a/sdk/python/agentfield/agent_server.py
+++ b/sdk/python/agentfield/agent_server.py
@@ -2,6 +2,7 @@ import asyncio
 import importlib.util
 import os
 import signal
+import urllib.parse
 from datetime import datetime
 from typing import Optional
 
@@ -835,8 +836,6 @@ class AgentServer:
         # Smart port resolution with priority order
         if port is None:
             # Check for AgentField CLI integration via environment variable
-            import os
-
             env_port = os.getenv("PORT")
             if env_port and env_port.isdigit():
                 suggested_port = int(env_port)
@@ -899,9 +898,6 @@ class AgentServer:
         # Set base_url for registration - preserve explicit callback URL if set
         if not self.agent.base_url:
             # Check AGENT_CALLBACK_URL environment variable before defaulting to localhost
-            import os
-            import urllib.parse
-
             env_callback_url = os.getenv("AGENT_CALLBACK_URL")
             if env_callback_url:
                 # Parse the environment variable URL to extract the hostname
@@ -926,8 +922,6 @@ class AgentServer:
                 self.agent.base_url = f"http://localhost:{port}"
         else:
             # Update port in existing base_url if needed
-            import urllib.parse
-
             parsed = urllib.parse.urlparse(self.agent.base_url)
             if parsed.port != port:
                 # Update the port in the existing URL, but preserve the hostname


### PR DESCRIPTION
## Summary

- Move `import os` from inside conditional blocks to module level
- Move `import urllib.parse` from inside conditional blocks to module level
- Fixes `UnboundLocalError` when passing explicit port to `serve()`

## Problem

The `serve()` method in `agent_server.py` had `import os` and `import urllib.parse` statements inside conditional blocks (lines 838, 902-903, and 928). When an explicit `port` was passed to `serve()`, the first conditional block (`if port is None:`) was skipped, but Python's scoping still saw the later conditional imports, causing an `UnboundLocalError`:

```
UnboundLocalError: cannot access local variable 'os' where it is not associated with a value
```

This worked locally when using `auto_port=True` (which executed the first code path that included `import os`), but failed in Docker containers when the `PORT` environment variable was set and an explicit port value was passed.

## Root Cause

Python scoping rules: when `import X` appears anywhere inside a function (even in an `if` block that doesn't execute), Python treats `X` as a local variable throughout the entire function. If the code path that contains the import isn't executed, `X` becomes unbound.

## Test plan

- [x] Syntax check passes (`python -m py_compile`)
- [ ] Docker container starts successfully with explicit PORT env var
- [ ] Agent registers and sends heartbeats to control plane

🤖 Generated with [Claude Code](https://claude.com/claude-code)