### PR TITLE
Hot reload controlplane local setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/
 **/dist/
 coverage.out
 *.test
+tmp/
 
 # Python
 __pycache__/

--- a/control-plane/.air.toml
+++ b/control-plane/.air.toml
@@ -1,0 +1,44 @@
+# Air configuration for hot-reload development
+# https://github.com/air-verse/air
+
+root = "."
+tmp_dir = "tmp"
+
+[build]
+# Build command - builds the control plane server
+cmd = "go build -tags 'sqlite_fts5' -o ./tmp/agentfield-server ./cmd/agentfield-server"
+# Binary to run
+bin = "./tmp/agentfield-server"
+# Watch these file extensions
+include_ext = ["go", "yaml", "yml"]
+# Exclude directories from watching
+exclude_dir = ["tmp", "vendor", "web/client/node_modules", "web/client/dist", ".git"]
+# Exclude files
+exclude_file = []
+# Exclude regex patterns
+exclude_regex = ["_test\\.go$"]
+# Delay before triggering rebuild (in milliseconds)
+delay = 1000
+# Stop running old binary when building
+stop_on_error = true
+# Send interrupt signal before killing (for graceful shutdown)
+send_interrupt = true
+# Delay after sending interrupt before killing
+kill_delay = 500
+
+[log]
+# Show log time
+time = true
+# Only show main log (hide runner, watcher logs)
+main_only = false
+
+[color]
+# Customize colors (green for build success, red for errors)
+main = "magenta"
+watcher = "cyan"
+build = "yellow"
+runner = "green"
+
+[misc]
+# Delete tmp directory on exit
+clean_on_exit = true

--- a/control-plane/Dockerfile.dev
+++ b/control-plane/Dockerfile.dev
@@ -1,0 +1,34 @@
+# Development Dockerfile with hot-reload support
+# Uses Air (https://github.com/air-verse/air) for automatic rebuild on file changes
+
+FROM golang:1.24-bookworm
+
+# Install build dependencies for CGO (required for SQLite)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Air for hot-reload (v1.61.7 is compatible with Go 1.24)
+RUN go install github.com/air-verse/air@v1.61.7
+
+WORKDIR /app
+
+# Copy go.mod and go.sum first for better layer caching
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy Air configuration
+COPY .air.toml ./
+
+# The rest of the source code will be mounted as a volume
+# This allows hot-reload to detect changes
+
+# Create tmp directory for Air builds
+RUN mkdir -p tmp
+
+# Expose the default port
+EXPOSE 8080
+
+# Run Air for hot-reload development
+CMD ["air", "-c", ".air.toml"]

--- a/control-plane/README.md
+++ b/control-plane/README.md
@@ -29,6 +29,25 @@ go run ./cmd/server
 
 Visit `http://localhost:8080/ui/` to access the embedded admin UI.
 
+## Local Docker Development
+
+For development with hot-reload, use the `dev.sh` script. This automatically rebuilds and restarts the server when Go files change.
+
+```bash
+cd control-plane
+./dev.sh            # SQLite mode (default, no dependencies)
+./dev.sh postgres   # PostgreSQL mode
+./dev.sh down       # Stop containers
+./dev.sh clean      # Stop and remove volumes
+```
+
+The server runs at `http://localhost:8080` and will automatically reload when you modify `.go`, `.yaml`, or `.yml` files.
+
+**Notes:**
+- Uses [Air](https://github.com/air-verse/air) for hot-reload
+- Go build cache is persisted in Docker volumes for faster rebuilds
+- Web UI is not included in dev mode; run `npm run dev` separately in `web/client/` if needed
+
 ## Configuration
 
 Environment variables override `config/agentfield.yaml`. Common options:

--- a/control-plane/dev.sh
+++ b/control-plane/dev.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Start control plane in Docker with hot-reload
+#
+# Usage:
+#   ./dev.sh           # SQLite mode (default)
+#   ./dev.sh postgres  # PostgreSQL mode
+#   ./dev.sh down      # Stop containers
+#   ./dev.sh clean     # Stop and remove volumes
+
+set -e
+cd "$(dirname "$0")"
+
+case "${1:-}" in
+  postgres|pg)
+    echo "Starting control plane with PostgreSQL..."
+    docker compose -f docker-compose.dev.yml --profile postgres up
+    ;;
+  down|stop)
+    echo "Stopping containers..."
+    docker compose -f docker-compose.dev.yml --profile postgres down
+    ;;
+  clean)
+    echo "Stopping and removing volumes..."
+    docker compose -f docker-compose.dev.yml --profile postgres down -v
+    ;;
+  *)
+    echo "Starting control plane with SQLite..."
+    docker compose -f docker-compose.dev.yml up
+    ;;
+esac

