### PR TITLE
chore(ci): migrate Docker publishing from GHCR to Docker Hub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -460,14 +460,12 @@ jobs:
         if: needs.prepare.outputs.publish_docker == 'true'
         id: docker_meta
         env:
-          OWNER: ${{ github.repository_owner }}
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
           VERSION: ${{ needs.prepare.outputs.version }}
           ENVIRONMENT: ${{ needs.prepare.outputs.environment }}
         run: |
           set -euo pipefail
-          owner="$(echo "${OWNER}" | tr '[:upper:]' '[:lower:]')"
-          image="ghcr.io/${owner}/agentfield-control-plane"
+          image="agentfield/control-plane"
           echo "image=${image}" >> "$GITHUB_OUTPUT"
 
           if [ "${ENVIRONMENT}" = "staging" ]; then
@@ -482,13 +480,12 @@ jobs:
         if: needs.prepare.outputs.publish_docker == 'true'
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GitHub Container Registry
+      - name: Log in to Docker Hub
         if: needs.prepare.outputs.publish_docker == 'true'
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push control plane image
         if: needs.prepare.outputs.publish_docker == 'true'


### PR DESCRIPTION
## Summary

- Change image path from `ghcr.io/agent-field/agentfield-control-plane` to `agentfield/control-plane`
- Update login step to use Docker Hub credentials (`DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`)
- Remove unused `OWNER` env var from Docker metadata step

## Why

Docker Hub provides pull analytics that GitHub Container Registry doesn't offer. This migration enables us to track image usage metrics.

## Required Setup

Before merging, add these secrets to the repository:
1. `DOCKERHUB_USERNAME` - Docker Hub username
2. `DOCKERHUB_TOKEN` - Docker Hub access token (not password)

## Test plan

- [x] Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets to repository settings
- [x] Trigger a manual staging release with `publish_docker: true`
- [ ] Verify image appears at `docker.io/agentfield/control-plane:staging-X.Y.Z-rc.N`

🤖 Generated with [Claude Code](https://claude.com/claude-code)