### PR TITLE
fix(ci): prevent shell injection in AI label workflow

### DIFF
--- a/.github/workflows/ai-label.yml
+++ b/.github/workflows/ai-label.yml
@@ -16,14 +16,15 @@ jobs:
 
       - name: Detect AI assistance in commits
         id: detect
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           echo "Checking commits for AI assistance signatures..."
 
           # Get all commit messages and bodies
           COMMIT_LOG=$(git log --format='%s%n%b' origin/${{ github.base_ref }}..HEAD 2>/dev/null || echo "")
 
-          # Also check the PR body if available
-          PR_BODY="${{ github.event.pull_request.body }}"
+          # PR_BODY is passed via environment variable to avoid shell injection
 
           # Combine for searching
           SEARCH_TEXT="$COMMIT_LOG"$'\n'"$PR_BODY"


### PR DESCRIPTION
## Summary

Fixes shell injection vulnerability in the AI label detection workflow that was causing all PRs to fail with:
```
CHANGELOG.md: command not found
```

## Problem

The PR body was being directly interpolated into a shell variable using direct GitHub Actions expression interpolation. When PR descriptions contained filenames like `CHANGELOG.md` on their own lines, the shell would attempt to execute them as commands.

## Solution

Pass the PR body via the `env:` block instead, which properly escapes the content as an environment variable.

## Test Plan

- [x] Open a test PR with a description containing `CHANGELOG.md` on its own line
- [ ] Verify the AI label workflow completes without errors

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)