### PR TITLE
fix: use status snapshot to prevent agent status flickering

### DIFF
--- a/control-plane/internal/handlers/nodes.go
+++ b/control-plane/internal/handlers/nodes.go
@@ -1151,7 +1151,10 @@ func UpdateLifecycleStatusHandler(storageProvider storage.StorageProvider, uiSer
 	}
 }
 
-// GetNodeStatusHandler handles getting the unified status for a specific node
+// GetNodeStatusHandler handles getting the unified status for a specific node.
+// Uses the snapshot (no live probe) so that status is controlled by the
+// background HealthMonitor which has proper consecutive-failure debouncing.
+// For a live health check, use the POST .../status/refresh endpoint instead.
 func GetNodeStatusHandler(statusManager *services.StatusManager) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
@@ -1172,7 +1175,7 @@ func GetNodeStatusHandler(statusManager *services.StatusManager) gin.HandlerFunc
 			return
 		}
 
-		status, err := statusManager.GetAgentStatus(ctx, nodeID)
+		status, err := statusManager.GetAgentStatusSnapshot(ctx, nodeID, nil)
 		if err != nil {
 			logger.Logger.Error().Err(err).Str("node_id", nodeID).Msg("❌ Failed to get node status")
 			c.JSON(http.StatusNotFound, gin.H{
@@ -1287,7 +1290,7 @@ func BulkNodeStatusHandler(statusManager *services.StatusManager, storageProvide
 		var errors []string
 
 		for _, nodeID := range request.NodeIDs {
-			status, err := statusManager.GetAgentStatus(ctx, nodeID)
+			status, err := statusManager.GetAgentStatusSnapshot(ctx, nodeID, nil)
 			if err != nil {
 				logger.Logger.Warn().Err(err).Str("node_id", nodeID).Msg("⚠️ Failed to get status for node in bulk request")
 				results[nodeID] = gin.H{


### PR DESCRIPTION
## Summary
- Node status GET endpoints now use `GetAgentStatusSnapshot` instead of `GetAgentStatus`, preventing live HTTP health checks on every poll
- Fixes agent status flickering (Active/Offline) in Railway deployments caused by transient network failures between services

## Problem
The UI polls `/api/v1/nodes/:node_id/status` every 3 seconds. `GetAgentStatus` performs a live HTTP health check with only a 1-second cache for active agents, so nearly every poll triggered a probe. A single transient failure immediately returned "offline" — bypassing the HealthMonitor's 3-consecutive-failure debouncing and heartbeat gate.

## Fix
Use `GetAgentStatusSnapshot` which returns the stored status as managed by the background HealthMonitor (proper consecutive-failure tracking + heartbeat gating). The explicit `POST .../status/refresh` endpoint remains for on-demand live checks.

## Test plan
- [ ] Deploy to Railway and verify agent status stops flickering
- [ ] Verify `POST .../status/refresh` still performs live health checks
- [ ] Run `go test ./internal/handlers/...` — all pass

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)