### PR TITLE
feat(ci): add contributor reminder and assignment tracking workflows

### DIFF
--- a/.github/workflows/contributor-reminders.yml
+++ b/.github/workflows/contributor-reminders.yml
@@ -1,0 +1,263 @@
+name: Contributor Reminders
+
+# Reminds assigned contributors about their issues and frees up stale assignments
+# so other contributors can pick up the work
+
+on:
+  schedule:
+    # Run daily at 9 AM UTC
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (no actual changes)'
+        type: boolean
+        default: false
+
+permissions:
+  issues: write
+  pull-requests: read
+
+env:
+  # Configurable thresholds (in days)
+  FIRST_REMINDER_DAYS: 7
+  SECOND_REMINDER_DAYS: 14
+  UNASSIGN_DAYS: 21
+
+jobs:
+  check-assigned-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check assigned issues without linked PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const dryRun = context.payload.inputs?.dry_run === 'true';
+            const firstReminderDays = parseInt(process.env.FIRST_REMINDER_DAYS);
+            const secondReminderDays = parseInt(process.env.SECOND_REMINDER_DAYS);
+            const unassignDays = parseInt(process.env.UNASSIGN_DAYS);
+
+            console.log(`Configuration: First reminder: ${firstReminderDays}d, Second: ${secondReminderDays}d, Unassign: ${unassignDays}d`);
+            console.log(`Dry run mode: ${dryRun}`);
+
+            // Get all open issues that have assignees
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            // Filter to only issues (not PRs) with assignees
+            const assignedIssues = issues.filter(issue =>
+              !issue.pull_request &&
+              issue.assignees &&
+              issue.assignees.length > 0
+            );
+
+            console.log(`Found ${assignedIssues.length} assigned issues`);
+
+            // Get all open PRs to check for linked issues
+            const pullRequests = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            // Extract issue numbers referenced in PR bodies/titles
+            const linkedIssueNumbers = new Set();
+            for (const pr of pullRequests) {
+              const text = `${pr.title} ${pr.body || ''}`;
+              // Match patterns like: #123, fixes #123, closes #123, resolves #123
+              const matches = text.match(/(close[sd]?|fix(e[sd])?|resolve[sd]?)?[\s:]*#(\d+)/gi) || [];
+              for (const match of matches) {
+                const num = match.match(/#(\d+)/);
+                if (num) linkedIssueNumbers.add(parseInt(num[1]));
+              }
+            }
+
+            console.log(`Issues with linked PRs: ${[...linkedIssueNumbers].join(', ') || 'none'}`);
+
+            const now = new Date();
+            let summary = { reminded: 0, secondReminder: 0, unassigned: 0, skipped: 0 };
+
+            for (const issue of assignedIssues) {
+              const issueNumber = issue.number;
+              const assignees = issue.assignees.map(a => a.login);
+              const labels = issue.labels.map(l => l.name);
+
+              // Skip if there's already a linked PR
+              if (linkedIssueNumbers.has(issueNumber)) {
+                console.log(`#${issueNumber}: Has linked PR, skipping`);
+                summary.skipped++;
+                continue;
+              }
+
+              // Skip issues with certain labels (e.g., on-hold, blocked)
+              if (labels.some(l => ['on-hold', 'blocked', 'wontfix', 'duplicate'].includes(l.toLowerCase()))) {
+                console.log(`#${issueNumber}: Has blocking label, skipping`);
+                summary.skipped++;
+                continue;
+              }
+
+              // Find the most recent assignment event or use issue creation date
+              const events = await github.rest.issues.listEvents({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                per_page: 100
+              });
+
+              // Find the most recent assignment
+              const assignmentEvents = events.data
+                .filter(e => e.event === 'assigned')
+                .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+              const lastAssignmentDate = assignmentEvents.length > 0
+                ? new Date(assignmentEvents[0].created_at)
+                : new Date(issue.created_at);
+
+              const daysSinceAssignment = Math.floor((now - lastAssignmentDate) / (1000 * 60 * 60 * 24));
+
+              console.log(`#${issueNumber}: Assigned to ${assignees.join(', ')}, ${daysSinceAssignment} days since assignment`);
+
+              // Check for recent activity from assignee (comments)
+              const comments = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                per_page: 50
+              });
+
+              const recentAssigneeComment = comments.data
+                .filter(c => assignees.includes(c.user.login))
+                .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
+
+              const lastActivityDate = recentAssigneeComment
+                ? new Date(recentAssigneeComment.created_at)
+                : lastAssignmentDate;
+
+              const daysSinceActivity = Math.floor((now - lastActivityDate) / (1000 * 60 * 60 * 24));
+
+              // Check existing reminder labels
+              const hasFirstReminder = labels.includes('reminder-sent');
+              const hasSecondReminder = labels.includes('needs-update');
+
+              // Determine action based on days since activity
+              if (daysSinceActivity >= unassignDays && hasSecondReminder) {
+                // Time to unassign
+                console.log(`#${issueNumber}: Unassigning after ${daysSinceActivity} days of inactivity`);
+
+                if (!dryRun) {
+                  // Remove assignees
+                  for (const assignee of assignees) {
+                    await github.rest.issues.removeAssignees({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: issueNumber,
+                      assignees: [assignee]
+                    });
+                  }
+
+                  // Update labels
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    name: 'needs-update'
+                  }).catch(() => {});
+
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    name: 'reminder-sent'
+                  }).catch(() => {});
+
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    labels: ['help wanted']
+                  });
+
+                  // Post comment
+                  const assigneeMentions = assignees.map(a => `@${a}`).join(' ');
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    body: `Hi ${assigneeMentions},\n\nIt's been ${daysSinceActivity} days since the last update on this issue. To keep the project moving, we've unassigned this issue so other contributors can pick it up.\n\n**No worries at all!** Life happens, and we totally understand. If you'd like to continue working on this, just comment here and we'll reassign it to you.\n\nThis issue is now available for anyone who'd like to contribute. Check out our contribution guidelines if you're interested!\n\nThanks for your interest in AgentField! :heart:`
+                  });
+                }
+                summary.unassigned++;
+
+              } else if (daysSinceActivity >= secondReminderDays && hasFirstReminder && !hasSecondReminder) {
+                // Send second reminder
+                console.log(`#${issueNumber}: Sending second reminder after ${daysSinceActivity} days`);
+
+                if (!dryRun) {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    labels: ['needs-update']
+                  });
+
+                  const assigneeMentions = assignees.map(a => `@${a}`).join(' ');
+                  const daysLeft = unassignDays - daysSinceActivity;
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    body: `Hi ${assigneeMentions},\n\nJust checking in again! It's been ${daysSinceActivity} days since we last heard from you on this issue.\n\n**Quick options:**\n- :speech_balloon: Drop a comment with a progress update\n- :link: Link a draft PR if you've started working on it\n- :wave: Let us know if you'd like to be unassigned (no judgment!)\n\nIf we don't hear back in **${daysLeft} days**, we'll unassign this issue to give other contributors a chance to help.\n\nThanks for understanding!`
+                  });
+                }
+                summary.secondReminder++;
+
+              } else if (daysSinceActivity >= firstReminderDays && !hasFirstReminder) {
+                // Send first reminder
+                console.log(`#${issueNumber}: Sending first reminder after ${daysSinceActivity} days`);
+
+                if (!dryRun) {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    labels: ['reminder-sent']
+                  });
+
+                  const assigneeMentions = assignees.map(a => `@${a}`).join(' ');
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    body: `Hey ${assigneeMentions}! :wave:\n\nJust a friendly reminder that you're assigned to this issue. It's been about a week since assignment.\n\n**How's it going?** We'd love to hear:\n- Any progress updates?\n- Running into any blockers we can help with?\n- Need more time? (Totally fine!)\n\nA quick comment helps us know you're still interested. If your plans have changed, no worries at all - just let us know and we can find another contributor.\n\nThanks for contributing to AgentField! :rocket:`
+                  });
+                }
+                summary.reminded++;
+
+              } else {
+                console.log(`#${issueNumber}: No action needed (${daysSinceActivity} days since activity)`);
+                summary.skipped++;
+              }
+            }
+
+            // Output summary
+            console.log('\n--- Summary ---');
+            console.log(`First reminders sent: ${summary.reminded}`);
+            console.log(`Second reminders sent: ${summary.secondReminder}`);
+            console.log(`Issues unassigned: ${summary.unassigned}`);
+            console.log(`Issues skipped: ${summary.skipped}`);
+
+            // Create summary for GitHub Actions
+            const summaryText = `## Contributor Reminder Summary\n\n` +
+              `| Action | Count |\n|--------|-------|\n` +
+              `| First reminders | ${summary.reminded} |\n` +
+              `| Second reminders | ${summary.secondReminder} |\n` +
+              `| Unassigned | ${summary.unassigned} |\n` +
+              `| Skipped | ${summary.skipped} |\n\n` +
+              `*Dry run: ${dryRun}*`;
+
+            await core.summary.addRaw(summaryText).write();

