### PR TITLE
feat(go-sdk): add per-request API key override for AI client

### DIFF
--- a/sdk/go/ai/client.go
+++ b/sdk/go/ai/client.go
@@ -94,7 +94,11 @@ func (c *Client) doRequest(ctx context.Context, req *Request) (*Response, error)
 
 	// Set headers
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+c.config.APIKey)
+	apiKey := c.config.APIKey
+	if strings.TrimSpace(req.APIKeyOverride) != "" {
+		apiKey = req.APIKeyOverride
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
 
 	// Add OpenRouter-specific headers if applicable
 	if c.config.IsOpenRouter() {
@@ -186,7 +190,11 @@ func (c *Client) StreamComplete(ctx context.Context, prompt string, opts ...Opti
 
 		// Set headers
 		httpReq.Header.Set("Content-Type", "application/json")
-		httpReq.Header.Set("Authorization", "Bearer "+c.config.APIKey)
+		apiKey := c.config.APIKey
+		if strings.TrimSpace(req.APIKeyOverride) != "" {
+			apiKey = req.APIKeyOverride
+		}
+		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
 		httpReq.Header.Set("Accept", "text/event-stream")
 
 		// Add OpenRouter-specific headers if applicable

--- a/sdk/go/ai/request.go
+++ b/sdk/go/ai/request.go
@@ -17,6 +17,10 @@ type Request struct {
 	// Messages for the chat completion
 	Messages []Message `json:"messages"`
 
+	// APIKeyOverride overrides the client's configured API key for this request only.
+	// This is used to support per-call api_key overrides for parity with the Python SDK.
+	APIKeyOverride string `json:"-"`
+
 	// Model to use (overrides default)
 	Model string `json:"model,omitempty"`
 
@@ -61,6 +65,14 @@ func WithSystem(content string) Option {
 func WithModel(model string) Option {
 	return func(r *Request) error {
 		r.Model = model
+		return nil
+	}
+}
+
+// WithAPIKey overrides the client's configured API key for this request only.
+func WithAPIKey(apiKey string) Option {
+	return func(r *Request) error {
+		r.APIKeyOverride = apiKey
 		return nil
 	}
 }


### PR DESCRIPTION
## Summary

- Add `WithAPIKey` option to override the client's configured API key on a per-request basis
- Brings the Go SDK AI client to feature parity with the Python SDK, which supports `api_key` overrides in individual completion calls
- API key override is excluded from JSON serialization for security

## Changes

- **sdk/go/ai/request.go**: Add `APIKeyOverride` field and `WithAPIKey` option function
- **sdk/go/ai/client.go**: Update `doRequest` and `StreamComplete` to use the override when provided
- **sdk/go/ai/client_test.go**: Add test verifying API key override behavior

## Test plan

- [x] Added unit test `TestComplete_WithAPIKeyOverride` that verifies the override key is used in Authorization header
- [ ] Run `go test ./sdk/go/ai/...` to verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)