### PR TITLE
Include input payload in execution events and add output schemas to reasoner examples

### DIFF
--- a/examples/ts-node-examples/init-example/reasoners.ts
+++ b/examples/ts-node-examples/init-example/reasoners.ts
@@ -31,6 +31,10 @@ const sentimentSchema = z.object({
 });
 type SentimentResult = z.infer<typeof sentimentSchema>;
 
+const analyzeSentimentOutputSchema = sentimentSchema.extend({
+  text: z.string()
+});
+
 reasonersRouter.reasoner<{ text: string }, SentimentResult & { text: string }>(
   'analyzeSentiment',
   async (ctx) => {
@@ -73,8 +77,14 @@ reasonersRouter.reasoner<{ text: string }, SentimentResult & { text: string }>(
     });
 
     return { ...sentiment, text: ctx.input.text };
-  }
+  },
+  { outputSchema: analyzeSentimentOutputSchema }
 );
+
+const processWithNotesOutputSchema = z.object({
+  processed: z.number(),
+  notes: z.number()
+});
 
 reasonersRouter.reasoner<{ items: string[] }, { processed: number; notes: number }>(
   'processWithNotes',
@@ -109,5 +119,6 @@ reasonersRouter.reasoner<{ items: string[] }, { processed: number; notes: number
       processed: processed.length,
       notes: notesSent
     };
-  }
+  },
+  { outputSchema: processWithNotesOutputSchema }
 );


### PR DESCRIPTION
## Summary
- Include input payload in execution status update, completion, and failure events
- Add explicit output schemas to example reasoners for better type visibility

## Changes Made
- **execute.go**: Add `input` field to event data when publishing execution events
- **reasoners.ts**: Add `outputSchema` configuration to `analyzeSentiment` and `processWithNotes` reasoners

## Why
Event consumers can now access the original input payload alongside results, enabling better debugging and observability. The explicit output schemas in examples demonstrate best practices for typed reasoner outputs.

## Test Plan
- [ ] Run existing control-plane tests
- [ ] Verify example reasoners work with new schema configuration

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)