### PR TITLE
fix(ui): center sidebar nav icons when collapsed

### DIFF
--- a/control-plane/web/client/src/components/Navigation/SidebarNew.tsx
+++ b/control-plane/web/client/src/components/Navigation/SidebarNew.tsx
@@ -46,8 +46,9 @@ export function SidebarNew({ sections }: SidebarNewProps) {
         </SidebarMenu>
       </SidebarHeader>
 
-      {/* Content - Add spacing between groups */}
-      <SidebarContent className="space-y-4 px-2">
+      {/* Content — groups provide their own p-2; no extra px here so
+           collapsed icons (32 px) centre inside the 48 px rail. */}
+      <SidebarContent className="space-y-4">
         {sections.map((section) => (
           <SidebarGroup key={section.id} className="space-y-0.5">
             {/* Apply caption styling for clear header differentiation */}


### PR DESCRIPTION
## Summary

- **Fix**: Sidebar navigation icons appeared right-justified instead of horizontally centered when the sidebar was collapsed to icon-only mode.

## Root Cause

Stacked horizontal padding overflowed the 48px collapsed sidebar rail:

```
Collapsed sidebar:  48px (--sidebar-width-icon: 3rem)
├── SidebarContent px-2:  -16px (8px each side)  ← REDUNDANT
├── SidebarGroup p-2:     -16px (8px each side)  ← standard shadcn
└── Available for button:   16px
    But button forced to:   32px (!size-8)  →  OVERFLOWS RIGHT
```

The `px-2` on `SidebarContent` was redundant with `SidebarGroup`'s built-in `p-2` padding. When both applied, the 32px icon buttons had only 16px of available space, causing them to overflow rightward and appear right-justified.

## Fix

Remove `px-2` from `SidebarContent` in `SidebarNew.tsx`. After fix:

```
Collapsed sidebar:  48px
├── SidebarGroup p-2:     -16px (8px each side)
└── Available for button:   32px  =  button size  →  CENTERED ✓
```

The `SidebarGroup` component's own `p-2` padding handles spacing for both expanded and collapsed states — this is the standard shadcn/ui sidebar pattern.

## Changed Files

- `control-plane/web/client/src/components/Navigation/SidebarNew.tsx` — remove redundant `px-2` from `SidebarContent`