### PR TITLE
perf(executions): skip large payload columns in all list and aggregate queries

### DIFF
--- a/control-plane/internal/handlers/ui/execution_timeline.go
+++ b/control-plane/internal/handlers/ui/execution_timeline.go
@@ -141,11 +141,12 @@ func (h *ExecutionTimelineHandler) generateTimelineData(ctx context.Context) ([]
 
 	// Get all executions for the last 24 hours
 	filters := types.ExecutionFilter{
-		StartTime:      &startTime,
-		EndTime:        &endTime,
-		Limit:          50000,
-		SortBy:         "started_at",
-		SortDescending: false,
+		StartTime:       &startTime,
+		EndTime:         &endTime,
+		Limit:           50000,
+		SortBy:          "started_at",
+		SortDescending:  false,
+		ExcludePayloads: true,
 	}
 
 	executions, err := h.store.QueryExecutionRecords(ctx, filters)

--- a/control-plane/internal/handlers/ui/executions.go
+++ b/control-plane/internal/handlers/ui/executions.go
@@ -238,11 +238,12 @@ func (h *ExecutionHandler) ListExecutionsHandler(c *gin.Context) {
 	sortDesc := strings.ToLower(c.DefaultQuery("sortOrder", "desc")) != "asc"
 
 	filter := types.ExecutionFilter{
-		AgentNodeID:    &agentID,
-		Limit:          pageSize,
-		Offset:         (page - 1) * pageSize,
-		SortBy:         sortField,
-		SortDescending: sortDesc,
+		AgentNodeID:     &agentID,
+		Limit:           pageSize,
+		Offset:          (page - 1) * pageSize,
+		SortBy:          sortField,
+		SortDescending:  sortDesc,
+		ExcludePayloads: true,
 	}
 	if status != "" {
 		filter.Status = &status
@@ -330,12 +331,13 @@ func (h *ExecutionHandler) GetExecutionsSummaryHandler(c *gin.Context) {
 	}
 
 	filter := types.ExecutionFilter{
-		Limit:          pageSize,
-		Offset:         (page - 1) * pageSize,
-		SortBy:         "started_at",
-		SortDescending: true,
-		StartTime:      startTime,
-		EndTime:        endTime,
+		Limit:           pageSize,
+		Offset:          (page - 1) * pageSize,
+		SortBy:          "started_at",
+		SortDescending:  true,
+		StartTime:       startTime,
+		EndTime:         endTime,
+		ExcludePayloads: true,
 	}
 	if status != "" {
 		filter.Status = &status
@@ -400,9 +402,10 @@ func (h *ExecutionHandler) GetExecutionStatsHandler(c *gin.Context) {
 	runID := strings.TrimSpace(c.Query("workflow_id"))
 
 	filter := types.ExecutionFilter{
-		Limit:          1000,
-		SortBy:         "started_at",
-		SortDescending: true,
+		Limit:           1000,
+		SortBy:          "started_at",
+		SortDescending:  true,
+		ExcludePayloads: true,
 	}
 	if agentID != "" {
 		filter.AgentNodeID = &agentID
@@ -463,10 +466,11 @@ func (h *ExecutionHandler) GetEnhancedExecutionsHandler(c *gin.Context) {
 	offset := (page - 1) * limit
 
 	filter := types.ExecutionFilter{
-		Limit:          limit,
-		Offset:         offset,
-		SortBy:         sanitizeExecutionSortField(c.DefaultQuery("sort_by", "started_at")),
-		SortDescending: strings.ToLower(c.DefaultQuery("sort_order", "desc")) != "asc",
+		Limit:           limit,
+		Offset:          offset,
+		SortBy:          sanitizeExecutionSortField(c.DefaultQuery("sort_by", "started_at")),
+		SortDescending:  strings.ToLower(c.DefaultQuery("sort_order", "desc")) != "asc",
+		ExcludePayloads: true,
 	}
 
 	if status := strings.TrimSpace(c.Query("status")); status != "" {

--- a/control-plane/internal/handlers/ui/recent_activity.go
+++ b/control-plane/internal/handlers/ui/recent_activity.go
@@ -122,10 +122,11 @@ func (h *RecentActivityHandler) GetRecentActivityHandler(c *gin.Context) {
 func (h *RecentActivityHandler) getRecentExecutions(ctx context.Context) ([]ActivityExecution, error) {
 	// Query for the last 20 executions to support dashboard display
 	filters := types.ExecutionFilter{
-		Limit:          20,
-		Offset:         0,
-		SortBy:         "started_at",
-		SortDescending: true,
+		Limit:           20,
+		Offset:          0,
+		SortBy:          "started_at",
+		SortDescending:  true,
+		ExcludePayloads: true,
 	}
 
 	executions, err := h.store.QueryExecutionRecords(ctx, filters)

--- a/control-plane/internal/handlers/ui/workflow_runs.go
+++ b/control-plane/internal/handlers/ui/workflow_runs.go
@@ -256,10 +256,11 @@ func (h *WorkflowRunHandler) GetWorkflowRunDetailHandler(c *gin.Context) {
 	}
 
 	filter := types.ExecutionFilter{
-		RunID:          &runID,
-		SortBy:         "started_at",
-		SortDescending: false,
-		Limit:          10000,
+		RunID:           &runID,
+		SortBy:          "started_at",
+		SortDescending:  false,
+		Limit:           10000,
+		ExcludePayloads: true,
 	}
 
 	executions, err := h.storage.QueryExecutionRecords(ctx, filter)


### PR DESCRIPTION
## Problem

All execution list, stats, and aggregate endpoints were fetching `input_payload` and `result_payload` for every row. In the pr-af deployment these columns average **~1.1 MB per row** (PostgreSQL TOAST). Common endpoints were materialising hundreds of MB per uncached request:

| Endpoint | Rows | ~Transfer |
|---|---|---|
| `GET /executions/enhanced` (main executions page) | 100 | 110 MB |
| `GET /executions/stats` | 1,000 | 1.1 GB |
| `GET /executions/timeline` | 50,000 | 55 GB |
| `GET /runs/:id/detail` | up to 10,000/run | 11 GB |

This caused the `/ui/executions` page and workflow run detail views to be slow to load. Follows the same pattern as #273 (dashboard fix).

## Fix

Set `ExcludePayloads: true` on every `QueryExecutionRecords` call site that does not use the actual payload content. The `ExcludePayloads` flag (added in #273) substitutes `NULL AS input_payload, NULL AS result_payload` in the SQL — same column count, no scan changes needed.

**Changed call sites:**
- `GetEnhancedExecutionsHandler` — `EnhancedExecution` has no payload fields
- `GetExecutionStatsHandler` — only status/duration counts used
- `GetExecutionTimelineHandler` — hourly buckets by status/timing only
- `GetRecentActivityHandler` — `ActivityExecution` has no payload fields
- `ListExecutionsHandler` — `InputSize`/`OutputSize` will show 0 in agent-scoped list (acceptable trade-off)
- `GetExecutionsSummaryHandler` — same
- `GetWorkflowRunDetailHandler` — `BuildWorkflowDAG` uses only IDs, status, timing

**Intentionally unchanged:** `GetExecutionDetailsGlobalHandler` and `GetExecutionDetailsHandler` — the individual execution detail page legitimately needs the full payload for the IO viewer tab.

## Test Plan

- [x] `go build ./...` passes
- [ ] Verify `/ui/executions` page load time is fast after deploy to pr-af
- [ ] Verify individual execution detail (`/ui/executions/:id`) still shows full input/output data
- [ ] Verify workflow run detail (`/ui/workflows/:id`) loads quickly for large runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)