### PR TITLE
docs: Add website deployment guide links

### DIFF
--- a/deployments/README.md
+++ b/deployments/README.md
@@ -1,6 +1,8 @@
 # Deployments
 
-This repository ships a few **ready-to-run** deployment options so you can evaluate AgentField quickly:
+This repository ships a few **ready-to-run** deployment options so you can evaluate AgentField quickly.
+
+**Full deployment guides:** [agentfield.ai/guides/deployment/overview](https://agentfield.ai/guides/deployment/overview)
 
 ## Pick one
 
@@ -8,17 +10,19 @@ This repository ships a few **ready-to-run** deployment options so you can evalu
 
 Best if you want to try the UI + execute API in minutes on a laptop.
 
-- Docs: `deployments/docker/README.md`
+- Docs: [`deployments/docker/README.md`](docker/README.md)
 
 ### 2) Helm (recommended for Kubernetes)
 
 Best for production-like installs and customization via `values.yaml`.
 
-- Chart + docs: `deployments/helm/agentfield`
+- Chart + docs: [`deployments/helm/agentfield`](helm/agentfield/README.md)
+- Website guide: [agentfield.ai/guides/deployment/helm](https://agentfield.ai/guides/deployment/helm)
 
 ### 3) Kustomize (plain Kubernetes YAML)
 
 Best if you want transparent manifests and minimal tooling.
 
-- Docs: `deployments/kubernetes/README.md`
+- Docs: [`deployments/kubernetes/README.md`](kubernetes/README.md)
+- Website guide: [agentfield.ai/guides/deployment/kubernetes](https://agentfield.ai/guides/deployment/kubernetes)
 


### PR DESCRIPTION
## Summary

Add links to the full deployment guides on agentfield.ai from the repository's `deployments/README.md`.

## Changes

- Add main link to deployment guides at top of file
- Add website guide links for Kubernetes and Helm sections  
- Make local README paths clickable

## Test plan

- [ ] Verify links render correctly on GitHub
- [ ] Confirm website URLs are correct once docs deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)