### PR TITLE
fix: Claude Code provider captures response via subtype='success'

### DIFF
--- a/sdk/python/agentfield/harness/providers/claude.py
+++ b/sdk/python/agentfield/harness/providers/claude.py
@@ -98,7 +98,8 @@ class ClaudeCodeProvider:
                 messages.append(msg_dict)
 
                 msg_type = str(msg_dict.get("type", ""))
-                if msg_type == "result":
+                msg_subtype = str(msg_dict.get("subtype", ""))
+                if msg_type == "result" or msg_subtype == "success":
                     raw_result = msg_dict.get("result", msg_dict.get("text", ""))
                     result_text = (
                         raw_result if isinstance(raw_result, str) else str(raw_result)

--- a/sdk/python/tests/test_harness_provider_claude.py
+++ b/sdk/python/tests/test_harness_provider_claude.py
@@ -88,6 +88,51 @@ async def test_execute_maps_options_and_extracts_result(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_execute_extracts_result_from_subtype_success(monkeypatch):
+    """Claude Agent SDK sends subtype='success' instead of type='result'."""
+    from agentfield.harness.providers.claude import ClaudeCodeProvider
+
+    class FakeClaudeAgentOptions:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+    def fake_query(*, prompt: str, options: FakeClaudeAgentOptions):
+        _ = (prompt, options)
+        return _AsyncStream(
+            [
+                {"subtype": "init", "data": {"session_id": "abc"}},
+                {
+                    "content": [{"type": "text", "text": "Hello world"}],
+                    "model": "claude-sonnet-4-6",
+                },
+                {
+                    "subtype": "success",
+                    "duration_ms": 2807,
+                    "is_error": False,
+                    "num_turns": 1,
+                    "session_id": "sess-2",
+                    "total_cost_usd": 0.008,
+                    "result": "Hello world",
+                },
+            ]
+        )
+
+    fake_sdk = ModuleType("claude_agent_sdk")
+    setattr(fake_sdk, "ClaudeAgentOptions", FakeClaudeAgentOptions)
+    setattr(fake_sdk, "query", fake_query)
+    monkeypatch.setitem(__import__("sys").modules, "claude_agent_sdk", fake_sdk)
+
+    provider = ClaudeCodeProvider()
+    raw = await provider.execute("hi", {})
+
+    assert raw.is_error is False
+    assert raw.result == "Hello world"
+    assert raw.metrics.session_id == "sess-2"
+    assert raw.metrics.total_cost_usd == 0.008
+    assert raw.metrics.num_turns == 1
+
+
+@pytest.mark.asyncio
 async def test_execute_returns_error_result_on_query_failure(monkeypatch):
     from agentfield.harness.providers.claude import ClaudeCodeProvider
 


### PR DESCRIPTION
## Summary
- Fix `HarnessResult.result` always being `None` when using the Claude Code provider
- The Claude Agent SDK sends the final result message with `subtype: "success"` (not `type: "result"`), so the provider never matched it
- Added test covering the actual SDK message format

Fixes #252

## Test plan
- [x] Existing tests still pass (legacy `type: "result"` format)
- [x] New test `test_execute_extracts_result_from_subtype_success` verifies the real SDK format
- [ ] Manual verification with `claude-agent-sdk` installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)