### PR TITLE
fix(sdk/python): break tool-call loop early on asyncio.TimeoutError

### DIFF
--- a/sdk/python/agentfield/tool_calling.py
+++ b/sdk/python/agentfield/tool_calling.py
@@ -7,6 +7,7 @@ an automatic tool-call execution loop that dispatches calls via app.call().
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 from dataclasses import dataclass, field
@@ -420,6 +421,7 @@ async def execute_tool_call_loop(
     trace = ToolCallTrace()
     total_calls = 0
     hydrated = not needs_lazy_hydration
+    _timeout_break = False
 
     for turn in range(config.max_turns):
         trace.total_turns = turn + 1
@@ -461,6 +463,7 @@ async def execute_tool_call_loop(
         messages.append(response_message.model_dump())
 
         # Execute each tool call
+        _timeout_break = False
         for tc in tool_calls:
             if total_calls >= config.max_tool_calls:
                 log_warn(
@@ -535,6 +538,29 @@ async def execute_tool_call_loop(
                     f"completed in {record.latency_ms:.0f}ms"
                 )
 
+            except asyncio.TimeoutError as e:
+                record.error = f"TimeoutError: {e}"
+                record.latency_ms = (time.monotonic() - start_time) * 1000
+
+                log_error(f"Tool call timed out: {func_name} - {e}")
+
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tc.id,
+                        "content": json.dumps(
+                            {
+                                "error": f"Tool execution timed out: {e}",
+                                "tool": func_name,
+                            }
+                        ),
+                    }
+                )
+
+                trace.calls.append(record)
+                _timeout_break = True
+                break
+
             except Exception as e:
                 record.error = str(e)
                 record.latency_ms = (time.monotonic() - start_time) * 1000
@@ -551,6 +577,9 @@ async def execute_tool_call_loop(
 
             trace.calls.append(record)
 
+        if _timeout_break:
+            break
+
         # Check if we've hit the tool call limit
         if total_calls >= config.max_tool_calls:
             # Make one final call without tools to get a response
@@ -560,6 +589,9 @@ async def execute_tool_call_loop(
             resp = await make_completion(final_params)
             trace.final_response = getattr(resp.choices[0].message, "content", None)
             return resp, trace
+
+    if _timeout_break:
+        return resp, trace
 
     # Max turns reached - make a final call without tools
     log_warn(f"Max turns reached ({config.max_turns}), requesting final response")

--- a/sdk/python/tests/test_tool_calling_error_paths.py
+++ b/sdk/python/tests/test_tool_calling_error_paths.py
@@ -1,5 +1,4 @@
 # TODO: source bug — see test_malformed_tool_call_missing_arguments_is_reported_and_loop_continues
-# TODO: source bug — see test_tool_execution_timeout_breaks_loop_early
 
 import asyncio
 import json
@@ -194,10 +193,14 @@ async def test_tool_execution_timeout_breaks_loop_early():
         make_completion=make_completion,
     )
 
-    if make_completion.await_count != 1:
-        pytest.skip("source bug: tool timeouts do not break the loop early")
-
+    assert make_completion.await_count == 1, (
+        f"Expected loop to bail after timeout, but make_completion was called "
+        f"{make_completion.await_count} times"
+    )
     assert trace.total_turns == 1
+    assert len(trace.calls) == 1
+    assert trace.calls[0].error is not None
+    assert "TimeoutError" in trace.calls[0].error
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Summary

`execute_tool_call_loop` in `tool_calling.py` now catches `asyncio.TimeoutError` specifically and breaks out of the loop instead of continuing to call the LLM. Timeouts indicate environmental failures that retrying won't fix, so burning additional turns is just wasting cost and latency.

## Testing

- [x] `./scripts/test-all.sh`
- [x] Additional verification (please describe):
  - Ran `pytest tests/test_tool_calling_error_paths.py tests/test_tool_calling.py` (43 tests pass, 0 failures)
  - The previously skipped `test_tool_execution_timeout_breaks_loop_early` now passes

## Checklist

- [ ] I updated documentation where applicable.
- [x] I added or updated tests (or none were needed).
- [x] I updated `CHANGELOG.md` (or this change does not warrant a changelog entry).

## Screenshots (if UI-related)

N/A

## Related issues

Fixes #354

---

![CE](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)