### PR TITLE
fix(sdk/python): use actual version and metadata in agent registration

### DIFF
--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -392,6 +392,9 @@ class Agent(FastAPI):
         node_id: str,
         agentfield_server: str = "http://localhost:8080",
         version: str = "1.0.0",
+        description: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        author: Optional[Dict[str, str]] = None,
         ai_config: Optional[AIConfig] = None,
         memory_config: Optional[MemoryConfig] = None,
         dev_mode: bool = False,
@@ -479,6 +482,9 @@ class Agent(FastAPI):
         self.node_id = node_id
         self.agentfield_server = agentfield_server
         self.version = version
+        self.description = description
+        self.agent_tags = tags or []
+        self.author = author
 
         # Memory-efficient handler registries (replaces old list-based storage)
         # Using Dict[str, Entry] with __slots__ dataclasses for minimal footprint
@@ -1268,6 +1274,17 @@ class Agent(FastAPI):
         ):
             return False
         return self._effective_component_vc_setting(component_id, overrides)
+
+    def _build_agent_metadata(self) -> Optional[Dict[str, Any]]:
+        """Build agent metadata (description, tags, author) for registration payload."""
+        metadata: Dict[str, Any] = {}
+        if self.description:
+            metadata["description"] = self.description
+        if self.agent_tags:
+            metadata["tags"] = self.agent_tags
+        if self.author:
+            metadata["author"] = self.author
+        return metadata if metadata else None
 
     def _build_vc_metadata(self) -> Dict[str, Any]:
         """Produce a serializable VC policy snapshot for control-plane visibility."""

--- a/sdk/python/agentfield/agent_field_handler.py
+++ b/sdk/python/agentfield/agent_field_handler.py
@@ -129,6 +129,8 @@ class AgentFieldHandler:
                 base_url=self.agent.base_url,
                 discovery=discovery_payload,
                 vc_metadata=self.agent._build_vc_metadata(),
+                version=self.agent.version,
+                agent_metadata=self.agent._build_agent_metadata(),
             )
             if success:
                 if payload:
@@ -427,6 +429,8 @@ class AgentFieldHandler:
                 status=AgentStatus.STARTING,
                 discovery=discovery_payload,
                 vc_metadata=self.agent._build_vc_metadata(),
+                version=self.agent.version,
+                agent_metadata=self.agent._build_agent_metadata(),
             )
 
             if success:

--- a/sdk/python/agentfield/client.py
+++ b/sdk/python/agentfield/client.py
@@ -525,14 +525,20 @@ class AgentFieldClient:
         base_url: str,
         discovery: Optional[Dict[str, Any]] = None,
         vc_metadata: Optional[Dict[str, Any]] = None,
+        version: str = "1.0.0",
+        agent_metadata: Optional[Dict[str, Any]] = None,
     ) -> Tuple[bool, Optional[Dict[str, Any]]]:
         """Register or update agent information with AgentField server."""
         try:
+            custom_metadata: Dict[str, Any] = {}
+            if agent_metadata:
+                custom_metadata.update(agent_metadata)
+
             registration_data = {
                 "id": node_id,
                 "team_id": "default",
                 "base_url": base_url,
-                "version": "1.0.0",
+                "version": version,
                 "reasoners": reasoners,
                 "skills": skills,
                 "communication_config": {
@@ -556,10 +562,10 @@ class AgentFieldClient:
                         "environment": "development",
                         "platform": "python",
                         "region": "local",
-                        "tags": {"sdk_version": "1.0.0", "language": "python"},
+                        "tags": {"sdk_version": importlib.import_module("agentfield").__version__, "language": "python"},
                     },
                     "performance": {"latency_ms": 0, "throughput_ps": 0},
-                    "custom": {},
+                    "custom": custom_metadata,
                 },
             }
 
@@ -1013,14 +1019,20 @@ class AgentFieldClient:
         discovery: Optional[Dict[str, Any]] = None,
         suppress_errors: bool = False,
         vc_metadata: Optional[Dict[str, Any]] = None,
+        version: str = "1.0.0",
+        agent_metadata: Optional[Dict[str, Any]] = None,
     ) -> Tuple[bool, Optional[Dict[str, Any]]]:
         """Register agent with immediate status reporting for fast lifecycle."""
         try:
