### PR TITLE
fix(release): prevent infinite loop with [skip ci]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,7 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add -A
-            git commit -m "chore(release): ${tag}"
+            git commit -m "chore(release): ${tag} [skip ci]"
             git tag -a "${tag}" -m "Release ${tag}"
             git push origin "HEAD:${REF_NAME}"
             git push origin "${tag}"


### PR DESCRIPTION
## Summary
- Adds `[skip ci]` to the version bump commit message in the release workflow
- The deploy key fix (#193) allowed the release workflow to successfully push to `main`, but each push triggered another release run, creating an infinite loop
- `[skip ci]` is a built-in GitHub feature that prevents a pushed commit from triggering any workflows

## What happened
1. Release workflow triggers on push to `main`
2. Release workflow bumps version and pushes commit to `main`
3. That push triggers another release workflow run → infinite loop

## Test plan
- [ ] Merge this PR and verify the next release creates only one version bump commit without re-triggering itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)