### PR TITLE
test(sdk/go): add HTTP error handling tests

### DIFF
--- a/sdk/go/client/client_test.go
+++ b/sdk/go/client/client_test.go
@@ -659,7 +659,6 @@ func TestAPIError_UnmarshalJSON(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				// Body is nil, StatusCode is 0 - this is correct behavior
 				assert.Nil(t, apiErr.Body)
 				assert.Equal(t, 0, apiErr.StatusCode)
 			}
@@ -668,7 +667,7 @@ func TestAPIError_UnmarshalJSON(t *testing.T) {
 }
 
 func TestClient_NetworkErrors(t *testing.T) {
-	// Test dial timeout - use invalid host
+	// Use invalid host
 	client, err := New("http://nonexistent.invalid:9999")
 	require.NoError(t, err)
 


### PR DESCRIPTION
Closes #112 

## Changes
✅ **HTTP Status Codes**: Tests 401, 403, 404, 429,  502, 503 in `TestDo_ErrorHandling`
✅ **APIError struct**: `TestAPIError_UnmarshalJSON`
✅ **Network failures**: `TestClient_NetworkErrors`
✅ **Context timeouts**: `TestClient_ContextTimeout`