### PR TITLE
chore(init-example): bump SDK to ^0.1.33

### DIFF
--- a/examples/ts-node-examples/init-example/package.json
+++ b/examples/ts-node-examples/init-example/package.json
@@ -1,19 +1,19 @@
 {
-  "name": "@agentfield/init-example",
-  "version": "1.0.0",
-  "private": true,
-  "type": "module",
-  "scripts": {
-    "start": "node --import tsx main.ts",
-    "dev": "tsx main.ts"
-  },
-  "dependencies": {
-    "@agentfield/sdk": "^0.1.32",
-    "dotenv": "^16.4.5",
-    "zod": "^3.22.4"
-  },
-  "devDependencies": {
-    "tsx": "^4.19.2",
-    "typescript": "^5.3.0"
-  }
+    "name": "@agentfield/init-example",
+    "version": "1.0.0",
+    "private": true,
+    "type": "module",
+    "scripts": {
+        "start": "node --import tsx main.ts",
+        "dev": "tsx main.ts"
+    },
+    "dependencies": {
+        "@agentfield/sdk": "^0.1.33",
+        "dotenv": "^16.4.5",
+        "zod": "^3.22.4"
+    },
+    "devDependencies": {
+        "tsx": "^4.19.2",
+        "typescript": "^5.3.0"
+    }
 }


### PR DESCRIPTION
## Summary
- Updates init-example to use `@agentfield/sdk` version ^0.1.33

## Why
SDK 0.1.33 includes the connection pooling fix that prevents socket exhaustion on long-running deployments (Railway, etc). Without this fix, agents leak TCP connections and eventually become unresponsive.

## Changes Made
- Bumped `@agentfield/sdk` from `^0.1.32` to `^0.1.33` in init-example/package.json

## Test Plan
- [ ] Redeploy init-example on Railway
- [ ] Verify agent stays online after 5+ minutes
- [ ] Monitor connection count remains stable

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)