### PR TITLE
fix(harness): preserve provider errors when schema output file is missing

### DIFF
--- a/sdk/python/agentfield/harness/_runner.py
+++ b/sdk/python/agentfield/harness/_runner.py
@@ -58,9 +58,11 @@ def _resolve_options(
             "system_prompt",
             "env",
             "cwd",
+            "project_dir",
             "codex_bin",
             "gemini_bin",
             "opencode_bin",
+            "opencode_server",
         ]:
             val = getattr(config, field_name, None)
             if val is not None:
@@ -116,9 +118,21 @@ class HarnessRunner:
         resolved_cwd = str(options.get("cwd", "."))
         provider_instance = self._build_provider(str(resolved_provider), options)
 
+        # When project_dir is set (opencode provider), place the output file
+        # inside project_dir so the coding agent's Write tool can reach it.
+        # Use a unique subdir to avoid collisions from parallel calls.
+        project_dir = options.get("project_dir")
+        output_dir = resolved_cwd
+        _temp_output_dir: Optional[str] = None
+        if isinstance(project_dir, str) and project_dir:
+            import tempfile as _tempfile
+
+            _temp_output_dir = _tempfile.mkdtemp(prefix=".secaf-out-", dir=project_dir)
+            output_dir = _temp_output_dir
+
         effective_prompt = prompt
         if schema is not None:
-            effective_prompt = prompt + build_prompt_suffix(schema, resolved_cwd)
+            effective_prompt = prompt + build_prompt_suffix(schema, output_dir)
 
         start_time = time.monotonic()
         try:
@@ -130,7 +144,7 @@ class HarnessRunner:
                 return self._handle_schema_output(
                     raw,
                     schema,
-                    resolved_cwd,
+                    output_dir,
                     start_time,
                 )
 
@@ -148,7 +162,11 @@ class HarnessRunner:
             )
         finally:
             if schema is not None:
-                cleanup_temp_files(resolved_cwd)
+                cleanup_temp_files(output_dir)
+            if _temp_output_dir:
+                import shutil as _shutil
+
+                _shutil.rmtree(_temp_output_dir, ignore_errors=True)
 
     def _build_provider(
         self, provider_name: str, options: Dict[str, Any]
@@ -208,6 +226,8 @@ class HarnessRunner:
         start_time: float,
     ) -> HarnessResult:
         output_path = get_output_path(cwd)
+        file_exists = os.path.exists(output_path)
+
         validated = parse_and_validate(output_path, schema)
         elapsed = int((time.monotonic() - start_time) * 1000)
 
@@ -225,7 +245,7 @@ class HarnessRunner:
 
         if raw.is_error:
             provider_error = raw.error_message or "Harness provider execution failed."
-            if not os.path.exists(output_path):
+            if not file_exists:
                 provider_error = (
                     f"{provider_error} Output file was not created at {output_path}."
                 )

--- a/sdk/python/agentfield/harness/providers/_factory.py
+++ b/sdk/python/agentfield/harness/providers/_factory.py
@@ -31,5 +31,8 @@ def build_provider(config: "HarnessConfig") -> "HarnessProvider":
     if provider_name == "opencode":
         from agentfield.harness.providers.opencode import OpenCodeProvider
 
-        return OpenCodeProvider(bin_path=getattr(config, "opencode_bin", "opencode"))
+        return OpenCodeProvider(
+            bin_path=getattr(config, "opencode_bin", "opencode"),
+            server_url=getattr(config, "opencode_server", None),
+        )
     raise NotImplementedError(f"Provider {provider_name!r} is not yet implemented.")

--- a/sdk/python/agentfield/harness/providers/claude.py
+++ b/sdk/python/agentfield/harness/providers/claude.py
@@ -71,7 +71,9 @@ class ClaudeCodeProvider:
                 else agent_options
             )
 
+            msg_count = 0
             async for msg in sdk.query(prompt=prompt, options=opts):
+                msg_count += 1
                 if isinstance(msg, dict):
                     msg_dict = msg
                 elif hasattr(msg, "__dict__"):
@@ -128,6 +130,11 @@ class ClaudeCodeProvider:
                 is_error=False,
             )
         except Exception as exc:
