### PR TITLE
feat(python-sdk): add MediaRouter for prefix-based provider dispatch (#463)

### DIFF
--- a/sdk/python/agentfield/agent_ai.py
+++ b/sdk/python/agentfield/agent_ai.py
@@ -154,6 +154,7 @@ class AgentAI:
         self._initialization_complete = False
         self._rate_limiter = None
         self._fal_provider_instance = None
+        self._media_router_instance = None
 
     @property
     def _fal_provider(self):
@@ -170,6 +171,26 @@ class AgentAI:
                 api_key=self.agent.ai_config.fal_api_key
             )
         return self._fal_provider_instance
+
+    @property
+    def _media_router(self):
+        """
+        Lazy-initialized MediaRouter for prefix-based provider dispatch.
+
+        Returns:
+            MediaRouter: Configured router with fal, openrouter, and litellm providers
+        """
+        if self._media_router_instance is None:
+            from agentfield.media_providers import LiteLLMProvider, OpenRouterProvider
+            from agentfield.media_router import MediaRouter
+
+            router = MediaRouter()
+            router.register("fal-ai/", self._fal_provider)
+            router.register("fal/", self._fal_provider)
+            router.register("openrouter/", OpenRouterProvider())
+            router.register("", LiteLLMProvider())  # catch-all fallback
+            self._media_router_instance = router
+        return self._media_router_instance
 
     def _get_rate_limiter(self) -> StatelessRateLimiter:
         """
@@ -1117,20 +1138,24 @@ class AgentAI:
                 self.agent.ai_config.audio_model
             )  # Use configured audio model (defaults to tts-1)
 
-        # Route based on model prefix - Fal TTS models
-        if model.startswith("fal-ai/") or model.startswith("fal/"):
-            # Combine all text inputs
-            text_input = " ".join(str(arg) for arg in args if isinstance(arg, str))
-            if not text_input:
-                text_input = "Hello, this is a test audio message."
-
-            return await self._fal_provider.generate_audio(
-                text=text_input,
-                model=model,
-                voice=voice,
-                format=format,
-                **kwargs,
-            )
+        # Try media router for fal models
+        try:
+            provider = self._media_router.resolve(model, "audio")
+            if provider.name == "fal":
+                text_input = " ".join(
+                    str(arg) for arg in args if isinstance(arg, str)
+                )
+                if not text_input:
+                    text_input = "Hello, this is a test audio message."
+                return await provider.generate_audio(
+                    text=text_input,
+                    model=model,
+                    voice=voice,
+                    format=format,
+                    **kwargs,
+                )
+        except ValueError:
+            pass  # Fall through to existing logic
 
         # Check if mode="openai_direct" is specified
         if mode == "openai_direct":
@@ -1393,44 +1418,26 @@ class AgentAI:
             # Get base64 data directly
             result = await agent.ai_with_vision("A sunset", response_format="b64_json")
         """
-        from agentfield import vision
-
         # Use image generation model if not specified
         if model is None:
             model = "dall-e-3"  # Default image model
 
