### PR TITLE
fix: CLI agent mode review — logging init, flag scoping, dead code

### DIFF
--- a/control-plane/internal/cli/agent_commands.go
+++ b/control-plane/internal/cli/agent_commands.go
@@ -39,9 +39,7 @@ func NewAgentCommand() *cobra.Command {
 		Use:   "agent",
 		Short: "Agent-mode JSON interface for agentic APIs",
 		Long:  "Machine-friendly CLI wrapper around /api/v1/agentic endpoints.",
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		},
-		Args: cobra.ArbitraryArgs,
+		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 || args[0] == "help" {
 				agentOutput(agentHelpData())
@@ -63,6 +61,9 @@ func NewAgentCommand() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 	}
+
+	cmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "json", "Output format: json, compact")
+	cmd.PersistentFlags().IntVarP(&requestTimeout, "timeout", "t", 30, "Request timeout in seconds")
 
 	cmd.AddCommand(newAgentStatusCmd())
 	cmd.AddCommand(newAgentDiscoverCmd())
@@ -454,9 +455,6 @@ func outputAgentJSON(v interface{}) error {
 
 func agentHTTP(method, path string, body interface{}) ([]byte, int, error) {
 	server := strings.TrimRight(GetServerURL(), "/")
-	if server == "" {
-		server = "http://localhost:8080"
-	}
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}

--- a/control-plane/internal/cli/root.go
+++ b/control-plane/internal/cli/root.go
@@ -84,8 +84,6 @@ AI Agent? Run "af agent help" for structured JSON output optimized for programma
 	RootCmd.PersistentFlags().StringVar(&postgresURLFlag, "postgres-url", "", "PostgreSQL connection URL or DSN (implies --storage-mode=postgres)")
 	RootCmd.PersistentFlags().StringVarP(&serverURL, "server", "s", "", "Control plane URL (env: AGENTFIELD_SERVER, default: http://localhost:8080)")
 	RootCmd.PersistentFlags().StringVarP(&apiKey, "api-key", "k", "", "API key for authenticated endpoints (env: AGENTFIELD_API_KEY)")
-	RootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "json", "Output format: json, compact")
-	RootCmd.PersistentFlags().IntVarP(&requestTimeout, "timeout", "t", 30, "Request timeout in seconds")
 
 	cobra.OnInitialize(initConfig)
 

--- a/control-plane/internal/packages/server_url.go
+++ b/control-plane/internal/packages/server_url.go
@@ -2,6 +2,7 @@ package packages
 
 import "os"
 
+// resolveServerURL returns the control plane URL from env vars or default.
 func resolveServerURL() string {
 	if v := os.Getenv("AGENTFIELD_SERVER"); v != "" {
 		return v

--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -491,21 +491,6 @@ class Agent(FastAPI):
         """
         Initialize a new AgentField Agent instance.
 
-        Sets log level to DEBUG if dev_mode is True, else INFO.
-        """
-        # Set logging level based on dev_mode
-        from agentfield.logger import set_log_level
-
-        set_log_level("DEBUG" if dev_mode else "INFO")
-
-        # Resolve control plane URL: explicit param > env vars > default
-        if agentfield_server is None:
-            agentfield_server = os.environ.get(
-                "AGENTFIELD_SERVER",
-                os.environ.get("AGENTFIELD_SERVER_URL", "http://localhost:8080"),
-            )
-
-        """
         Creates a new agent node that can host reasoners (AI-powered functions) and skills
         (deterministic functions) while integrating with the AgentField ecosystem for distributed
         AI workflows and cross-agent communication.
@@ -567,6 +552,18 @@ class Agent(FastAPI):
             memory management, workflow tracking, and server functionality. MCP servers
             are discovered and started automatically if present in the agent directory.
         """
+        # Set logging level based on dev_mode
+        from agentfield.logger import set_log_level
+
+        set_log_level("DEBUG" if dev_mode else "INFO")
+
+        # Resolve control plane URL: explicit param > env vars > default
+        if agentfield_server is None:
+            agentfield_server = os.environ.get(
+                "AGENTFIELD_SERVER",
+                os.environ.get("AGENTFIELD_SERVER_URL", "http://localhost:8080"),
+            )
+
         super().__init__(**kwargs)
 
         self.node_id = node_id


### PR DESCRIPTION
## Summary

Post-merge review fixes for PR #284 (CLI Agent Mode). These issues were found during code review but the PR was merged before the fix commit landed.

## Issues Found & Fixed

### Bug (High)
- **Empty `PersistentPreRun` on agent command silently overrode root `PersistentPreRunE`** — `logger.InitLogger()` was never called for any `af agent *` subcommand. Removed the empty override so cobra traverses to parent's hook.

### Quality (Medium)
- **`--output` and `--timeout` as root PersistentFlags** polluted `af dev`, `af server`, `af run` help text with irrelevant flags. Moved to agent command's local `PersistentFlags`.
- **Redundant server URL fallback in `agentHTTP()`** — dead code since `GetServerURL()` already returns the default. Removed.
- **Python SDK split docstring** — URL resolution code was inserted between two docstrings; the second was an orphaned string literal. Merged into one proper docstring with resolution code after it.

### Low
- Added doc comment to `packages/server_url.go` for parity with `services/server_url.go`.

## Changed Files (4 files, +17/-23)
- `control-plane/internal/cli/agent_commands.go`
- `control-plane/internal/cli/root.go`
- `control-plane/internal/packages/server_url.go`
- `sdk/python/agentfield/agent.py`

## Verification
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test` — 190 tests pass ✅

Relates to #281, #282