+            custom_metadata: Dict[str, Any] = {}
+            if agent_metadata:
+                custom_metadata.update(agent_metadata)
+
             registration_data = {
                 "id": node_id,
                 "team_id": "default",
                 "base_url": base_url,
-                "version": "1.0.0",
+                "version": version,
                 "reasoners": reasoners,
                 "skills": skills,
                 "lifecycle_status": status.value,
@@ -1045,10 +1057,10 @@ class AgentFieldClient:
                         "environment": "development",
                         "platform": "python",
                         "region": "local",
-                        "tags": {"sdk_version": "1.0.0", "language": "python"},
+                        "tags": {"sdk_version": importlib.import_module("agentfield").__version__, "language": "python"},
                     },
                     "performance": {"latency_ms": 0, "throughput_ps": 0},
-                    "custom": {},
+                    "custom": custom_metadata,
                 },
             }
 

--- a/sdk/python/agentfield/connection_manager.py
+++ b/sdk/python/agentfield/connection_manager.py
@@ -141,6 +141,8 @@ class ConnectionManager:
                     discovery=discovery_payload,
                     suppress_errors=True,  # Suppress verbose error logging for connection attempts
                     vc_metadata=self.agent._build_vc_metadata(),
+                    version=self.agent.version,
+                    agent_metadata=self.agent._build_agent_metadata(),
                 )
             finally:
                 # Restore original logging levels

--- a/sdk/python/tests/helpers.py
+++ b/sdk/python/tests/helpers.py
@@ -28,6 +28,8 @@ class DummyAgentFieldClient:
         base_url: str,
         discovery=None,
         vc_metadata=None,
+        version: str = "1.0.0",
+        agent_metadata=None,
     ) -> Tuple[bool, Optional[Dict[str, Any]]]:
         self.register_calls.append(
             {
@@ -37,6 +39,8 @@ class DummyAgentFieldClient:
                 "base_url": base_url,
                 "discovery": discovery,
                 "vc_metadata": vc_metadata,
+                "version": version,
+                "agent_metadata": agent_metadata,
             }
         )
         return True, {"resolved_base_url": base_url}
@@ -51,6 +55,8 @@ class DummyAgentFieldClient:
         discovery=None,
         suppress_errors: bool = False,
         vc_metadata=None,
+        version: str = "1.0.0",
+        agent_metadata=None,
     ) -> Tuple[bool, Optional[Dict[str, Any]]]:
         return await self.register_agent(
             node_id=node_id,
@@ -59,6 +65,8 @@ class DummyAgentFieldClient:
             base_url=base_url,
             discovery=discovery,
             vc_metadata=vc_metadata,
+            version=version,
+            agent_metadata=agent_metadata,
         )
 
     async def send_enhanced_heartbeat(
@@ -104,6 +112,9 @@ class StubAgent:
 
     def _build_vc_metadata(self):
         return {"agent_default": True}
+
+    def _build_agent_metadata(self):
+        return None
 
     def __post_init__(self):
         self._heartbeat_stop_event = threading.Event()


### PR DESCRIPTION
## Summary
- Fixes hardcoded `"version": "1.0.0"` in registration payload to use the agent's actual version
- Adds support for `description`, `tags`, and `author` metadata in registration via `metadata.custom`
- Fixes hardcoded `sdk_version` in deployment tags to use real package version from `agentfield.__version__`

Fixes #148

## Changes Made
- **`client.py`**: Added `version` and `agent_metadata` parameters to `register_agent()` and `register_agent_with_status()`; replaced hardcoded `sdk_version` with dynamic import
- **`agent.py`**: Added `description`, `tags`, `author` constructor params and `_build_agent_metadata()` helper
- **`agent_field_handler.py`**: Pass version and metadata from all registration call sites
- **`connection_manager.py`**: Same for reconnection call site
- **`tests/helpers.py`**: Updated `DummyAgentFieldClient` and `StubAgent` to match new signatures

## Test Plan
- [x] All existing pytest tests pass
- [x] Ruff linting passes
- [x] Manual verification: agent registers with correct version (`2.5.3`) and metadata fields visible in `/api/v1/nodes` response

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)