### PR TITLE
fix: wire up workflow notes SSE endpoint

### DIFF
--- a/control-plane/internal/server/server.go
+++ b/control-plane/internal/server/server.go
@@ -807,6 +807,10 @@ func (s *AgentFieldServer) setupRoutes() {
 				workflows.POST("/vc-status", didHandler.GetWorkflowVCStatusBatchHandler)
 				workflows.GET("/:workflowId/vc-chain", didHandler.GetWorkflowVCChainHandler)
 				workflows.POST("/:workflowId/verify-vc", didHandler.VerifyWorkflowVCComprehensiveHandler)
+
+				// Workflow notes SSE streaming
+				workflowNotesHandler := ui.NewExecutionHandler(s.storage, s.payloadStore, s.webhookDispatcher)
+				workflows.GET("/:workflowId/notes/events", workflowNotesHandler.StreamWorkflowNodeNotesHandler)
 			}
 
 			// Reasoners management group


### PR DESCRIPTION
## Summary

- Wire up the `StreamWorkflowNodeNotesHandler` to the workflows route group
- The handler existed since the initial commit but was never registered

**New endpoint:** `GET /api/ui/v1/workflows/:workflowId/notes/events`

## Test plan

- [ ] Rebuild control-plane
- [ ] Test SSE endpoint: `curl -N http://localhost:8080/api/ui/v1/workflows/{workflowId}/notes/events`
- [ ] Verify heartbeat events are received

🤖 Generated with [Claude Code](https://claude.com/claude-code)