### PR TITLE
docs: add direct repo links to Kubernetes and Helm deployment guides

### DIFF
--- a/deployments/helm/agentfield/README.md
+++ b/deployments/helm/agentfield/README.md
@@ -2,6 +2,8 @@
 
 This chart installs the AgentField control plane and optional demo agents.
 
+**Source files:** [Chart.yaml](https://github.com/Agent-Field/agentfield/blob/main/deployments/helm/agentfield/Chart.yaml) | [values.yaml](https://github.com/Agent-Field/agentfield/blob/main/deployments/helm/agentfield/values.yaml) | [Templates](https://github.com/Agent-Field/agentfield/tree/main/deployments/helm/agentfield/templates)
+
 ## Quick start (recommended)
 
 Install with PostgreSQL and the demo Python agent (no custom image required):
@@ -67,6 +69,8 @@ For Minikube, build and load the default image used by the chart:
 docker build -t agentfield-demo-go-agent:local -f deployments/docker/Dockerfile.demo-go-agent .
 minikube image load agentfield-demo-go-agent:local
 ```
+
+> See the [Dockerfile.demo-go-agent](https://github.com/Agent-Field/agentfield/blob/main/deployments/docker/Dockerfile.demo-go-agent) for build details.
 
 ```bash
 helm upgrade --install agentfield deployments/helm/agentfield \

--- a/deployments/kubernetes/README.md
+++ b/deployments/kubernetes/README.md
@@ -2,13 +2,17 @@
 
 Plain Kubernetes manifests for evaluating AgentField without Helm.
 
-If you want a values-driven install, use `deployments/helm/agentfield`.
+If you want a values-driven install, use [`deployments/helm/agentfield`](https://github.com/Agent-Field/agentfield/tree/main/deployments/helm/agentfield).
+
+**Source files:** [Base manifests](https://github.com/Agent-Field/agentfield/tree/main/deployments/kubernetes/base) | [Overlays](https://github.com/Agent-Field/agentfield/tree/main/deployments/kubernetes/overlays)
 
 ## Choose an overlay
 
-- `deployments/kubernetes/overlays/python-demo`: control plane + a small Python agent (good default)
-- `deployments/kubernetes/overlays/local-demo`: control plane + Go demo agent (requires a custom image)
-- `deployments/kubernetes/overlays/postgres-demo`: PostgreSQL + Go demo agent (production-like storage)
+| Overlay | Description | Source |
+|---------|-------------|--------|
+| `python-demo` | Control plane + a small Python agent (good default) | [View](https://github.com/Agent-Field/agentfield/tree/main/deployments/kubernetes/overlays/python-demo) |
+| `local-demo` | Control plane + Go demo agent (requires a custom image) | [View](https://github.com/Agent-Field/agentfield/tree/main/deployments/kubernetes/overlays/local-demo) |
+| `postgres-demo` | PostgreSQL + Go demo agent (production-like storage) | [View](https://github.com/Agent-Field/agentfield/tree/main/deployments/kubernetes/overlays/postgres-demo) |
 
 If you use `local-demo` or `postgres-demo`, build and load the Go demo agent image first (example for Minikube):
 
@@ -16,6 +20,8 @@ If you use `local-demo` or `postgres-demo`, build and load the Go demo agent ima
 docker build -t agentfield-demo-go-agent:local -f deployments/docker/Dockerfile.demo-go-agent .
 minikube image load agentfield-demo-go-agent:local
 ```
+
+> See the [Dockerfile.demo-go-agent](https://github.com/Agent-Field/agentfield/blob/main/deployments/docker/Dockerfile.demo-go-agent) for build details.
 
 ## Quick start
 


### PR DESCRIPTION
## Summary

- Add **source file links** at the top of the Kubernetes (Kustomize) README with links to base manifests and overlays directories
- Convert the Kubernetes overlay list to a **table format** with direct links to each overlay directory
- Add **source file links** at the top of the Helm chart README (Chart.yaml, values.yaml, templates)
- Add **Dockerfile reference links** for Go demo agent builds in both guides

This makes it easier for users to navigate directly to the source files they need when reading the deployment documentation.

## Test plan

- [ ] Verify all links resolve correctly on GitHub
- [ ] Verify table renders properly in GitHub markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)