### PR TITLE
fix(harness): add concurrency limiter, stdout fallback, and stronger prompts

### DIFF
--- a/sdk/python/agentfield/harness/_runner.py
+++ b/sdk/python/agentfield/harness/_runner.py
@@ -15,6 +15,7 @@ from agentfield.harness._schema import (
     diagnose_output_failure,
     get_output_path,
     parse_and_validate,
+    try_parse_from_text,
 )
 from agentfield.harness.providers._base import HarnessProvider
 from agentfield.harness.providers._factory import build_provider
@@ -266,6 +267,16 @@ class HarnessRunner:
         all_raws: List[RawResult] = [initial_raw]
 
         validated = parse_and_validate(output_path, schema)
+
+        if validated is None and initial_raw.result:
+            logger.info(
+                "Output file missing/invalid at %s — trying stdout fallback",
+                output_path,
+            )
+            validated = try_parse_from_text(initial_raw.result, schema)
+            if validated is not None:
+                logger.info("Stdout fallback succeeded")
+
         if validated is not None:
             elapsed = int((time.monotonic() - start_time) * 1000)
             cost, turns, sid, msgs = _accumulate_metrics(all_raws)
@@ -360,6 +371,15 @@ class HarnessRunner:
                 continue
 
             validated = parse_and_validate(output_path, schema)
+
+            if validated is None and retry_raw.result:
+                validated = try_parse_from_text(retry_raw.result, schema)
+                if validated is not None:
+                    logger.info(
+                        "Schema retry %d succeeded via stdout fallback",
+                        retry_num + 1,
+                    )
+
             if validated is not None:
                 elapsed = int((time.monotonic() - start_time) * 1000)
                 cost, turns, sid, msgs = _accumulate_metrics(all_raws)

--- a/sdk/python/agentfield/harness/_schema.py
+++ b/sdk/python/agentfield/harness/_schema.py
@@ -81,19 +81,21 @@ def build_prompt_suffix(schema: Any, cwd: str) -> str:
         write_schema_file(schema_json, cwd)
         return (
             "\n\n---\n"
-            "OUTPUT REQUIREMENTS:\n"
+            "CRITICAL OUTPUT REQUIREMENTS:\n"
             f"Read the JSON Schema at: {schema_path}\n"
-            f"Write your final answer as valid JSON conforming to that schema to: {output_path}\n"
-            "Do not include any text outside the JSON in that file. Do not wrap in markdown fences."
+            f"You MUST use your Write tool to create this file: {output_path}\n"
+            "The file MUST contain ONLY valid JSON conforming to that schema.\n"
+            "Do NOT output the JSON in your response text — write it to the file."
         )
 
     return (
         "\n\n---\n"
-        "OUTPUT REQUIREMENTS:\n"
-        f"Write your final answer as valid JSON to the file: {output_path}\n"
-        "The JSON must conform to this schema:\n"
-        f"{schema_json}\n"
-        "Do not include any text outside the JSON in that file. Do not wrap in markdown fences."
+        "CRITICAL OUTPUT REQUIREMENTS:\n"
+        f"You MUST use your Write tool to create this file: {output_path}\n"
+        "The file MUST contain ONLY valid JSON matching the schema below.\n"
+        "Do NOT output the JSON in your response text — write it to the file.\n\n"
+        f"Required JSON Schema:\n{schema_json}\n\n"
+        "Write ONLY valid JSON to the file. No markdown fences, no comments, no extra text."
     )
 
 
@@ -200,6 +202,61 @@ def parse_and_validate(file_path: str, schema: Any) -> Optional[Any]:
             return validate_against_schema(data, schema)
         except Exception:
             pass
+
+    return None
+
+
+def try_parse_from_text(text: str, schema: Any) -> Optional[Any]:
+    """Best-effort: extract JSON from LLM conversation text and validate.
+
+    Used as a fallback when the LLM outputs JSON in its response instead
+    of writing it to the output file.
+
+    Strategies tried in order:
+    1. JSON fenced code blocks (```json ... ```)
+    2. Largest top-level { ... } block
+    3. Cosmetic repair of entire text
+    """
+    if not text or not text.strip():
+        return None
+
+    # Strategy 1: fenced code blocks
+    for match in re.finditer(r"```(?:json)?\s*\n(.*?)```", text, re.DOTALL):
+        try:
+            data = json.loads(match.group(1).strip())
+            return validate_against_schema(data, schema)
+        except Exception:
+            continue
+
+    # Strategy 2: largest top-level { ... } block
+    candidates: list[str] = []
+    depth = 0
+    start = -1
+    for i, ch in enumerate(text):
+        if ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0 and start >= 0:
+                candidates.append(text[start : i + 1])
+                start = -1
+
+    for candidate in sorted(candidates, key=len, reverse=True):
+        try:
+            data = json.loads(candidate)
+            return validate_against_schema(data, schema)
+        except Exception:
+            continue
+
+    # Strategy 3: cosmetic repair on entire text
+    try:
+        repaired = cosmetic_repair(text)
+        data = json.loads(repaired)
+        return validate_against_schema(data, schema)
+    except Exception:
+        pass
 
     return None
 

