### PR TITLE
revert: remove opencode JSON cost parsing

### DIFF
--- a/sdk/python/agentfield/harness/providers/opencode.py
+++ b/sdk/python/agentfield/harness/providers/opencode.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import os
 import shutil
@@ -78,7 +77,6 @@ class OpenCodeProvider:
                 f"---\n\nUSER REQUEST:\n{prompt}"
             )
 
-        cmd.extend(["-f", "json"])
         cmd.append(effective_prompt)
 
         env: Dict[str, str] = {}
@@ -121,26 +119,7 @@ class OpenCodeProvider:
             shutil.rmtree(temp_data_dir, ignore_errors=True)
 
         api_ms = int((time.monotonic() - start_api) * 1000)
-
-        parsed_cost: float | None = None
-        parsed_prompt_tokens: int | None = None
-        parsed_completion_tokens: int | None = None
-
-        try:
-            json_output = json.loads(stdout.strip())
-            result_text = json_output.get("response", "").strip() or None
-            raw_cost = json_output.get("cost")
-            if raw_cost is not None and float(raw_cost) > 0:
-                parsed_cost = float(raw_cost)
-            raw_pt = json_output.get("prompt_tokens")
-            if raw_pt is not None:
-                parsed_prompt_tokens = int(raw_pt)
-            raw_ct = json_output.get("completion_tokens")
-            if raw_ct is not None:
-                parsed_completion_tokens = int(raw_ct)
-        except (json.JSONDecodeError, ValueError, TypeError):
-            result_text = stdout.strip() if stdout.strip() else None
-
+        result_text = stdout.strip() if stdout.strip() else None
         clean_stderr = strip_ansi(stderr.strip()) if stderr else ""
 
         logger.info(
@@ -173,21 +152,11 @@ class OpenCodeProvider:
             is_error = False
             error_message = None
 
-        if parsed_cost is not None:
-            final_cost = parsed_cost
-        else:
-            final_cost = estimate_cli_cost(
-                model=str(options.get("model", "")),
-                prompt=effective_prompt,
-                result_text=result_text,
-            )
-
-        usage_data = None
-        if parsed_prompt_tokens is not None or parsed_completion_tokens is not None:
-            usage_data = {
-                "prompt_tokens": parsed_prompt_tokens or 0,
-                "completion_tokens": parsed_completion_tokens or 0,
-            }
+        estimated_cost = estimate_cli_cost(
+            model=str(options.get("model", "")),
+            prompt=effective_prompt,
+            result_text=result_text,
+        )
 
         return RawResult(
             result=result_text,
@@ -195,8 +164,7 @@ class OpenCodeProvider:
             metrics=Metrics(
                 duration_api_ms=api_ms,
                 num_turns=1 if result_text else 0,
-                total_cost_usd=final_cost,
-                usage=usage_data,
+                total_cost_usd=estimated_cost,
                 session_id="",
             ),
             is_error=is_error,

--- a/sdk/python/tests/test_harness_provider_opencode.py
+++ b/sdk/python/tests/test_harness_provider_opencode.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 # pyright: reportMissingImports=false
 
-import json
 from typing import Any
 from unittest.mock import patch
 
@@ -43,8 +42,6 @@ async def test_opencode_provider_constructs_command_and_maps_result(
     assert captured["cmd"] == [
         "/usr/local/bin/opencode",
         "run",
-        "-f",
-        "json",
         "hello",
     ]
     assert captured["env"]["A"] == "1"
@@ -128,8 +125,6 @@ async def test_opencode_passes_model_flag(monkeypatch: pytest.MonkeyPatch):
         "run",
         "--model",
         "openai/gpt-5",
-        "-f",
-        "json",
         "hello",
     ]
     assert raw.is_error is False
@@ -170,141 +165,3 @@ async def test_opencode_cost_none_without_model(monkeypatch: pytest.MonkeyPatch)
 
     # No model → estimate_cli_cost gets empty string → returns None
     assert raw.metrics.total_cost_usd is None
-
-
-# ---------------------------------------------------------------------------
-# Functional tests for JSON cost parsing (new opencode -f json output)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.functional
-@pytest.mark.asyncio
-async def test_json_parsing_full_cost_data(monkeypatch: pytest.MonkeyPatch):
-    """JSON output with all cost fields populates metrics correctly."""
-    json_output = json.dumps(
-        {
-            "response": "hello",
-            "cost": 0.04329,
-            "prompt_tokens": 13985,
-            "completion_tokens": 89,
-        }
-    )
-
-    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
-        _ = (env, cwd, timeout)
-        return json_output, "", 0
-
-    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
-
-    provider = OpenCodeProvider(server_url="http://127.0.0.1:9999")
-    raw = await provider.execute("test prompt", {"model": "openai/gpt-4o"})
-
-    assert raw.result == "hello"
-    assert raw.metrics.total_cost_usd == 0.04329
-    assert raw.metrics.usage == {
-        "prompt_tokens": 13985,
-        "completion_tokens": 89,
-    }
-    assert raw.is_error is False
-    assert raw.metrics.num_turns == 1
-
-
-@pytest.mark.functional
-@pytest.mark.asyncio
-async def test_json_without_cost_fields_falls_back_to_estimate(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """JSON output missing cost fields falls back to estimate_cli_cost."""
-    json_output = json.dumps({"response": "some answer"})
-
-    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
-        _ = (env, cwd, timeout)
-        return json_output, "", 0
-
-    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
-
-    with patch(
-        "agentfield.harness.providers.opencode.estimate_cli_cost",
-        return_value=0.002,
-    ) as mock_estimate:
-        provider = OpenCodeProvider(server_url="http://127.0.0.1:9999")
-        raw = await provider.execute("test", {"model": "openai/gpt-4o"})
-
-    assert raw.result == "some answer"
-    assert raw.metrics.total_cost_usd == 0.002
-    assert raw.metrics.usage is None
-    mock_estimate.assert_called_once()
-
-
-@pytest.mark.functional
-@pytest.mark.asyncio
-async def test_plain_text_fallback_pre_json_opencode(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """Plain text (non-JSON) stdout falls back to text result + estimate."""
-
-    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
-        _ = (env, cwd, timeout)
-        return "This is plain text, not JSON.\n", "", 0
-
-    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
-
-    with patch(
-        "agentfield.harness.providers.opencode.estimate_cli_cost",
-        return_value=0.001,
-    ) as mock_estimate:
-        provider = OpenCodeProvider(server_url="http://127.0.0.1:9999")
-        raw = await provider.execute("test", {"model": "openai/gpt-4o"})
-
-    assert raw.result == "This is plain text, not JSON."
-    assert raw.metrics.total_cost_usd == 0.001
-    assert raw.metrics.usage is None
-    mock_estimate.assert_called_once()
-
-
-@pytest.mark.functional
-@pytest.mark.asyncio
-async def test_zero_cost_falls_back_to_estimate(monkeypatch: pytest.MonkeyPatch):
-    """Zero cost in JSON is treated as unknown and falls back to estimate."""
-    json_output = json.dumps(
-        {"response": "answer", "cost": 0, "prompt_tokens": 0, "completion_tokens": 0}
-    )
-
-    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
-        _ = (env, cwd, timeout)
-        return json_output, "", 0
-
-    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
-
-    with patch(
-        "agentfield.harness.providers.opencode.estimate_cli_cost",
-        return_value=0.003,
-    ) as mock_estimate:
-        provider = OpenCodeProvider(server_url="http://127.0.0.1:9999")
-        raw = await provider.execute("test", {"model": "openai/gpt-4o"})
-
-    assert raw.result == "answer"
-    # cost <= 0 → parsed_cost stays None → falls back to estimate
-    assert raw.metrics.total_cost_usd == 0.003
-    mock_estimate.assert_called_once()
-
-
-@pytest.mark.functional
-@pytest.mark.asyncio
-async def test_partial_fields_cost_without_tokens(monkeypatch: pytest.MonkeyPatch):
-    """JSON with cost but no token fields: cost is used, usage is None."""
-    json_output = json.dumps({"response": "answer", "cost": 0.05})
-
-    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
-        _ = (env, cwd, timeout)
-        return json_output, "", 0
-
-    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
-
-    provider = OpenCodeProvider(server_url="http://127.0.0.1:9999")
-    raw = await provider.execute("test", {"model": "openai/gpt-4o"})
-
-    assert raw.result == "answer"
-    assert raw.metrics.total_cost_usd == 0.05
-    assert raw.metrics.usage is None
-    assert raw.is_error is False


### PR DESCRIPTION
## Summary
- Reverts #269 (feat: parse real cost from opencode JSON output)
- The opencode repo is archived, so we can't upstream the Go-side change that surfaces cost/token metrics in `-f json` output
- Without the upstream change, the `-f json` flag and JSON parsing are dead code

## What's kept
- Claude CLI stderr capture (#268) is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)