### PR TITLE
docs: add AI tool calling documentation to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,20 @@ analysis = await app.call("analyst.evaluate", input={"data": dataset})
 report = await app.call("writer.summarize", input={"analysis": analysis})
 ```
 
+### AI Tool Calling
+LLMs automatically discover and invoke agent capabilities. No manual tool registration—`tools="discover"` queries the control plane, converts capabilities to LLM tool schemas, dispatches calls, and feeds results back in a loop.
+
+```python
+# LLM discovers and calls tools from other agents automatically
+result = await app.ai(
+    system="You are a helpful assistant.",
+    user="What's the weather in Tokyo and calculate 42 * 17",
+    tools="discover",  # Auto-discover all available capabilities
+)
+print(result)       # Final answer from LLM
+print(result.trace) # Full observability: tool calls, latency, turns
+```
+
 ### Developer Experience
 Standard REST APIs. No magic abstractions. Build agents the way you build microservices.
 
@@ -373,6 +387,7 @@ AgentField isn't a framework you extend. It's infrastructure you deploy on.
 ### Multi-Agent Native
 - **Discovery**: Agents register capabilities. Others find them via API.
 - **Cross-Agent Calls**: `app.call("other.reasoner", input={...})` routed through control plane
+- **AI Tool Calling**: `app.ai(tools="discover")` — LLMs automatically discover and call agent capabilities
 - **Workflow DAGs**: Every execution path visualized automatically
 - **Shared Memory**: Scoped to global, agent, session, or run—with vector search
 

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -46,6 +46,39 @@ func main() {
 - `types`: Shared data structures and contracts.
 - `ai`: Helpers for interacting with AI providers via the control plane.
 
+## AI Tool Calling
+
+Execute LLM tool-call loops with automatic capability discovery:
+
+```go
+import (
+    "github.com/Agent-Field/agentfield/sdk/go/ai"
+    "github.com/Agent-Field/agentfield/sdk/go/agent"
+)
+
+// Convert discovered capabilities to LLM tool definitions
+tools := ai.CapabilitiesToToolDefinitions(discoveryResult.Capabilities)
+
+// Execute tool-call loop with guardrails
+response, trace, err := aiClient.ExecuteToolCallLoop(
+    ctx,
+    messages,
+    tools,
+    ai.ToolCallConfig{MaxTurns: 10, MaxToolCalls: 25},
+    func(ctx context.Context, target string, input map[string]interface{}) (map[string]interface{}, error) {
+        return agent.Call(ctx, target, input)
+    },
+)
+
+fmt.Printf("Final: %s\n", response.Text())
+fmt.Printf("Tool calls: %d, Turns: %d\n", trace.TotalToolCalls, trace.TotalTurns)
+```
+
+**Key features:**
+- `CapabilitiesToToolDefinitions` — Convert discovery results to OpenAI tool schemas
+- `ExecuteToolCallLoop` — Automatic LLM tool-call loop with turn/call limits
+- `ToolCallTrace` — Per-call latency tracking and observability
+
 ## Human-in-the-Loop Approvals
 
 The `client` package provides methods for requesting human approval, checking status, and waiting for decisions:

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -39,6 +39,50 @@ if __name__ == "__main__":
     agent.serve(port=8001)
 ```
 
