### PR TITLE
fix: prevent async executions stuck in running state

### DIFF
--- a/control-plane/config/agentfield.yaml
+++ b/control-plane/config/agentfield.yaml
@@ -3,9 +3,10 @@ agentfield:
   execution_cleanup:
     enabled: true
     retention_period: 72h
-    cleanup_interval: 1h
+    cleanup_interval: 5m
     batch_size: 200
     preserve_recent_duration: 1h
+    stale_execution_timeout: 10m
   execution_queue:
     agent_call_timeout: 1800s  # Timeout for agent HTTP calls (0s or -1s to disable)
     webhook_timeout: 10s          # Per-attempt timeout for webhook deliveries

--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -608,6 +608,9 @@ class Agent(FastAPI):
         # Manages pending pause/approval futures resolved via webhook callback
         self._pause_manager = _PauseManager()
 
+        # prevent GC of fire-and-forget async execution tasks
+        self._background_tasks: set[asyncio.Task] = set()
+
         # Initialize async execution manager (will be lazily created when needed)
         self._async_execution_manager: Optional[AsyncExecutionManager] = None
 
@@ -1741,13 +1744,16 @@ class Agent(FastAPI):
 
                 execution_id_header = request.headers.get("X-Execution-ID")
                 if execution_id_header and self.agentfield_server:
-                    asyncio.create_task(
+                    task = asyncio.create_task(
                         self._execute_async_with_callback(
                             reasoner_coro=run_reasoner,
                             execution_id=execution_id_header,
                             reasoner_name=reasoner_id,
                         )
                     )
+                    # prevent GC of fire-and-forget tasks
+                    self._background_tasks.add(task)
+                    task.add_done_callback(self._background_tasks.discard)
                     return JSONResponse(
                         status_code=202,
                         content={
@@ -2081,6 +2087,7 @@ class Agent(FastAPI):
                     callback_url,
                     json=safe_payload,
                     headers={"Content-Type": "application/json"},
+                    timeout=30.0,  # longer timeout for critical status callbacks
                 )
                 if 200 <= response.status_code < 300:
                     if self.dev_mode:


### PR DESCRIPTION
## Summary
- **SDK**: Store `asyncio.create_task()` references in a set to prevent GC of fire-and-forget callback tasks; increase callback POST timeout from 10s → 30s for reliability under concurrent load
- **CP config**: Reduce stale execution reaper interval from 1h → 5m and add explicit `stale_execution_timeout: 10m` (was implicit 30m default) so stuck executions are cleaned up within ~15 minutes

## Root cause
When async executions fail, the SDK fires a background task to POST the failure status back to the CP. Under concurrent load (multiple executions failing simultaneously), some callbacks were silently lost due to:
1. Task references not being stored (eligible for GC)
2. 10-second httpx timeout being too aggressive for Railway internal networking

With no callback and a 1-hour cleanup cycle, executions stayed in "running" state for up to 90 minutes.

## Test plan
- [ ] Fire multiple async executions that fail immediately and verify all transition to "failed"
- [ ] Verify stale reaper marks stuck executions within 15 minutes
- [ ] Existing SDK tests pass (`pytest sdk/python/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)