-        # Route based on model prefix
-        if model.startswith("fal-ai/") or model.startswith("fal/"):
-            # Fal: Use FalProvider for Flux, SDXL, Recraft, etc.
-            return await self._fal_provider.generate_image(
-                prompt=prompt,
-                model=model,
-                size=size,
-                quality=quality,
-                **kwargs,
-            )
-        elif model.startswith("openrouter/"):
-            # OpenRouter: Use chat completions API with image modality
-            return await vision.generate_image_openrouter(
-                prompt=prompt,
-                model=model,
-                size=size,
-                quality=quality,
-                style=style,
-                response_format=response_format,
-                **kwargs,
-            )
-        else:
-            # LiteLLM: Use image generation API
-            return await vision.generate_image_litellm(
-                prompt=prompt,
-                model=model,
-                size=size,
-                quality=quality,
-                style=style,
-                response_format=response_format,
-                **kwargs,
-            )
+        # Route via MediaRouter (longest-prefix match)
+        provider = self._media_router.resolve(model, "image")
+
+        # Pass style/response_format for providers that support them
+        if style is not None:
+            kwargs["style"] = style
+        if response_format is not None:
+            kwargs["response_format"] = response_format
+
+        return await provider.generate_image(
+            prompt=prompt,
+            model=model,
+            size=size,
+            quality=quality,
+            **kwargs,
+        )
 
     async def ai_with_multimodal(
         self,
@@ -1688,14 +1695,9 @@ class AgentAI:
         if model is None:
             model = self.agent.ai_config.video_model
 
-        # Currently only Fal supports video generation
-        if not (model.startswith("fal-ai/") or model.startswith("fal/")):
-            raise ValueError(
-                f"Video generation currently only supports Fal.ai models. "
-                f"Use models like 'fal-ai/minimax-video/image-to-video'. Got: {model}"
-            )
-
-        return await self._fal_provider.generate_video(
+        # Route via MediaRouter (longest-prefix match)
+        provider = self._media_router.resolve(model, "video")
+        return await provider.generate_video(
             prompt=prompt,
             model=model,
             image_url=image_url,

--- a/sdk/python/agentfield/media_router.py
+++ b/sdk/python/agentfield/media_router.py
@@ -1,0 +1,43 @@
+"""
+MediaRouter — prefix-based provider dispatch for media generation.
+
+Routes model strings to the correct MediaProvider by matching the longest
+registered prefix that also supports the requested capability (modality).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agentfield.media_providers import MediaProvider
+
+
+class MediaRouter:
+    """
+    Resolve ``(model, capability)`` pairs to a :class:`MediaProvider`.
+
+    Prefixes are matched longest-first so that ``"fal-ai/"`` beats the
+    empty-string catch-all even if registered later.
+    """
+
+    def __init__(self) -> None:
+        self._providers: list[tuple[str, MediaProvider]] = []
+
+    def register(self, prefix: str, provider: MediaProvider) -> None:
+        """Register *provider* for every model whose name starts with *prefix*."""
+        self._providers.append((prefix, provider))
+        self._providers.sort(key=lambda x: len(x[0]), reverse=True)
+
+    def resolve(self, model: str, capability: str) -> MediaProvider:
+        """Return the first provider matching *model* and *capability*.
+
+        Raises:
+            ValueError: If no registered provider matches.
+        """
+        for prefix, provider in self._providers:
+            if model.startswith(prefix) and capability in provider.supported_modalities:
+                return provider
+        raise ValueError(
+            f"No provider for model '{model}' with '{capability}' capability."
+        )

--- a/sdk/python/tests/test_agent_ai.py
+++ b/sdk/python/tests/test_agent_ai.py
@@ -32,6 +32,8 @@ class DummyAIConfig:
         self.model_limits_cache = {}
         self.audio_model = "tts-1"
         self.vision_model = "dall-e-3"
+        self.video_model = "fal-ai/minimax-video/image-to-video"
+        self.fal_api_key = None
 
     def copy(self, deep=False):
         return copy.deepcopy(self)

--- a/sdk/python/tests/test_agent_ai_comprehensive.py
+++ b/sdk/python/tests/test_agent_ai_comprehensive.py
@@ -35,6 +35,8 @@ class DummyAIConfig:
         self.model_limits_cache = {}
         self.audio_model = "tts-1"
         self.vision_model = "dall-e-3"
+        self.video_model = "fal-ai/minimax-video/image-to-video"
+        self.fal_api_key = None
 
     def copy(self, deep=False):
         """Create a copy of the config."""

--- a/sdk/python/tests/test_agent_ai_deadlock_recovery.py
+++ b/sdk/python/tests/test_agent_ai_deadlock_recovery.py
@@ -70,6 +70,8 @@ class _DeadlockTestConfig:
         self.model_limits_cache = {}
         self.audio_model = "tts-1"
         self.vision_model = "dall-e-3"
+        self.video_model = "fal-ai/minimax-video/image-to-video"
+        self.fal_api_key = None
 
     def copy(self, deep=False):
         return copy.deepcopy(self)

--- a/sdk/python/tests/test_agent_ai_final90.py
+++ b/sdk/python/tests/test_agent_ai_final90.py
@@ -20,6 +20,7 @@ class _DummyAIConfig:
     audio_model = "tts-1"
     vision_model = "dall-e-3"
     video_model = "fal-ai/video"
+    fal_api_key = None
     rate_limit_max_retries = 1
     rate_limit_base_delay = 0.1
     rate_limit_max_delay = 1.0
@@ -97,7 +98,11 @@ async def test_audio_generation_paths(ai_agent, monkeypatch):
         generate_audio=fal_audio,
         generate_video=fal_video,
         generate_image=AsyncMock(return_value="fal-image"),
+        supported_modalities=["image", "audio", "video"],
+        name="fal",
     )
+    # Reset router so it picks up the new fal mock
+    ai_agent._media_router_instance = None
 
     tts_result = await ai_agent.ai_with_audio("say hi", model="fal-ai/kokoro")
     assert tts_result == "fal-audio"
@@ -119,7 +124,7 @@ async def test_audio_generation_paths(ai_agent, monkeypatch):
     assert ai_agent.ai.await_args.kwargs["audio"]["voice"] == "alloy"
 
     assert await ai_agent.ai_generate_video("clip") == "fal-video"
-    with pytest.raises(ValueError, match="only supports Fal.ai models"):
+    with pytest.raises(ValueError, match="No provider"):
         await ai_agent.ai_generate_video("clip", model="openai/not-video")
 
 
@@ -178,17 +183,36 @@ async def test_openai_direct_audio_success_and_fallback(ai_agent, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_vision_and_generate_wrappers(ai_agent, monkeypatch):
-    vision_module = types.SimpleNamespace(
-        generate_image_openrouter=AsyncMock(return_value="openrouter-image"),
-        generate_image_litellm=AsyncMock(return_value="litellm-image"),
+    mock_openrouter = SimpleNamespace(
+        generate_image=AsyncMock(return_value="openrouter-image"),
+        generate_audio=AsyncMock(),
+        supported_modalities=["image"],
+        name="openrouter",
     )
-    monkeypatch.setattr("agentfield.vision", vision_module, raising=False)
+    mock_litellm = SimpleNamespace(
+        generate_image=AsyncMock(return_value="litellm-image"),
+        generate_audio=AsyncMock(),
+        supported_modalities=["image", "audio"],
+        name="litellm",
+    )
 
     ai_agent._fal_provider_instance = SimpleNamespace(
         generate_image=AsyncMock(return_value="fal-image"),
         generate_audio=AsyncMock(),
         generate_video=AsyncMock(),
+        supported_modalities=["image", "audio", "video"],
+        name="fal",
     )
+
+    # Build a custom router with our mocks
+    from agentfield.media_router import MediaRouter
+
+    router = MediaRouter()
+    router.register("fal-ai/", ai_agent._fal_provider_instance)
+    router.register("fal/", ai_agent._fal_provider_instance)
+    router.register("openrouter/", mock_openrouter)
+    router.register("", mock_litellm)
+    ai_agent._media_router_instance = router
 
     assert await ai_agent.ai_with_vision("draw", model="fal-ai/flux") == "fal-image"
     assert (

--- a/sdk/python/tests/test_media_providers.py
+++ b/sdk/python/tests/test_media_providers.py
@@ -344,7 +344,10 @@ class TestAgentAIProviderRouting:
         # Patch the instance attribute directly
         mock_provider = MagicMock()
         mock_provider.generate_image = mock_generate
+        mock_provider.supported_modalities = ["image", "audio", "video"]
+        mock_provider.name = "fal"
         ai._fal_provider_instance = mock_provider
+        ai._media_router_instance = None
 
         result = await ai.ai_with_vision(
             prompt="A sunset",
@@ -370,7 +373,10 @@ class TestAgentAIProviderRouting:
         # Patch the instance attribute directly
         mock_provider = MagicMock()
         mock_provider.generate_image = mock_generate
+        mock_provider.supported_modalities = ["image", "audio", "video"]
+        mock_provider.name = "fal"
         ai._fal_provider_instance = mock_provider
+        ai._media_router_instance = None
 
         await ai.ai_with_vision(
             prompt="A sunset",
@@ -395,7 +401,10 @@ class TestAgentAIProviderRouting:
         # Patch the instance attribute directly
         mock_provider = MagicMock()
         mock_provider.generate_audio = mock_generate
+        mock_provider.supported_modalities = ["image", "audio", "video"]
+        mock_provider.name = "fal"
         ai._fal_provider_instance = mock_provider
+        ai._media_router_instance = None
 
         result = await ai.ai_with_audio(
             "Hello world",
@@ -430,7 +439,10 @@ class TestAIGenerateVideo:
         # Patch the instance attribute directly
         mock_provider = MagicMock()
         mock_provider.generate_video = mock_generate
+        mock_provider.supported_modalities = ["image", "audio", "video"]
+        mock_provider.name = "fal"
         ai._fal_provider_instance = mock_provider
+        ai._media_router_instance = None
 
         await ai.ai_generate_video(prompt="A cat playing")
 
@@ -455,7 +467,10 @@ class TestAIGenerateVideo:
         # Patch the instance attribute directly
         mock_provider = MagicMock()
         mock_provider.generate_video = mock_generate
+        mock_provider.supported_modalities = ["image", "audio", "video"]
+        mock_provider.name = "fal"
         ai._fal_provider_instance = mock_provider
+        ai._media_router_instance = None
 
         await ai.ai_generate_video(
             prompt="Camera pans",
@@ -471,7 +486,7 @@ class TestAIGenerateVideo:
         """ai_generate_video should reject non-Fal models."""
         ai = AgentAI(agent_with_ai)
 
-        with pytest.raises(ValueError, match="only supports Fal.ai models"):
+        with pytest.raises(ValueError, match="No provider"):
             await ai.ai_generate_video(
                 prompt="A cat",
                 model="openai/video-model",
@@ -497,7 +512,10 @@ class TestAITranscribeAudio:
         # Patch the instance attribute directly
         mock_provider = MagicMock()
         mock_provider.transcribe_audio = mock_transcribe
+        mock_provider.supported_modalities = ["image", "audio", "video"]
+        mock_provider.name = "fal"
         ai._fal_provider_instance = mock_provider
+        ai._media_router_instance = None
 
         result = await ai.ai_transcribe_audio(
             audio_url="https://example.com/audio.mp3"
@@ -518,7 +536,10 @@ class TestAITranscribeAudio:
         # Patch the instance attribute directly
         mock_provider = MagicMock()
         mock_provider.transcribe_audio = mock_transcribe
+        mock_provider.supported_modalities = ["image", "audio", "video"]
+        mock_provider.name = "fal"
         ai._fal_provider_instance = mock_provider
+        ai._media_router_instance = None
 
         await ai.ai_transcribe_audio(
             audio_url="https://example.com/spanish.mp3",
@@ -568,7 +589,10 @@ class TestUnifiedMultimodalUX:
         # Setup mocks - patch the instance attribute directly
         mock_provider = MagicMock()
         mock_provider.generate_image = mock_fal_generate
+        mock_provider.supported_modalities = ["image", "audio", "video"]
+        mock_provider.name = "fal"
         ai._fal_provider_instance = mock_provider
+        ai._media_router_instance = None
 
         # Test fal-ai/ prefix
         await ai.ai_with_vision(prompt="test", model="fal-ai/flux/dev")

--- a/sdk/python/tests/test_media_router.py
+++ b/sdk/python/tests/test_media_router.py
@@ -1,0 +1,50 @@
+"""Unit tests for MediaRouter prefix-based provider dispatch."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from agentfield.media_router import MediaRouter
+
+
+def test_resolve_fal():
+    mock_fal = MagicMock()
+    mock_fal.supported_modalities = ["image", "audio", "video"]
+    router = MediaRouter()
+    router.register("fal-ai/", mock_fal)
+    assert router.resolve("fal-ai/flux/dev", "image") is mock_fal
+
+
+def test_resolve_openrouter():
+    mock_or = MagicMock()
+    mock_or.supported_modalities = ["image", "video"]
+    router = MediaRouter()
+    router.register("openrouter/", mock_or)
+    assert router.resolve("openrouter/google/veo-3.1", "video") is mock_or
+
+
+def test_resolve_fallback():
+    mock_litellm = MagicMock()
+    mock_litellm.supported_modalities = ["image", "audio"]
+    router = MediaRouter()
+    router.register("", mock_litellm)
+    assert router.resolve("dall-e-3", "image") is mock_litellm
+
+
+def test_resolve_longest_prefix_wins():
+    mock_fal = MagicMock()
+    mock_fal.supported_modalities = ["image"]
+    mock_fallback = MagicMock()
+    mock_fallback.supported_modalities = ["image"]
+    router = MediaRouter()
+    router.register("", mock_fallback)
+    router.register("fal-ai/", mock_fal)
+    assert router.resolve("fal-ai/flux/dev", "image") is mock_fal
+
+
+def test_resolve_unsupported_raises():
+    mock = MagicMock()
+    mock.supported_modalities = ["image"]
+    router = MediaRouter()
+    router.register("fal-ai/", mock)
+    with pytest.raises(ValueError, match="No provider"):
+        router.resolve("fal-ai/flux/dev", "music")


### PR DESCRIPTION
## Summary
- New `MediaRouter` class in `media_router.py` — prefix-based provider dispatch, longest-match-first
- Lazy `_media_router` property in `AgentAI` registers fal/openrouter/litellm providers
- Refactored `ai_with_vision()`, `ai_with_audio()`, `ai_generate_video()` to use router instead of if/elif chains
- Unit tests for router resolution logic

## Architecture
```
router.register("fal-ai/", fal_provider)
router.register("openrouter/", openrouter_provider)  
router.register("", litellm_provider)  # catch-all

provider = router.resolve("openrouter/google/veo-3.1", "video")
```

## Test plan
- [x] MediaRouter unit tests (prefix matching, fallback, unsupported raises)
- [x] Full test suite passes
- [x] Ruff clean

Closes #463