### PR TITLE
fix(web-ui): replace vcStatus any casts with shared VCStatusData

### DIFF
--- a/control-plane/web/client/src/components/WorkflowDAG/HoverDetailPanel.tsx
+++ b/control-plane/web/client/src/components/WorkflowDAG/HoverDetailPanel.tsx
@@ -142,8 +142,8 @@ export const HoverDetailPanel = memo(({ node, position, visible }: HoverDetailPa
   const tone = statusTone[toneKey];
 
   // Handle optional fields that may not exist on WorkflowDAGLightweightNode
-  const agentNameField = (node as any).agent_name;
-  const taskNameField = (node as any).task_name;
+  const agentNameField = node.agent_name;
+  const taskNameField = node.task_name;
 
   const agentColor = agentColorManager.getAgentColor(
     agentNameField || node.agent_node_id,

--- a/control-plane/web/client/src/components/execution/CompactExecutionHeader.tsx
+++ b/control-plane/web/client/src/components/execution/CompactExecutionHeader.tsx
@@ -8,6 +8,7 @@ import {
 import { ArrowDown, ArrowUp } from "@/components/ui/icon-bridge";
 import { useNavigate } from "react-router-dom";
 import type { WorkflowExecution } from "../../types/executions";
+import type { VCStatusData } from "../../types/vc";
 import { DIDDisplay } from "../did/DIDDisplay";
 import { Button } from "../ui/button";
 import { CopyButton } from "../ui/copy-button";
@@ -18,13 +19,7 @@ import { normalizeExecutionStatus } from "../../utils/status";
 
 interface CompactExecutionHeaderProps {
   execution: WorkflowExecution;
-  vcStatus?: {
-    has_vc: boolean;
-    vc_id?: string;
-    status: string;
-    created_at?: string;
-    vc_document?: any;
-  } | null;
+  vcStatus?: VCStatusData | null;
   vcLoading?: boolean;
   onClose?: () => void;
 }
@@ -245,7 +240,7 @@ export function CompactExecutionHeader({
               <VerifiableCredentialBadge
                 hasVC={vcStatus.has_vc}
                 status={vcStatus.status}
-                vcData={vcStatus as any}
+                vcData={vcStatus}
                 executionId={execution.execution_id}
                 showCopyButton={false}
                 showVerifyButton={false}

--- a/control-plane/web/client/src/components/execution/EnhancedExecutionHeader.tsx
+++ b/control-plane/web/client/src/components/execution/EnhancedExecutionHeader.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/icon-bridge";
 import { useNavigate } from "react-router-dom";
 import type { WorkflowExecution } from "../../types/executions";
+import type { VCStatusData } from "../../types/vc";
 import { DIDDisplay } from "../did/DIDDisplay";
 import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";
@@ -22,13 +23,7 @@ import { CopyButton } from "../ui/copy-button";
 
 interface EnhancedExecutionHeaderProps {
   execution: WorkflowExecution;
-  vcStatus?: {
-    has_vc: boolean;
-    vc_id?: string;
-    status: string;
-    created_at?: string;
-    vc_document?: any;
-  } | null;
+  vcStatus?: VCStatusData | null;
   vcLoading?: boolean;
   onClose?: () => void;
 }
@@ -326,7 +321,7 @@ export function EnhancedExecutionHeader({
                 <VerifiableCredentialBadge
                   hasVC={vcStatus.has_vc}
                   status={vcStatus.status}
-                  vcData={vcStatus as any}
+                  vcData={vcStatus}
                   executionId={execution.execution_id}
                   showCopyButton={false}
                   showVerifyButton={false}

--- a/control-plane/web/client/src/components/execution/EnhancedModal.tsx
+++ b/control-plane/web/client/src/components/execution/EnhancedModal.tsx
@@ -100,6 +100,10 @@ function EnhancedModal({
 export function DataModal({ isOpen, onClose, title, icon, data }: DataModalProps) {
   const [viewMode, setViewMode] = React.useState<"formatted" | "raw" | "markdown">("formatted");
 
+  const isViewMode = (value: string): value is "formatted" | "raw" | "markdown" => {
+    return value === "formatted" || value === "raw" || value === "markdown";
+  };
+
   const jsonString = React.useMemo(() => {
     try {
       return JSON.stringify(data, null, 2);
@@ -149,7 +153,11 @@ export function DataModal({ isOpen, onClose, title, icon, data }: DataModalProps
         <div className="flex-shrink-0 border-b border-border bg-background/95">
           <Tabs
             value={viewMode}
-            onValueChange={(value) => setViewMode(value as any)}
+            onValueChange={(value) => {
+              if (isViewMode(value)) {
+                setViewMode(value);
+              }
+            }}
             className="w-full"
           >
             <TabsList variant="underline" className="grid w-full grid-cols-3 h-12">

--- a/control-plane/web/client/src/components/execution/ExecutionHeader.tsx
+++ b/control-plane/web/client/src/components/execution/ExecutionHeader.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/icon-bridge";
 import { useNavigate } from "react-router-dom";
 import type { WorkflowExecution } from "../../types/executions";
+import type { VCStatusData } from "../../types/vc";
 import type { CanonicalStatus } from "../../utils/status";
 import { DIDDisplay } from "../did/DIDDisplay";
 import StatusIndicator from "../ui/status-indicator";
@@ -25,13 +26,7 @@ import {
 
 interface ExecutionHeaderProps {
   execution: WorkflowExecution;
-  vcStatus?: {
-    has_vc: boolean;
-    vc_id?: string;
-    status: string;
-    created_at?: string;
-    vc_document?: any;
-  } | null;
+  vcStatus?: VCStatusData | null;
   vcLoading?: boolean;
   onNavigateBack?: () => void;
 }
@@ -271,7 +266,7 @@ export function ExecutionHeader({
                 <VerifiableCredentialBadge
                   hasVC={vcStatus.has_vc}
                   status={vcStatus.status}
-                  vcData={vcStatus as any}
+                  vcData={vcStatus}
                   executionId={execution.execution_id}
                   showCopyButton={false}
                   showVerifyButton={false}

--- a/control-plane/web/client/src/components/execution/ExecutionHero.tsx
+++ b/control-plane/web/client/src/components/execution/ExecutionHero.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/icon-bridge";
 import { useNavigate } from "react-router-dom";
 import type { WorkflowExecution } from "../../types/executions";
+import type { VCStatusData } from "../../types/vc";
 import { DIDDisplay } from "../did/DIDDisplay";
 import { Button } from "../ui/button";
 import { Card, CardContent } from "../ui/card";
@@ -20,16 +21,11 @@ import { CopyButton } from "../ui/copy-button";
 import { ExecutionTimeline } from "./ExecutionTimeline";
 import { statusTone } from "@/lib/theme";
 import { cn } from "@/lib/utils";
+import { normalizeExecutionStatus } from "../../utils/status";
 
 interface ExecutionHeroProps {
   execution: WorkflowExecution;
-  vcStatus?: {
-    has_vc: boolean;
-    vc_id?: string;
-    status: string;
-    created_at?: string;
-    vc_document?: any;
-  } | null;
+  vcStatus?: VCStatusData | null;
   vcLoading?: boolean;
 }
 
@@ -38,13 +34,7 @@ function VCStatusCard({
   vcLoading,
   executionId,
 }: {
-  vcStatus?: {
-    has_vc: boolean;
-    vc_id?: string;
-    status: string;
-    created_at?: string;
-    vc_document?: any;
-  } | null;
+  vcStatus?: VCStatusData | null;
   vcLoading?: boolean;
   executionId: string;
 }) {
@@ -69,7 +59,7 @@ function VCStatusCard({
           <VerifiableCredentialBadge
             hasVC={vcStatus.has_vc}
             status={vcStatus.status}
-            vcData={vcStatus as any}
+            vcData={vcStatus}
             executionId={executionId}
             showCopyButton={true}
             showVerifyButton={true}
@@ -134,7 +124,7 @@ export function ExecutionHero({
                   {execution.reasoner_id}
                 </h1>
                 <StatusIndicator
-                  status={execution.status as any}
+                  status={normalizeExecutionStatus(execution.status)}
                   animated={execution.status === "running"}
                   className="text-base"
                 />

--- a/control-plane/web/client/src/components/execution/ExecutionIdentityPanel.tsx
+++ b/control-plane/web/client/src/components/execution/ExecutionIdentityPanel.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Shield, ExternalLink, AlertCircle, CheckCircle, Eye, Download, Loader2 } from "@/components/ui/icon-bridge";
 import { ResponsiveGrid } from "@/components/layout/ResponsiveGrid";
 import type { WorkflowExecution } from "../../types/executions";
+import type { VCStatusData } from "../../types/vc";
 import { DIDDisplay } from "../did/DIDDisplay";
 import { Button } from "../ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
@@ -13,13 +14,7 @@ import { CopyButton } from "../ui/copy-button";
 
 interface ExecutionIdentityPanelProps {
   execution: WorkflowExecution;
-  vcStatus?: {
-    has_vc: boolean;
-    vc_id?: string;
-    status: string;
-    created_at?: string;
-    vc_document?: any;
-  } | null;
+  vcStatus?: VCStatusData | null;
   vcLoading?: boolean;
 }
 
@@ -166,7 +161,7 @@ export function ExecutionIdentityPanel({
                     <VerifiableCredentialBadge
                       hasVC={vcStatus.has_vc}
                       status={vcStatus.status}
-                      vcData={vcStatus as any}
+                      vcData={vcStatus}
                       executionId={execution.execution_id}
                       showCopyButton={false}
                       showVerifyButton={false}

--- a/control-plane/web/client/src/components/layout/ResponsiveGrid.tsx
+++ b/control-plane/web/client/src/components/layout/ResponsiveGrid.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type ElementType, type HTMLAttributes } from "react";
+import { forwardRef, type ElementType, type HTMLAttributes, type Ref } from "react";
 import { cn } from "@/lib/utils";
 
 type Breakpoint = "base" | "sm" | "md" | "lg" | "xl" | "2xl";
@@ -330,7 +330,7 @@ const ResponsiveGridItem = forwardRef<HTMLDivElement, ResponsiveGridItemProps>(
 
     return (
       <Component
-        ref={ref as any}
+        ref={ref as Ref<HTMLDivElement>}
         className={cn(spanClasses, className)}
         {...props}
       >

--- a/control-plane/web/client/src/components/reasoners/EnhancedJsonViewer.tsx
+++ b/control-plane/web/client/src/components/reasoners/EnhancedJsonViewer.tsx
@@ -14,7 +14,7 @@ import { SmartStringRenderer } from './SmartStringRenderer';
 import { JsonModal } from './JsonModal';
 
 interface EnhancedJsonViewerProps {
-  data: any;
+  data: unknown;
   title?: string;
   className?: string;
   maxInlineHeight?: number;
@@ -22,7 +22,7 @@ interface EnhancedJsonViewerProps {
 
 interface JsonItem {
   key: string;
-  value: any;
+  value: unknown;
   type: 'string' | 'number' | 'boolean' | 'array' | 'object' | 'null';
   path: string[];
   isExpandable: boolean;
@@ -36,7 +36,7 @@ export function EnhancedJsonViewer({
   const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
   const [modalState, setModalState] = useState<{
     isOpen: boolean;
-    content: any;
+    content: unknown | null;
     path: string[];
     title: string;
   }>({
@@ -56,7 +56,7 @@ export function EnhancedJsonViewer({
     setExpandedItems(newExpanded);
   };
 
-  const openModal = (content: any, path: string[], itemTitle: string) => {
+  const openModal = (content: unknown, path: string[], itemTitle: string) => {
     setModalState({
       isOpen: true,
       content,
@@ -74,12 +74,12 @@ export function EnhancedJsonViewer({
     });
   };
 
-  const copyToClipboard = (content: any) => {
+  const copyToClipboard = (content: unknown) => {
     const text = typeof content === 'string' ? content : JSON.stringify(content, null, 2);
     navigator.clipboard.writeText(text);
   };
 
-  const processJsonData = (obj: any, parentPath: string[] = []): JsonItem[] => {
+  const processJsonData = (obj: unknown, parentPath: string[] = []): JsonItem[] => {
     if (obj === null || obj === undefined) {
       return [];
     }
@@ -88,7 +88,7 @@ export function EnhancedJsonViewer({
       return [{
         key: 'value',
         value: obj,
-        type: typeof obj as any,
+        type: typeof obj as JsonItem["type"],
         path: parentPath,
         isExpandable: false
       }];
@@ -113,7 +113,7 @@ export function EnhancedJsonViewer({
       return {
         key,
         value,
-        type: type as any,
+        type: type as JsonItem["type"],
         path,
         isExpandable: type === 'object' || type === 'array'
       };
@@ -133,50 +133,56 @@ export function EnhancedJsonViewer({
     const isExpanded = expandedItems.has(itemKey);
 
     switch (item.type) {
-      case 'string':
+      case 'string': {
+        const stringValue = typeof item.value === 'string' ? item.value : String(item.value);
         return (
           <SmartStringRenderer
-            content={item.value}
+            content={stringValue}
             label={item.key}
             path={item.path}
-            onOpenModal={() => openModal(item.value, item.path, formatLabel(item.key))}
+            onOpenModal={() => openModal(stringValue, item.path, formatLabel(item.key))}
             maxInlineHeight={maxInlineHeight}
           />
         );
+      }
 
-      case 'number':
+      case 'number': {
+        const numberValue = typeof item.value === 'number' ? item.value : Number(item.value ?? 0);
         return (
           <div className="flex items-center gap-2">
             <span className="text-sm font-mono text-foreground">
-              {item.value.toLocaleString()}
+              {numberValue.toLocaleString()}
             </span>
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => copyToClipboard(item.value)}
+              onClick={() => copyToClipboard(numberValue)}
               className="h-6 w-6 p-0"
             >
               <Copy className="h-3 w-3" />
             </Button>
           </div>
         );
+      }
 
-      case 'boolean':
+      case 'boolean': {
+        const boolValue = Boolean(item.value);
         return (
           <div className="flex items-center gap-2">
-            <Badge variant={item.value ? "default" : "secondary"} className="text-xs">
-              {item.value ? 'true' : 'false'}
+            <Badge variant={boolValue ? "default" : "secondary"} className="text-xs">
+              {boolValue ? 'true' : 'false'}
             </Badge>
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => copyToClipboard(item.value)}
+              onClick={() => copyToClipboard(boolValue)}
               className="h-6 w-6 p-0"
             >
               <Copy className="h-3 w-3" />
             </Button>
           </div>
         );
+      }
 
       case 'null':
         return (
@@ -193,7 +199,8 @@ export function EnhancedJsonViewer({
           </div>
         );
 
-      case 'array':
+      case 'array': {
+        const arrayValue = Array.isArray(item.value) ? item.value : [];
         return (
           <div className="space-y-2">
             <Collapsible open={isExpanded} onOpenChange={() => toggleExpanded(itemKey)}>
@@ -218,7 +225,7 @@ export function EnhancedJsonViewer({
                     Array
                   </span>
                   <Badge variant="secondary" className="text-xs">
-                    {item.value.length} items
+                    {arrayValue.length} items
                   </Badge>
                 </div>
 
@@ -244,7 +251,7 @@ export function EnhancedJsonViewer({
 
               <CollapsibleContent>
                 <div className="ml-6 mt-2 space-y-2">
-                  {item.value.slice(0, 10).map((arrayItem: any, index: number) => (
+                  {arrayValue.slice(0, 10).map((arrayItem: unknown, index: number) => (
                     <div key={index} className="flex items-start gap-2 p-2 bg-muted/30 rounded text-sm">
                       <span className="text-muted-foreground font-mono text-xs mt-0.5 flex-shrink-0">
                         [{index}]
@@ -272,9 +279,9 @@ export function EnhancedJsonViewer({
                       </div>
                     </div>
                   ))}
-                  {item.value.length > 10 && (
+                  {arrayValue.length > 10 && (
                     <div className="text-body-small text-center py-2">
-                      ... and {item.value.length - 10} more items
+                      ... and {arrayValue.length - 10} more items
                     </div>
                   )}
                 </div>
@@ -282,8 +289,12 @@ export function EnhancedJsonViewer({
             </Collapsible>
           </div>
         );
+      }
 
-      case 'object':
+      case 'object': {
+        const objectValue = item.value && typeof item.value === 'object' && !Array.isArray(item.value)
+          ? (item.value as Record<string, unknown>)
+          : {};
         return (
           <div className="space-y-2">
             <Collapsible open={isExpanded} onOpenChange={() => toggleExpanded(itemKey)}>
@@ -308,7 +319,7 @@ export function EnhancedJsonViewer({
                     Object
                   </span>
                   <Badge variant="secondary" className="text-xs">
-                    {Object.keys(item.value).length} keys
+                    {Object.keys(objectValue).length} keys
                   </Badge>
                 </div>
 
@@ -335,7 +346,7 @@ export function EnhancedJsonViewer({
               <CollapsibleContent>
                 <div className="ml-6 mt-2">
                   <EnhancedJsonViewer
-                    data={item.value}
+                    data={objectValue}
                     maxInlineHeight={maxInlineHeight}
                   />
                 </div>
@@ -343,6 +354,7 @@ export function EnhancedJsonViewer({
             </Collapsible>
           </div>
         );
+      }
 
       default:
         return (

--- a/control-plane/web/client/src/components/reasoners/ExecutionQueue.tsx
+++ b/control-plane/web/client/src/components/reasoners/ExecutionQueue.tsx
@@ -1,4 +1,4 @@
-import { useState, forwardRef, useImperativeHandle } from 'react';
+import { useState, forwardRef, useImperativeHandle, type KeyboardEvent, type MouseEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '../ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
@@ -362,7 +362,7 @@ export const ExecutionQueue = forwardRef<ExecutionQueueRef, ExecutionQueueProps>
     }
   };
 
-  const handleExecutionCardClick = (execution: QueuedExecution, event: React.MouseEvent) => {
+  const handleExecutionCardClick = (execution: QueuedExecution, event: MouseEvent<HTMLElement>) => {
     // Prevent navigation if clicking on action buttons
     if ((event.target as HTMLElement).closest('button')) {
       return;
@@ -383,7 +383,7 @@ export const ExecutionQueue = forwardRef<ExecutionQueueRef, ExecutionQueueProps>
     }
   };
 
-  const handleViewDetailsClick = (event: React.MouseEvent, execution: QueuedExecution) => {
+  const handleViewDetailsClick = (event: MouseEvent<HTMLElement>, execution: QueuedExecution) => {
     event.stopPropagation();
     if (execution.execution_id && execution.page_available) {
       handleNavigateToExecution(execution);
@@ -449,10 +449,17 @@ export const ExecutionQueue = forwardRef<ExecutionQueueRef, ExecutionQueueProps>
                 role={execution.execution_id ? "button" : undefined}
                 tabIndex={execution.execution_id ? 0 : undefined}
                 aria-label={execution.execution_id ? `Navigate to execution ${execution.execution_id}` : undefined}
-                onKeyDown={execution.execution_id ? (e) => {
+                onKeyDown={execution.execution_id ? (e: KeyboardEvent<HTMLDivElement>) => {
                   if (e.key === 'Enter' || e.key === ' ') {
                     e.preventDefault();
-                    handleExecutionCardClick(execution, e as any);
+                    if (execution.execution_id && execution.page_available) {
+                      handleNavigateToExecution(execution);
+                    } else {
+                      const isCurrentlySelected = selectedExecution === execution.id;
+                      const newSelection = isCurrentlySelected ? null : execution.id;
+                      setSelectedExecution(newSelection);
+                      onExecutionSelect?.(isCurrentlySelected ? null : execution);
+                    }
                   }
                 } : undefined}
               >
@@ -562,10 +569,17 @@ export const ExecutionQueue = forwardRef<ExecutionQueueRef, ExecutionQueueProps>
                         ? `Execution ${execution.execution_id} page not ready yet`
                         : `View execution details`
                 }
-                onKeyDown={(e) => {
+                onKeyDown={(e: KeyboardEvent<HTMLDivElement>) => {
                   if (e.key === 'Enter' || e.key === ' ') {
                     e.preventDefault();
-                    handleExecutionCardClick(execution, e as any);
+                    if (execution.execution_id && execution.page_available) {
+                      handleNavigateToExecution(execution);
+                    } else {
+                      const isCurrentlySelected = selectedExecution === execution.id;
+                      const newSelection = isCurrentlySelected ? null : execution.id;
+                      setSelectedExecution(newSelection);
+                      onExecutionSelect?.(isCurrentlySelected ? null : execution);
+                    }
                   }
                 }}
               >

--- a/control-plane/web/client/src/components/vc/VerifiableCredentialBadge.tsx
+++ b/control-plane/web/client/src/components/vc/VerifiableCredentialBadge.tsx
@@ -21,11 +21,12 @@ import type {
   WorkflowVC,
   ComprehensiveVCVerificationResult
 } from "../../types/did";
+import type { VCStatusData } from "../../types/vc";
 
 interface VerifiableCredentialBadgeProps {
   hasVC: boolean;
   status: string;
-  vcData?: ExecutionVC | WorkflowVC;
+  vcData?: ExecutionVC | WorkflowVC | VCStatusData;
   workflowId?: string; // For workflow-level VCs
   executionId?: string; // For execution-level VCs
   showCopyButton?: boolean; // Show copy button for detail pages

--- a/control-plane/web/client/src/hooks/useVCVerification.ts
+++ b/control-plane/web/client/src/hooks/useVCVerification.ts
@@ -13,6 +13,7 @@ import {
   getExecutionVCStatus,
   getWorkflowVCStatuses
 } from '../services/vcApi';
+import type { VCStatusData } from '../types/vc';
 
 /**
  * Hook for managing VC verification operations
@@ -169,13 +170,7 @@ export function useAuditTrail(workflowId: string) {
  * Hook for managing execution VC status
  */
 export function useExecutionVCStatus(executionId: string) {
-  const [vcStatus, setVCStatus] = useState<{
-    has_vc: boolean;
-    vc_id?: string;
-    status: string;
-    created_at?: string;
-    vc_document?: any; // Include vc_document for download functionality
-  } | null>(null);
+  const [vcStatus, setVCStatus] = useState<VCStatusData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 

--- a/control-plane/web/client/src/pages/EnhancedExecutionDetailPage.tsx
+++ b/control-plane/web/client/src/pages/EnhancedExecutionDetailPage.tsx
@@ -13,6 +13,7 @@ import { ErrorBoundary } from "../components/ErrorBoundary";
 import { getExecutionDetails, retryExecutionWebhook } from "../services/executionsApi";
 import { getExecutionVCStatus } from "../services/vcApi";
 import type { WorkflowExecution } from "../types/executions";
+import type { VCStatusData } from "../types/vc";
 import { Database, Bug, Shield, Wrench, FileText, RadioTower, Cog, PauseCircle } from "../components/ui/icon-bridge";
 import { Badge } from "../components/ui/badge";
 import { ExecutionWebhookActivity } from "../components/execution/ExecutionWebhookActivity";
@@ -43,16 +44,7 @@ export function EnhancedExecutionDetailPage() {
 
   // Core data state
   const [execution, setExecution] = useState<WorkflowExecution | null>(null);
-  const [vcStatus, setVcStatus] = useState<{
-    has_vc: boolean;
-    vc_id?: string;
-    status: string;
-    created_at?: string;
-    vc_document?: any;
-    storage_uri?: string;
-    document_size_bytes?: number;
-    original_status?: string;
-  } | null>(null);
+  const [vcStatus, setVcStatus] = useState<VCStatusData | null>(null);
   const [loading, setLoading] = useState(true);
   const [vcLoading, setVcLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/control-plane/web/client/src/pages/ExecutionDetailPage.tsx
+++ b/control-plane/web/client/src/pages/ExecutionDetailPage.tsx
@@ -17,6 +17,7 @@ import { Card, CardContent } from "../components/ui/card";
 import { getExecutionDetails } from "../services/executionsApi";
 import { getExecutionVCStatus } from "../services/vcApi";
 import type { WorkflowExecution } from "../types/executions";
+import type { VCStatusData } from "../types/vc";
 
 function InlineCopyButton({ value }: { value: string }) {
   const [copied, setCopied] = useState(false);
@@ -75,13 +76,7 @@ export function ExecutionDetailPage() {
   const { executionId } = useParams<{ executionId: string }>();
   const navigate = useNavigate();
   const [execution, setExecution] = useState<WorkflowExecution | null>(null);
-  const [vcStatus, setVcStatus] = useState<{
-    has_vc: boolean;
-    vc_id?: string;
-    status: string;
-    created_at?: string;
-    vc_document?: any;
-  } | null>(null);
+  const [vcStatus, setVcStatus] = useState<VCStatusData | null>(null);
   const [loading, setLoading] = useState(true);
   const [vcLoading, setVcLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/control-plane/web/client/src/pages/RedesignedExecutionDetailPage.tsx
+++ b/control-plane/web/client/src/pages/RedesignedExecutionDetailPage.tsx
@@ -10,18 +10,13 @@ import { CollapsibleSection } from "../components/execution/CollapsibleSection";
 import { getExecutionDetails } from "../services/executionsApi";
 import { getExecutionVCStatus } from "../services/vcApi";
 import type { WorkflowExecution } from "../types/executions";
+import type { VCStatusData } from "../types/vc";
 import { Settings } from "@/components/ui/icon-bridge";
 
 export function RedesignedExecutionDetailPage() {
   const { executionId } = useParams<{ executionId: string }>();
   const [execution, setExecution] = useState<WorkflowExecution | null>(null);
-  const [vcStatus, setVcStatus] = useState<{
-    has_vc: boolean;
-    vc_id?: string;
-    status: string;
-    created_at?: string;
-    vc_document?: any;
-  } | null>(null);
+  const [vcStatus, setVcStatus] = useState<VCStatusData | null>(null);
   const [loading, setLoading] = useState(true);
   const [vcLoading, setVcLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/control-plane/web/client/src/types/vc.ts
+++ b/control-plane/web/client/src/types/vc.ts
@@ -1,0 +1,11 @@
+import type { ExecutionVC } from "./did";
+
+export interface VCStatusData
+  extends Partial<Pick<ExecutionVC, "storage_uri" | "document_size_bytes">> {
+  has_vc: boolean;
+  vc_id?: string;
+  status: string;
+  created_at?: string;
+  vc_document?: Record<string, unknown>;
+  original_status?: string;
+}

--- a/control-plane/web/client/src/types/workflows.ts
+++ b/control-plane/web/client/src/types/workflows.ts
@@ -126,6 +126,8 @@ export interface WorkflowDAGLightweightNode {
   completed_at?: string;
   duration_ms?: number;
   workflow_depth: number;
+  agent_name?: string;
+  task_name?: string;
 }
 
 export interface WorkflowDAGLightweightResponse {


### PR DESCRIPTION
# Summary

Fixes #233 by removing `vcStatus as any` usage across execution components and replacing related TSX `as any` casts called out in the issue.

### What changed

- Added shared `VCStatusData` type:
  - `control-plane/web/client/src/types/vc.ts`
- Updated execution components/pages/hooks to use `VCStatusData` instead of inline `any`-shaped objects:
  - `CompactExecutionHeader.tsx`
  - `ExecutionHeader.tsx`
  - `EnhancedExecutionHeader.tsx`
  - `ExecutionIdentityPanel.tsx`
  - `ExecutionHero.tsx`
  - `ExecutionDetailPage.tsx`
  - `EnhancedExecutionDetailPage.tsx`
  - `RedesignedExecutionDetailPage.tsx`
  - `useVCVerification.ts`
- Updated `VerifiableCredentialBadge` to accept `VCStatusData` in `vcData`.
- Removed remaining TSX `as any` patterns listed in #233:
  - `HoverDetailPanel.tsx` (typed `agent_name`/`task_name` via `WorkflowDAGLightweightNode`)
  - `ExecutionQueue.tsx` (typed keyboard/mouse event handlers)
  - `EnhancedJsonViewer.tsx` (typed conversions instead of `as any`)
  - `EnhancedModal.tsx` (typed tab value guard)
  - `ResponsiveGrid.tsx` (typed forwarded ref)
- Added optional `agent_name` and `task_name` to `WorkflowDAGLightweightNode`.

## Testing

- [ ] `./scripts/test-all.sh`
- [x] Additional verification (please describe):
  - `npm run build` in `control-plane/web/client` passes.
  - Verified no `as any` remains in the 10 TSX files listed in #233.

## Checklist

- [ ] I updated documentation where applicable.
- [ ] I added or updated tests (or none were needed).
- [ ] I updated `CHANGELOG.md` (or this change does not warrant a changelog entry).

## Screenshots (if UI-related)

N/A (typing/refactor only).

## Related issues

Fixes #233
