### PR TITLE
fix(ci): enable performance comments on fork PRs

### DIFF
--- a/.github/workflows/memory-metrics-report.yml
+++ b/.github/workflows/memory-metrics-report.yml
@@ -1,0 +1,165 @@
+name: Performance Report
+
+# This workflow runs in the context of the base repository,
+# allowing it to post comments on PRs from forks.
+on:
+  workflow_run:
+    workflows: ["Performance Check"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  report:
+    name: Post Report
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download results
+        uses: actions/download-artifact@v4
+        with:
+          name: perf-results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            // Load benchmark results
+            const results = JSON.parse(fs.readFileSync('perf-results.json', 'utf8'));
+            const baseline = JSON.parse(fs.readFileSync('examples/benchmarks/baseline.json', 'utf8'));
+            const thresholds = baseline.thresholds;
+
+            const prNumber = results.pr_number;
+            const rows = [];
+            const warnings = [];
+
+            // Python
+            if (results.python.changed) {
+              const mem = parseFloat(results.python.memory) || 0;
+              const lat = parseFloat(results.python.latency) || 0;
+              const tests = results.python.tests;
+              const baseMem = baseline.metrics.python.memory_per_handler_kb;
+              const baseLat = baseline.metrics.python.latency_p99_us;
+
+              const memDelta = baseMem > 0 ? ((mem - baseMem) / baseMem * 100) : 0;
+              const latDelta = baseLat > 0 ? ((lat - baseLat) / baseLat * 100) : 0;
+
+              let status = '✓';
+              if (tests === 'fail') status = '✗';
+              else if (memDelta > thresholds.memory_fail_pct || latDelta > thresholds.latency_fail_pct) status = '✗';
+              else if (memDelta > thresholds.memory_warning_pct || latDelta > thresholds.latency_warning_pct) status = '⚠';
+
+              const memStr = memDelta > 1 ? `+${memDelta.toFixed(0)}%` : (memDelta < -1 ? `${memDelta.toFixed(0)}%` : '-');
+              const latStr = latDelta > 1 ? `+${latDelta.toFixed(0)}%` : (latDelta < -1 ? `${latDelta.toFixed(0)}%` : '-');
+
+              rows.push(`| Python | ${mem.toFixed(1)} KB | ${memStr} | ${lat.toFixed(2)} µs | ${latStr} | ${tests === 'pass' ? '✓' : '✗'} | ${status} |`);
+
+              if (memDelta > thresholds.memory_warning_pct) {
+                warnings.push(`Python memory: ${baseMem.toFixed(1)} KB → ${mem.toFixed(1)} KB (+${memDelta.toFixed(0)}%)`);
+              }
+            }
+
+            // Go
+            if (results.go.changed) {
+              const mem = parseFloat(results.go.memory) || 0;
+              const lat = parseFloat(results.go.latency) || 0;
+              const tests = results.go.tests;
+              const baseMem = baseline.metrics.go.memory_per_handler_bytes;
+              const baseLat = baseline.metrics.go.latency_p99_us;
+
+              const memDelta = baseMem > 0 ? ((mem - baseMem) / baseMem * 100) : 0;
+              const latDelta = baseLat > 0 ? ((lat - baseLat) / baseLat * 100) : 0;
+
+              let status = '✓';
+              if (tests === 'fail') status = '✗';
+              else if (memDelta > thresholds.memory_fail_pct || latDelta > thresholds.latency_fail_pct) status = '✗';
+              else if (memDelta > thresholds.memory_warning_pct || latDelta > thresholds.latency_warning_pct) status = '⚠';
+
+              const memStr = memDelta > 1 ? `+${memDelta.toFixed(0)}%` : (memDelta < -1 ? `${memDelta.toFixed(0)}%` : '-');
+              const latStr = latDelta > 1 ? `+${latDelta.toFixed(0)}%` : (latDelta < -1 ? `${latDelta.toFixed(0)}%` : '-');
+
+              rows.push(`| Go | ${mem} B | ${memStr} | ${lat.toFixed(2)} µs | ${latStr} | ${tests === 'pass' ? '✓' : '✗'} | ${status} |`);
+
+              if (memDelta > thresholds.memory_warning_pct) {
+                warnings.push(`Go memory: ${baseMem} B → ${mem} B (+${memDelta.toFixed(0)}%)`);
+              }
+            }
+
+            // TypeScript
+            if (results.typescript.changed) {
+              const mem = parseFloat(results.typescript.memory) || 0;
+              const lat = parseFloat(results.typescript.latency) || 0;
+              const tests = results.typescript.tests;
+              const baseMem = baseline.metrics.typescript.memory_per_handler_bytes;
+              const baseLat = baseline.metrics.typescript.latency_p99_us;
+
+              const memDelta = baseMem > 0 ? ((mem - baseMem) / baseMem * 100) : 0;
+              const latDelta = baseLat > 0 ? ((lat - baseLat) / baseLat * 100) : 0;
+
+              let status = '✓';
+              if (tests === 'fail') status = '✗';
+              else if (memDelta > thresholds.memory_fail_pct || latDelta > thresholds.latency_fail_pct) status = '✗';
+              else if (memDelta > thresholds.memory_warning_pct || latDelta > thresholds.latency_warning_pct) status = '⚠';
+
+              const memStr = memDelta > 1 ? `+${memDelta.toFixed(0)}%` : (memDelta < -1 ? `${memDelta.toFixed(0)}%` : '-');
+              const latStr = latDelta > 1 ? `+${latDelta.toFixed(0)}%` : (latDelta < -1 ? `${latDelta.toFixed(0)}%` : '-');
+
+              rows.push(`| TS | ${mem} B | ${memStr} | ${lat.toFixed(2)} µs | ${latStr} | ${tests === 'pass' ? '✓' : '✗'} | ${status} |`);
+
+              if (memDelta > thresholds.memory_warning_pct) {
+                warnings.push(`TypeScript memory: ${baseMem} B → ${mem} B (+${memDelta.toFixed(0)}%)`);
+              }
+            }
+
+            // Build comment body
+            let body = `## Performance\n\n`;
+
+            if (rows.length === 0) {
+              body += `No SDK changes detected.\n`;
+            } else {
+              body += `| SDK | Memory | Δ | Latency | Δ | Tests | Status |\n`;
+              body += `|-----|--------|---|---------|---|-------|--------|\n`;
+              body += rows.join('\n') + '\n\n';
+
+              if (warnings.length > 0) {
+                body += `⚠ **Regression detected:**\n`;
+                warnings.forEach(w => body += `- ${w}\n`);
+              } else {
+                body += `✓ No regressions detected\n`;
+              }
+            }
+
+            // Find existing comment or create new one
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber
+            });
+
+            const existing = comments.find(c => c.user.type === 'Bot' && c.body.includes('## Performance'));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body
+              });
+            }
+
+            console.log(`Posted performance report to PR #${prNumber}`);

