### PR TITLE
fix(sdk/go): send configured heartbeat interval in node registration

### DIFF
--- a/sdk/go/agent/agent.go
+++ b/sdk/go/agent/agent.go
@@ -207,11 +207,16 @@ type Config struct {
 
 	// LeaseRefreshInterval controls how frequently the agent refreshes its
 	// lease/heartbeat with the control plane. Optional.
-	// Default: 2m (2 minutes). Valid: any positive time.Duration.
+	// Default: 2m (2 minutes). Valid: any positive time.Duration. This value
+	// is also sent to the control plane as the HeartbeatInterval during node
+	// registration; when zero, the registration falls back to 30s. When
+	// DisableLeaseLoop is true, "0s" is registered instead so the control
+	// plane does not expect heartbeats.
 	LeaseRefreshInterval time.Duration
 
 	// DisableLeaseLoop disables automatic periodic lease refreshes.
-	// Optional. Default: false.
+	// Optional. Default: false. When true, node registration reports
+	// HeartbeatInterval as "0s" to signal that the agent does not heartbeat.
 	DisableLeaseLoop bool
 
 	// Logger is used for agent logging output. Optional.
@@ -681,7 +686,7 @@ func (a *Agent) registerNode(ctx context.Context) error {
 		Skills:    []types.SkillDefinition{},
 		CommunicationConfig: types.CommunicationConfig{
 			Protocols:         []string{"http"},
-			HeartbeatInterval: "0s",
+			HeartbeatInterval: a.registeredHeartbeatInterval(),
 		},
 		HealthStatus:  "healthy",
 		LastHeartbeat: now,
@@ -2182,3 +2187,32 @@ func (a *Agent) shouldGenerateVC(reasoner *Reasoner) bool {
 	}
 	return true
 }
+
+// registeredHeartbeatInterval returns the HeartbeatInterval value sent to
+// the control plane during node registration. When the lease loop is
+// disabled, the agent does not send periodic heartbeats, so we advertise
+// "0s" to signal that behavior accurately rather than registering a
+// cadence the agent does not honor.
+func (a *Agent) registeredHeartbeatInterval() string {
+	if a.cfg.DisableLeaseLoop {
+		return "0s"
+	}
+	return formatHeartbeatInterval(a.cfg.LeaseRefreshInterval)
+}
+
+// formatHeartbeatInterval formats a LeaseRefreshInterval as a Go duration
+// string for the control plane's HeartbeatInterval field. If the interval
+// is zero (which should not happen after NewAgent's default, but guards
+// against direct field construction), it falls back to the documented
+// default so the control plane does not receive "0s".
+func formatHeartbeatInterval(d time.Duration) string {
+	if d <= 0 {
+		return defaultHeartbeatInterval.String()
+	}
+	return d.String()
+}
+
+// defaultHeartbeatInterval is the fallback sent to the control plane when
+// LeaseRefreshInterval is zero. Kept in sync with the LeaseRefreshInterval
+// default applied in NewAgent.
+var defaultHeartbeatInterval = 30 * time.Second

--- a/sdk/go/agent/agent_test.go
+++ b/sdk/go/agent/agent_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Agent-Field/agentfield/sdk/go/ai"
+	agentclient "github.com/Agent-Field/agentfield/sdk/go/client"
 	"github.com/Agent-Field/agentfield/sdk/go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -242,6 +243,102 @@ func TestInitialize(t *testing.T) {
 	err = agent.Initialize(context.Background())
 	assert.NoError(t, err)
 	assert.True(t, agent.initialized)
+}
+
+func TestRegistration_UsesConfiguredHeartbeatInterval(t *testing.T) {
+	var captured types.NodeRegistrationRequest
+	httpClient := &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, http.MethodPost, req.Method)
+			require.Equal(t, "/api/v1/nodes", req.URL.Path)
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&captured))
+
+			resp := types.NodeRegistrationResponse{
+				ID:      "node-1",
+				Success: true,
+			}
+			body, err := json.Marshal(resp)
+			require.NoError(t, err)
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(bytes.NewReader(body)),
+			}, nil
+		}),
+	}
+
+	cfg := Config{
+		NodeID:               "node-1",
+		Version:              "1.0.0",
+		TeamID:               "team-1",
+		AgentFieldURL:        "https://agentfield.example.com",
+		Logger:               log.New(io.Discard, "", 0),
+		DisableLeaseLoop:     true,
+		LeaseRefreshInterval: 45 * time.Second,
+	}
+
+	agent, err := New(cfg)
+	require.NoError(t, err)
+	agent.cfg.DisableLeaseLoop = false
+	agent.client, err = agentclient.New(cfg.AgentFieldURL, agentclient.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	agent.RegisterReasoner("test", func(ctx context.Context, input map[string]any) (any, error) {
+		return map[string]any{"ok": true}, nil
+	})
+
+	require.NoError(t, agent.registerNode(context.Background()))
+	assert.Equal(t, "45s", captured.CommunicationConfig.HeartbeatInterval)
+}
+
+func TestRegistration_HeartbeatIntervalFallsBackToDefault(t *testing.T) {
+	assert.Equal(t, "30s", formatHeartbeatInterval(0))
+}
+
+func TestRegistration_DisableLeaseLoopRegistersZeroHeartbeat(t *testing.T) {
+	var captured types.NodeRegistrationRequest
+	httpClient := &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&captured))
+			resp := types.NodeRegistrationResponse{ID: "node-2", Success: true}
+			body, err := json.Marshal(resp)
+			require.NoError(t, err)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(bytes.NewReader(body)),
+			}, nil
+		}),
+	}
+
+	cfg := Config{
+		NodeID:               "node-2",
+		Version:              "1.0.0",
+		TeamID:               "team-1",
+		AgentFieldURL:        "https://agentfield.example.com",
+		Logger:               log.New(io.Discard, "", 0),
+		DisableLeaseLoop:     true,
+		LeaseRefreshInterval: 45 * time.Second,
+	}
+
+	agent, err := New(cfg)
+	require.NoError(t, err)
+	agent.client, err = agentclient.New(cfg.AgentFieldURL, agentclient.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	agent.RegisterReasoner("test", func(ctx context.Context, input map[string]any) (any, error) {
+		return map[string]any{"ok": true}, nil
+	})
+
+	require.NoError(t, agent.registerNode(context.Background()))
+	assert.Equal(t, "0s", captured.CommunicationConfig.HeartbeatInterval)
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 func TestInitialize_NoReasoners(t *testing.T) {
@@ -803,16 +900,16 @@ func TestAIWithTools(t *testing.T) {
 		assert.Equal(t, 1, trace.TotalTurns)
 	})
 
-		t.Run("discovers tools and dispatches local calls", func(t *testing.T) {
-			var chatRequests atomic.Int32
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				switch r.URL.Path {
-				case "/api/v1/discovery/capabilities":
-					_, _ = w.Write([]byte(`{"discovered_at":"2025-01-01T00:00:00Z","total_agents":1,"total_reasoners":1,"total_skills":0,"pagination":{"limit":50,"offset":0,"has_more":false},"capabilities":[{"agent_id":"agent-1","reasoners":[{"id":"lookup","invocation_target":"agent-1.lookup","input_schema":{"type":"object"}}],"skills":[]}]}`))
-				case "/api/v1/execute/agent-1.lookup":
-					_, _ = w.Write([]byte(`{"status":"open"}`))
-				case "/chat/completions":
-					count := chatRequests.Add(1)
+	t.Run("discovers tools and dispatches local calls", func(t *testing.T) {
+		var chatRequests atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/v1/discovery/capabilities":
+				_, _ = w.Write([]byte(`{"discovered_at":"2025-01-01T00:00:00Z","total_agents":1,"total_reasoners":1,"total_skills":0,"pagination":{"limit":50,"offset":0,"has_more":false},"capabilities":[{"agent_id":"agent-1","reasoners":[{"id":"lookup","invocation_target":"agent-1.lookup","input_schema":{"type":"object"}}],"skills":[]}]}`))
+			case "/api/v1/execute/agent-1.lookup":
+				_, _ = w.Write([]byte(`{"status":"open"}`))
+			case "/chat/completions":
+				count := chatRequests.Add(1)
 				if count == 1 {
 					_ = json.NewEncoder(w).Encode(ai.Response{Choices: []ai.Choice{{Message: ai.Message{ToolCalls: []ai.ToolCall{{ID: "call-1", Type: "function", Function: ai.ToolCallFunction{Name: "agent-1.lookup", Arguments: `{"query":"status"}`}}}}}}})
 					return
@@ -832,7 +929,7 @@ func TestAIWithTools(t *testing.T) {
 			AIConfig:      &ai.Config{APIKey: "test-key", BaseURL: server.URL, Model: "gpt-4o"},
 		})
 		require.NoError(t, err)
-			resp, trace, err := agent.AIWithTools(context.Background(), "hello", ai.DefaultToolCallConfig())
+		resp, trace, err := agent.AIWithTools(context.Background(), "hello", ai.DefaultToolCallConfig())
 		require.NoError(t, err)
 		assert.Equal(t, "tool answer", resp.Text())
 		require.Len(t, trace.Calls, 1)


### PR DESCRIPTION
## Summary

`registerNode` in the Go SDK hardcoded `HeartbeatInterval: "0s"` in the registration payload, so the control plane never saw the agent's configured `LeaseRefreshInterval`. Fix that by sending the configured interval and guarding the zero case + the `DisableLeaseLoop` case explicitly.

## Changes

- `sdk/go/agent/agent.go`
  - Replace the hardcoded `"0s"` at registration with `a.registeredHeartbeatInterval()`.
  - New method `(*Agent).registeredHeartbeatInterval()` returns `"0s"` when `DisableLeaseLoop` is true (accurate: that agent never heartbeats) and otherwise formats `LeaseRefreshInterval` as a Go duration string.
  - New helper `formatHeartbeatInterval(time.Duration) string` with a `defaultHeartbeatInterval = 30 * time.Second` fallback for zero-valued durations (guards direct field construction that bypasses `New`'s 2m default).
  - Extended the `LeaseRefreshInterval` and `DisableLeaseLoop` godoc to describe the registration-time behavior.
- `sdk/go/agent/agent_test.go`
  - `TestRegistration_UsesConfiguredHeartbeatInterval`: asserts a 45s-configured agent registers `communication_config.heartbeat_interval == "45s"`.
  - `TestRegistration_HeartbeatIntervalFallsBackToDefault`: unit test for the zero-value fallback.
  - `TestRegistration_DisableLeaseLoopRegistersZeroHeartbeat`: asserts `DisableLeaseLoop: true` still registers `"0s"` regardless of `LeaseRefreshInterval`.

## Test plan

Verified with:

```
cd sdk/go
go build ./agent/...
go test ./agent/... -run TestRegistration -count=1
```

Both pass.

Fixes #439
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
