### PR TITLE
fix(web-ui): remove debug console logs

### DIFF
--- a/control-plane/web/client/src/components/NodeCard.tsx
+++ b/control-plane/web/client/src/components/NodeCard.tsx
@@ -45,9 +45,6 @@ const NodeCard = memo(
     const [isHovered, setIsHovered] = useState(false);
     const [actionLoading, setActionLoading] = useState<string | null>(null);
 
-    // Console log to verify we're using the updated build and check node data
-    console.log('🎯 NodeCard: Rendering node with defensive checks - Node ID:', nodeSummary?.id, 'MCP Summary:', nodeSummary?.mcp_summary);
-
     // Get DID status for this node
     const { status: didStatus } = useDIDStatus(nodeSummary.id);
 
@@ -175,7 +172,6 @@ const NodeCard = memo(
       setActionLoading('start');
       try {
         await startAgent(nodeSummary.id);
-        console.log(`Agent ${nodeSummary.id} started successfully`);
       } catch (error) {
         console.error(`Failed to start agent ${nodeSummary.id}:`, error);
       } finally {
@@ -187,7 +183,6 @@ const NodeCard = memo(
       setActionLoading('stop');
       try {
         await stopAgent(nodeSummary.id);
-        console.log(`Agent ${nodeSummary.id} stopped successfully`);
       } catch (error) {
         console.error(`Failed to stop agent ${nodeSummary.id}:`, error);
       } finally {
@@ -199,7 +194,6 @@ const NodeCard = memo(
       setActionLoading('reconcile');
       try {
         await reconcileAgent(nodeSummary.id);
-        console.log(`Agent ${nodeSummary.id} reconciled successfully`);
       } catch (error) {
         console.error(`Failed to reconcile agent ${nodeSummary.id}:`, error);
       } finally {

--- a/control-plane/web/client/src/components/NodesList.tsx
+++ b/control-plane/web/client/src/components/NodesList.tsx
@@ -41,7 +41,6 @@ const NodesList: React.FC = () => {
 
     eventSource.onopen = () => {
       setConnectionStatus('connected');
-      console.log('SSE connection opened.');
     };
 
     eventSource.onerror = (err) => {
@@ -52,7 +51,6 @@ const NodesList: React.FC = () => {
 
     eventSource.addEventListener('node_registered', (event) => {
       const data: NodeEvent = JSON.parse(event.data);
-      console.log('Node registered event:', data);
       setNodes(prevNodes => {
         const newNode = data.node as AgentNodeSummary;
         // Check if node already exists (for updates)
@@ -69,7 +67,6 @@ const NodesList: React.FC = () => {
 
     eventSource.addEventListener('node_health_changed', (event) => {
       const data: NodeEvent = JSON.parse(event.data);
-      console.log('Node health changed event:', data);
       setNodes(prevNodes => {
         const updatedNode = data.node as AgentNodeSummary;
         return prevNodes.map(node =>
@@ -80,20 +77,16 @@ const NodesList: React.FC = () => {
 
     eventSource.addEventListener('node_removed', (event) => {
       const data: NodeEvent = JSON.parse(event.data);
-      console.log('Node removed event:', data);
       setNodes(prevNodes => {
         setTotalCount(prevCount => Math.max(0, prevCount - 1));
         return prevNodes.filter(node => node.id !== (data.node as { id: string }).id);
       });
     });
 
-    eventSource.addEventListener('heartbeat', (event) => {
-      console.log('SSE Heartbeat:', event.data);
-    });
+    eventSource.addEventListener('heartbeat', () => {});
 
     return () => {
       eventSource.close();
-      console.log('SSE connection closed.');
     };
   }, [fetchNodes]);
 

--- a/control-plane/web/client/src/components/WorkflowDAG/AgentLegend.tsx
+++ b/control-plane/web/client/src/components/WorkflowDAG/AgentLegend.tsx
@@ -44,20 +44,17 @@ export function AgentLegend({
 
   // Extract unique agents from current workflow nodes
   const workflowAgents = useMemo(() => {
-    console.log('AgentLegend: Processing nodes:', nodes.length, nodes);
     const agentSet = new Set<string>();
 
     nodes.forEach((node) => {
       const nodeData = node.data as unknown as WorkflowDAGNode;
       const agentName = nodeData.agent_name || nodeData.agent_node_id;
-      console.log('AgentLegend: Node agent:', agentName, nodeData);
       if (agentName) {
         agentSet.add(agentName);
       }
     });
 
     const agents = Array.from(agentSet);
-    console.log('AgentLegend: Extracted agents:', agents);
     return agents;
   }, [nodes]);
 

--- a/control-plane/web/client/src/components/WorkflowDAG/hooks/useNodeDetails.ts
+++ b/control-plane/web/client/src/components/WorkflowDAG/hooks/useNodeDetails.ts
@@ -55,8 +55,6 @@ export function useNodeDetails(executionId?: string): UseNodeDetailsReturn {
     setError(null);
 
     try {
-      // Fetch execution details from the API (using same endpoint as ExecutionDetailPage)
-      console.log(`🔍 SIDEBAR DEBUG: Fetching execution details for ${executionId}`);
       const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api/ui/v1';
       const headers: HeadersInit = {};
       const apiKey = getGlobalApiKey();
@@ -71,7 +69,6 @@ export function useNodeDetails(executionId?: string): UseNodeDetailsReturn {
       }
 
       const data = await response.json();
-      console.log(`🔍 SIDEBAR DEBUG: Raw API response:`, data);
 
       // Transform the API response to match our NodeDetails interface
       // The API returns input_data/output_data, not input/output
@@ -86,10 +83,6 @@ export function useNodeDetails(executionId?: string): UseNodeDetailsReturn {
           tokens_used: data.performance_metrics.tokens_used
         } : undefined
       };
-
-      console.log(`🔍 SIDEBAR DEBUG: Transformed details:`, details);
-      console.log(`🔍 SIDEBAR DEBUG: Input available:`, !!details.input);
-      console.log(`🔍 SIDEBAR DEBUG: Output available:`, !!details.output);
 
       setNodeDetails(details);
       NODE_DETAILS_CACHE.set(executionId, {

--- a/control-plane/web/client/src/components/WorkflowDAG/index.tsx
+++ b/control-plane/web/client/src/components/WorkflowDAG/index.tsx
@@ -1079,8 +1079,6 @@ function decorateEdgesWithStatus(
 
       // Process the data if we have it
       if (data) {
-        console.log("🔍 DAG DEBUG: Processing data:", data);
-        console.log("🔍 DAG DEBUG: Timeline executions:", data.timeline);
 
         const timeline = data.timeline ?? [];
 

--- a/control-plane/web/client/src/components/dashboard/ActivityHeatmap.tsx
+++ b/control-plane/web/client/src/components/dashboard/ActivityHeatmap.tsx
@@ -41,14 +41,6 @@ export function ActivityHeatmap({
           length: heatmapData?.length,
           sample: heatmapData?.[0]?.slice(0, 3),
         });
-      } else {
-        const totalActivity = heatmapData.reduce(
-          (sum, day) => sum + day.reduce((daySum, cell) => daySum + cell.total, 0),
-          0
-        );
-        if (totalActivity > 0) {
-          console.log('[ActivityHeatmap] Heatmap data loaded:', { totalActivity });
-        }
       }
     }
   }, [heatmapData]);

--- a/control-plane/web/client/src/components/execution/AdvancedJsonViewer.tsx
+++ b/control-plane/web/client/src/components/execution/AdvancedJsonViewer.tsx
@@ -368,10 +368,6 @@ export function AdvancedJsonViewer({
 }: AdvancedJsonViewerProps) {
   const [searchTerm, setSearchTerm] = useState("");
 
-  const handleCopy = (value: string, path: string[]) => {
-    console.log(`Copied ${path.join(".")}:`, value);
-  };
-
   return (
     <div
       className={`border border-border rounded-lg bg-background ${className}`}
@@ -399,7 +395,6 @@ export function AdvancedJsonViewer({
           level={0}
           path={[]}
           searchTerm={searchTerm}
-          onCopy={handleCopy}
         />
       </div>
     </div>

--- a/control-plane/web/client/src/components/execution/ExecutionIdentityPanel.tsx
+++ b/control-plane/web/client/src/components/execution/ExecutionIdentityPanel.tsx
@@ -36,8 +36,6 @@ export function ExecutionIdentityPanel({
   const [downloadingBundle, setDownloadingBundle] = useState(false);
 
   const handleVerifyVC = () => {
-    // This would typically open a verification modal or navigate to verification page
-    console.log("Verify VC:", vcStatus?.vc_id);
     // For now, just toggle details
     setShowVCDetails(!showVCDetails);
   };

--- a/control-plane/web/client/src/components/execution/ExecutionStatusBar.tsx
+++ b/control-plane/web/client/src/components/execution/ExecutionStatusBar.tsx
@@ -63,8 +63,6 @@ export function ExecutionStatusBar({
   const theme = getStatusTheme(status);
 
   const handleRetry = () => {
-    // TODO: Implement retry functionality
-    console.log("Retry execution");
   };
 
   const handleShare = () => {

--- a/control-plane/web/client/src/components/ui/UnifiedJsonViewer.tsx
+++ b/control-plane/web/client/src/components/ui/UnifiedJsonViewer.tsx
@@ -423,10 +423,6 @@ export function UnifiedJsonViewer({
 
   const isFlexibleHeight = maxHeight === "none";
 
-  const handleCopy = (value: string, path: string[]) => {
-    console.log(`Copied ${path.join(".")}:`, value);
-  };
-
   return (
     <div
       className={cn(
@@ -515,7 +511,6 @@ export function UnifiedJsonViewer({
               level={0}
               path={[]}
               searchTerm={searchTerm}
-              onCopy={handleCopy}
             />
           </div>
         )}

--- a/control-plane/web/client/src/hooks/useSSE.ts
+++ b/control-plane/web/client/src/hooks/useSSE.ts
@@ -157,7 +157,6 @@ export function useSSE<T = any>(
       let actualEventType = eventType;
       if (data.type && typeof data.type === 'string') {
         actualEventType = data.type;
-        console.log('🔍 SSE: Extracted event type from data:', actualEventType);
       }
 
       const sseEvent: SSEEvent<T> = {
@@ -166,8 +165,6 @@ export function useSSE<T = any>(
         timestamp: new Date(),
         id: event.lastEventId || undefined
       };
-
-      console.log('🔄 SSE: Processing event:', { type: actualEventType, hasData: !!data });
       setLatestEvent(sseEvent);
       setEvents(prev => [...prev.slice(-99), sseEvent]); // Keep last 100 events
     } catch (error) {
@@ -180,8 +177,6 @@ export function useSSE<T = any>(
    */
   const connect = useCallback(() => {
     if (!url || !mountedRef.current) return;
-
-    console.log('🔄 SSE: connect() called for URL:', url);
     closeConnection();
 
     try {
@@ -194,12 +189,9 @@ export function useSSE<T = any>(
 
       const eventSource = new EventSource(finalUrl);
       eventSourceRef.current = eventSource;
-      console.log('🔌 SSE: EventSource created for URL:', finalUrl);
 
       eventSource.onopen = () => {
         if (!mountedRef.current) return;
-
-        console.log('✅ SSE: Connection opened for URL:', url);
         setState(prev => ({
           ...prev,
           connected: true,
@@ -213,8 +205,6 @@ export function useSSE<T = any>(
 
       eventSource.onerror = (error) => {
         if (!mountedRef.current) return;
-
-        console.log('❌ SSE: Connection error for URL:', url, error);
         setState(prev => ({
           ...prev,
           connected: false,
@@ -227,7 +217,6 @@ export function useSSE<T = any>(
         // Only attempt reconnect if the connection was previously established
         // or if this is not a permanent failure
         if (eventSource.readyState === EventSource.CLOSED) {
-          console.log('🔄 SSE: Attempting reconnect for URL:', url);
           attemptReconnect();
         }
       };
@@ -277,20 +266,14 @@ export function useSSE<T = any>(
 
   // Initialize connection when URL changes
   useEffect(() => {
-    console.log('🚀 SSE: Main useEffect triggered for URL:', url, 'Connected:', state.connected);
     if (url && !state.connected && !eventSourceRef.current) {
-      console.log('🔗 SSE: Calling connect() for URL:', url);
       connect();
     } else if (!url) {
-      console.log('🔌 SSE: No URL, closing connection');
       closeConnection();
       setState(prev => ({ ...prev, connected: false }));
-    } else {
-      console.log('🔄 SSE: Skipping connect - already connected or connecting');
     }
 
     return () => {
-      console.log('🧹 SSE: Cleanup called for URL:', url);
       closeConnection();
     };
   }, [url]); // Only depend on URL changes, not the functions

--- a/control-plane/web/client/src/pages/AllReasonersPage.tsx
+++ b/control-plane/web/client/src/pages/AllReasonersPage.tsx
@@ -60,14 +60,11 @@ export function AllReasonersPage() {
   const fetchReasoners = useCallback(
     async (currentFilters: ReasonerFilters) => {
       try {
-        console.log("🔄 fetchReasoners called with filters:", currentFilters);
-        console.trace("🔍 fetchReasoners call stack:");
         setLoading(true);
         setError(null);
         const response = await reasonersApi.getAllReasoners(currentFilters);
         setData(response);
         setLastRefresh(new Date());
-        console.log("✅ fetchReasoners completed successfully");
       } catch (err) {
         console.error("❌ fetchReasoners failed:", err);
         if (err instanceof ReasonersApiError) {
@@ -101,8 +98,6 @@ export function AllReasonersPage() {
 
   // Handle filter changes - this will trigger data fetch
   useEffect(() => {
-    console.log("🔄 useEffect triggered for filters change:", filters);
-    console.trace("🔍 useEffect call stack:");
     fetchReasoners(filters);
   }, [
     filters.status,
@@ -115,20 +110,16 @@ export function AllReasonersPage() {
   useEffect(() => {
     const setupSSE = () => {
       try {
-        console.log("🔄 Setting up SSE connection for reasoners...");
         setSseError(null);
 
         const eventSource = reasonersApi.createEventStream(
           (event) => {
-            console.log("📡 SSE Event received:", event);
             // Handle different event types
             switch (event.type) {
               case "connected":
                 setSseConnected(true);
-                console.log("✅ Reasoner SSE connected successfully");
                 break;
               case "heartbeat":
-                console.log("💓 SSE Heartbeat received - connection alive");
                 // Keep connection alive, no action needed
                 break;
               case "reasoner_online":
@@ -137,39 +128,25 @@ export function AllReasonersPage() {
               case "reasoner_status_changed":
               case "node_status_changed":
               case "reasoners_refresh":
-                // Log events but don't auto-refresh to prevent scroll jumping
-                console.log("📡 Received reasoner update event:", event);
-                console.log("ℹ️ Auto-refresh disabled - use refresh button for latest data");
                 break;
               default:
-                console.log(
-                  "📡 Received unknown event type:",
-                  event.type,
-                  event
-                );
             }
           },
           (error) => {
             console.error("❌ SSE Error occurred:", error);
             setSseConnected(false);
             setSseError(error.message);
-            console.log(
-              "⚠️ SSE connection failed, will rely on manual refresh"
-            );
           },
           () => {
-            console.log("✅ SSE connection established successfully");
             setSseConnected(true);
             setSseError(null);
           }
         );
 
         eventSourceRef.current = eventSource;
-        console.log("📡 SSE EventSource created:", eventSource);
       } catch (error) {
         console.error("❌ Failed to setup SSE:", error);
         setSseError("Failed to establish real-time connection");
-        console.log("⚠️ SSE setup failed, will rely on manual refresh only");
       }
     };
 
@@ -178,7 +155,6 @@ export function AllReasonersPage() {
 
     // Cleanup on unmount
     return () => {
-      console.log("🧹 Cleaning up SSE connection...");
       if (eventSourceRef.current) {
         reasonersApi.closeEventStream(eventSourceRef.current);
         eventSourceRef.current = null;
@@ -194,8 +170,6 @@ export function AllReasonersPage() {
     const event = unifiedStatusEvent || nodeEvent;
     if (!event) return;
 
-    console.log('🔄 AllReasonersPage: Received status event:', event.type, event);
-
     // Handle events that might affect reasoner status (since reasoners depend on nodes)
     switch (event.type) {
       case 'node_unified_status_changed':
@@ -204,13 +178,11 @@ export function AllReasonersPage() {
       case 'node_health_changed':
       case 'node_online':
       case 'node_offline':
-        console.log('📡 Node status changed, reasoners may be affected');
         // Note: We don't auto-refresh to prevent scroll jumping
         // Users can manually refresh to see updated reasoner status
         break;
 
       case 'bulk_status_update':
-        console.log('📡 Bulk status update received');
         // Could trigger a refresh if many nodes are affected
         break;
 

--- a/control-plane/web/client/src/pages/NodeDetailPage.tsx
+++ b/control-plane/web/client/src/pages/NodeDetailPage.tsx
@@ -118,11 +118,6 @@ function NodeDetailPageContent() {
   // Handle SSE events for real-time updates
   useEffect(() => {
     if (latestEvent && latestEvent.data) {
-      console.log(
-        "🔄 SSE: Received event:",
-        latestEvent.type,
-        latestEvent.data
-      );
 
       // Update MCP health data based on event
       if (
@@ -156,12 +151,6 @@ function NodeDetailPageContent() {
   // Handle unified status events for real-time status updates
   useEffect(() => {
     if (!unifiedStatusEvent) return;
-
-    console.log(
-      "🔄 NodeDetailPage: Received unified status event:",
-      unifiedStatusEvent.type,
-      unifiedStatusEvent
-    );
 
     const eventData = unifiedStatusEvent.data;
 
@@ -221,10 +210,6 @@ function NodeDetailPageContent() {
         break;
 
       default:
-        console.log(
-          "Unhandled unified status event type:",
-          unifiedStatusEvent.type
-        );
     }
   }, [unifiedStatusEvent, nodeId]);
 
@@ -294,12 +279,7 @@ function NodeDetailPageContent() {
               console.warn("Failed to fetch MCP health:", mcpData.reason);
             }
 
-            if (metricsData.status === "fulfilled") {
-              // MCP metrics dashboard components have been removed
-              console.log(
-                "MCP metrics data available but dashboard components removed"
-              );
-            } else {
+            if (metricsData.status !== "fulfilled") {
               console.warn("Failed to fetch MCP metrics:", metricsData.reason);
             }
 
@@ -407,9 +387,8 @@ function NodeDetailPageContent() {
     showInfo(`🔄 Reconciling agent ${nodeId} state...`);
 
     try {
-      const result = await reconcileAgent(nodeId);
+      await reconcileAgent(nodeId);
       showSuccess(`✅ Agent ${nodeId} state reconciled successfully!`);
-      console.log("Reconciliation result:", result);
       // Refresh data to get updated status
       fetchData(false);
     } catch (error: any) {
@@ -688,7 +667,6 @@ function NodeDetailPageContent() {
     <StatusRefreshButton
       nodeId={nodeId}
       onRefresh={(status) => {
-        console.log("Node status refreshed:", status);
         if (
           status &&
           typeof status === "object" &&
@@ -733,7 +711,6 @@ function NodeDetailPageContent() {
     <StatusRefreshButton
       nodeId={nodeId}
       onRefresh={(status) => {
-        console.log("Node status refreshed:", status);
         if (
           status &&
           typeof status === "object" &&

--- a/control-plane/web/client/src/pages/NodesPage.tsx
+++ b/control-plane/web/client/src/pages/NodesPage.tsx
@@ -63,12 +63,6 @@ export function NodesPage() {
   const [lastRefresh, setLastRefresh] = useState<Date>(new Date());
   const [showServerlessModal, setShowServerlessModal] = useState(false);
 
-  // Console log to verify we're using the updated build
-  console.log(
-    "🚀 NodesPage: Component loaded with SSE fixes - Build timestamp:",
-    new Date().toISOString()
-  );
-
   // Use the new SSE hook for real-time updates
   const sseHook = useNodeEventsSSE();
   const { connected, reconnecting, latestEvent, reconnect } = sseHook;
@@ -139,12 +133,6 @@ export function NodesPage() {
   useEffect(() => {
     if (!latestEvent) return;
 
-    console.log(
-      "🔄 Frontend: Received node SSE event:",
-      latestEvent.type,
-      latestEvent
-    );
-
     // The new dedicated node event system sends events directly with node data in the 'data' field
     // latestEvent.data contains the NodeEvent structure: { type, node_id, status, timestamp, data }
     const eventData = latestEvent.data;
@@ -155,25 +143,13 @@ export function NodesPage() {
       return;
     }
 
-    const nodeData = eventData?.data || eventData; // Extract node data from the nested structure
-
-    console.log("🔍 Frontend: Event data:", eventData);
-    console.log("🔍 Frontend: Event type:", latestEvent.type);
-    console.log("🔍 Frontend: Node data:", nodeData);
-    console.log("🔍 Frontend: Event structure check:", {
-      hasEventData: !!eventData,
-      hasNestedData: !!eventData?.data,
-      eventDataType: eventData?.type,
-      nodeId: eventData?.node_id,
-    });
+    const nodeData = eventData?.data || eventData;
 
     switch (latestEvent.type) {
       case "node_registered":
-        console.log("🆕 Frontend: Processing node_registered event");
         if (nodeData) {
           setNodes((prevNodes) => {
             const newNode = nodeData as AgentNodeSummary;
-            console.log("🆕 Frontend: New node data:", newNode);
             const existingIndex = prevNodes.findIndex(
               (node) => node.id === newNode.id
             );
@@ -181,11 +157,8 @@ export function NodesPage() {
               // Update existing node
               const updatedNodes = [...prevNodes];
               updatedNodes[existingIndex] = newNode;
-              console.log("🔄 Frontend: Updated existing node:", newNode.id);
               return updatedNodes;
             }
-            // Add new node
-            console.log("➕ Frontend: Added new node:", newNode.id);
             return [...prevNodes, newNode];
           });
         }
@@ -196,20 +169,12 @@ export function NodesPage() {
       case "node_status_updated":
       case "node_status_changed":
       case "node_health_changed":
-        console.log(`🔄 Frontend: Processing ${latestEvent.type} event`);
         if (nodeData) {
           setNodes((prevNodes) => {
             const updatedNode = nodeData as AgentNodeSummary;
-            console.log("🔄 Frontend: Updated node data:", {
-              id: updatedNode.id,
-              health_status: updatedNode.health_status,
-              lifecycle_status: updatedNode.lifecycle_status,
-              last_heartbeat: updatedNode.last_heartbeat,
-            });
             const newNodes = prevNodes.map((node) =>
               node.id === updatedNode.id ? updatedNode : node
             );
-            console.log("🔄 Frontend: Node state updated for:", updatedNode.id);
             return newNodes;
           });
         }
@@ -244,9 +209,6 @@ export function NodesPage() {
 
       // New unified status events
       case "node_unified_status_changed":
-        console.log(
-          "🔄 Frontend: Processing node_unified_status_changed event"
-        );
         if (
           eventData &&
           typeof eventData === "object" &&
@@ -281,7 +243,6 @@ export function NodesPage() {
         break;
 
       case "node_state_transition":
-        console.log("🔄 Frontend: Processing node_state_transition event");
         if (
           eventData &&
           typeof eventData === "object" &&
@@ -310,7 +271,6 @@ export function NodesPage() {
         break;
 
       case "node_status_refreshed":
-        console.log("🔄 Frontend: Processing node_status_refreshed event");
         if (
           eventData &&
           typeof eventData === "object" &&
@@ -344,7 +304,6 @@ export function NodesPage() {
         break;
 
       case "bulk_status_update":
-        console.log("🔄 Frontend: Processing bulk_status_update event");
         // Trigger a full refresh after bulk updates
         fetchNodes();
         break;
@@ -352,27 +311,15 @@ export function NodesPage() {
       case "connected":
       case "heartbeat":
       case "node_heartbeat":
-        // Handle connection and heartbeat events - no action needed
-        console.log(
-          "🔗 Frontend: Connection event received:",
-          latestEvent.type
-        );
         break;
 
       default:
-        console.log("Unhandled event type:", latestEvent.type);
     }
   }, [latestEvent, normalizeHealthStatus, normalizeLifecycleStatus]);
 
   // Handle unified status events
   useEffect(() => {
     if (!unifiedStatusEvent) return;
-
-    console.log(
-      "🔄 Frontend: Received unified status event:",
-      unifiedStatusEvent.type,
-      unifiedStatusEvent
-    );
 
     const eventData = unifiedStatusEvent.data;
 
@@ -443,10 +390,6 @@ export function NodesPage() {
         break;
 
       default:
-        console.log(
-          "Unhandled unified status event type:",
-          unifiedStatusEvent.type
-        );
     }
   }, [unifiedStatusEvent, normalizeHealthStatus, normalizeLifecycleStatus]);
 
@@ -691,8 +634,7 @@ export function NodesPage() {
       <ServerlessRegistrationModal
         isOpen={showServerlessModal}
         onClose={() => setShowServerlessModal(false)}
-        onSuccess={(nodeId) => {
-          console.log("✅ Serverless agent registered:", nodeId);
+        onSuccess={() => {
           fetchNodes();
         }}
       />

--- a/control-plane/web/client/src/pages/PackagesPage.tsx
+++ b/control-plane/web/client/src/pages/PackagesPage.tsx
@@ -107,8 +107,6 @@ const PackagesPageContent: React.FC = () => {
         {
           label: "View Logs",
           onClick: () => {
-            // TODO: Navigate to logs or node detail page
-            console.log(`Navigate to logs for ${pkg.id}`);
           }
         }
       );

--- a/control-plane/web/client/src/pages/ReasonerDetailPage.tsx
+++ b/control-plane/web/client/src/pages/ReasonerDetailPage.tsx
@@ -147,10 +147,7 @@ export function ReasonerDetailPage() {
     setIsExecuting(true);
 
     // Add execution to queue
-    const executionId = executionQueueRef.current.addExecution(
-      formData.input || {}
-    );
-    console.log("Added execution to queue:", executionId);
+    executionQueueRef.current.addExecution(formData.input || {});
 
     // Reset executing state after a brief delay
     setTimeout(() => setIsExecuting(false), 500);

--- a/control-plane/web/client/src/pages/WorkflowDeckGLTestPage.tsx
+++ b/control-plane/web/client/src/pages/WorkflowDeckGLTestPage.tsx
@@ -200,9 +200,6 @@ export function WorkflowDeckGLTestPage() {
             <WorkflowDeckGLView
               nodes={deckData.nodes}
               edges={deckData.edges}
-              onNodeClick={(node) =>
-                console.log("Node selected:", node.execution_id)
-              }
               onNodeHover={(node) => setHoveredNode(node)}
             />
             {hoveredNode && (

--- a/control-plane/web/client/src/pages/WorkflowDetailPage.tsx
+++ b/control-plane/web/client/src/pages/WorkflowDetailPage.tsx
@@ -16,23 +16,6 @@ import { useWorkflowDAGSmart } from "../hooks/useWorkflowDAG";
 import type { WorkflowSummary } from "../types/workflows";
 import type { WorkflowVCChainResponse } from "../types/did";
 
-interface WorkflowDAGNode {
-  workflow_id: string;
-  execution_id: string;
-  agent_node_id: string;
-  reasoner_id: string;
-  status: string;
-  started_at: string;
-  completed_at?: string;
-  duration_ms?: number;
-  parent_workflow_id?: string;
-  parent_execution_id?: string;
-  workflow_depth: number;
-  children?: WorkflowDAGNode[];
-  agent_name?: string;
-  task_name?: string;
-}
-
 export function WorkflowDetailPage() {
   const { workflowId: runId } = useParams<{ workflowId: string }>();
   const navigate = useNavigate();
@@ -123,19 +106,8 @@ export function WorkflowDetailPage() {
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, []);
 
-  const handleExecutionClick = (execution: WorkflowDAGNode) => {
-    console.log("Execution clicked:", execution);
-  };
-
-  const handleNodeSelect = (node: WorkflowDAGNode) => {
-    // TODO: Highlight node in DAG
-    console.log("Node selected:", node);
-  };
-
   const handleTagFilter = (tags: string[]) => {
     setTimelineSelectedTags(tags);
-    // TODO: Apply tag filter to DAG visualization
-    console.log("Tag filter changed:", tags);
   };
 
   // Timeline state handlers
@@ -244,14 +216,12 @@ export function WorkflowDetailPage() {
             dagData={dagData}
             loading={dagLoading}
             error={dagError?.message || null}
-            onExecutionClick={handleExecutionClick}
             className="min-h-[800px]"
           />
         }
         rightColumn={
           <WorkflowTimeline
             nodes={dagData?.timeline || []}
-            onNodeSelect={handleNodeSelect}
             onTagFilter={handleTagFilter}
             className="min-h-[800px]"
             // Lifted state props

--- a/control-plane/web/client/src/services/reasonersApi.ts
+++ b/control-plane/web/client/src/services/reasonersApi.ts
@@ -391,18 +391,15 @@ export const reasonersApi = {
     const url = apiKey
       ? `${API_BASE_URL}/reasoners/events?api_key=${encodeURIComponent(apiKey)}`
       : `${API_BASE_URL}/reasoners/events`;
-    console.log('🔄 Attempting to create SSE connection to:', url);
     const eventSource = new EventSource(url);
 
     eventSource.onopen = () => {
-      console.log('✅ Reasoner SSE connection opened successfully');
       onConnect?.();
     };
 
     eventSource.onmessage = (event) => {
       try {
         const data = JSON.parse(event.data);
-        console.log('📡 Received reasoner event:', data);
         onEvent(data);
       } catch (error) {
         console.error('❌ Failed to parse SSE event data:', error, 'Raw data:', event.data);
@@ -426,7 +423,6 @@ export const reasonersApi = {
   closeEventStream: (eventSource: EventSource): void => {
     if (eventSource) {
       eventSource.close();
-      console.log('🔌 Reasoner SSE connection closed');
     }
   }
 };

--- a/control-plane/web/client/src/services/searchService.ts
+++ b/control-plane/web/client/src/services/searchService.ts
@@ -44,7 +44,6 @@ class SearchService {
       return flattenedResults.sort((a, b) => a.title.localeCompare(b.title));
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {
-        console.log('Search aborted');
         return [];
       }
       console.error('Search failed:', error);

--- a/control-plane/web/client/src/services/vcApi.ts
+++ b/control-plane/web/client/src/services/vcApi.ts
@@ -241,8 +241,6 @@ export async function getExecutionVCStatus(executionId: string): Promise<{
   original_status?: string;
 }> {
   try {
-    // DEBUG: Log the execution ID being requested
-    console.log('DEBUG: getExecutionVCStatus called for executionId:', executionId);
 
     // Try to get execution VC directly from a dedicated endpoint first
     try {
@@ -256,25 +254,18 @@ export async function getExecutionVCStatus(executionId: string): Promise<{
         document_size_bytes?: number;
         original_status?: string;
       }>(`/executions/${executionId}/vc-status`);
-
-      console.log('DEBUG: Direct endpoint response:', result);
       return result;
     } catch (directError) {
       // If direct endpoint doesn't exist, fall back to export method
       console.warn('Direct VC status endpoint not available, using fallback method');
-      console.log('DEBUG: Direct endpoint error:', directError);
 
       const response = await exportVCs({
         limit: 100, // Get more VCs to search through
       });
 
-      console.log('DEBUG: Export VCs response:', response);
-
       const executionVC = response.execution_vcs.find(vc => vc.execution_id === executionId);
 
       if (executionVC) {
-        console.log('DEBUG: Found execution VC in export:', executionVC);
-        console.log('DEBUG: ExecutionVCInfo does not include vc_document field');
         return {
           has_vc: true,
           vc_id: executionVC.vc_id,
@@ -286,8 +277,6 @@ export async function getExecutionVCStatus(executionId: string): Promise<{
           // Note: vc_document is not available in ExecutionVCInfo type
         };
       }
-
-      console.log('DEBUG: No execution VC found in export for executionId:', executionId);
       return {
         has_vc: false,
         status: 'none'
@@ -307,12 +296,9 @@ export async function getExecutionVCStatus(executionId: string): Promise<{
  */
 export async function getExecutionVCDocument(executionId: string): Promise<ExecutionVC> {
   try {
-    console.log('DEBUG: getExecutionVCDocument called for executionId:', executionId);
 
     // Try to get the full execution VC from the backend
     const result = await fetchWrapper<ExecutionVC>(`/executions/${executionId}/vc`);
-
-    console.log('DEBUG: getExecutionVCDocument response:', result);
 
     if (!result.vc_document) {
       throw new Error('VC document not found or not available for download');
@@ -342,7 +328,6 @@ export async function getExecutionVCDocument(executionId: string): Promise<Execu
  */
 export async function getExecutionVCDocumentEnhanced(executionId: string): Promise<any> {
   try {
-    console.log('DEBUG: getExecutionVCDocumentEnhanced called for executionId:', executionId);
 
     // Get the execution VC
     const executionVC = await getExecutionVCDocument(executionId);
@@ -417,8 +402,6 @@ export async function getExecutionVCDocumentEnhanced(executionId: string): Promi
         export_timestamp: new Date().toISOString()
       }
     };
-
-    console.log('DEBUG: Enhanced execution VC chain created:', enhancedChain);
     return enhancedChain;
   } catch (error) {
     console.error('Failed to get enhanced execution VC document:', error);
@@ -455,10 +438,6 @@ export async function getWorkflowAuditTrail(workflowId: string): Promise<AuditTr
  */
 export async function downloadVCDocument(vc: ExecutionVC): Promise<void> {
   try {
-    // DEBUG: Log the VC object to understand what data we have
-    console.log('DEBUG: downloadVCDocument called with VC:', vc);
-    console.log('DEBUG: vc.vc_document type:', typeof vc.vc_document);
-    console.log('DEBUG: vc.vc_document value:', vc.vc_document);
 
     if (!vc.vc_document) {
       console.error('DEBUG: vc_document is missing or undefined');
@@ -468,8 +447,6 @@ export async function downloadVCDocument(vc: ExecutionVC): Promise<void> {
     const vcDocument = typeof vc.vc_document === 'string'
       ? JSON.parse(vc.vc_document)
       : vc.vc_document;
-
-    console.log('DEBUG: Parsed VC document:', vcDocument);
 
     const blob = new Blob([JSON.stringify(vcDocument, null, 2)], {
       type: 'application/json'
@@ -706,7 +683,6 @@ export async function getDIDResolutionBundle(did: string): Promise<{
  */
 export async function downloadDIDResolutionBundle(did: string): Promise<void> {
   try {
-    console.log('DEBUG: downloadDIDResolutionBundle called for DID:', did);
 
     const response = await fetch(`${API_BASE_URL}/did/${encodeURIComponent(did)}/resolution-bundle/download`);
 

--- a/control-plane/web/client/src/utils/elkLayout.ts
+++ b/control-plane/web/client/src/utils/elkLayout.ts
@@ -204,19 +204,11 @@ export const applyElkLayout = async (
       edges: elkEdges,
     };
 
-    console.log('🔍 ELK DEBUG: Input graph:', elkGraph);
-    console.log('🔍 ELK DEBUG: Using algorithm:', algorithm);
-    console.log('🔍 ELK DEBUG: Layout options:', layoutOptions);
-
     // Apply layout
     const layoutedGraph = await elk.layout(elkGraph);
 
-    console.log('🔍 ELK DEBUG: Layouted graph:', layoutedGraph);
-
     // Convert back to ReactFlow format
     const result = convertElkToReactFlow(layoutedGraph, nodes, edges);
-
-    console.log('🔍 ELK DEBUG: Final nodes:', result.nodes.length, result.nodes);
 
     return result;
   } catch (error) {


### PR DESCRIPTION
## Summary
- remove debug `console.log` and `console.trace` statements across the Web UI client
- clean up unused callbacks and empty blocks left behind by those removals so the client still type-checks and builds
- remove the remaining DeckGL test page node-click debug log

Fixes #107.

## Testing
- `rg -n "console\\.(log|trace)\\(" src -g "*.ts" -g "*.tsx"`
- `npm run build`
- `npm test`

## Notes
- `npm run lint` still fails on the current Web UI baseline in pre-existing files such as `src/components/ExecutionViewTabs.tsx`, `src/components/WorkflowDAG/index.tsx`, and `src/services/api.ts`.
- I kept this PR scoped to debug log removal instead of mixing in a repository-wide lint cleanup.
