### PR TITLE
docs: document hosted CLA bot policy

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -163,6 +163,18 @@ Workflows only run if you changed relevant files:
 - Manually trigger the workflow from GitHub Actions tab
 - Or make a trivial change to trigger it (e.g., add a comment)
 
+### `license/cla` is stuck pending on a bot PR
+- This repository uses the hosted `cla-assistant.io` integration for the
+  `license/cla` status.
+- Bot PRs such as Dependabot cannot sign the CLA interactively.
+- Maintainers must update the hosted CLA Assistant allowlist for approved bot
+  accounts such as `dependabot[bot]`, `github-actions[bot]`, and
+  `renovate[bot]`.
+- Workflow changes in this repo do not update the hosted CLA Assistant
+  configuration. If `license/cla` remains pending after code checks are green,
+  update the external CLA Assistant settings or recheck the PR from the
+  CLA Assistant UI.
+
 ## Getting Help
 
 If you're stuck with failing CI:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -44,6 +44,24 @@ When opening a PR:
 - Include screenshots for UI changes.
 - Link to the issue being resolved.
 
+### CLA Requirements
+
+This repository currently uses the hosted `cla-assistant.io` integration for the
+`license/cla` status check.
+
+- Human contributors must sign the CLA through the link shown on the pull request.
+- Bot-authored pull requests do not have a human signer, so maintainers must
+  allowlist approved bot accounts in the hosted CLA Assistant repository
+  settings.
+- Recommended bot allowlist entries:
+  - `dependabot[bot]`
+  - `github-actions[bot]`
+  - `renovate[bot]`
+
+Important: this CLA gate is not managed from `.github/workflows`. Updating
+repository workflows alone will not clear a pending `license/cla` status from
+the hosted integration.
+
 ## Issue Reporting
 
 - Search existing issues to avoid duplicates.


### PR DESCRIPTION
## Summary
- document that the repository's active `license/cla` check comes from hosted CLA Assistant, not a GitHub Actions workflow
- record the maintainer procedure for allowlisting approved bot accounts such as `dependabot[bot]`
- add branch-protection troubleshooting guidance for bot-authored PRs that are blocked on pending CLA

## Why
Dependabot and other bot-authored PRs cannot complete the hosted CLA flow interactively. The repository needed an in-repo record of the required maintainer-side configuration so this failure mode is understood and repeatable.

## Validation
- reviewed the current workflow set to confirm there is no repo-managed CLA workflow
- verified the repository currently receives the external `license/cla` status on PRs
