### PR TITLE
fix(auth): allow root path to redirect to UI without auth

### DIFF
--- a/control-plane/internal/server/middleware/auth.go
+++ b/control-plane/internal/server/middleware/auth.go
@@ -40,7 +40,8 @@ func APIKeyAuth(config AuthConfig) gin.HandlerFunc {
 		}
 
 		// Allow UI static files to load (the React app handles auth prompting)
-		if strings.HasPrefix(c.Request.URL.Path, "/ui") {
+		// Also allow root "/" which redirects to /ui/
+		if strings.HasPrefix(c.Request.URL.Path, "/ui") || c.Request.URL.Path == "/" {
 			c.Next()
 			return
 		}


### PR DESCRIPTION
## Summary
- Fixes UX issue where accessing `localhost:8080` with auth enabled returns `{"error":"unauthorized"}` instead of redirecting to the UI login page

## Changes Made
- Added root path `/` to the auth middleware's skip list in `auth.go`
- The root path only performs a redirect to `/ui/`, no sensitive data is exposed

## Security Note
This change is safe because:
- `/` only redirects to `/ui/` (no data access)
- `/ui/*` was already in the skip list (serves static React files)
- All API endpoints (`/api/v1/*`) still require authentication
- The React app handles auth prompting for actual API calls

## Test Plan
- [ ] Start control plane with `AGENTFIELD_API_AUTH_API_KEY=secret`
- [ ] Visit `localhost:8080` → should redirect to `/ui/`
- [ ] UI should prompt for API key
- [ ] API calls without key should still fail

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)