### PR TITLE
Add skill execution data to observability events

### DIFF
--- a/control-plane/internal/handlers/execute.go
+++ b/control-plane/internal/handlers/execute.go
@@ -603,6 +603,19 @@ func (c *executionController) publishExecutionEventWithReasonerInfo(exec *types.
 			}
 		}
 
+		// Find the specific skill being executed
+		for _, s := range agent.Skills {
+			if s.ID == rID {
+				data["skill"] = map[string]interface{}{
+					"id":           s.ID,
+					"input_schema": s.InputSchema,
+					"tags":         s.Tags,
+				}
+				data["skill_id"] = s.ID
+				break
+			}
+		}
+
 		// Include all reasoners on this agent node for back-population
 		if len(agent.Reasoners) > 0 {
 			reasonerList := make([]map[string]interface{}, 0, len(agent.Reasoners))
@@ -614,6 +627,19 @@ func (c *executionController) publishExecutionEventWithReasonerInfo(exec *types.
 				})
 			}
 			data["agent_reasoners"] = reasonerList
+		}
+
+		// Include all skills on this agent node for back-population
+		if len(agent.Skills) > 0 {
+			skillList := make([]map[string]interface{}, 0, len(agent.Skills))
+			for _, s := range agent.Skills {
+				skillList = append(skillList, map[string]interface{}{
+					"id":           s.ID,
+					"input_schema": s.InputSchema,
+					"tags":         s.Tags,
+				})
+			}
+			data["agent_skills"] = skillList
 		}
 
 		// Include agent node info


### PR DESCRIPTION
## Summary

Extends observability execution events to include skill metadata when skills are invoked, mirroring the existing pattern for reasoner data.

## Changes Made

- Add `skill_id` field to event data when executing a skill
- Add `skill` object with schema details (id, input_schema, tags)
- Add `agent_skills` array listing all skills on the agent node

## Motivation

Currently, execution events include detailed information about reasoners (`reasoner`, `reasoner_id`, `agent_reasoners`) but not skills. This change enables downstream observability systems to:
- Track skill execution frequency
- Monitor skill usage patterns
- Aggregate metrics by skill across agents

## Test Plan

- [x] Build passes: `go build ./...`
- [x] Tests pass: `go test ./internal/handlers/...`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)