### PR TITLE
fix(release): use deploy key to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
       - name: Set up Python for tooling
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- Uses the `RELEASE_DEPLOY_KEY` secret (deploy key) in the release workflow checkout step so that version bump pushes to `main` can bypass the branch ruleset requiring PRs
- Deploy keys are in the ruleset bypass list; the default `GITHUB_TOKEN` is not

## Context
After adding branch rulesets requiring PRs for all changes to `main`, the automated release pipeline started failing with `GH006: Protected branch update failed`. The `GITHUB_TOKEN` cannot bypass this rule, but deploy keys (which are in the bypass list) can.

## Test plan
- [ ] Merge this PR and verify the next push to `main` triggers a successful release workflow (version bump commit pushes without error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)