--- a/control-plane/docker-compose.dev.yml
+++ b/control-plane/docker-compose.dev.yml
@@ -1,0 +1,87 @@
+# Docker Compose for local development with hot-reload
+#
+# Usage:
+#   docker compose -f docker-compose.dev.yml up        # SQLite mode (default)
+#   docker compose -f docker-compose.dev.yml --profile postgres up  # PostgreSQL mode
+#
+# The control plane will automatically rebuild and restart when Go files change.
+
+services:
+  control-plane:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    ports:
+      - "8080:8080"
+    environment:
+      # SQLite/local mode (no external dependencies)
+      AGENTFIELD_STORAGE_MODE: local
+      AGENTFIELD_HOME: /data
+      AGENTFIELD_HTTP_ADDR: 0.0.0.0:8080
+      AGENTFIELD_LOG_LEVEL: debug
+      GIN_MODE: debug
+      CGO_ENABLED: "1"
+    volumes:
+      # Mount source code for hot-reload
+      - .:/app
+      # Persist data directory
+      - dev-data:/data
+      # Use named volume for Go build cache (faster rebuilds)
+      - go-build-cache:/root/.cache/go-build
+      - go-mod-cache:/go/pkg/mod
+    # Keep container running and show logs
+    tty: true
+    stdin_open: true
+
+  # PostgreSQL mode - use with: docker compose --profile postgres up
+  control-plane-pg:
+    profiles: ["postgres"]
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    ports:
+      - "8080:8080"
+    environment:
+      AGENTFIELD_STORAGE_MODE: postgres
+      AGENTFIELD_HOME: /data
+      AGENTFIELD_HTTP_ADDR: 0.0.0.0:8080
+      AGENTFIELD_LOG_LEVEL: debug
+      AGENTFIELD_DATABASE_URL: postgres://agentfield:agentfield@postgres:5432/agentfield?sslmode=disable
+      AGENTFIELD_POSTGRES_URL: postgres://agentfield:agentfield@postgres:5432/agentfield?sslmode=disable
+      AGENTFIELD_STORAGE_POSTGRES_URL: postgres://agentfield:agentfield@postgres:5432/agentfield?sslmode=disable
+      GIN_MODE: debug
+      CGO_ENABLED: "1"
+    volumes:
+      - .:/app
+      - dev-data-pg:/data
+      - go-build-cache:/root/.cache/go-build
+      - go-mod-cache:/go/pkg/mod
+    depends_on:
+      postgres:
+        condition: service_healthy
+    tty: true
+    stdin_open: true
+
+  postgres:
+    profiles: ["postgres"]
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_USER: agentfield
+      POSTGRES_PASSWORD: agentfield
+      POSTGRES_DB: agentfield
+    volumes:
+      - pgdata-dev:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U agentfield"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    ports:
+      - "5432:5432"
+
+volumes:
+  dev-data:
+  dev-data-pg:
+  pgdata-dev:
+  go-build-cache:
+  go-mod-cache:


### PR DESCRIPTION
## Summary

Adds Docker-based local development environment with hot-reload for the control plane. When you modify Go files, the server automatically rebuilds and restarts.

### What's included

| File | Purpose |
|------|---------|
| `control-plane/dev.sh` | Simple script to start/stop dev environment |
| `control-plane/docker-compose.dev.yml` | Docker Compose with SQLite (default) and PostgreSQL modes |
| `control-plane/Dockerfile.dev` | Dev container with Go toolchain and Air |
| `control-plane/.air.toml` | Air configuration for hot-reload |
| `control-plane/README.md` | Documentation for local Docker development |
| `.gitignore` | Added `tmp/` for Air build artifacts |

### Usage

```bash
cd control-plane
./dev.sh            # SQLite mode (default, no dependencies)
./dev.sh postgres   # PostgreSQL mode
./dev.sh down       # Stop containers
./dev.sh clean      # Stop and remove volumes
```

The server runs at `http://localhost:8080` and automatically reloads when `.go`, `.yaml`, or `.yml` files change.

### Technical details

- Uses [Air](https://github.com/air-verse/air) v1.61.7 for hot-reload (compatible with Go 1.24)
- Go build cache and module cache persisted in Docker volumes for faster rebuilds
- Web UI not included in dev mode (run `npm run dev` separately if needed)

## Testing

- [x] Verified Docker build succeeds
- [x] Verified hot-reload triggers on file changes
- [ ] `./scripts/test-all.sh`

## Checklist

- [x] I updated documentation where applicable.
- [ ] I added or updated tests (or none were needed).
- [ ] I updated `CHANGELOG.md` (or this change does not warrant a changelog entry).