### PR TITLE
feat(typescript-sdk): add MediaProvider interface and OpenRouter media generation

### DIFF
--- a/sdk/typescript/src/ai/MediaProvider.ts
+++ b/sdk/typescript/src/ai/MediaProvider.ts
@@ -1,0 +1,88 @@
+/**
+ * MediaProvider interface and MediaRouter for multi-provider media generation.
+ * Mirrors the Python SDK's MediaProvider abstraction.
+ */
+
+export interface VideoRequest {
+  prompt: string;
+  model?: string;
+  duration?: number;
+  resolution?: '480p' | '720p' | '1080p' | '1K' | '2K' | '4K';
+  aspectRatio?: '16:9' | '9:16' | '1:1' | '4:3' | '3:4' | '21:9' | '9:21';
+  generateAudio?: boolean;
+  seed?: number;
+  frameImages?: Array<{ type: string; imageUrl: { url: string }; frameType?: string }>;
+  inputReferences?: Array<{ type: string; imageUrl: { url: string } }>;
+  pollInterval?: number; // ms, default 30000
+  timeout?: number; // ms, default 600000
+}
+
+export interface ImageRequest {
+  prompt: string;
+  model?: string;
+  size?: string;
+  quality?: string;
+  imageConfig?: {
+    aspectRatio?: string;
+    imageSize?: string;
+    superResolutionReferences?: string[];
+    fontInputs?: Array<{ fontUrl: string; text: string }>;
+  };
+}
+
+export interface AudioRequest {
+  text: string;
+  model?: string;
+  voice?: string;
+  format?: string;
+}
+
+export interface MediaResponse {
+  text: string;
+  images: Array<{ url?: string; b64Json?: string; revisedPrompt?: string }>;
+  audio: { data?: string; format: string; url?: string } | null;
+  files: Array<{ url?: string; data?: string; mimeType?: string; filename?: string }>;
+  videos: Array<{
+    url?: string;
+    data?: string;
+    mimeType?: string;
+    filename?: string;
+    duration?: number;
+    resolution?: string;
+    aspectRatio?: string;
+    hasAudio?: boolean;
+    costUsd?: number;
+  }>;
+  rawResponse: unknown;
+}
+
+export interface MediaProvider {
+  readonly name: string;
+  readonly supportedModalities: string[];
+  generateImage(request: ImageRequest): Promise<MediaResponse>;
+  generateAudio(request: AudioRequest): Promise<MediaResponse>;
+  generateVideo(request: VideoRequest): Promise<MediaResponse>;
+}
+
+/**
+ * Prefix-based media provider router.
+ * Resolves model strings to providers by longest-prefix match.
+ */
+export class MediaRouter {
+  private providers: Array<{ prefix: string; provider: MediaProvider }> = [];
+
+  register(prefix: string, provider: MediaProvider): void {
+    this.providers.push({ prefix, provider });
+    // Sort longest prefix first for greedy matching
+    this.providers.sort((a, b) => b.prefix.length - a.prefix.length);
+  }
+
+  resolve(model: string, capability: string): MediaProvider {
+    for (const { prefix, provider } of this.providers) {
+      if (model.startsWith(prefix) && provider.supportedModalities.includes(capability)) {
+        return provider;
+      }
+    }
+    throw new Error(`No provider for model '${model}' with '${capability}' capability`);
+  }
+}

