### PR TITLE
fix(sdk): tune rate limiter for fail-fast behavior

### DIFF
--- a/sdk/python/agentfield/rate_limiter.py
+++ b/sdk/python/agentfield/rate_limiter.py
@@ -25,12 +25,12 @@ class StatelessRateLimiter:
 
     def __init__(
         self,
-        max_retries: int = 20,
-        base_delay: float = 1.0,
-        max_delay: float = 300.0,
+        max_retries: int = 5,
+        base_delay: float = 0.5,
+        max_delay: float = 30.0,
         jitter_factor: float = 0.25,
-        circuit_breaker_threshold: int = 10,
-        circuit_breaker_timeout: int = 300,
+        circuit_breaker_threshold: int = 5,
+        circuit_breaker_timeout: int = 30,
     ):
         self.max_retries = max_retries
         self.base_delay = base_delay

--- a/sdk/python/agentfield/types.py
+++ b/sdk/python/agentfield/types.py
@@ -434,27 +434,27 @@ class AIConfig(BaseModel):
 
     # Rate limiting configuration
     rate_limit_max_retries: int = Field(
-        default=20,
-        description="Maximum number of retries for rate limit errors (allows up to ~20 minutes of retries).",
+        default=5,
+        description="Maximum number of retries for rate limit errors.",
     )
     rate_limit_base_delay: float = Field(
-        default=1.0,
+        default=0.5,
         description="Base delay for rate limit exponential backoff in seconds.",
     )
     rate_limit_max_delay: float = Field(
-        default=300.0,
-        description="Maximum delay for rate limit backoff in seconds (5 minutes).",
+        default=30.0,
+        description="Maximum delay for rate limit backoff in seconds.",
     )
     rate_limit_jitter_factor: float = Field(
         default=0.25,
         description="Jitter factor for rate limit backoff (±25% randomization).",
     )
     rate_limit_circuit_breaker_threshold: int = Field(
-        default=10,
+        default=5,
         description="Number of consecutive rate limit failures before opening circuit breaker.",
     )
     rate_limit_circuit_breaker_timeout: int = Field(
-        default=300, description="Circuit breaker timeout in seconds (5 minutes)."
+        default=30, description="Circuit breaker timeout in seconds."
     )
     enable_rate_limit_retry: bool = Field(
         default=True, description="Enable automatic retry for rate limit errors."

--- a/sdk/python/tests/test_ai_config.py
+++ b/sdk/python/tests/test_ai_config.py
@@ -1,4 +1,34 @@
+from agentfield.rate_limiter import StatelessRateLimiter
 from agentfield.types import AIConfig
+
+
+def test_rate_limiter_fail_fast_defaults():
+    """Verify rate limiter defaults are tuned for fail-fast behavior."""
+    limiter = StatelessRateLimiter()
+    assert limiter.max_retries == 5
+    assert limiter.base_delay == 0.5
+    assert limiter.max_delay == 30.0
+    assert limiter.jitter_factor == 0.25
+    assert limiter.circuit_breaker_threshold == 5
+    assert limiter.circuit_breaker_timeout == 30
+
+
+def test_ai_config_rate_limit_defaults_match_limiter():
+    """AIConfig defaults must stay in sync with StatelessRateLimiter defaults."""
+    cfg = AIConfig()
+    assert cfg.rate_limit_max_retries == 5
+    assert cfg.rate_limit_base_delay == 0.5
+    assert cfg.rate_limit_max_delay == 30.0
+    assert cfg.rate_limit_jitter_factor == 0.25
+    assert cfg.rate_limit_circuit_breaker_threshold == 5
+    assert cfg.rate_limit_circuit_breaker_timeout == 30
+
+
+def test_rate_limiter_max_theoretical_wait():
+    """Max theoretical wait with new defaults should be under 3 minutes."""
+    limiter = StatelessRateLimiter()
+    max_wait = limiter.max_retries * limiter.max_delay
+    assert max_wait <= 180, f"Max theoretical wait {max_wait}s exceeds 3 minutes"
 
 
 def test_ai_config_defaults_and_to_dict():

--- a/sdk/typescript/src/ai/RateLimiter.ts
+++ b/sdk/typescript/src/ai/RateLimiter.ts
@@ -39,12 +39,12 @@ export class StatelessRateLimiter {
   protected _circuitOpenTime?: number;
 
   constructor(options: RateLimiterOptions = {}) {
-    this.maxRetries = options.maxRetries ?? 20;
-    this.baseDelay = options.baseDelay ?? 1.0;
-    this.maxDelay = options.maxDelay ?? 300.0;
+    this.maxRetries = options.maxRetries ?? 5;
+    this.baseDelay = options.baseDelay ?? 0.5;
+    this.maxDelay = options.maxDelay ?? 30.0;
     this.jitterFactor = options.jitterFactor ?? 0.25;
-    this.circuitBreakerThreshold = options.circuitBreakerThreshold ?? 10;
-    this.circuitBreakerTimeout = options.circuitBreakerTimeout ?? 300;
+    this.circuitBreakerThreshold = options.circuitBreakerThreshold ?? 5;
+    this.circuitBreakerTimeout = options.circuitBreakerTimeout ?? 30;
 
     this._containerSeed = this._getContainerSeed();
   }


### PR DESCRIPTION
## Summary
- Reduce rate limiter default aggressiveness to prevent 2+ hour workflow runtimes when using rate-limited providers (OpenRouter, etc.)
- Previous defaults: 20 retries, 300s max delay, 300s circuit breaker timeout — caused cascading backoff that compounded across parallel agents
- New defaults: 5 retries, 0.5s base delay, 30s max delay, circuit breaker threshold 5 with 30s timeout
- Max theoretical wait per call drops from ~100 minutes to ~2.5 minutes

### Changes
| Parameter | Before | After |
|-----------|--------|-------|
| `max_retries` | 20 | 5 |
| `base_delay` | 1.0s | 0.5s |
| `max_delay` | 300s | 30s |
| `circuit_breaker_threshold` | 10 | 5 |
| `circuit_breaker_timeout` | 300s | 30s |

Applied consistently across:
- Python `StatelessRateLimiter`
- TypeScript `StatelessRateLimiter`
- Python `AIConfig` Field defaults

## Test plan
- [x] Python rate limiter tests (10 tests pass)
- [x] TypeScript rate limiter tests (9 tests pass)
- [x] AIConfig tests (7 tests pass, 3 new functional tests added)
- [x] All existing tests pass with no regressions
- [ ] Deploy and verify workflow runtime reduction on OpenRouter+MiniMax workloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)