### PR TITLE
fix: opencode CLI v1.4+ compat — use run subcommand

### DIFF
--- a/sdk/python/agentfield/harness/providers/opencode.py
+++ b/sdk/python/agentfield/harness/providers/opencode.py
@@ -17,7 +17,7 @@ logger = logging.getLogger("agentfield.harness.opencode")
 
 
 class OpenCodeProvider:
-    """OpenCode CLI provider. Invokes ``opencode -p <prompt>`` subprocess."""
+    """OpenCode CLI provider. Invokes ``opencode run`` subprocess (v1.4+)."""
 
     # Global concurrency limiter: prevents too many simultaneous opencode
     # processes from overwhelming the LLM API with concurrent requests.
@@ -46,18 +46,22 @@ class OpenCodeProvider:
             return await self._execute_impl(prompt, options)
 
     async def _execute_impl(self, prompt: str, options: dict[str, object]) -> RawResult:
-        cmd = [self._bin]
+        # opencode v1.4+ uses the `run` subcommand (replaces deprecated -p/-c flags)
+        cmd = [self._bin, "run"]
 
-        # Use -c for cwd (project directory)
+        # Use --dir for project directory (replaces deprecated -c which now means --continue)
         cwd_value = options.get("cwd")
         if isinstance(cwd_value, str):
-            cmd.extend(["-c", cwd_value])
+            cmd.extend(["--dir", cwd_value])
         elif isinstance(options.get("project_dir"), str):
-            # Fall back to project_dir if no cwd
-            cmd.extend(["-c", str(options["project_dir"])])
+            cmd.extend(["--dir", str(options["project_dir"])])
 
-        # Model is set via environment, not CLI flag
-        # (opencode picks up MODEL env var automatically)
+        # Pass model via -m flag on the run subcommand
+        if options.get("model"):
+            cmd.extend(["-m", str(options["model"])])
+
+        # Skip interactive permission prompts for headless execution
+        cmd.append("--dangerously-skip-permissions")
 
         # Handle system prompt - prepend to user prompt since OpenCode
         # has no native --system-prompt flag
@@ -69,8 +73,8 @@ class OpenCodeProvider:
                 f"---\n\nUSER REQUEST:\n{prompt}"
             )
 
-        # Use -p for single prompt mode (non-interactive)
-        cmd.extend(["-p", effective_prompt])
+        # Prompt is a positional arg to `opencode run` (not -p)
+        cmd.append(effective_prompt)
 
         env: Dict[str, str] = {}
         env_value = options.get("env")
@@ -81,9 +85,7 @@ class OpenCodeProvider:
                 if isinstance(key, str) and isinstance(value, str)
             }
 
-        # Set model via environment variable (opencode reads MODEL env var)
-        if options.get("model"):
-            env["MODEL"] = str(options["model"])
+        # Model is passed via -m flag on the run subcommand (see above)
 
         cwd: Optional[str] = None
 

