### PR TITLE
fix(python-sdk): harden pytest tempdir handling

### DIFF
--- a/.github/workflows/memory-metrics.yml
+++ b/.github/workflows/memory-metrics.yml
@@ -57,7 +57,7 @@ jobs:
         id: tests
         working-directory: sdk/python
         run: |
-          if python -m pytest tests/ --ignore=tests/integration -q 2>&1; then
+          if ./scripts/run_pytest.sh tests/ --ignore=tests/integration -q 2>&1; then
             echo "status=pass" >> $GITHUB_OUTPUT
           else
             echo "status=fail" >> $GITHUB_OUTPUT

--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .[dev]
-          pip install ruff pytest
+          pip install ruff
 
       - name: Lint
         working-directory: sdk/python
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run tests
         working-directory: sdk/python
-        run: pytest
+        run: ./scripts/run_pytest.sh
 
   # Verify websockets version compatibility (v14 renamed extra_headers → additional_headers)
   websockets-compat:
@@ -72,7 +72,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .[dev]
-          pip install pytest
           pip install websockets==${{ matrix.websockets-version }}
 
       - name: Verify websockets version
@@ -80,7 +79,7 @@ jobs:
 
       - name: Run memory events tests
         working-directory: sdk/python
-        run: pytest tests/test_memory_events.py -v --no-cov
+        run: ./scripts/run_pytest.sh tests/test_memory_events.py -v --no-cov
 
   # Summary job that depends on all critical checks
   required-checks:

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -123,14 +123,17 @@ See `docs/DEVELOPMENT.md` for instructions on wiring agents to the control plane
 ## Testing
 
 ```bash
-pytest
+./scripts/run_pytest.sh
 ```
 
 To run coverage locally:
 
 ```bash
-pytest --cov=agentfield --cov-report=term-missing
+./scripts/run_pytest.sh --cov=agentfield --cov-report=term-missing
 ```
+
+The wrapper sets a private `PYTEST_DEBUG_TEMPROOT` automatically so local runs
+and CI do not rely on pytest's predictable default temp directory layout.
 
 ## License
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -57,14 +57,17 @@ harness = [
     "claude-agent-sdk>=0.1",
 ]
 dev = [
-    "pytest>=7.4,<9",
-    "pytest-asyncio>=0.21,<0.24",
+    "pytest>=8.4,<9; python_version<'3.10'",
+    "pytest>=9.0.3,<10; python_version>='3.10'",
+    "pytest-asyncio>=0.21,<0.24; python_version<'3.10'",
+    "pytest-asyncio>=1.3,<2; python_version>='3.10'",
     "pytest-cov>=4.1,<5",
     "pytest-httpx>=0.30,<1; python_version>='3.10'",
     "responses>=0.23,<0.26",
     "respx>=0.20,<0.22",
     "freezegun>=1.2,<2",
-    "syrupy>=4,<5",
+    "syrupy>=4,<5; python_version<'3.10'",
+    "syrupy>=5,<6; python_version>='3.10'",
     "hypothesis>=6.88,<7",
     "pytest-socket>=0.6,<0.8",
 ]

--- a/sdk/python/requirements-dev.txt
+++ b/sdk/python/requirements-dev.txt
@@ -1,12 +1,15 @@
 # Development/test dependencies for AgentField SDK (Python 3.8+)
 # Install with: pip install -r requirements-dev.txt
-pytest>=7.4,<9
-pytest-asyncio>=0.21,<0.24
+pytest>=8.4,<9; python_version<'3.10'
+pytest>=9.0.3,<10; python_version>='3.10'
+pytest-asyncio>=0.21,<0.24; python_version<'3.10'
+pytest-asyncio>=1.3,<2; python_version>='3.10'
 pytest-cov>=4.1,<5
 pytest-httpx>=0.30,<1; python_version>='3.10'
 responses>=0.23,<0.26
 respx>=0.20,<0.22
 freezegun>=1.2,<2
-syrupy>=4,<5
+syrupy>=4,<5; python_version<'3.10'
+syrupy>=5,<6; python_version>='3.10'
 hypothesis>=6.88,<7
 pytest-socket>=0.6,<0.8

--- a/sdk/python/scripts/run_pytest.sh
+++ b/sdk/python/scripts/run_pytest.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# pytest <9 uses a predictable /tmp root on UNIX. Use a private temp root unless
+# the caller has already chosen one explicitly.
+if [[ -z "${PYTEST_DEBUG_TEMPROOT:-}" ]]; then
+  _agentfield_pytest_root="$(mktemp -d)"
+  cleanup() {
+    rm -rf "${_agentfield_pytest_root}"
+  }
+  trap cleanup EXIT
+  export PYTEST_DEBUG_TEMPROOT="${_agentfield_pytest_root}"
+fi
+
+exec pytest "$@"


### PR DESCRIPTION
## Summary
- move Python 3.10+ dev dependencies to the patched pytest 9.0.3 line
- update Python 3.10+ compatibility pins for pytest-asyncio and syrupy so the dev stack resolves cleanly with pytest 9
- run SDK tests through a wrapper that sets a private PYTEST_DEBUG_TEMPROOT to avoid pytest's predictable default temp root in CI and local runs

## Verification
- installed the Python 3.12 dev dependency set from sdk/python/requirements-dev.txt in a clean venv
- ran scripts/run_pytest.sh tests/test_memory_events.py -v --no-cov with pytest 9.0.3, pytest-asyncio 1.3.0, syrupy 5.1.0
