### PR TITLE
fix: flush SSE headers immediately in memory events handler

### DIFF
--- a/control-plane/internal/handlers/memory_events.go
+++ b/control-plane/internal/handlers/memory_events.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"path/filepath"
@@ -9,23 +10,28 @@ import (
 	"time"
 
 	"github.com/Agent-Field/agentfield/control-plane/internal/logger"
-	"github.com/Agent-Field/agentfield/control-plane/internal/storage"
 	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 )
 
+// MemoryEventsStorage captures the storage operations required by MemoryEventsHandler.
+type MemoryEventsStorage interface {
+	SubscribeToMemoryChanges(ctx context.Context, scope, scopeID string) (<-chan types.MemoryChangeEvent, error)
+	GetEventHistory(ctx context.Context, filter types.EventFilter) ([]*types.MemoryChangeEvent, error)
+}
+
 // MemoryEventsHandler handles real-time memory event subscriptions.
 type MemoryEventsHandler struct {
-	storage  storage.StorageProvider
+	storage  MemoryEventsStorage
 	upgrader websocket.Upgrader
 }
 
 // NewMemoryEventsHandler creates a new MemoryEventsHandler.
 // Origin checking is not needed because auth middleware already validates API keys
 // before requests reach this handler.
-func NewMemoryEventsHandler(storage storage.StorageProvider) *MemoryEventsHandler {
+func NewMemoryEventsHandler(storage MemoryEventsStorage) *MemoryEventsHandler {
 	return &MemoryEventsHandler{
 		storage: storage,
 		upgrader: websocket.Upgrader{
@@ -113,32 +119,35 @@ func (h *MemoryEventsHandler) WebSocketHandler(c *gin.Context) {
 // SSEHandler handles Server-Sent Events connections for memory events.
 func (h *MemoryEventsHandler) SSEHandler(c *gin.Context) {
 	ctx := c.Request.Context()
-	// Set headers for SSE
-	c.Writer.Header().Set("Content-Type", "text/event-stream")
-	c.Writer.Header().Set("Cache-Control", "no-cache")
-	c.Writer.Header().Set("Connection", "keep-alive")
 
 	// Parse query parameters for filtering
 	scope := c.Query("scope")
 	scopeID := c.Query("scope_id")
 	patterns := normalizePatterns(c.Query("patterns"))
 
-	// Subscribe to memory changes
+	// Subscribe before writing headers so errors can still return a JSON response.
 	eventChan, err := h.storage.SubscribeToMemoryChanges(ctx, scope, scopeID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to subscribe to events"})
 		return
 	}
 
-	// Create a channel to notify when the client disconnects
-	clientClosed := c.Writer.CloseNotify()
+	// Flush headers immediately so the client unblocks before the first event.
+	c.Writer.Header().Set("Content-Type", "text/event-stream")
+	c.Writer.Header().Set("Cache-Control", "no-cache")
+	c.Writer.Header().Set("Connection", "keep-alive")
+	c.Writer.WriteHeader(http.StatusOK)
+	_, _ = c.Writer.Write([]byte(": connected\n\n"))
+	c.Writer.Flush()
 
 	for {
 		select {
-		case <-clientClosed:
-			// Client disconnected
+		case <-ctx.Done():
 			return
-		case event := <-eventChan:
+		case event, ok := <-eventChan:
+			if !ok {
+				return
+			}
 			// Apply pattern matching
 			if len(patterns) > 0 {
 				match := false
@@ -153,13 +162,11 @@ func (h *MemoryEventsHandler) SSEHandler(c *gin.Context) {
 				}
 			}
 
-			// Marshal event to JSON
 			eventJSON, err := json.Marshal(event)
 			if err != nil {
-				continue // Skip events that can't be marshaled
+				continue
 			}
 
-			// Send event to client
 			c.SSEvent("message", string(eventJSON))
 			c.Writer.Flush()
 		}
@@ -167,7 +174,7 @@ func (h *MemoryEventsHandler) SSEHandler(c *gin.Context) {
 }
 
 // GetEventHistoryHandler handles requests for historical memory events.
-func GetEventHistoryHandler(storage storage.StorageProvider) gin.HandlerFunc {
+func GetEventHistoryHandler(storage MemoryEventsStorage) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		var filter types.EventFilter

--- a/control-plane/internal/handlers/memory_events_test.go
+++ b/control-plane/internal/handlers/memory_events_test.go
@@ -1,0 +1,134 @@
+package handlers
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+// eventsStub is a minimal MemoryEventsStorage for tests.
+type eventsStub struct {
+	ch  chan types.MemoryChangeEvent
+	err error
+}
+
+func (s *eventsStub) SubscribeToMemoryChanges(_ context.Context, _, _ string) (<-chan types.MemoryChangeEvent, error) {
+	return s.ch, s.err
+}
+
+func (s *eventsStub) GetEventHistory(_ context.Context, _ types.EventFilter) ([]*types.MemoryChangeEvent, error) {
+	return nil, nil
+}
+
+func newEventsRouter(stub *eventsStub) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	h := NewMemoryEventsHandler(stub)
+	r := gin.New()
+	r.GET("/sse", h.SSEHandler)
+	r.GET("/ws", h.WebSocketHandler)
+	return r
+}
+
+func TestMemoryEventsHandler_SSEHappyPathHonorsScopeFilter(t *testing.T) {
+	ch := make(chan types.MemoryChangeEvent, 4)
+	stub := &eventsStub{ch: ch}
+	srv := httptest.NewServer(newEventsRouter(stub))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/sse?patterns=match.*", nil)
+	require.NoError(t, err)
+
+	// With headers flushed immediately, Do must return without waiting for an event.
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+
+	// Non-matching event should be silently dropped on the server side.
+	ch <- types.MemoryChangeEvent{Key: "skip.this", Action: "set"}
+	// Matching event should appear in the stream.
+	ch <- types.MemoryChangeEvent{Key: "match.foo", Action: "set"}
+
+	scanner := bufio.NewScanner(resp.Body)
+	var found bool
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "data:") && strings.Contains(line, "match.foo") {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expected match.foo event in SSE stream")
+}
+
+func TestMemoryEventsHandler_SSEInvalidPatternDropsEventsAndDisconnectCleansUp(t *testing.T) {
+	ch := make(chan types.MemoryChangeEvent, 4)
+	stub := &eventsStub{ch: ch}
+	srv := httptest.NewServer(newEventsRouter(stub))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// "[invalid" is a malformed glob — filepath.Match returns ErrBadPattern.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/sse?patterns=[invalid", nil)
+	require.NoError(t, err)
+
+	// Headers are flushed immediately regardless of the pattern.
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Events with bad patterns are dropped; handler must not panic.
+	ch <- types.MemoryChangeEvent{Key: "any.key", Action: "set"}
+
+	// Cancel triggers ctx.Done() in the handler — verify clean exit.
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestMemoryEventsHandler_WebSocketHappyPath(t *testing.T) {
+	ch := make(chan types.MemoryChangeEvent, 2)
+	stub := &eventsStub{ch: ch}
+	srv := httptest.NewServer(newEventsRouter(stub))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer conn.Close() //nolint:errcheck
+
+	ch <- types.MemoryChangeEvent{Key: "ws.key", Action: "set"}
+
+	var event types.MemoryChangeEvent
+	require.NoError(t, conn.ReadJSON(&event))
+	require.Equal(t, "ws.key", event.Key)
+}
+
+func TestMemoryEventsHandler_UpgradeRejection(t *testing.T) {
+	stub := &eventsStub{ch: make(chan types.MemoryChangeEvent)}
+	srv := httptest.NewServer(newEventsRouter(stub))
+	defer srv.Close()
+
+	// Plain HTTP GET to the WS endpoint — upgrader rejects non-upgrade requests.
+	resp, err := http.Get(srv.URL + "/ws") //nolint:noctx
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+	require.NotEqual(t, http.StatusOK, resp.StatusCode)
+}


### PR DESCRIPTION
Fixes #358

## Summary
SSE handler was deferring headers until after subscription, causing clients to hang. Now we subscribe first, then send and flush headers immediately. Also extracted a MemoryEventsStorage interface instead of depending on the full StorageProvider.

## Type of change
Bug fix

## Test plan
Added SSE tests verifying headers are flushed before events, and that subscription errors return JSON responses. Tested locally.

## Test coverage
New tests cover header flush timing and subscription error paths.

## Checklist
- [x] Code follows style guidelines
- [x] Tests added for the fix
- [x] Existing tests pass
- [x] No breaking changes to public API