### PR TITLE
fix(ts-sdk): add HTTP timeout and always log heartbeat failures

### DIFF
--- a/sdk/typescript/src/agent/Agent.ts
+++ b/sdk/typescript/src/agent/Agent.ts
@@ -969,9 +969,7 @@ export class Agent {
       try {
         await this.agentFieldClient.heartbeat('ready');
       } catch (err) {
-        if (!this.config.devMode) {
-          console.warn('Heartbeat failed', err);
-        }
+        console.warn('Heartbeat failed', err);
       }
     };
 

--- a/sdk/typescript/src/client/AgentFieldClient.ts
+++ b/sdk/typescript/src/client/AgentFieldClient.ts
@@ -24,7 +24,7 @@ export class AgentFieldClient {
 
   constructor(config: AgentConfig) {
     const baseURL = (config.agentFieldUrl ?? 'http://localhost:8080').replace(/\/$/, '');
-    this.http = axios.create({ baseURL });
+    this.http = axios.create({ baseURL, timeout: 30000 });
     this.config = config;
 
     const mergedHeaders = { ...(config.defaultHeaders ?? {}) };


### PR DESCRIPTION
## Summary

Fixes an issue where TypeScript SDK agents would silently stop working after ~5 minutes on Railway (and other cloud platforms).

## Root Cause

1. **No timeout on axios client** - HTTP requests could hang forever on network issues
2. **Silent heartbeat failures in devMode** - When `devMode: true`, heartbeat errors were swallowed with no logs

The Python SDK has proper timeouts configured, which is why Python agents work fine for days while TypeScript agents would fail after ~5 minutes.

## Changes

- Add 30-second timeout to axios HTTP client in `AgentFieldClient.ts`
- Always log heartbeat failures in `Agent.ts` (removed devMode check)

## Test Plan

- [ ] Deploy TypeScript agent to Railway
- [ ] Verify agent stays online beyond 5 minutes
- [ ] If network issues occur, verify "Heartbeat failed" appears in logs

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)