### PR TITLE
fix: add config_management to connector capability env var map

### DIFF
--- a/control-plane/internal/config/config.go
+++ b/control-plane/internal/config/config.go
@@ -337,6 +337,7 @@ func applyEnvOverrides(cfg *Config) {
 		"AGENTFIELD_CONNECTOR_CAP_REASONER_MANAGEMENT": "reasoner_management",
 		"AGENTFIELD_CONNECTOR_CAP_STATUS_READ":          "status_read",
 		"AGENTFIELD_CONNECTOR_CAP_OBSERVABILITY_CONFIG": "observability_config",
+		"AGENTFIELD_CONNECTOR_CAP_CONFIG_MANAGEMENT":    "config_management",
 	}
 	for envKey, capName := range connectorCapEnvMap {
 		if val := os.Getenv(envKey); val != "" {


### PR DESCRIPTION
## Summary
- The `connectorCapEnvMap` was missing `config_management`, so `AGENTFIELD_CONNECTOR_CAP_CONFIG_MANAGEMENT` env var was silently ignored
- This caused the Config tab on hax-sdk Live Control to show "endpoint not found" on Railway deployments where connector capabilities are configured via env vars

## Root Cause
The Railway CP had `AGENTFIELD_CONNECTOR_CAP_CONFIG_MANAGEMENT=true` set but the code didn't map it to the `config_management` capability. Additionally, `AGENTFIELD_CONNECTOR_ENABLED` and `AGENTFIELD_CONNECTOR_TOKEN` were missing from the Railway env vars entirely, so connector routes were never registered (returning 404 on all `/api/v1/connector/*` paths).

## Fix
1. Added `config_management` to the env var map in `config.go`
2. Set `AGENTFIELD_CONNECTOR_ENABLED=true` and `AGENTFIELD_CONNECTOR_TOKEN` on Railway CP service

## Test plan
- [ ] Verify connector routes are registered after redeployment
- [ ] Verify Config tab loads without "endpoint not found" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)