+            import logging as _logging
+
+            _logging.getLogger("agentfield.harness.claude").error(
+                "ClaudeCodeProvider error: %s", exc
+            )
             api_ms = int((time.monotonic() - start_api) * 1000)
             return RawResult(
                 result=None,

--- a/sdk/python/agentfield/harness/providers/opencode.py
+++ b/sdk/python/agentfield/harness/providers/opencode.py
@@ -1,26 +1,163 @@
-"""OpenCode provider using CLI subprocess."""
+"""OpenCode provider using CLI subprocess.
+
+Uses ``opencode serve`` + ``opencode run --attach`` to work around the
+"Session not found" bug in ``opencode run`` standalone (v1.2.10–v1.2.16).
+
+The provider auto-manages the serve process: it starts one lazily on the
+first call and reuses it for all subsequent calls.  The server is cleaned
+up on process exit.
+
+To skip auto-management, set ``OPENCODE_SERVER`` (or ``opencode_server``
+in HarnessConfig) to point to an externally managed server.
+"""
 
 from __future__ import annotations
 
+import asyncio
+import atexit
+import os
+import signal
+import socket
+import subprocess
 import time
-from typing import Dict, Optional
+from typing import ClassVar, Dict, Optional
 
 from agentfield.harness._cli import run_cli
 from agentfield.harness._result import Metrics, RawResult
 
 
-class OpenCodeProvider:
-    """OpenCode CLI provider. Invokes `opencode` CLI subprocess."""
+def _find_free_port() -> int:
+    """Find a free TCP port by briefly binding to port 0."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
 
-    def __init__(self, bin_path: str = "opencode"):
+
+class OpenCodeProvider:
+    """OpenCode CLI provider with auto-managed ``opencode serve``.
+
+    On first invocation the provider starts ``opencode serve`` on a random
+    port and connects all subsequent ``opencode run --attach`` calls to it.
+    The serve process is terminated when the Python process exits.
+    """
+
+    # Class-level singleton: one serve process shared across all provider
+    # instances (parallel harness calls all hit the same server).
+    _serve_proc: ClassVar[Optional[subprocess.Popen[bytes]]] = None
+    _serve_url: ClassVar[Optional[str]] = None
+    _serve_lock: ClassVar[Optional[asyncio.Lock]] = None
+
+    def __init__(
+        self,
+        bin_path: str = "opencode",
+        server_url: Optional[str] = None,
+    ):
         self._bin = bin_path
+        # Explicit URL takes precedence over auto-managed server.
+        self._explicit_server = server_url or os.environ.get("OPENCODE_SERVER")
+
+    @classmethod
+    def _get_lock(cls) -> asyncio.Lock:
+        if cls._serve_lock is None:
+            cls._serve_lock = asyncio.Lock()
+        return cls._serve_lock
+
+    @classmethod
+    def _cleanup_serve(cls) -> None:
+        """Kill the managed serve process (called via atexit)."""
+        proc = cls._serve_proc
+        if proc is not None and proc.poll() is None:
+            try:
+                proc.send_signal(signal.SIGTERM)
+                proc.wait(timeout=5)
+            except Exception:
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
+            cls._serve_proc = None
+            cls._serve_url = None
+
+    async def _ensure_serve(self) -> str:
+        """Return the URL of a running ``opencode serve`` instance."""
+        if self._explicit_server:
+            return self._explicit_server
+
+        # Fast path — server already running.
+        if self.__class__._serve_url and self.__class__._serve_proc:
+            if self.__class__._serve_proc.poll() is None:
+                return self.__class__._serve_url
+
+        async with self._get_lock():
+            # Double-check after acquiring lock.
+            if self.__class__._serve_url and self.__class__._serve_proc:
+                if self.__class__._serve_proc.poll() is None:
+                    return self.__class__._serve_url
+
+            port = _find_free_port()
+            url = f"http://127.0.0.1:{port}"
+
+            proc = subprocess.Popen(
+                [self._bin, "serve", "--port", str(port)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                env={**os.environ},
+            )
+
+            # Wait for the server to be ready (up to 15s).
+            deadline = time.monotonic() + 15
+            while time.monotonic() < deadline:
+                if proc.poll() is not None:
+                    raise RuntimeError(
+                        f"opencode serve exited immediately (code {proc.returncode}). "
+                        "Ensure opencode is installed and OPENROUTER_API_KEY is set."
+                    )
+                try:
+                    with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                        break
+                except OSError:
+                    await asyncio.sleep(0.3)
+            else:
+                proc.kill()
+                raise RuntimeError(
+                    f"opencode serve did not start within 15s on port {port}."
+                )
+
+            self.__class__._serve_proc = proc
+            self.__class__._serve_url = url
+            atexit.register(self.__class__._cleanup_serve)
+            return url
 
     async def execute(self, prompt: str, options: dict[str, object]) -> RawResult:
-        cmd = [self._bin, "run"]
+        server_url = await self._ensure_serve()
+
+        cmd = [self._bin, "run", "--attach", server_url]
 
         if options.get("model"):
             cmd.extend(["--model", str(options["model"])])
-        cmd.append(prompt)
+
+        # --dir sets the project root the coding agent explores.
+        # Use project_dir (the actual target repo) if available, otherwise
+        # fall back to cwd (which may be a temp dir for output).
+        project_dir = options.get("project_dir")
+        if isinstance(project_dir, str) and project_dir:
+            cmd.extend(["--dir", project_dir])
+
+        cwd: Optional[str] = None
+        cwd_value = options.get("cwd")
+        if isinstance(cwd_value, str):
+            cwd = cwd_value
+
+        # Prepend system prompt to the user prompt if provided.
+        system_prompt = options.get("system_prompt")
+        effective_prompt = prompt
+        if isinstance(system_prompt, str) and system_prompt.strip():
+            effective_prompt = (
+                f"SYSTEM INSTRUCTIONS:\n{system_prompt.strip()}\n\n"
+                f"---\n\nUSER REQUEST:\n{prompt}"
+            )
+
+        cmd.append(effective_prompt)
 
         env: Dict[str, str] = {}
         env_value = options.get("env")
@@ -31,11 +168,6 @@ class OpenCodeProvider:
                 if isinstance(key, str) and isinstance(value, str)
             }
 
-        cwd: Optional[str] = None
-        cwd_value = options.get("cwd")
-        if isinstance(cwd_value, str):
-            cwd = cwd_value
-
         start_api = time.monotonic()
 
         try:
@@ -45,7 +177,7 @@ class OpenCodeProvider:
                 is_error=True,
                 error_message=(
                     f"OpenCode binary not found at '{self._bin}'. "
-                    "Install OpenCode: https://github.com/opencode-ai/opencode"
+                    "Install OpenCode: https://opencode.ai"
                 ),
                 metrics=Metrics(),
             )

--- a/sdk/python/agentfield/types.py
+++ b/sdk/python/agentfield/types.py
@@ -312,10 +312,28 @@ class HarnessConfig(BaseModel):
         default_factory=dict, description="Environment variables for the agent."
     )
     cwd: Optional[str] = Field(default=None, description="Default working directory.")
+    project_dir: Optional[str] = Field(
+        default=None,
+        description=(
+            "Project directory for the coding agent to explore (e.g. a target "
+            "repository path). Maps to --dir in opencode. When set, cwd is used "
+            "only for output file placement while project_dir controls the "
+            "agent's working context."
+        ),
+    )
     codex_bin: str = Field(default="codex", description="Path to codex binary.")
     gemini_bin: str = Field(default="gemini", description="Path to gemini binary.")
     opencode_bin: str = Field(
         default="opencode", description="Path to opencode binary."
+    )
+    opencode_server: Optional[str] = Field(
+        default=None,
+        description=(
+            "URL of a running ``opencode serve`` instance "
+            '(e.g. "http://127.0.0.1:4096"). When set, the opencode provider '
+            "uses ``--attach`` mode which avoids the standalone session bug. "
+            "Falls back to OPENCODE_SERVER env var."
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- preserve the underlying provider failure when schema-mode parsing fails instead of always returning a generic schema validation error
- append explicit missing output-file context when `.agentfield_output.json` was never created
- closes #217

## Why
Schema-mode failures currently mask real provider/runtime failures (for example `opencode run` returning `Session not found`) behind `Schema validation failed...`, which makes diagnosis noisy and misleading.

## Verification
- Ran standalone harness debug script with Claude provider (`permission_mode=auto`) on `/tmp/dvga` and confirmed complex schemas parse successfully from file output (`parsed != None` for `ArchitectureMap` and `ReconResult`).
- Reproduced provider failure path with OpenCode provider and confirmed the harness now returns provider error context including missing output-file path.
- Checked LSP diagnostics (error severity) clean for changed files.