### PR TITLE
fix(ci): allow coverage workflow to pass on fork PRs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -221,6 +221,10 @@ jobs:
 
       - name: Comment coverage report on PR
         if: github.event_name == 'pull_request'
+        # continue-on-error: fork PRs get a read-only GITHUB_TOKEN that
+        # cannot post comments. The coverage gate result is unaffected —
+        # only the PR comment is skipped.
+        continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: coverage-gate
@@ -228,6 +232,7 @@ jobs:
 
       - name: Comment patch coverage report on PR
         if: github.event_name == 'pull_request' && hashFiles('test-reports/coverage/patch-gate-report.md') != ''
+        continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: patch-coverage-gate


### PR DESCRIPTION
## Summary

- Fork PRs get a read-only `GITHUB_TOKEN` that cannot post PR comments
- `marocchino/sticky-pull-request-comment@v2` fails with `Resource not accessible by integration`, marking the entire `coverage-summary` check as failed — even when all tests and gates pass
- Added `continue-on-error: true` to both comment steps so the coverage gate result drives the job outcome, not the comment permission

## Context

This unblocks #381 (and any future fork PRs). The actual coverage gate, tests, and patch-coverage checks all passed on #381 — only the "post comment" step failed.

## Test plan

- [ ] Merge this, then re-run the coverage workflow on #381 — `coverage-summary` should pass
- [ ] Verify non-fork PRs still get coverage comments posted normally