### PR TITLE
fix(install): BSD sed compatibility and env var pipe scoping

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -196,8 +196,8 @@ agentfield-X.Y.Z.tar.gz             # Python source distribution
 # Latest stable version
 curl -fsSL https://agentfield.ai/install.sh | bash
 
-# Specific version
-VERSION=v0.1.28 curl -fsSL https://agentfield.ai/install.sh | bash
+# Specific version (VERSION must be set on the bash side of the pipe)
+curl -fsSL https://agentfield.ai/install.sh | VERSION=v0.1.28 bash
 ```
 
 ### Staging Install
@@ -206,11 +206,11 @@ VERSION=v0.1.28 curl -fsSL https://agentfield.ai/install.sh | bash
 # Latest prerelease version (using --staging flag)
 curl -fsSL https://agentfield.ai/install.sh | bash -s -- --staging
 
-# Or using environment variable
-STAGING=1 curl -fsSL https://agentfield.ai/install.sh | bash
+# Or using environment variable (must be on the bash side of the pipe)
+curl -fsSL https://agentfield.ai/install.sh | STAGING=1 bash
 
 # Specific prerelease version
-VERSION=v0.1.28-rc.4 curl -fsSL https://agentfield.ai/install.sh | bash -s -- --staging
+curl -fsSL https://agentfield.ai/install.sh | VERSION=v0.1.28-rc.4 bash -s -- --staging
 ```
 
 **Key differences when using `--staging`:**

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # Usage:
 #   Production:  curl -fsSL https://agentfield.ai/install.sh | bash
 #   Staging:     curl -fsSL https://agentfield.ai/install.sh | bash -s -- --staging
-#   Version pin: VERSION=v1.0.0 curl -fsSL https://agentfield.ai/install.sh | bash
+#   Version pin: curl -fsSL https://agentfield.ai/install.sh | VERSION=v1.0.0 bash
 
 set -e
 
@@ -226,19 +226,20 @@ get_latest_prerelease_version() {
 
   if command -v curl >/dev/null 2>&1; then
     # Get all releases and find the first prerelease
+    # Note: Use [[:space:]]* instead of \s* for macOS BSD sed compatibility
     version=$(curl -fsSL "$releases_url" 2>/dev/null | \
       grep -E '"tag_name"|"prerelease"' | \
       paste - - | \
       grep '"prerelease": true' | \
       head -1 | \
-      sed -E 's/.*"tag_name":\s*"([^"]+)".*/\1/')
+      sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/')
   elif command -v wget >/dev/null 2>&1; then
     version=$(wget -qO- "$releases_url" 2>/dev/null | \
       grep -E '"tag_name"|"prerelease"' | \
       paste - - | \
       grep '"prerelease": true' | \
       head -1 | \
-      sed -E 's/.*"tag_name":\s*"([^"]+)".*/\1/')
+      sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/')
   else
     print_error "Neither curl nor wget found. Please install one of them."
     exit 1


### PR DESCRIPTION
## Summary

Fixes #250 — `install.sh --staging` fails on macOS with malformed URL error.

**Two bugs fixed:**

- **BSD sed `\s` incompatibility**: `get_latest_prerelease_version()` used `\s*` (GNU extension) in the sed regex. macOS BSD sed treats `\s` as literal `s`, so the regex never matches and VERSION gets set to raw JSON. Replaced with POSIX `[[:space:]]*`.

- **Env var pipe scoping in docs**: The documented pattern `VERSION=X curl ... | bash` never worked — POSIX shells scope `VAR=val` to `cmd1` only in a pipeline `cmd1 | cmd2`. Fixed all docs to `curl ... | VERSION=X bash`.

## Changes

| File | What |
|------|------|
| `scripts/install.sh` | `\s*` → `[[:space:]]*` in both curl and wget branches (lines 234, 241); fix version-pin usage comment |
| `docs/RELEASE.md` | Fix 3 documented env var patterns (VERSION, STAGING) to bash side of pipe |

## Testing

```bash
# Before (macOS):
curl -fsSL https://agentfield.ai/install.sh | bash -s -- --staging
# → curl: (3) URL rejected: Malformed input to a URL function

# After:
curl -fsSL https://agentfield.ai/install.sh | bash -s -- --staging
# → Installing STAGING version: v0.1.48-rc.2 ✓
```

Note: The `--staging` flag approach was unaffected by the pipe scoping bug (it's passed as an argument, not an env var). The sed fix is the critical change for `--staging` to work on macOS.