--- a/sdk/typescript/src/ai/OpenRouterMediaProvider.ts
+++ b/sdk/typescript/src/ai/OpenRouterMediaProvider.ts
@@ -1,0 +1,289 @@
+/**
+ * OpenRouter-backed MediaProvider implementation.
+ * Supports video generation (async job), image generation, and audio generation via SSE.
+ */
+
+import type {
+  MediaProvider,
+  MediaResponse,
+  VideoRequest,
+  ImageRequest,
+  AudioRequest,
+} from './MediaProvider.js';
+
+const OPENROUTER_BASE = 'https://openrouter.ai/api/v1';
+
+const DEFAULT_POLL_INTERVAL = 30_000; // 30s
+const DEFAULT_TIMEOUT = 600_000; // 10min
+
+function emptyMediaResponse(raw: unknown): MediaResponse {
+  return { text: '', images: [], audio: null, files: [], videos: [], rawResponse: raw };
+}
+
+function stripPrefix(model: string): string {
+  return model.startsWith('openrouter/') ? model.slice('openrouter/'.length) : model;
+}
+
+export interface OpenRouterMediaProviderOptions {
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+export class OpenRouterMediaProvider implements MediaProvider {
+  readonly name = 'openrouter';
+  readonly supportedModalities = ['image', 'audio', 'video'];
+
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+
+  constructor(options: OpenRouterMediaProviderOptions = {}) {
+    this.apiKey = options.apiKey ?? process.env.OPENROUTER_API_KEY ?? '';
+    this.baseUrl = options.baseUrl ?? OPENROUTER_BASE;
+    if (!this.apiKey) {
+      throw new Error('OpenRouter API key required: pass apiKey or set OPENROUTER_API_KEY');
+    }
+  }
+
+  // ── Video ──────────────────────────────────────────────────────────
+
+  async generateVideo(request: VideoRequest): Promise<MediaResponse> {
+    const model = stripPrefix(request.model ?? 'google/veo-3');
+    const pollInterval = request.pollInterval ?? DEFAULT_POLL_INTERVAL;
+    const timeout = request.timeout ?? DEFAULT_TIMEOUT;
+
+    // Build request body
+    const body: Record<string, unknown> = {
+      model,
+      prompt: request.prompt,
+    };
+    if (request.duration != null) body.duration = request.duration;
+    if (request.resolution) body.resolution = request.resolution;
+    if (request.aspectRatio) body.aspect_ratio = request.aspectRatio;
+    if (request.generateAudio != null) body.generate_audio = request.generateAudio;
+    if (request.seed != null) body.seed = request.seed;
+    if (request.frameImages) body.frame_images = request.frameImages;
+    if (request.inputReferences) body.input_references = request.inputReferences;
+
+    // Submit job
+    const submitRes = await this.post(`${this.baseUrl}/videos`, body);
+    if (!submitRes.ok) {
+      throw new Error(`Video submit failed: ${submitRes.status} ${await submitRes.text()}`);
+    }
+    const submitData = (await submitRes.json()) as Record<string, unknown>;
+    const jobId = submitData.id as string;
+    if (!jobId) {
+      throw new Error('No job id returned from video submit');
+    }
+
+    // Poll until done
+    const deadline = Date.now() + timeout;
+    let jobData: Record<string, unknown> = {};
+    while (Date.now() < deadline) {
+      await sleep(pollInterval);
+      const pollRes = await this.get(`${this.baseUrl}/videos/${jobId}`);
+      if (!pollRes.ok) {
+        throw new Error(`Video poll failed: ${pollRes.status} ${await pollRes.text()}`);
+      }
+      jobData = (await pollRes.json()) as Record<string, unknown>;
+      const status = jobData.status as string | undefined;
+      if (status === 'completed') break;
+      if (status === 'failed' || status === 'error') {
+        throw new Error(`Video generation failed: ${JSON.stringify(jobData)}`);
+      }
+    }
+
+    if ((jobData.status as string) !== 'completed') {
+      throw new Error('Video generation timed out');
+    }
+
+    // Extract video URL
+    const unsignedUrl = jobData.unsigned_url as string | undefined;
+    const signedUrl = jobData.url as string | undefined;
+    const videoUrl = unsignedUrl ?? signedUrl;
+
+    // Download video bytes if URL available
+    let videoData: string | undefined;
+    if (videoUrl) {
+      const dlRes = await fetch(videoUrl);
+      if (dlRes.ok) {
+        const buf = Buffer.from(await dlRes.arrayBuffer());
+        videoData = buf.toString('base64');
+      }
+    }
+
+    const resp = emptyMediaResponse(jobData);
+    resp.videos.push({
+      url: videoUrl,
+      data: videoData,
+      mimeType: 'video/mp4',
+      duration: request.duration,
+      resolution: request.resolution,
+      aspectRatio: request.aspectRatio,
+      hasAudio: request.generateAudio,
+      costUsd: jobData.cost_usd as number | undefined,
+    });
+    return resp;
+  }
+
+  // ── Image ──────────────────────────────────────────────────────────
+
+  async generateImage(request: ImageRequest): Promise<MediaResponse> {
+    const model = stripPrefix(request.model ?? 'openai/gpt-image-1');
+
+    const messages: unknown[] = [{ role: 'user', content: request.prompt }];
+    const body: Record<string, unknown> = {
+      model,
+      messages,
+      modalities: ['image', 'text'],
+    };
+    if (request.size) body.size = request.size;
+    if (request.quality) body.quality = request.quality;
+    if (request.imageConfig) body.image_config = request.imageConfig;
+
+    const res = await this.post(`${this.baseUrl}/chat/completions`, body);
+    if (!res.ok) {
+      throw new Error(`Image generation failed: ${res.status} ${await res.text()}`);
+    }
+    const data = (await res.json()) as Record<string, unknown>;
+    const resp = emptyMediaResponse(data);
+
+    // Extract images from choices
+    const choices = data.choices as Array<Record<string, unknown>> | undefined;
+    if (choices) {
+      for (const choice of choices) {
+        const msg = choice.message as Record<string, unknown> | undefined;
+        if (!msg) continue;
+        // Text
+        if (typeof msg.content === 'string') {
+          resp.text += msg.content;
+        }
+        // Content array (multimodal)
+        if (Array.isArray(msg.content)) {
+          for (const part of msg.content) {
+            const p = part as Record<string, unknown>;
+            if (p.type === 'text') {
+              resp.text += p.text as string;
+            } else if (p.type === 'image_url') {
+              const imgUrl = p.image_url as Record<string, unknown> | undefined;
+              const url = imgUrl?.url as string | undefined;
+              if (url?.startsWith('data:')) {
+                const b64 = url.split(',', 2)[1];
+                resp.images.push({ url, b64Json: b64 });
+              } else if (url) {
+                resp.images.push({ url });
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return resp;
+  }
+
+  // ── Audio ──────────────────────────────────────────────────────────
+
+  async generateAudio(request: AudioRequest): Promise<MediaResponse> {
+    const model = stripPrefix(request.model ?? 'openai/gpt-4o-mini-tts');
+
+    const messages: unknown[] = [{ role: 'user', content: request.text }];
+    const body: Record<string, unknown> = {
+      model,
+      messages,
+      modalities: ['text', 'audio'],
+      stream: true,
+      audio: {
+        voice: request.voice ?? 'alloy',
+        format: request.format ?? 'wav',
+      },
+    };
+
+    const res = await this.post(`${this.baseUrl}/chat/completions`, body);
+    if (!res.ok) {
+      throw new Error(`Audio generation failed: ${res.status} ${await res.text()}`);
+    }
+
+    // Parse SSE stream and collect audio chunks
+    const audioChunks: string[] = [];
+    let textContent = '';
+    const reader = res.body?.getReader();
+    if (!reader) {
+      throw new Error('No response body stream available');
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      // Keep last incomplete line in buffer
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith('data:')) continue;
+        const payload = trimmed.slice(5).trim();
+        if (payload === '[DONE]') continue;
+
+        try {
+          const chunk = JSON.parse(payload) as Record<string, unknown>;
+          const choices = chunk.choices as Array<Record<string, unknown>> | undefined;
+          if (!choices) continue;
+          for (const choice of choices) {
+            const delta = choice.delta as Record<string, unknown> | undefined;
+            if (!delta) continue;
+            if (typeof delta.content === 'string') {
+              textContent += delta.content;
+            }
+            const audioDelta = delta.audio as Record<string, unknown> | undefined;
+            if (audioDelta?.data) {
+              audioChunks.push(audioDelta.data as string);
+            }
+          }
+        } catch {
+          // skip malformed chunks
+        }
+      }
+    }
+
+    const resp = emptyMediaResponse(null);
+    resp.text = textContent;
+    if (audioChunks.length > 0) {
+      resp.audio = {
+        data: audioChunks.join(''),
+        format: request.format ?? 'wav',
+      };
+    }
+    return resp;
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────
+
+  private post(url: string, body: unknown): Promise<Response> {
+    return fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  private get(url: string): Promise<Response> {
+    return fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+    });
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -18,6 +18,8 @@ export * from './did/DidManager.js';
 export * from './ai/RateLimiter.js';
 export * from './ai/multimodal.js';
 export * from './ai/MultimodalResponse.js';
+export * from './ai/MediaProvider.js';
+export * from './ai/OpenRouterMediaProvider.js';
 export * from './types/agent.js';
 export * from './types/reasoner.js';
 export * from './types/skill.js';

--- a/sdk/typescript/tests/media_provider.test.ts
+++ b/sdk/typescript/tests/media_provider.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MediaRouter } from '../src/ai/MediaProvider.js';
+import type { MediaProvider, MediaResponse } from '../src/ai/MediaProvider.js';
+import { OpenRouterMediaProvider } from '../src/ai/OpenRouterMediaProvider.js';
+
+// ── MediaRouter tests ────────────────────────────────────────────────
+
+function makeStubProvider(
+  name: string,
+  modalities: string[] = ['image', 'audio', 'video']
+): MediaProvider {
+  const empty: MediaResponse = {
+    text: '',
+    images: [],
+    audio: null,
+    files: [],
+    videos: [],
+    rawResponse: null,
+  };
+  return {
+    name,
+    supportedModalities: modalities,
+    generateImage: vi.fn().mockResolvedValue(empty),
+    generateAudio: vi.fn().mockResolvedValue(empty),
+    generateVideo: vi.fn().mockResolvedValue(empty),
+  };
+}
+
+describe('MediaRouter', () => {
+  it('resolves provider by prefix', () => {
+    const router = new MediaRouter();
+    const prov = makeStubProvider('openrouter');
+    router.register('openrouter/', prov);
+    expect(router.resolve('openrouter/google/veo-3', 'video')).toBe(prov);
+  });
+
+  it('longest prefix wins', () => {
+    const router = new MediaRouter();
+    const generic = makeStubProvider('generic');
+    const specific = makeStubProvider('specific');
+    router.register('openrouter/', generic);
+    router.register('openrouter/google/', specific);
+
+    expect(router.resolve('openrouter/google/veo-3', 'video')).toBe(specific);
+    expect(router.resolve('openrouter/openai/dall-e', 'image')).toBe(generic);
+  });
+
+  it('throws when no provider matches', () => {
+    const router = new MediaRouter();
+    expect(() => router.resolve('unknown/model', 'video')).toThrow(
+      "No provider for model 'unknown/model' with 'video' capability"
+    );
+  });
+
+  it('checks capability filter', () => {
+    const router = new MediaRouter();
+    const imageOnly = makeStubProvider('img', ['image']);
+    router.register('img/', imageOnly);
+
+    expect(router.resolve('img/model', 'image')).toBe(imageOnly);
+    expect(() => router.resolve('img/model', 'video')).toThrow();
+  });
+});
+
+// ── OpenRouterMediaProvider tests ────────────────────────────────────
+
+describe('OpenRouterMediaProvider', () => {
+  const originalFetch = globalThis.fetch;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    globalThis.fetch = mockFetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('throws without API key', () => {
+    const orig = process.env.OPENROUTER_API_KEY;
+    delete process.env.OPENROUTER_API_KEY;
+    expect(() => new OpenRouterMediaProvider()).toThrow('API key required');
+    if (orig) process.env.OPENROUTER_API_KEY = orig;
+  });
+
+  it('accepts apiKey in constructor', () => {
+    const p = new OpenRouterMediaProvider({ apiKey: 'test-key' });
+    expect(p.name).toBe('openrouter');
+    expect(p.supportedModalities).toContain('video');
+  });
+
+  it('strips openrouter/ prefix from model', async () => {
+    const provider = new OpenRouterMediaProvider({ apiKey: 'test-key' });
+
+    // Mock image generation
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        choices: [
+          {
+            message: {
+              content: [
+                { type: 'text', text: 'Generated' },
+                { type: 'image_url', image_url: { url: 'https://example.com/img.png' } },
+              ],
+            },
+          },
+        ],
+      }),
+    });
+
+    await provider.generateImage({ prompt: 'a cat', model: 'openrouter/openai/gpt-image-1' });
+
+    // Verify the model sent in the body has prefix stripped
+    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(callBody.model).toBe('openai/gpt-image-1');
+  });
+
+  describe('generateVideo', () => {
+    it('submits job, polls, downloads', async () => {
+      const provider = new OpenRouterMediaProvider({ apiKey: 'test-key' });
+      const videoBytes = Buffer.from('fake-video-data');
+
+      // Submit
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 'job-123' }),
+      });
+      // Poll -> completed
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'job-123',
+          status: 'completed',
+          unsigned_url: 'https://example.com/video.mp4',
+          cost_usd: 0.05,
+        }),
+      });
+      // Download
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => videoBytes.buffer.slice(
+          videoBytes.byteOffset,
+          videoBytes.byteOffset + videoBytes.byteLength
+        ),
+      });
+
+      const resp = await provider.generateVideo({
+        prompt: 'a sunset',
+        model: 'openrouter/google/veo-3',
+        pollInterval: 1, // 1ms for test speed
+      });
+
+      expect(resp.videos).toHaveLength(1);
+      expect(resp.videos[0].url).toBe('https://example.com/video.mp4');
+      expect(resp.videos[0].data).toBe(videoBytes.toString('base64'));
+      expect(resp.videos[0].costUsd).toBe(0.05);
+
+      // Verify calls: submit, poll, download
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('throws on submit failure', async () => {
+      const provider = new OpenRouterMediaProvider({ apiKey: 'test-key' });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 402,
+        text: async () => 'Insufficient credits',
+      });
+
+      await expect(
+        provider.generateVideo({ prompt: 'test', pollInterval: 1 })
+      ).rejects.toThrow('Video submit failed: 402');
+    });
+
+    it('throws on generation failure status', async () => {
+      const provider = new OpenRouterMediaProvider({ apiKey: 'test-key' });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 'job-fail' }),
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 'job-fail', status: 'failed', error: 'content policy' }),
+      });
+
+      await expect(
+        provider.generateVideo({ prompt: 'test', pollInterval: 1 })
+      ).rejects.toThrow('Video generation failed');
+    });
+
+    it('throws on timeout', async () => {
+      const provider = new OpenRouterMediaProvider({ apiKey: 'test-key' });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 'job-slow' }),
+      });
+      // Always return pending
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ id: 'job-slow', status: 'pending' }),
+      });
+
+      await expect(
+        provider.generateVideo({ prompt: 'test', pollInterval: 1, timeout: 10 })
+      ).rejects.toThrow('timed out');
+    });
+  });
+
+  describe('generateImage', () => {
+    it('extracts images from response', async () => {
+      const provider = new OpenRouterMediaProvider({ apiKey: 'test-key' });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content: [
+                  { type: 'text', text: 'Here is your image' },
+                  { type: 'image_url', image_url: { url: 'https://cdn.example.com/img.png' } },
+                ],
+              },
+            },
+          ],
+        }),
+      });
+
+      const resp = await provider.generateImage({ prompt: 'a cat' });
+      expect(resp.text).toBe('Here is your image');
+      expect(resp.images).toHaveLength(1);
+      expect(resp.images[0].url).toBe('https://cdn.example.com/img.png');
+    });
+
+    it('handles data URL images with b64', async () => {
+      const provider = new OpenRouterMediaProvider({ apiKey: 'test-key' });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content: [
+                  {
+                    type: 'image_url',
+                    image_url: { url: 'data:image/png;base64,iVBOR' },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      });
+
+      const resp = await provider.generateImage({ prompt: 'test' });
+      expect(resp.images[0].b64Json).toBe('iVBOR');
+    });
+  });
+
+  describe('generateAudio', () => {
+    it('parses SSE stream and collects audio chunks', async () => {
+      const provider = new OpenRouterMediaProvider({ apiKey: 'test-key' });
+
+      const sseLines = [
+        'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n',
+        'data: {"choices":[{"delta":{"audio":{"data":"AAAA"}}}]}\n\n',
+        'data: {"choices":[{"delta":{"audio":{"data":"BBBB"}}}]}\n\n',
+        'data: [DONE]\n\n',
+      ];
+      const encoder = new TextEncoder();
+      let callIndex = 0;
+
+      const mockReader = {
+        read: vi.fn().mockImplementation(async () => {
+          if (callIndex < sseLines.length) {
+            const chunk = encoder.encode(sseLines[callIndex]);
+            callIndex++;
+            return { done: false, value: chunk };
+          }
+          return { done: true, value: undefined };
+        }),
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        body: { getReader: () => mockReader },
+      });
+
+      const resp = await provider.generateAudio({ text: 'say hello' });
+      expect(resp.text).toBe('Hello');
+      expect(resp.audio).not.toBeNull();
+      expect(resp.audio!.data).toBe('AAAABBBB');
+      expect(resp.audio!.format).toBe('wav');
+    });
+
+    it('throws on failure', async () => {
+      const provider = new OpenRouterMediaProvider({ apiKey: 'test-key' });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => 'Internal error',
+      });
+
+      await expect(
+        provider.generateAudio({ text: 'test' })
+      ).rejects.toThrow('Audio generation failed: 500');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `MediaProvider` interface with `VideoRequest`, `ImageRequest`, `AudioRequest`, and `MediaResponse` types
- Adds `MediaRouter` for prefix-based provider dispatch (longest-prefix-first matching)
- Implements `OpenRouterMediaProvider` with video (async job submit/poll/download), image (chat completions with image modality), and audio (SSE stream parsing) generation
- 15 tests covering router logic, prefix stripping, error handling, and all three generation methods with mocked fetch

Closes #467

## Test plan
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] All 15 new tests pass (`vitest run tests/media_provider.test.ts`)
- [x] Full suite (525 tests) passes with 0 failures