--- a/sdk/python/tests/test_harness_provider_opencode.py
+++ b/sdk/python/tests/test_harness_provider_opencode.py
@@ -40,15 +40,15 @@ async def test_opencode_provider_constructs_command_and_maps_result(
 
     assert captured["cmd"] == [
         "/usr/local/bin/opencode",
-        "-c",
+        "run",
+        "--dir",
         "/tmp/work",
-        "-p",
+        "--dangerously-skip-permissions",
         "hello",
     ]
     assert captured["env"]["A"] == "1"
-    assert "MODEL" not in captured["env"]
     assert "XDG_DATA_HOME" in captured["env"]
-    # Note: cwd is None because we use -c in command instead of cwd param
+    # Note: cwd is None because we use --dir in command instead of cwd param
     assert raw.is_error is False
     assert raw.result == "final text"
     assert raw.metrics.session_id == ""
@@ -122,10 +122,13 @@ async def test_opencode_passes_model_flag(monkeypatch: pytest.MonkeyPatch):
 
     assert captured["cmd"] == [
         "opencode",
-        "-p",
+        "run",
+        "-m",
+        "openai/gpt-5",
+        "--dangerously-skip-permissions",
         "hello",
     ]
-    assert captured["env"]["MODEL"] == "openai/gpt-5"
+    # Model is now passed via -m flag, not environment variable
     assert raw.is_error is False
 
 
@@ -188,14 +191,14 @@ async def test_opencode_command_does_not_use_attach_pattern(
     assert "http://" not in cmd_str
     assert "127.0.0.1" not in cmd_str
     assert "localhost" not in cmd_str
-    assert "opencode -p" in cmd_str
+    assert "opencode run" in cmd_str
 
 
 @pytest.mark.asyncio
 async def test_opencode_uses_project_dir_when_no_cwd(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """Verify project_dir is used as -c argument when cwd is not provided."""
+    """Verify project_dir is used as --dir argument when cwd is not provided."""
     captured_cmd = None
 
     async def capture_cmd(cmd, *, env=None, cwd=None, timeout=None):
@@ -208,5 +211,48 @@ async def test_opencode_uses_project_dir_when_no_cwd(
     provider = OpenCodeProvider()
     await provider.execute("test", {"project_dir": "/my/project"})
 
-    assert "-c" in captured_cmd
+    assert "--dir" in captured_cmd
     assert "/my/project" in captured_cmd
+
+
+@pytest.mark.asyncio
+async def test_opencode_v14_cli_shape_no_deprecated_flags(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Regression test for SWE-AF#45: deprecated -p/-c flags must not be used.
+
+    opencode v1.4+ replaced:
+      -p <prompt>  → positional arg to `run` subcommand
+      -c <dir>     → --dir <dir> (since -c now means --continue)
+
+    Using the old flags causes silent failures where opencode prints help text
+    and exits with no output, which surfaces as 'Product manager failed to
+    produce a valid PRD'.
+    """
+    captured_cmd = None
+
+    async def capture_cmd(cmd, *, env=None, cwd=None, timeout=None):
+        nonlocal captured_cmd
+        captured_cmd = cmd
+        return "result", "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", capture_cmd)
+
+    provider = OpenCodeProvider(bin_path="opencode")
+    await provider.execute("build the feature", {"cwd": "/repo", "model": "gpt-4o"})
+
+    cmd_str = " ".join(captured_cmd)
+    # Must use `run` subcommand
+    assert captured_cmd[1] == "run", "Must use 'opencode run' subcommand (v1.4+)"
+    # Must NOT use deprecated -p flag
+    assert "-p" not in captured_cmd, "Must not use deprecated -p flag (v1.4+)"
+    # Must NOT use deprecated -c flag (now means --continue)
+    assert "-c" not in captured_cmd, "Must not use deprecated -c flag (v1.4+)"
+    # Must use --dir for project directory
+    assert "--dir" in captured_cmd, "Must use --dir for project directory (v1.4+)"
+    # Must use -m for model
+    assert "-m" in captured_cmd, "Must use -m flag for model (v1.4+)"
+    # Must skip permissions for headless execution
+    assert "--dangerously-skip-permissions" in cmd_str
+    # Prompt must be positional (last arg)
+    assert captured_cmd[-1] == "build the feature"


### PR DESCRIPTION
## Summary

- Update `OpenCodeProvider` to use opencode v1.4+ CLI interface
- Replace deprecated `-p` (prompt) flag with positional arg to `run` subcommand
- Replace deprecated `-c` (project dir) flag with `--dir` (since `-c` now means `--continue`)
- Pass model via `-m` flag instead of `MODEL` env var
- Add `--dangerously-skip-permissions` for headless execution

Before: `opencode -c /repo -p "prompt"` (prints help text, exits with no output)
After: `opencode run --dir /repo -m model --dangerously-skip-permissions "prompt"`

### Files changed

| File | Change |
|---|---|
| `sdk/python/agentfield/harness/providers/opencode.py` | Update CLI invocation to v1.4+ format |
| `sdk/python/tests/test_harness_provider_opencode.py` | Update assertions + add regression test |

## Test plan

- [x] `pytest tests/test_harness_provider_opencode.py` — 10 passed
- [x] Manual verification of command construction (3 scenarios: full options, minimal, project_dir fallback)
- [x] No deprecated `-p` or `-c` flags in any generated command

Cross-ref: Agent-Field/SWE-AF#45

🤖 Generated with [Claude Code](https://claude.com/claude-code)