### PR TITLE
chore: sync web client package-lock with installed deps

### DIFF
--- a/control-plane/web/client/package-lock.json
+++ b/control-plane/web/client/package-lock.json
@@ -9812,7 +9812,6 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
             "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
             "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",


### PR DESCRIPTION
## Summary
- Removes a stale `dev: true` marker on `glob@10.5.0` so the lockfile matches the actual install graph (it's pulled in as a runtime transitive dep).

## Test plan
- [ ] CI lockfile-check passes
- [ ] `npm ci` in `control-plane/web/client` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)