--- a/.github/workflows/memory-metrics.yml
+++ b/.github/workflows/memory-metrics.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   detect-changes:
@@ -250,146 +249,43 @@ jobs:
           echo "memory=$(grep 'memory=' bench.txt | cut -d= -f2)" >> $GITHUB_OUTPUT
           echo "latency=$(grep 'latency=' bench.txt | cut -d= -f2)" >> $GITHUB_OUTPUT
 
-  report:
-    name: Report
+  # Save results as artifact for the report workflow to pick up
+  save-results:
+    name: Save Results
     needs: [detect-changes, python-perf, go-perf, typescript-perf]
     if: always() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Create results file
+        run: |
+          cat > perf-results.json << 'EOF'
+          {
+            "pr_number": ${{ github.event.pull_request.number }},
+            "python": {
+              "changed": ${{ needs.detect-changes.outputs.python == 'true' }},
+              "memory": "${{ needs.python-perf.outputs.memory }}",
+              "latency": "${{ needs.python-perf.outputs.latency }}",
+              "tests": "${{ needs.python-perf.outputs.tests }}"
+            },
+            "go": {
+              "changed": ${{ needs.detect-changes.outputs.go == 'true' }},
+              "memory": "${{ needs.go-perf.outputs.memory }}",
+              "latency": "${{ needs.go-perf.outputs.latency }}",
+              "tests": "${{ needs.go-perf.outputs.tests }}"
+            },
+            "typescript": {
+              "changed": ${{ needs.detect-changes.outputs.typescript == 'true' }},
+              "memory": "${{ needs.typescript-perf.outputs.memory }}",
+              "latency": "${{ needs.typescript-perf.outputs.latency }}",
+              "tests": "${{ needs.typescript-perf.outputs.tests }}"
+            }
+          }
+          EOF
+          cat perf-results.json
 
