### PR TITLE
ci: allow coverage-summary to pass on fork PRs

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -1,0 +1,48 @@
+name: Coverage Report
+
+# This workflow runs in the context of the base repository,
+# allowing it to post comments on PRs from forks.
+on:
+  workflow_run:
+    workflows: ["Coverage Summary"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Post Coverage Comment
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download coverage-summary artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-summary
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: coverage
+
+      - name: Read PR number
+        id: pr
+        run: |
+          PR=$(cat coverage/pr-number.txt)
+          echo "number=$PR" >> "$GITHUB_OUTPUT"
+
+      - name: Comment coverage gate report
+        if: hashFiles('coverage/gate-report.md') != ''
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.pr.outputs.number }}
+          header: coverage-gate
+          path: coverage/gate-report.md
+
+      - name: Comment patch coverage report
+        if: hashFiles('coverage/patch-gate-report.md') != ''
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.pr.outputs.number }}
+          header: patch-coverage-gate
+          path: coverage/patch-gate-report.md

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -32,7 +32,7 @@ jobs:
           echo "number=$PR" >> "$GITHUB_OUTPUT"
 
       - name: Comment coverage gate report
-        if: hashFiles('coverage/gate-report.md') != ''
+        if: steps.pr.outputs.number != ''
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           number: ${{ steps.pr.outputs.number }}
@@ -40,7 +40,7 @@ jobs:
           path: coverage/gate-report.md
 
       - name: Comment patch coverage report
-        if: hashFiles('coverage/patch-gate-report.md') != ''
+        if: steps.pr.outputs.number != '' && hashFiles('coverage/patch-gate-report.md') != ''
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -220,8 +220,11 @@ jobs:
           retention-days: 7
 
       - name: Comment coverage report on PR
+        # Fork PRs get a read-only GITHUB_TOKEN, so commenting will fail.
+        # Use continue-on-error so the required check still passes.
         if: github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@v2
+        continue-on-error: true
         with:
           header: coverage-gate
           path: test-reports/coverage/gate-report.md
@@ -229,6 +232,7 @@ jobs:
       - name: Comment patch coverage report on PR
         if: github.event_name == 'pull_request' && hashFiles('test-reports/coverage/patch-gate-report.md') != ''
         uses: marocchino/sticky-pull-request-comment@v2
+        continue-on-error: true
         with:
           header: patch-coverage-gate
           path: test-reports/coverage/patch-gate-report.md

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: coverage-${{ github.ref }}
@@ -211,6 +210,10 @@ jobs:
           ./scripts/patch-coverage-gate.sh
         continue-on-error: true
 
+      - name: Save PR metadata for report workflow
+        if: github.event_name == 'pull_request'
+        run: echo '${{ github.event.pull_request.number }}' > test-reports/coverage/pr-number.txt
+
       - name: Upload aggregated coverage artifact
         if: github.event_name != 'merge_group'
         uses: actions/upload-artifact@v4
@@ -218,24 +221,6 @@ jobs:
           name: coverage-summary
           path: test-reports/coverage/
           retention-days: 7
-
-      - name: Comment coverage report on PR
-        # Fork PRs get a read-only GITHUB_TOKEN, so commenting will fail.
-        # Use continue-on-error so the required check still passes.
-        if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
-        continue-on-error: true
-        with:
-          header: coverage-gate
-          path: test-reports/coverage/gate-report.md
-
-      - name: Comment patch coverage report on PR
-        if: github.event_name == 'pull_request' && hashFiles('test-reports/coverage/patch-gate-report.md') != ''
-        uses: marocchino/sticky-pull-request-comment@v2
-        continue-on-error: true
-        with:
-          header: patch-coverage-gate
-          path: test-reports/coverage/patch-gate-report.md
 
       - name: Fail the job if any gate failed
         if: github.event_name != 'merge_group' && (steps.gate.outcome == 'failure' || steps.patch_gate.outcome == 'failure')


### PR DESCRIPTION
## Summary
- Fork PRs (like #381) get a read-only `GITHUB_TOKEN` from GitHub's security policy, causing the `marocchino/sticky-pull-request-comment` steps to fail with `Resource not accessible by integration`
- This makes the `coverage-summary` required check fail even when all coverage gates actually pass
- Adopts the same `workflow_run` pattern already used by the Performance Report workflow ([memory-metrics-report.yml](.github/workflows/memory-metrics-report.yml)), which runs in the base repo context and has write permissions

## Changes
- **coverage.yml**: Remove PR comment steps and `pull-requests: write` permission. Save PR number into the artifact before upload.
- **coverage-report.yml** (new): Triggers on `workflow_run` completion of "Coverage Summary". Downloads the artifact and posts both sticky comments with write permissions.

## Test plan
- [ ] Verify coverage comments still appear on internal PRs
- [ ] Re-run coverage on #381 after merge to confirm the required check passes and comments are posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)