--- a/sdk/python/agentfield/harness/providers/opencode.py
+++ b/sdk/python/agentfield/harness/providers/opencode.py
@@ -2,18 +2,29 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import os
 import shutil
 import tempfile
 import time
-from typing import Dict, Optional
+from typing import ClassVar, Dict, Optional
 
 from agentfield.harness._cli import run_cli, strip_ansi
 from agentfield.harness._result import FailureType, Metrics, RawResult
 
+logger = logging.getLogger("agentfield.harness.opencode")
+
 
 class OpenCodeProvider:
     """OpenCode CLI provider. Invokes ``opencode run`` subprocess."""
+
+    # Global concurrency limiter: prevents too many simultaneous opencode
+    # processes from overwhelming the LLM API with concurrent requests.
+    # Each opencode run spawns a full subprocess (pyright, DB migration, etc.)
+    # so unbounded concurrency causes rate-limiting and transient failures.
+    _MAX_CONCURRENT: ClassVar[int] = int(os.environ.get("OPENCODE_MAX_CONCURRENT", "3"))
+    _concurrency_sem: ClassVar[Optional[asyncio.Semaphore]] = None
 
     def __init__(
         self,
@@ -23,7 +34,23 @@ class OpenCodeProvider:
         self._bin = bin_path
         self._explicit_server = server_url or os.environ.get("OPENCODE_SERVER")
 
+    @classmethod
+    def _get_semaphore(cls) -> asyncio.Semaphore:
+        if cls._concurrency_sem is None:
+            cls._concurrency_sem = asyncio.Semaphore(cls._MAX_CONCURRENT)
+        return cls._concurrency_sem
+
     async def execute(self, prompt: str, options: dict[str, object]) -> RawResult:
+        sem = self._get_semaphore()
+        logger.debug(
+            "Waiting for concurrency slot (%d/%d in use)",
+            self._MAX_CONCURRENT - sem._value,
+            self._MAX_CONCURRENT,
+        )
+        async with sem:
+            return await self._execute_impl(prompt, options)
+
+    async def _execute_impl(self, prompt: str, options: dict[str, object]) -> RawResult:
         cmd = [self._bin, "run"]
 
         if options.get("model"):
@@ -68,7 +95,9 @@ class OpenCodeProvider:
 
         try:
             try:
-                stdout, stderr, returncode = await run_cli(cmd, env=env, cwd=cwd)
+                stdout, stderr, returncode = await run_cli(
+                    cmd, env=env, cwd=cwd, timeout=600
+                )
             except FileNotFoundError:
                 return RawResult(
                     is_error=True,
@@ -92,6 +121,15 @@ class OpenCodeProvider:
         api_ms = int((time.monotonic() - start_api) * 1000)
         result_text = stdout.strip() if stdout.strip() else None
         clean_stderr = strip_ansi(stderr.strip()) if stderr else ""
+
+        logger.info(
+            "opencode finished: returncode=%d stdout=%d chars elapsed=%ds",
+            returncode,
+            len(stdout),
+            api_ms // 1000,
+        )
+        if not result_text and clean_stderr:
+            logger.warning("opencode no stdout. stderr: %s", clean_stderr[:800])
 
         if returncode < 0:
             failure_type = FailureType.CRASH


### PR DESCRIPTION
## Summary

Fixes transient harness failures ("Schema validation failed / output file was NOT created") under concurrent load by adding a global concurrency limiter to the OpenCode provider.

## Root Cause

When SEC-AF runs 4+ hunters concurrently (each with 5 enrichments), it spawns 20+ simultaneous `opencode run` subprocesses. Each process does DB migration + pyright + LLM API call. This overwhelms OpenRouter with concurrent requests, causing some calls to fail to write their output file.

## Changes

- **`opencode.py`**: Global `asyncio.Semaphore` (default 3, configurable via `OPENCODE_MAX_CONCURRENT`) throttles concurrent processes; 600s timeout prevents hung processes; structured logging for debugging
- **`_schema.py`**: Stronger prompt wording ("CRITICAL OUTPUT REQUIREMENTS", emphasize Write tool); new `try_parse_from_text()` fallback extracts JSON from LLM stdout when output file is missing (tries fenced blocks → brace matching → cosmetic repair)
- **`_runner.py`**: Wire stdout fallback after `parse_and_validate` in both initial and retry paths

## Validation

Full SEC-AF pipeline against DVGA benchmark:
- **Before**: Multiple enricher failures requiring retries, `dos_hunter` stuck 30+ min
- **After**: 11 hunt strategies, 89 raw → 55 dedup → 30 verified findings, **0 enricher failures**
- All 13 existing harness tests pass