-      - name: Generate Report
-        uses: actions/github-script@v7
+      - name: Upload results
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            const fs = require('fs');
-            const baseline = JSON.parse(fs.readFileSync('examples/benchmarks/baseline.json', 'utf8'));
-            const thresholds = baseline.thresholds;
-
-            // Collect results
-            const results = [];
-            const warnings = [];
-
-            // Python
-            const pyChanged = '${{ needs.detect-changes.outputs.python }}' === 'true';
-            if (pyChanged) {
-              const mem = parseFloat('${{ needs.python-perf.outputs.memory }}') || 0;
-              const lat = parseFloat('${{ needs.python-perf.outputs.latency }}') || 0;
-              const tests = '${{ needs.python-perf.outputs.tests }}';
-              const baseMem = baseline.metrics.python.memory_per_handler_kb;
-              const baseLat = baseline.metrics.python.latency_p99_us;
-
-              const memDelta = baseMem > 0 ? ((mem - baseMem) / baseMem * 100) : 0;
-              const latDelta = baseLat > 0 ? ((lat - baseLat) / baseLat * 100) : 0;
-
-              let status = '✓';
-              if (tests === 'fail') status = '✗';
-              else if (memDelta > thresholds.memory_fail_pct || latDelta > thresholds.latency_fail_pct) status = '✗';
-              else if (memDelta > thresholds.memory_warning_pct || latDelta > thresholds.latency_warning_pct) status = '⚠';
-
-              const memStr = memDelta > 1 ? `+${memDelta.toFixed(0)}%` : (memDelta < -1 ? `${memDelta.toFixed(0)}%` : '-');
-              const latStr = latDelta > 1 ? `+${latDelta.toFixed(0)}%` : (latDelta < -1 ? `${latDelta.toFixed(0)}%` : '-');
-
-              results.push(`| Python | ${mem.toFixed(1)} KB | ${memStr} | ${lat.toFixed(2)} µs | ${latStr} | ${tests === 'pass' ? '✓' : '✗'} | ${status} |`);
-
-              if (memDelta > thresholds.memory_warning_pct) {
-                warnings.push(`Python memory: ${baseMem.toFixed(1)} KB → ${mem.toFixed(1)} KB (+${memDelta.toFixed(0)}%)`);
-              }
-            }
-
-            // Go
-            const goChanged = '${{ needs.detect-changes.outputs.go }}' === 'true';
-            if (goChanged) {
-              const mem = parseFloat('${{ needs.go-perf.outputs.memory }}') || 0;
-              const lat = parseFloat('${{ needs.go-perf.outputs.latency }}') || 0;
-              const tests = '${{ needs.go-perf.outputs.tests }}';
-              const baseMem = baseline.metrics.go.memory_per_handler_bytes;
-              const baseLat = baseline.metrics.go.latency_p99_us;
-
-              const memDelta = baseMem > 0 ? ((mem - baseMem) / baseMem * 100) : 0;
-              const latDelta = baseLat > 0 ? ((lat - baseLat) / baseLat * 100) : 0;
-
-              let status = '✓';
-              if (tests === 'fail') status = '✗';
-              else if (memDelta > thresholds.memory_fail_pct || latDelta > thresholds.latency_fail_pct) status = '✗';
-              else if (memDelta > thresholds.memory_warning_pct || latDelta > thresholds.latency_warning_pct) status = '⚠';
-
-              const memStr = memDelta > 1 ? `+${memDelta.toFixed(0)}%` : (memDelta < -1 ? `${memDelta.toFixed(0)}%` : '-');
-              const latStr = latDelta > 1 ? `+${latDelta.toFixed(0)}%` : (latDelta < -1 ? `${latDelta.toFixed(0)}%` : '-');
-
-              results.push(`| Go | ${mem} B | ${memStr} | ${lat.toFixed(2)} µs | ${latStr} | ${tests === 'pass' ? '✓' : '✗'} | ${status} |`);
-
-              if (memDelta > thresholds.memory_warning_pct) {
-                warnings.push(`Go memory: ${baseMem} B → ${mem} B (+${memDelta.toFixed(0)}%)`);
-              }
-            }
-
-            // TypeScript
-            const tsChanged = '${{ needs.detect-changes.outputs.typescript }}' === 'true';
-            if (tsChanged) {
-              const mem = parseFloat('${{ needs.typescript-perf.outputs.memory }}') || 0;
-              const lat = parseFloat('${{ needs.typescript-perf.outputs.latency }}') || 0;
-              const tests = '${{ needs.typescript-perf.outputs.tests }}';
-              const baseMem = baseline.metrics.typescript.memory_per_handler_bytes;
-              const baseLat = baseline.metrics.typescript.latency_p99_us;
-
-              const memDelta = baseMem > 0 ? ((mem - baseMem) / baseMem * 100) : 0;
-              const latDelta = baseLat > 0 ? ((lat - baseLat) / baseLat * 100) : 0;
-
-              let status = '✓';
-              if (tests === 'fail') status = '✗';
-              else if (memDelta > thresholds.memory_fail_pct || latDelta > thresholds.latency_fail_pct) status = '✗';
-              else if (memDelta > thresholds.memory_warning_pct || latDelta > thresholds.latency_warning_pct) status = '⚠';
-
-              const memStr = memDelta > 1 ? `+${memDelta.toFixed(0)}%` : (memDelta < -1 ? `${memDelta.toFixed(0)}%` : '-');
-              const latStr = latDelta > 1 ? `+${latDelta.toFixed(0)}%` : (latDelta < -1 ? `${latDelta.toFixed(0)}%` : '-');
-
-              results.push(`| TS | ${mem} B | ${memStr} | ${lat.toFixed(2)} µs | ${latStr} | ${tests === 'pass' ? '✓' : '✗'} | ${status} |`);
-
-              if (memDelta > thresholds.memory_warning_pct) {
-                warnings.push(`TypeScript memory: ${baseMem} B → ${mem} B (+${memDelta.toFixed(0)}%)`);
-              }
-            }
-
-            // Build comment
-            let body = `## Performance\n\n`;
-
-            if (results.length === 0) {
-              body += `No SDK changes detected.\n`;
-            } else {
-              body += `| SDK | Memory | Δ | Latency | Δ | Tests | Status |\n`;
-              body += `|-----|--------|---|---------|---|-------|--------|\n`;
-              body += results.join('\n') + '\n\n';
-
-              if (warnings.length > 0) {
-                body += `⚠ **Regression detected:**\n`;
-                warnings.forEach(w => body += `- ${w}\n`);
-              } else {
-                body += `✓ No regressions detected\n`;
-              }
-            }
-
-            // Post comment
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number
-            });
-
-            const existing = comments.find(c => c.user.type === 'Bot' && c.body.includes('## Performance'));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body
-              });
-            }
+          name: perf-results
+          path: perf-results.json
+          retention-days: 1


### PR DESCRIPTION
## Summary

Fixes the `403 Resource not accessible by integration` error that prevents the Performance Check workflow from posting comments on PRs from forks.

## Problem

GitHub restricts `GITHUB_TOKEN` permissions on fork PRs for security. The `pull-requests: write` permission is ignored, causing the comment post to fail.

## Solution

Split into two workflows using the `workflow_run` pattern:

1. **Performance Check** (`memory-metrics.yml`) - Runs benchmarks and saves results as artifact
2. **Performance Report** (`memory-metrics-report.yml`) - Triggered by `workflow_run`, downloads artifact and posts comment with base repo permissions

## Changes

- `memory-metrics.yml`: Replaced `report` job with `save-results` job that uploads benchmark data as artifact
- `memory-metrics-report.yml`: New workflow that posts the performance comment

## Test Plan

- [ ] Trigger workflow on a fork PR to verify comments are posted correctly
- [ ] Verify same-repo PRs still work

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)