+## AI Tool Calling
+
+Let LLMs automatically discover and invoke agent capabilities across your system:
+
+```python
+from agentfield import Agent, AIConfig, ToolCallConfig
+
+app = Agent(
+    node_id="orchestrator",
+    agentfield_server="http://localhost:8080",
+    ai_config=AIConfig(model="openai/gpt-4o-mini"),
+)
+
+@app.reasoner()
+async def ask_with_tools(question: str) -> dict:
+    # Auto-discover all tools and let the LLM use them
+    result = await app.ai(
+        system="You are a helpful assistant.",
+        user=question,
+        tools="discover",
+    )
+    return {"answer": str(result), "trace": result.trace}
+
+# Filter by tags, limit turns, use lazy hydration
+result = await app.ai(
+    user="Get weather for Tokyo",
+    tools=ToolCallConfig(
+        tags=["weather"],
+        schema_hydration="lazy",  # Reduces token usage for large catalogs
+        max_turns=5,
+        max_tool_calls=10,
+    ),
+)
+```
+
+**Key features:**
+- `tools="discover"` — Auto-discover all capabilities from the control plane
+- `ToolCallConfig` — Filter by tags, agent IDs, health status
+- **Lazy hydration** — Send only tool names/descriptions first, hydrate schemas on demand
+- **Guardrails** — `max_turns` and `max_tool_calls` prevent runaway loops
+- **Observability** — `result.trace` tracks every tool call with latency
+
+See `examples/python_agent_nodes/tool_calling/` for a complete orchestrator + worker example.
+
 ## Human-in-the-Loop Approvals
 
 The Python SDK provides a first-class waiting state for pausing agent execution mid-reasoner and waiting for human approval:

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -39,6 +39,50 @@ const limiter = new StatelessRateLimiter({ maxRetries: 3, baseDelay: 0.5 });
 const result = await limiter.executeWithRetry(() => makeAiCall());
 ```
 
+## AI Tool Calling
+
+Let LLMs automatically discover and invoke agent capabilities:
+
+```ts
+import { Agent } from '@agentfield/sdk';
+import type { ToolCallConfig } from '@agentfield/sdk';
+
+const agent = new Agent({
+  nodeId: 'orchestrator',
+  agentFieldUrl: 'http://localhost:8080',
+  aiConfig: { provider: 'openrouter', model: 'openai/gpt-4o-mini' },
+});
+
+agent.reasoner('ask', async (ctx) => {
+  // Auto-discover all tools and let the LLM use them
+  const { text, trace } = await ctx.aiWithTools(ctx.input.question, {
+    tools: 'discover',
+    system: 'You are a helpful assistant.',
+  });
+
+  console.log(`Tool calls: ${trace.totalToolCalls}, Turns: ${trace.totalTurns}`);
+  return { answer: text };
+});
+
+// Filter by tags, set guardrails
+agent.reasoner('weather', async (ctx) => {
+  const { text } = await ctx.aiWithTools(ctx.input.cities, {
+    tools: { tags: ['weather'] } satisfies ToolCallConfig,
+    maxTurns: 3,
+    maxToolCalls: 5,
+  });
+  return { report: text };
+});
+```
+
+**Key features:**
+- `tools: 'discover'` — Auto-discover all capabilities from the control plane
+- `ToolCallConfig` — Filter by tags, agent IDs; lazy/eager schema hydration
+- **Guardrails** — `maxTurns` and `maxToolCalls` prevent runaway loops
+- **Observability** — `trace` tracks every tool call with latency
+
+See `examples/ts_agent_nodes/tool_calling/` for a complete orchestrator + worker example.
+
 ## Execution Notes
 
 Log execution progress with `ctx.note(message: string, tags?: string[])` for fire-and-forget debugging in the AgentField UI.


### PR DESCRIPTION
## Summary

Documents the native LLM tool-calling feature from #228 in all relevant READMEs:

- **Main README**: Added tool calling to Key Features section with code example showing `tools="discover"` and observability trace
- **Python SDK README**: Full section covering auto-discovery, `ToolCallConfig` filtering, lazy hydration, guardrails, and observability
- **TypeScript SDK README**: Full section covering `ctx.aiWithTools()`, `ToolCallConfig`, guardrails, and trace observability
- **Go SDK README**: Section covering `CapabilitiesToToolDefinitions`, `ExecuteToolCallLoop`, `ToolCallTrace`

All examples use real API patterns from the actual implementation and reference the example code in `examples/`.

## Test plan

- [x] Verified code examples match actual SDK API signatures
- [x] README renders correctly in GitHub preview
- [x] No existing content was removed or broken

## Related

- Companion website-docs PR: Agent-Field/website-docs (docs/tool-calling branch)
- Implementation: #228

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>