### PR TITLE
fix(control-plane): enforce lifecycle_status consistency with agent state

### DIFF
--- a/control-plane/internal/events/node_events.go
+++ b/control-plane/internal/events/node_events.go
@@ -28,6 +28,9 @@ const (
 	NodeStateTransition      NodeEventType = "node_state_transition"
 	NodeStatusRefreshed      NodeEventType = "node_status_refreshed"
 	BulkStatusUpdate         NodeEventType = "bulk_status_update"
+
+	// System state snapshot - periodic inventory of all agents and reasoners
+	SystemStateSnapshot NodeEventType = "system_state_snapshot"
 )
 
 // NodeEvent represents a node state change event
@@ -465,6 +468,19 @@ func PublishNodeHealthChangedEnhanced(nodeID string, oldHealth, newHealth string
 	}
 
 	logger.Logger.Debug().Msgf("🔍 NODE_EVENT_DEBUG: Publishing Enhanced NodeHealthChanged event - NodeID: %s, %s -> %s", nodeID, oldHealth, newHealth)
+
+	GlobalNodeEventBus.Publish(event)
+}
+
+// PublishSystemStateSnapshot publishes a system state snapshot event containing all agents and their reasoners
+func PublishSystemStateSnapshot(data interface{}) {
+	event := NodeEvent{
+		Type:      SystemStateSnapshot,
+		Timestamp: time.Now(),
+		Data:      data,
+	}
+
+	logger.Logger.Debug().Msg("[NodeEventBus] Publishing SystemStateSnapshot event")
 
 	GlobalNodeEventBus.Publish(event)
 }

--- a/control-plane/internal/services/observability_forwarder_test.go
+++ b/control-plane/internal/services/observability_forwarder_test.go
@@ -111,6 +111,11 @@ func (m *mockObservabilityStore) ClearDeadLetterQueue(ctx context.Context) error
 	return nil
 }
 
+func (m *mockObservabilityStore) ListAgents(ctx context.Context, filters types.AgentFilters) ([]*types.AgentNode, error) {
+	// Return empty list for tests - can be extended as needed
+	return []*types.AgentNode{}, nil
+}
+
 // Test config normalization
 func TestNormalizeObservabilityConfig(t *testing.T) {
 	t.Run("uses defaults when values are zero", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Bug Fix**: Control plane now correctly sets `lifecycle_status` to `"offline"` when agents go down
- **Feature**: Added `system_state_snapshot` event for periodic agent/reasoner inventory (every 60s)
- **Enhancement**: Execution events now include full reasoner context and metadata

## Problem

When agents went offline, the control plane was sending inconsistent data in observability events:
- `health_status: "inactive"` ✅ (correct)
- `lifecycle_status: "ready"` ❌ (should be `"offline"`)

This caused observability webhook handlers to incorrectly mark offline nodes as online because they check `lifecycle_status`.

## Solution

Added defensive consistency enforcement in `persistStatus()` that ensures `lifecycle_status` is always consistent with the agent's state:
- `state: inactive/stopping` → `lifecycle_status: offline`
- `state: active` → `lifecycle_status: ready`
- `state: starting` → `lifecycle_status: starting`

## Changes Made

| File | Change |
|------|--------|
| `status_manager.go` | Added defensive lifecycle_status enforcement in `persistStatus()` |
| `health_monitor.go` | Fixed fallback paths to also update lifecycle_status |
| `node_events.go` | Added `SystemStateSnapshot` event type |
| `observability_forwarder.go` | Added periodic system state snapshot publishing |
| `observability_forwarder_test.go` | Added `ListAgents` stub to mock store |
| `execute.go` | Enhanced execution events with reasoner context |

## Test Plan

- [x] Build passes (`go build ./...`)
- [x] Tests pass (`go test ./...`)
- [ ] Manual verification: Start control-plane, connect agent, close agent, verify webhook receives correct `lifecycle_status: "offline"`
- [ ] Verify `system_state_snapshot` events show correct status for all agents

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)