### PR TITLE
Fix async execution polling missing auth headers

### DIFF
--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -3318,8 +3318,11 @@ class Agent(FastAPI):
         """
         if self._async_execution_manager is None:
             # Create async execution manager with the same base URL as the client
+            auth_headers = {"X-API-Key": self.api_key} if self.api_key else {}
             self._async_execution_manager = AsyncExecutionManager(
-                base_url=self.agentfield_server, config=self.async_config
+                base_url=self.agentfield_server,
+                config=self.async_config,
+                auth_headers=auth_headers,
             )
             # Start the manager
             await self._async_execution_manager.start()

--- a/sdk/python/agentfield/client.py
+++ b/sdk/python/agentfield/client.py
@@ -1125,7 +1125,9 @@ class AgentFieldClient:
         """
         if self._async_execution_manager is None:
             self._async_execution_manager = AsyncExecutionManager(
-                base_url=self.base_url, config=self.async_config
+                base_url=self.base_url,
+                config=self.async_config,
+                auth_headers=self._get_auth_headers(),
             )
             await self._async_execution_manager.start()
             self._maybe_update_event_stream_headers(None)


### PR DESCRIPTION
## Summary
- Fix `_poll_single_execution` and `_batch_poll_executions` in `AsyncExecutionManager` to include authentication headers (e.g. `X-API-Key`) when polling execution status
- Previously, polling GET requests to `/api/v1/executions/{id}` were sent without auth, causing 401 Unauthorized errors when the control plane requires API key authentication

## Changes Made
- Added `auth_headers` parameter to `AsyncExecutionManager.__init__` to store persistent auth headers
- `_poll_single_execution`: passes stored auth headers in every polling request
- `_batch_poll_executions`: includes auth headers in batch polling requests
- `AgentFieldClient._get_async_execution_manager`: passes `_get_auth_headers()` when creating the manager
- `Agent._get_async_execution_manager`: passes API key header when creating the manager

## Test Plan
- [x] All 495 existing Python SDK tests pass
- [ ] Deploy an agent with `api_key` set, trigger an `app.call()`, and confirm polling GET `/api/v1/executions/{id}` requests no longer return 401

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)