### PR TITLE
fix(ci): add issues:write permission for AI label workflow

### DIFF
--- a/.github/workflows/ai-label.yml
+++ b/.github/workflows/ai-label.yml
@@ -8,7 +8,9 @@ jobs:
   detect-ai:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

Fixes the GitHub Actions workflow permission error when adding the `ai-assisted` label to PRs.

## Problem

The AI label workflow was failing with:
```
GraphQL: Resource not accessible by integration (addLabelsToLabelable)
```

## Root Cause

The `gh pr edit --add-label` command requires `issues: write` permission because labels are managed through the GitHub issues API, even when applied to pull requests. The workflow only had `pull-requests: write`.

## Changes

Added permissions to `.github/workflows/ai-label.yml`:
- `issues: write` - Required for adding labels (the missing permission)
- `contents: read` - Explicit permission for checkout

## Test Plan

- [ ] Merge this PR and verify the AI label workflow succeeds on subsequent PRs

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)