### PR TITLE
fix(server): add public /health endpoint for load balancer health checks

### DIFF
--- a/control-plane/internal/server/middleware/auth.go
+++ b/control-plane/internal/server/middleware/auth.go
@@ -34,7 +34,7 @@ func APIKeyAuth(config AuthConfig) gin.HandlerFunc {
 		}
 
 		// Always allow health and metrics by default
-		if strings.HasPrefix(c.Request.URL.Path, "/api/v1/health") || c.Request.URL.Path == "/metrics" {
+		if strings.HasPrefix(c.Request.URL.Path, "/api/v1/health") || c.Request.URL.Path == "/health" || c.Request.URL.Path == "/metrics" {
 			c.Next()
 			return
 		}

--- a/control-plane/internal/server/server.go
+++ b/control-plane/internal/server/server.go
@@ -664,6 +664,9 @@ func (s *AgentFieldServer) setupRoutes() {
 	// Expose Prometheus metrics
 	s.Router.GET("/metrics", gin.WrapH(promhttp.Handler()))
 
+	// Public health check endpoint for load balancers and container orchestration (e.g., Railway, K8s)
+	s.Router.GET("/health", s.healthCheckHandler)
+
 	// Serve UI files - embedded or filesystem based on availability
 	if s.config.UI.Enabled {
 		// Check if UI is embedded in the binary


### PR DESCRIPTION
## Summary
- Add root-level `/health` endpoint that bypasses API key authentication
- Enable load balancers and container orchestration platforms to perform health checks without credentials
- Reuses existing `healthCheckHandler` which checks storage and cache health

## Test plan
- [ ] Deploy to staging and verify `/health` returns 200 OK without API key
- [ ] Verify `/api/v1/health` still works as before
- [ ] Verify other endpoints still require authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)