### PR TITLE
fix(cors): remove wildcard Access-Control-Allow-Origin from SSE handlers

### DIFF
--- a/control-plane/internal/handlers/ui/execution_logs.go
+++ b/control-plane/internal/handlers/ui/execution_logs.go
@@ -81,8 +81,6 @@ func (h *ExecutionLogsHandler) StreamExecutionLogsHandler(c *gin.Context) {
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")
 	c.Header("Connection", "keep-alive")
-	c.Header("Access-Control-Allow-Origin", "*")
-	c.Header("Access-Control-Allow-Headers", "Cache-Control")
 	c.Header("X-Accel-Buffering", "no")
 
 	subscriberID := fmt.Sprintf("exec_logs_%s_%d_%s", executionID, time.Now().UnixNano(), c.ClientIP())

--- a/control-plane/internal/handlers/ui/executions.go
+++ b/control-plane/internal/handlers/ui/executions.go
@@ -57,8 +57,6 @@ func (h *ExecutionHandler) StreamWorkflowNodeNotesHandler(c *gin.Context) {
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")
 	c.Header("Connection", "keep-alive")
-	c.Header("Access-Control-Allow-Origin", "*")
-	c.Header("Access-Control-Allow-Headers", "Cache-Control")
 
 	workflowID := c.Param("workflowId")
 	if workflowID == "" {
@@ -622,7 +620,6 @@ func (h *ExecutionHandler) StreamExecutionEventsHandler(c *gin.Context) {
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")
 	c.Header("Connection", "keep-alive")
-	c.Header("Access-Control-Allow-Origin", "*")
 
 	subscriberID := fmt.Sprintf("ui_exec_events_%d", time.Now().UnixNano())
 	eventBus := h.storage.GetExecutionEventBus()

--- a/control-plane/internal/handlers/ui/mcp.go
+++ b/control-plane/internal/handlers/ui/mcp.go
@@ -257,8 +257,6 @@ func (h *MCPHandler) GetMCPEventsHandler(c *gin.Context) {
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")
 	c.Header("Connection", "keep-alive")
-	c.Header("Access-Control-Allow-Origin", "*")
-	c.Header("Access-Control-Allow-Headers", "Cache-Control")
 
 	// Get the response writer
 	w := c.Writer

--- a/control-plane/internal/handlers/ui/nodes.go
+++ b/control-plane/internal/handlers/ui/nodes.go
@@ -61,8 +61,6 @@ func (h *NodesHandler) StreamNodeEventsHandler(c *gin.Context) {
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")
 	c.Header("Connection", "keep-alive")
-	c.Header("Access-Control-Allow-Origin", "*")
-	c.Header("Access-Control-Allow-Headers", "Cache-Control")
 	c.Header("X-Accel-Buffering", "no") // Disable buffering for Nginx
 
 	// Generate unique subscriber ID

--- a/control-plane/internal/handlers/ui/reasoners.go
+++ b/control-plane/internal/handlers/ui/reasoners.go
@@ -475,8 +475,6 @@ func (h *ReasonersHandler) StreamReasonerEventsHandler(c *gin.Context) {
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")
 	c.Header("Connection", "keep-alive")
-	c.Header("Access-Control-Allow-Origin", "*")
-	c.Header("Access-Control-Allow-Headers", "Cache-Control")
 
 	// Generate unique subscriber ID
 	subscriberID := fmt.Sprintf("reasoner_sse_%d_%s", time.Now().UnixNano(), c.ClientIP())


### PR DESCRIPTION
## Summary

Six SSE handler endpoints hardcode `Access-Control-Allow-Origin: *` and `Access-Control-Allow-Headers: Cache-Control` directly in the handler, bypassing the global `gin-contrib/cors` middleware configured via `agentfield.yaml`. This allows **any origin** to connect to real-time streaming endpoints and read execution data, log streams, node events, MCP events, and reasoner events — regardless of the CORS policy configured by the operator.

This PR removes the per-handler CORS overrides so the router-level middleware handles origin validation consistently across all endpoints, including SSE.

## Problem

The global CORS middleware in `setupRoutes()` (server.go) reads `api.cors.allowed_origins` from configuration and enforces a restricted origin list. However, these SSE handlers set their own headers **after** the middleware runs, overriding it with `*`:

| Handler | File | Line |
|---------|------|------|
| `StreamExecutionLogsHandler` | `execution_logs.go` | 84 |
| `StreamWorkflowNodeNotesHandler` | `executions.go` | 60 |
| `StreamExecutionEventsHandler` | `executions.go` | 625 |
| `GetMCPEventsHandler` | `mcp.go` | 260 |
| `StreamNodeEventsHandler` | `nodes.go` | 64 |
| `StreamReasonerEventsHandler` | `reasoners.go` | 478 |

## Fix

Remove all 6 occurrences of hardcoded `Access-Control-Allow-Origin: *` and `Access-Control-Allow-Headers: Cache-Control` from SSE handlers. The global CORS middleware already handles these headers for all routes, including SSE.

**5 files changed, 11 deletions, 0 additions.**

## Test plan

- [ ] Existing `sse_test.go` passes — the CORS assertion (line 516-520) is already conditional (`if corsOrigin != "" { ... }`) and handles the absence of the header gracefully
- [ ] CI build succeeds
- [ ] SSE endpoints respect the configured `allowed_origins` from `agentfield.yaml` instead of allowing `*`
- [ ] Dashboard SSE connections from configured origins (localhost:3000, localhost:5173, etc.) continue to work normally via the global CORS middleware