### PR TITLE
Fix UI workflow delete 404 by wiring cleanup route

### DIFF
--- a/control-plane/internal/server/server.go
+++ b/control-plane/internal/server/server.go
@@ -838,6 +838,7 @@ func (s *AgentFieldServer) setupRoutes() {
 			workflows := uiAPI.Group("/workflows")
 			{
 				workflows.GET("/:workflowId/dag", handlers.GetWorkflowDAGHandler(s.storage))
+				workflows.DELETE("/:workflowId/cleanup", handlers.CleanupWorkflowHandler(s.storage))
 				didHandler := ui.NewDIDHandler(s.storage, s.didService, s.vcService)
 				workflows.POST("/vc-status", didHandler.GetWorkflowVCStatusBatchHandler)
 				workflows.GET("/:workflowId/vc-chain", didHandler.GetWorkflowVCChainHandler)


### PR DESCRIPTION
## Summary
- register missing UI cleanup route: `DELETE /api/ui/v1/workflows/:workflowId/cleanup`
- add route regression test to ensure the cleanup endpoint is wired and reachable
- make stub cleanup response non-nil in route tests so handler assertions are meaningful

## Root cause
The frontend correctly called `/api/ui/v1/workflows/:id/cleanup?confirm=true`, but `setupRoutes()` never registered that route, so Gin returned a framework-level `404` before `CleanupWorkflowHandler` executed.

## Validation
- `go test ./internal/server -run "TestSetupRoutesRegistersWorkflowCleanupUIRoute"` (from `control-plane/`)

## Issue
Closes #173
