### PR TITLE
feat: add config_management connector capability env var

### DIFF
--- a/control-plane/internal/config/config.go
+++ b/control-plane/internal/config/config.go
@@ -337,6 +337,7 @@ func applyEnvOverrides(cfg *Config) {
 		"AGENTFIELD_CONNECTOR_CAP_REASONER_MANAGEMENT": "reasoner_management",
 		"AGENTFIELD_CONNECTOR_CAP_STATUS_READ":          "status_read",
 		"AGENTFIELD_CONNECTOR_CAP_OBSERVABILITY_CONFIG": "observability_config",
+		"AGENTFIELD_CONNECTOR_CAP_CONFIG_MANAGEMENT":    "config_management",
 	}
 	for envKey, capName := range connectorCapEnvMap {
 		if val := os.Getenv(envKey); val != "" {


### PR DESCRIPTION
## Summary
- Adds `AGENTFIELD_CONNECTOR_CAP_CONFIG_MANAGEMENT` to the env var map for connector capabilities
- This was the only capability domain missing from the env var configuration
- Required for Railway/container deployments where config files aren't used

## Test plan
- [ ] Verify CP starts with `AGENTFIELD_CONNECTOR_CAP_CONFIG_MANAGEMENT=true` and exposes config_management in connector manifest
- [ ] Verify existing capability env vars still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)