### PR TITLE
fix(sdk): Update TypeScript SDK license to Apache-2.0

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -60,7 +60,7 @@
   "bugs": {
     "url": "https://github.com/Agent-Field/agentfield/issues"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "keywords": [
     "agentfield",
     "ai-agents",


### PR DESCRIPTION
## Summary

Align the TypeScript SDK's package.json license field with the project's root Apache 2.0 license.

## Changes Made

- Changed `"license": "MIT"` to `"license": "Apache-2.0"` in `sdk/typescript/package.json`

## Why

The npm package was incorrectly displaying MIT license while the repository uses Apache 2.0. This ensures consistency across the project and accurate license information on npm.

## Test Plan

- [ ] Verify package.json has correct license field
- [ ] Next npm publish will display Apache-2.0

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)