### PR TITLE
fix: add maxTotalSockets to prevent socket exhaustion across IPv4/IPv6

### DIFF
--- a/examples/ts-node-examples/init-example/package.json
+++ b/examples/ts-node-examples/init-example/package.json
@@ -8,7 +8,7 @@
         "dev": "tsx main.ts"
     },
     "dependencies": {
-        "@agentfield/sdk": "^0.1.34",
+        "@agentfield/sdk": "^0.1.35",
         "dotenv": "^16.4.5",
         "zod": "^3.22.4"
     },

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentfield/sdk",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "AgentField TypeScript SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/sdk/typescript/src/client/AgentFieldClient.ts
+++ b/sdk/typescript/src/client/AgentFieldClient.ts
@@ -12,18 +12,19 @@ import type {
 } from '../types/agent.js';
 
 // Shared HTTP agents with connection pooling to prevent socket exhaustion
+// maxTotalSockets limits total connections across all hosts (IPv4 + IPv6)
 const httpAgent = new http.Agent({
   keepAlive: true,
   maxSockets: 10,
-  maxFreeSockets: 5,
-  timeout: 30000
+  maxTotalSockets: 50,
+  maxFreeSockets: 5
 });
 
 const httpsAgent = new https.Agent({
   keepAlive: true,
   maxSockets: 10,
-  maxFreeSockets: 5,
-  timeout: 30000
+  maxTotalSockets: 50,
+  maxFreeSockets: 5
 });
 
 export interface ExecutionStatusUpdate {

--- a/sdk/typescript/src/did/DidClient.ts
+++ b/sdk/typescript/src/did/DidClient.ts
@@ -4,18 +4,19 @@ import https from 'node:https';
 import axios, { type AxiosInstance } from 'axios';
 
 // Shared HTTP agents with connection pooling to prevent socket exhaustion
+// maxTotalSockets limits total connections across all hosts (IPv4 + IPv6)
 const httpAgent = new http.Agent({
   keepAlive: true,
   maxSockets: 10,
-  maxFreeSockets: 5,
-  timeout: 30000
+  maxTotalSockets: 50,
+  maxFreeSockets: 5
 });
 
 const httpsAgent = new https.Agent({
   keepAlive: true,
   maxSockets: 10,
-  maxFreeSockets: 5,
-  timeout: 30000
+  maxTotalSockets: 50,
+  maxFreeSockets: 5
 });
 
 // ============================================================================

--- a/sdk/typescript/src/mcp/MCPClient.ts
+++ b/sdk/typescript/src/mcp/MCPClient.ts
@@ -5,18 +5,19 @@ import type { MCPServerConfig } from '../types/agent.js';
 import type { MCPTool } from '../types/mcp.js';
 
 // Shared HTTP agents with connection pooling to prevent socket exhaustion
+// maxTotalSockets limits total connections across all hosts (IPv4 + IPv6)
 const httpAgent = new http.Agent({
   keepAlive: true,
   maxSockets: 10,
-  maxFreeSockets: 5,
-  timeout: 30000
+  maxTotalSockets: 50,
+  maxFreeSockets: 5
 });
 
 const httpsAgent = new https.Agent({
   keepAlive: true,
   maxSockets: 10,
-  maxFreeSockets: 5,
-  timeout: 30000
+  maxTotalSockets: 50,
+  maxFreeSockets: 5
 });
 
 export class MCPClient {

--- a/sdk/typescript/src/memory/MemoryClient.ts
+++ b/sdk/typescript/src/memory/MemoryClient.ts
@@ -4,18 +4,19 @@ import https from 'node:https';
 import type { MemoryScope } from '../types/agent.js';
 
 // Shared HTTP agents with connection pooling to prevent socket exhaustion
+// maxTotalSockets limits total connections across all hosts (IPv4 + IPv6)
 const httpAgent = new http.Agent({
   keepAlive: true,
   maxSockets: 10,
-  maxFreeSockets: 5,
-  timeout: 30000
+  maxTotalSockets: 50,
+  maxFreeSockets: 5
 });
 
 const httpsAgent = new https.Agent({
   keepAlive: true,
   maxSockets: 10,
-  maxFreeSockets: 5,
-  timeout: 30000
+  maxTotalSockets: 50,
+  maxFreeSockets: 5
 });
 
 export interface MemoryRequestMetadata {


### PR DESCRIPTION
## Summary
- Fix socket exhaustion in dual-stack (IPv4 + IPv6) environments
- Add `maxTotalSockets: 50` to limit total connections across ALL hosts
- Railway DNS returns both IPv4 and IPv6 which were treated as separate hosts

## Root Cause
`maxSockets: 10` only limits connections per-host, but IPv4 and IPv6 addresses are treated as different hosts by Node.js http.Agent. This caused unbounded connection growth (28k+ connections in 10 minutes).

## Changes
- Add `maxTotalSockets: 50` to all http.Agent instances
- Remove deprecated `timeout` option from http.Agent
- Bump SDK version to 0.1.35
- Update init-example to use 0.1.35

## Test plan
- [ ] Merge and publish SDK 0.1.35
- [ ] Redeploy Railway agent
- [ ] Verify connections stay bounded with `cat /proc/net/sockstat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)