### PR TITLE
Added type annotations to Agent.__init__

### DIFF
--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -486,8 +486,8 @@ class Agent(FastAPI):
         enable_did: bool = True,
         local_verification: bool = False,
         verification_refresh_interval: int = 300,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         """
         Initialize a new AgentField Agent instance.
 


### PR DESCRIPTION
Closes #113 

# Summary

Add proper type annotations to the `Agent.__init__` method in the Python SDK to improve type safety and IDE support.

## Changes

- Added `**kwargs: Any` type annotation to `Agent.__init__`
- Added `-> None` return type annotation to `Agent.__init__`

## Acceptance Criteria

- [x] `Agent.__init__` has `-> None` return type
- [x] All parameters have type annotations
- [x] Type checker passes (mypy or pyright)
- [x] Linting passes (`ruff check`)

## Testing

- [x] `ruff check sdk/python/agentfield/agent.py` - All checks passed
- [x] `ruff format sdk/python/agentfield/agent.py` - Formatted correctly
- [x] `pytest sdk/python/` - 282 passed, 1 failed (pre-existing failure in `test_connection_manager.py`, unrelated to this change)

## Checklist

- [x] I updated documentation where applicable. (N/A - no functional changes)
- [x] I added or updated tests (or none were needed). (N/A - typing only)
- [x] I updated `CHANGELOG.md` (or this change does not warrant a changelog entry). (N/A - minor typing fix)