--- a/.github/workflows/issue-assignment-tracking.yml
+++ b/.github/workflows/issue-assignment-tracking.yml
@@ -1,0 +1,207 @@
+name: Issue Assignment Tracking
+
+# Tracks issue assignments in real-time and clears reminder labels when activity happens
+
+on:
+  issues:
+    types: [assigned, unassigned]
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  # Handle new assignments
+  on-assignment:
+    if: github.event_name == 'issues' && github.event.action == 'assigned'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Welcome new assignee
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const assignee = context.payload.assignee;
+
+            console.log(`Issue #${issue.number} assigned to ${assignee.login}`);
+
+            // Check if this is the first assignment (no previous reminder labels)
+            const labels = issue.labels.map(l => l.name);
+            const hasReminderLabels = labels.some(l =>
+              ['reminder-sent', 'needs-update'].includes(l)
+            );
+
+            // Remove 'help wanted' label if present
+            if (labels.includes('help wanted')) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                name: 'help wanted'
+              }).catch(() => {});
+            }
+
+            // Only welcome if this is a fresh assignment (no previous reminders)
+            if (!hasReminderLabels) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Thanks for picking this up, @${assignee.login}! :tada:\n\n**Here's what to expect:**\n- We'll check in after **7 days** if we haven't heard an update\n- After **14 days**, we'll send a second reminder\n- After **21 days** without activity, we'll unassign to let others contribute\n\n**Tips for success:**\n- Drop a comment when you start working on it\n- Share any blockers - we're here to help!\n- Link your PR with \`Fixes #${issue.number}\` in the description\n\nHappy coding! :rocket:`
+              });
+            }
+
+  # Clear reminder labels when assignee comments
+  on-assignee-comment:
+    if: github.event_name == 'issue_comment'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clear reminder labels on assignee activity
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const comment = context.payload.comment;
+            const commenter = comment.user.login;
+
+            // Skip if this is a PR comment
+            if (issue.pull_request) return;
+
+            // Check if commenter is an assignee
+            const assignees = issue.assignees.map(a => a.login);
+            if (!assignees.includes(commenter)) {
+              console.log(`Commenter ${commenter} is not an assignee, skipping`);
+              return;
+            }
+
+            console.log(`Assignee ${commenter} commented on #${issue.number}`);
+
+            const labels = issue.labels.map(l => l.name);
+            const reminderLabels = ['reminder-sent', 'needs-update'].filter(l => labels.includes(l));
+
+            if (reminderLabels.length === 0) {
+              console.log('No reminder labels to clear');
+              return;
+            }
+
+            // Clear reminder labels
+            for (const label of reminderLabels) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                name: label
+              }).catch(() => {});
+            }
+
+            console.log(`Cleared labels: ${reminderLabels.join(', ')}`);
+
+  # Handle unassignment
+  on-unassignment:
+    if: github.event_name == 'issues' && github.event.action == 'unassigned'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Handle unassignment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const unassignee = context.payload.assignee;
+
+            console.log(`${unassignee.login} unassigned from #${issue.number}`);
+
+            // If no assignees left, add 'help wanted' label
+            if (issue.assignees.length === 0) {
+              const labels = issue.labels.map(l => l.name);
+
+              // Clear any reminder labels
+              for (const label of ['reminder-sent', 'needs-update']) {
+                if (labels.includes(label)) {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    name: label
+                  }).catch(() => {});
+                }
+              }
+
+              // Add 'help wanted' if not already present
+              if (!labels.includes('help wanted')) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  labels: ['help wanted']
+                });
+              }
+            }
+
+  # Track PRs that link to issues
+  on-pr-link:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clear reminders when PR is linked
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const prAuthor = pr.user.login;
+            const text = `${pr.title} ${pr.body || ''}`;
+
+            // Find linked issues
+            const issueMatches = text.match(/(close[sd]?|fix(e[sd])?|resolve[sd]?)[\s:]*#(\d+)/gi) || [];
+            const issueNumbers = [...new Set(
+              issueMatches.map(m => {
+                const num = m.match(/#(\d+)/);
+                return num ? parseInt(num[1]) : null;
+              }).filter(Boolean)
+            )];
+
+            if (issueNumbers.length === 0) {
+              console.log('No linked issues found in PR');
+              return;
+            }
+
+            console.log(`PR #${pr.number} links to issues: ${issueNumbers.join(', ')}`);
+
+            for (const issueNumber of issueNumbers) {
+              try {
+                const issue = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber
+                });
+
+                // Check if PR author is an assignee
+                const assignees = issue.data.assignees.map(a => a.login);
+                if (!assignees.includes(prAuthor)) {
+                  console.log(`PR author ${prAuthor} is not assigned to #${issueNumber}`);
+                  continue;
+                }
+
+                const labels = issue.data.labels.map(l => l.name);
+                const reminderLabels = ['reminder-sent', 'needs-update'].filter(l => labels.includes(l));
+
+                // Clear reminder labels
+                for (const label of reminderLabels) {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    name: label
+                  }).catch(() => {});
+                }
+
+                if (reminderLabels.length > 0) {
+                  console.log(`Cleared labels on #${issueNumber}: ${reminderLabels.join(', ')}`);
+                }
+              } catch (err) {
+                console.log(`Error processing issue #${issueNumber}: ${err.message}`);
+              }
+            }


### PR DESCRIPTION
Add automated system to remind assigned contributors and free up stale assignments:

- contributor-reminders.yml: Scheduled daily check that:
  - Sends friendly reminder at 7 days without activity
  - Sends second reminder at 14 days with unassign warning
  - Unassigns and re-labels as 'help wanted' at 21 days
  - Skips issues with linked PRs or blocking labels
  - Supports dry-run mode for testing

- issue-assignment-tracking.yml: Real-time event handling that:
  - Welcomes new assignees with timeline expectations
  - Clears reminder labels when assignees comment
  - Clears labels when assignee opens linked PR
  - Auto-adds 'help wanted' when last assignee leaves

This improves contributor experience by setting clear expectations
while ensuring stale assignments don't block other contributors.