### PR TITLE
feat(python-sdk): add OpenRouter audio output and music generation (#465)

### DIFF
--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -1482,7 +1482,10 @@ class Agent(FastAPI):
             "preferred": self.base_url,
             "callback_candidates": self.callback_candidates,
             "container": _is_running_in_container(),
-            "submitted_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
+            "submitted_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[
+                :-3
+            ]
+            + "Z",
         }
 
         return payload
@@ -2049,9 +2052,7 @@ class Agent(FastAPI):
                 "execution_id": execution_id,
                 "reasoner": reasoner_name,
             }
-            log_error(
-                f"Execution {execution_id} timed out after {reasoner_timeout}s"
-            )
+            log_error(f"Execution {execution_id} timed out after {reasoner_timeout}s")
         except Exception as exc:
             error_details = getattr(exc, "error_details", None)
             payload = {
@@ -3258,6 +3259,42 @@ class Agent(FastAPI):
             voice=voice,
             format=format,
             speed=speed,
+            **kwargs,
+        )
+
+    async def ai_generate_music(  # pragma: no cover - relies on external services
+        self,
+        prompt: str,
+        model: Optional[str] = None,
+        duration: Optional[int] = None,
+        **kwargs,
+    ) -> "MultimodalResponse":
+        """
+        Generate music from a text prompt.
+
+        Routes to a music-capable provider (OpenRouter with models like
+        google/lyria-3-pro). Returns a MultimodalResponse with audio data.
+
+        Args:
+            prompt (str): Text description of the music to generate.
+            model (str, optional): Music model to use.
+            duration (int, optional): Duration hint in seconds.
+            **kwargs: Provider-specific parameters (e.g., format="wav").
+
+        Returns:
+            MultimodalResponse: Response with .audio containing AudioOutput.
+
+        Example:
+            ```python
+            result = await app.ai_generate_music("upbeat jazz piano solo")
+            if result.has_audio:
+                result.audio.save("jazz.wav")
+            ```
+        """
+        return await self.ai_handler.ai_generate_music(
+            prompt=prompt,
+            model=model,
+            duration=duration,
             **kwargs,
         )
 

--- a/sdk/python/agentfield/agent_ai.py
+++ b/sdk/python/agentfield/agent_ai.py
@@ -546,7 +546,9 @@ class AgentAI:
                     )
 
                 async def _make_call():
-                    timeout = getattr(self.agent.async_config, "llm_call_timeout", 120.0)
+                    timeout = getattr(
+                        self.agent.async_config, "llm_call_timeout", 120.0
+                    )
                     # Ensure litellm/httpx itself enforces the timeout at the
                     # socket level, so cancelled requests don't poison the
                     # connection pool for subsequent calls.
@@ -728,7 +730,9 @@ class AgentAI:
                 hasattr(self.agent, "cost_tracker")
                 and multimodal_response.cost_usd is not None
             ):
-                model_name = getattr(resp, "model", "") or final_config.model or "unknown"
+                model_name = (
+                    getattr(resp, "model", "") or final_config.model or "unknown"
+                )
                 usage = multimodal_response.usage
                 from agentfield.execution_context import get_current_context
 
@@ -746,7 +750,11 @@ class AgentAI:
                 try:
                     json_data = json.loads(str(multimodal_response.text))
                     return schema(**json_data)
-                except (json.JSONDecodeError, ValueError, ValidationError) as parse_error:
+                except (
+                    json.JSONDecodeError,
+                    ValueError,
+                    ValidationError,
+                ) as parse_error:
                     log_error(f"Failed to parse JSON response: {parse_error}")
                     log_debug(f"Raw response: {multimodal_response.text}")
                     json_match = re.search(
@@ -1631,6 +1639,50 @@ class AgentAI:
             voice=voice,
             format=format,
             speed=speed,
+            **kwargs,
+        )
+
+    async def ai_generate_music(
+        self,
+        prompt: str,
+        model: Optional[str] = None,
+        duration: Optional[int] = None,
+        **kwargs,
+    ) -> "MultimodalResponse":
+        """
+        Generate music from a text prompt.
+
+        Routes to a music-capable media provider (currently OpenRouter with
+        models like google/lyria-3-pro). Returns a MultimodalResponse with
+        generated audio data (48kHz stereo).
+
+        Args:
+            prompt: Text description of the music to generate
+            model: Music model to use (defaults to "google/lyria-3-pro")
+            duration: Duration hint in seconds
+            **kwargs: Provider-specific parameters (e.g., format="wav")
+
+        Returns:
+            MultimodalResponse: Response with .audio containing AudioOutput.
+
+        Examples:
+            result = await app.ai_generate_music("upbeat jazz piano solo")
+            if result.has_audio:
+                result.audio.save("jazz.wav")
+
+            result = await app.ai_generate_music(
+                "calm ambient electronic music",
+                duration=30,
+                format="mp3",
+            )
+        """
+        from agentfield.media_providers import OpenRouterProvider
+
+        provider = OpenRouterProvider(api_key=None)
+        return await provider.generate_music(
+            prompt=prompt,
+            model=model,
+            duration=duration,
             **kwargs,
         )
 

--- a/sdk/python/agentfield/media_providers.py
+++ b/sdk/python/agentfield/media_providers.py
@@ -24,12 +24,12 @@ from agentfield.multimodal_response import (
 
 # Fal image size presets
 FalImageSize = Literal[
-    "square_hd",      # 1024x1024
-    "square",         # 512x512
-    "portrait_4_3",   # 768x1024
+    "square_hd",  # 1024x1024
+    "square",  # 512x512
+    "portrait_4_3",  # 768x1024
     "portrait_16_9",  # 576x1024
     "landscape_4_3",  # 1024x768
-    "landscape_16_9", # 1024x576
+    "landscape_16_9",  # 1024x576
 ]
 
 
@@ -121,6 +121,27 @@ class MediaProvider(ABC):
         """
         raise NotImplementedError(f"{self.name} does not support video generation")
 
+    async def generate_music(
+        self,
+        prompt: str,
+        model: Optional[str] = None,
+        duration: Optional[int] = None,
+        **kwargs,
+    ) -> MultimodalResponse:
+        """
+        Generate music from a text prompt.
+
+        Args:
+            prompt: Text description of the music to generate
+            model: Music generation model to use
+            duration: Duration in seconds
+            **kwargs: Provider-specific options
+
+        Returns:
+            MultimodalResponse with generated audio
+        """
+        raise NotImplementedError(f"{self.name} does not support music generation")
+
 
 class FalProvider(MediaProvider):
     """
@@ -191,6 +212,7 @@ class FalProvider(MediaProvider):
 
                 if self._api_key:
                     import os
+
                     os.environ["FAL_KEY"] = self._api_key
 
                 self._client = fal_client
@@ -200,9 +222,7 @@ class FalProvider(MediaProvider):
                 )
         return self._client
 
-    def _parse_image_size(
-        self, size: str
-    ) -> Union[str, Dict[str, int]]:
+    def _parse_image_size(self, size: str) -> Union[str, Dict[str, int]]:
         """
         Parse image size into fal format.
 
@@ -214,8 +234,12 @@ class FalProvider(MediaProvider):
         """
         # Check if it's a fal preset
         fal_presets = {
-            "square_hd", "square", "portrait_4_3", "portrait_16_9",
-            "landscape_4_3", "landscape_16_9"
+            "square_hd",
+            "square",
+            "portrait_4_3",
+            "portrait_16_9",
+            "landscape_4_3",
+            "landscape_16_9",
         }
         if size in fal_presets:
             return size
@@ -346,6 +370,7 @@ class FalProvider(MediaProvider):
 
         except Exception as e:
             from agentfield.logger import log_error
+
             log_error(f"Fal image generation failed: {e}")
             raise
 
@@ -434,6 +459,7 @@ class FalProvider(MediaProvider):
 
         except Exception as e:
             from agentfield.logger import log_error
+
             log_error(f"Fal audio generation failed: {e}")
             raise
 
@@ -532,6 +558,7 @@ class FalProvider(MediaProvider):
 
         except Exception as e:
             from agentfield.logger import log_error
+
             log_error(f"Fal video generation failed: {e}")
             raise
 
@@ -587,6 +614,7 @@ class FalProvider(MediaProvider):
 
         except Exception as e:
             from agentfield.logger import log_error
+
             log_error(f"Fal transcription failed: {e}")
             raise
 
@@ -722,7 +750,7 @@ class OpenRouterProvider(MediaProvider):
 
     @property
     def supported_modalities(self) -> List[str]:
-        return ["image"]  # OpenRouter primarily supports image generation
+        return ["image", "audio", "music"]
 
     async def generate_image(
         self,
@@ -759,9 +787,223 @@ class OpenRouterProvider(MediaProvider):
         format: str = "wav",
         **kwargs,
     ) -> MultimodalResponse:
-        """OpenRouter doesn't support TTS directly."""
-        raise NotImplementedError(
-            "OpenRouter doesn't support audio generation. Use LiteLLMProvider or FalProvider."
+        """
+        Generate audio via OpenRouter chat completions with SSE streaming.
+
+        Uses the modalities parameter to request audio output from audio-capable
+        models on OpenRouter.
+
+        Args:
+            text: Text to convert to speech
+            model: OpenRouter model ID (e.g., "openai/gpt-4o-mini-tts")
+            voice: Voice identifier (alloy, echo, fable, onyx, nova, shimmer)
+            format: Audio format (wav, mp3, flac, opus, pcm16)
+            **kwargs: Additional parameters
+
+        Returns:
+            MultimodalResponse with generated audio
+        """
+        import json as json_mod
+        import os
+
+        import aiohttp
+
+        api_key = self._api_key or os.environ.get("OPENROUTER_API_KEY", "")
+        if not api_key:
+            raise ValueError(
+                "OpenRouter API key required. Set OPENROUTER_API_KEY env var or pass api_key."
+            )
+
+        # Strip openrouter/ prefix if present
+        send_model = model or "openai/gpt-4o-mini-tts"
+        if send_model.startswith("openrouter/"):
+            send_model = send_model[len("openrouter/") :]
+
+        supported_voices = {"alloy", "echo", "fable", "onyx", "nova", "shimmer"}
+        if voice not in supported_voices:
+            voice = "alloy"
+
+        supported_formats = {"wav", "mp3", "flac", "opus", "pcm16"}
+        if format not in supported_formats:
+            format = "wav"
+
+        payload = {
+            "model": send_model,
+            "messages": [{"role": "user", "content": text}],
+            "modalities": ["text", "audio"],
+            "audio": {"voice": voice, "format": format},
+            "stream": True,
+        }
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        b64_chunks: list = []
+        transcript_parts: list = []
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                json=payload,
+                headers=headers,
+            ) as resp:
+                if resp.status != 200:
+                    body = await resp.text()
+                    raise RuntimeError(
+                        f"OpenRouter audio request failed ({resp.status}): {body}"
+                    )
+
+                async for line in resp.content:
+                    decoded = line.decode("utf-8", errors="replace").strip()
+                    if not decoded.startswith("data: "):
+                        continue
+                    data_str = decoded[len("data: ") :]
+                    if data_str == "[DONE]":
+                        break
+                    try:
+                        event = json_mod.loads(data_str)
+                    except json_mod.JSONDecodeError:
+                        continue
+
+                    choices = event.get("choices", [])
+                    if not choices:
+                        continue
+                    delta = choices[0].get("delta", {})
+                    audio_delta = delta.get("audio", {})
+                    if audio_delta.get("data"):
+                        b64_chunks.append(audio_delta["data"])
+                    if audio_delta.get("transcript"):
+                        transcript_parts.append(audio_delta["transcript"])
+
+        # Concatenate base64 chunks and decode once
+        b64_full = "".join(b64_chunks)
+        transcript = "".join(transcript_parts)
+
+        audio_output = AudioOutput(
+            data=b64_full if b64_full else None,
+            format=format,
+            url=None,
+        )
+
+        return MultimodalResponse(
+            text=transcript or text,
+            audio=audio_output if b64_full else None,
+            images=[],
+            files=[],
+            raw_response={"transcript": transcript, "model": send_model},
+        )
+
+    async def generate_music(
+        self,
+        prompt: str,
+        model: Optional[str] = None,
+        duration: Optional[int] = None,
+        **kwargs,
+    ) -> MultimodalResponse:
+        """
+        Generate music via OpenRouter using a music-capable model.
+
+        Uses SSE streaming chat completions with audio modality, similar to
+        generate_audio but targeting music generation models.
+
+        Args:
+            prompt: Text description of the music to generate
+            model: Music model (defaults to "google/lyria-3-pro")
+            duration: Duration hint in seconds (passed in prompt context)
+            **kwargs: Additional parameters
+
+        Returns:
+            MultimodalResponse with generated audio (48kHz stereo)
+        """
+        import json as json_mod
+        import os
+
+        import aiohttp
+
+        api_key = self._api_key or os.environ.get("OPENROUTER_API_KEY", "")
+        if not api_key:
+            raise ValueError(
+                "OpenRouter API key required. Set OPENROUTER_API_KEY env var or pass api_key."
+            )
+
+        send_model = model or "google/lyria-3-pro"
+        if send_model.startswith("openrouter/"):
+            send_model = send_model[len("openrouter/") :]
+
+        # Build the user message with optional duration hint
+        user_content = prompt
+        if duration is not None:
+            user_content = f"{prompt} (duration: {duration} seconds)"
+
+        audio_format = kwargs.pop("format", "wav")
+
+        payload = {
+            "model": send_model,
+            "messages": [{"role": "user", "content": user_content}],
+            "modalities": ["text", "audio"],
+            "audio": {"format": audio_format},
+            "stream": True,
+        }
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        b64_chunks: list = []
+        transcript_parts: list = []
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                json=payload,
+                headers=headers,
+            ) as resp:
+                if resp.status != 200:
+                    body = await resp.text()
+                    raise RuntimeError(
+                        f"OpenRouter music request failed ({resp.status}): {body}"
+                    )
+
+                async for line in resp.content:
+                    decoded = line.decode("utf-8", errors="replace").strip()
+                    if not decoded.startswith("data: "):
+                        continue
+                    data_str = decoded[len("data: ") :]
+                    if data_str == "[DONE]":
+                        break
+                    try:
+                        event = json_mod.loads(data_str)
+                    except json_mod.JSONDecodeError:
+                        continue
+
+                    choices = event.get("choices", [])
+                    if not choices:
+                        continue
+                    delta = choices[0].get("delta", {})
+                    audio_delta = delta.get("audio", {})
+                    if audio_delta.get("data"):
+                        b64_chunks.append(audio_delta["data"])
+                    if audio_delta.get("transcript"):
+                        transcript_parts.append(audio_delta["transcript"])
+
+        b64_full = "".join(b64_chunks)
+        transcript = "".join(transcript_parts)
+
+        audio_output = AudioOutput(
+            data=b64_full if b64_full else None,
+            format=audio_format,
+            url=None,
+        )
+
+        return MultimodalResponse(
+            text=transcript or prompt,
+            audio=audio_output if b64_full else None,
+            images=[],
+            files=[],
+            raw_response={"transcript": transcript, "model": send_model},
         )
 
 

--- a/sdk/python/tests/test_media_providers_additional.py
+++ b/sdk/python/tests/test_media_providers_additional.py
@@ -166,7 +166,8 @@ async def test_fal_provider_logs_and_reraises(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_openrouter_audio_is_not_supported():
+async def test_openrouter_audio_requires_api_key(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     provider = OpenRouterProvider()
-    with pytest.raises(NotImplementedError, match="doesn't support audio generation"):
+    with pytest.raises(ValueError, match="API key required"):
         await provider.generate_audio("hello")

--- a/sdk/python/tests/test_openrouter_audio.py
+++ b/sdk/python/tests/test_openrouter_audio.py
@@ -1,0 +1,480 @@
+"""
+Tests for OpenRouter audio output and music generation.
+
+Covers:
+- SSE stream parsing for generate_audio
+- Audio chunk concatenation
+- Transcript extraction
+- Model prefix stripping
+- generate_music on ABC (raises NotImplementedError by default)
+- supported_modalities includes "audio" and "music"
+- ai_generate_music convenience method on AgentAI
+"""
+
+import base64
+import copy
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agentfield.agent_ai import AgentAI
+from agentfield.media_providers import (
+    FalProvider,
+    LiteLLMProvider,
+    OpenRouterProvider,
+)
+from agentfield.multimodal_response import AudioOutput, MultimodalResponse
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_sse_lines(events: list[dict], done: bool = True) -> list[bytes]:
+    """Build raw SSE byte lines from a list of event dicts."""
+    lines = []
+    for ev in events:
+        lines.append(f"data: {json.dumps(ev)}\n".encode())
+    if done:
+        lines.append(b"data: [DONE]\n")
+    return lines
+
+
+def _audio_event(b64_chunk: str = "", transcript: str = "") -> dict:
+    """Build a single SSE audio delta event."""
+    audio = {}
+    if b64_chunk:
+        audio["data"] = b64_chunk
+    if transcript:
+        audio["transcript"] = transcript
+    return {"choices": [{"delta": {"audio": audio}}]}
+
+
+class _FakeStreamResponse:
+    """Fake aiohttp response supporting async iteration over content lines."""
+
+    def __init__(self, lines: list[bytes], status: int = 200):
+        self.status = status
+        self._lines = lines
+        self.content = self
+
+    async def text(self):
+        return "error"
+
+    def __aiter__(self):
+        return self._iter_lines()
+
+    async def _iter_lines(self):
+        for line in self._lines:
+            yield line
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
+class _FakeSession:
+    """Fake aiohttp.ClientSession."""
+
+    def __init__(self, response: _FakeStreamResponse):
+        self._response = response
+
+    def post(self, url, **kwargs):
+        self._last_post_kwargs = kwargs
+        self._last_post_url = url
+        return self._response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
+class DummyAIConfig:
+    def __init__(self):
+        self.model = "openai/gpt-4"
+        self.temperature = 0.1
+        self.max_tokens = 100
+        self.top_p = 1.0
+        self.stream = False
+        self.response_format = "auto"
+        self.fallback_models = []
+        self.final_fallback_model = None
+        self.enable_rate_limit_retry = True
+        self.rate_limit_max_retries = 2
+        self.rate_limit_base_delay = 0.1
+        self.rate_limit_max_delay = 1.0
+        self.rate_limit_jitter_factor = 0.1
+        self.rate_limit_circuit_breaker_threshold = 3
+        self.rate_limit_circuit_breaker_timeout = 1
+        self.auto_inject_memory = []
+        self.model_limits_cache = {}
+        self.audio_model = "tts-1"
+        self.vision_model = "dall-e-3"
+        self.fal_api_key = None
+        self.video_model = "fal-ai/minimax-video/image-to-video"
+
+    def copy(self, deep=False):
+        return copy.deepcopy(self)
+
+    async def get_model_limits(self, model=None):
+        return {"context_length": 1000, "max_output_tokens": 100}
+
+    def get_litellm_params(self, **overrides):
+        params = {
+            "model": self.model,
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
+        }
+        params.update(overrides)
+        return params
+
+
+class StubAgent:
+    def __init__(self):
+        self.node_id = "test-agent"
+        self.ai_config = DummyAIConfig()
+        self.memory = SimpleNamespace()
+
+
+# =============================================================================
+# OpenRouterProvider.generate_audio tests
+# =============================================================================
+
+
+class TestOpenRouterGenerateAudio:
+    """Tests for OpenRouterProvider.generate_audio SSE streaming."""
+
+    @pytest.mark.asyncio
+    async def test_sse_stream_parsing_and_concatenation(self, monkeypatch):
+        """Audio base64 chunks from SSE should be concatenated correctly."""
+        chunk1 = base64.b64encode(b"audio_part_1").decode()
+        chunk2 = base64.b64encode(b"audio_part_2").decode()
+
+        events = [
+            _audio_event(b64_chunk=chunk1, transcript="Hello "),
+            _audio_event(b64_chunk=chunk2, transcript="world"),
+        ]
+        lines = _make_sse_lines(events)
+        fake_resp = _FakeStreamResponse(lines)
+        fake_session = _FakeSession(fake_resp)
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            result = await provider.generate_audio(
+                text="Say hello",
+                model="openai/gpt-4o-mini-tts",
+                voice="alloy",
+                format="wav",
+            )
+
+        assert result.has_audio
+        assert result.audio.data == chunk1 + chunk2
+        assert result.audio.format == "wav"
+        assert result.text == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_transcript_extraction(self, monkeypatch):
+        """Transcript text should be accumulated from SSE events."""
+        events = [
+            _audio_event(b64_chunk="AAAA", transcript="First "),
+            _audio_event(b64_chunk="BBBB", transcript="second "),
+            _audio_event(b64_chunk="CCCC", transcript="third."),
+        ]
+        lines = _make_sse_lines(events)
+        fake_resp = _FakeStreamResponse(lines)
+        fake_session = _FakeSession(fake_resp)
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            result = await provider.generate_audio(text="test")
+
+        assert result.text == "First second third."
+
+    @pytest.mark.asyncio
+    async def test_model_prefix_stripping(self, monkeypatch):
+        """openrouter/ prefix should be stripped from model before sending."""
+        events = [_audio_event(b64_chunk="AAAA")]
+        lines = _make_sse_lines(events)
+        fake_resp = _FakeStreamResponse(lines)
+        fake_session = _FakeSession(fake_resp)
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            await provider.generate_audio(
+                text="test",
+                model="openrouter/openai/gpt-4o-mini-tts",
+            )
+
+        # Check the payload sent
+        post_kwargs = fake_session._last_post_kwargs
+        payload = post_kwargs["json"]
+        assert payload["model"] == "openai/gpt-4o-mini-tts"
+        assert not payload["model"].startswith("openrouter/")
+
+    @pytest.mark.asyncio
+    async def test_empty_stream_returns_no_audio(self, monkeypatch):
+        """Empty SSE stream should return response with no audio."""
+        lines = _make_sse_lines([])
+        fake_resp = _FakeStreamResponse(lines)
+        fake_session = _FakeSession(fake_resp)
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            result = await provider.generate_audio(text="test")
+
+        assert not result.has_audio
+        assert result.text == "test"
+
+    @pytest.mark.asyncio
+    async def test_invalid_voice_defaults_to_alloy(self, monkeypatch):
+        """Invalid voice should fall back to alloy."""
+        events = [_audio_event(b64_chunk="AAAA")]
+        lines = _make_sse_lines(events)
+        fake_resp = _FakeStreamResponse(lines)
+        fake_session = _FakeSession(fake_resp)
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            await provider.generate_audio(text="test", voice="invalid_voice")
+
+        payload = fake_session._last_post_kwargs["json"]
+        assert payload["audio"]["voice"] == "alloy"
+
+    @pytest.mark.asyncio
+    async def test_invalid_format_defaults_to_wav(self, monkeypatch):
+        """Invalid format should fall back to wav."""
+        events = [_audio_event(b64_chunk="AAAA")]
+        lines = _make_sse_lines(events)
+        fake_resp = _FakeStreamResponse(lines)
+        fake_session = _FakeSession(fake_resp)
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            await provider.generate_audio(text="test", format="invalid_fmt")
+
+        payload = fake_session._last_post_kwargs["json"]
+        assert payload["audio"]["format"] == "wav"
+
+    @pytest.mark.asyncio
+    async def test_http_error_raises(self, monkeypatch):
+        """Non-200 response should raise RuntimeError."""
+        fake_resp = _FakeStreamResponse([], status=400)
+        fake_session = _FakeSession(fake_resp)
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            with pytest.raises(RuntimeError, match="failed.*400"):
+                await provider.generate_audio(text="test")
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key_raises(self, monkeypatch):
+        """Missing API key should raise ValueError."""
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        provider = OpenRouterProvider()
+        with pytest.raises(ValueError, match="API key required"):
+            await provider.generate_audio(text="test")
+
+    @pytest.mark.asyncio
+    async def test_malformed_sse_lines_skipped(self, monkeypatch):
+        """Non-JSON SSE lines and non-data lines should be safely skipped."""
+        lines = [
+            b"event: ping\n",
+            b"data: not_json\n",
+            b'data: {"choices": []}\n',
+            f"data: {json.dumps(_audio_event(b64_chunk='QUFB'))}\n".encode(),
+            b"data: [DONE]\n",
+        ]
+        fake_resp = _FakeStreamResponse(lines)
+        fake_session = _FakeSession(fake_resp)
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            result = await provider.generate_audio(text="test")
+
+        assert result.has_audio
+        assert result.audio.data == "QUFB"
+
+
+# =============================================================================
+# generate_music tests
+# =============================================================================
+
+
+class TestGenerateMusic:
+    """Tests for music generation."""
+
+    def test_abc_generate_music_raises_not_implemented(self):
+        """MediaProvider.generate_music should raise NotImplementedError by default."""
+        # FalProvider and LiteLLMProvider don't override generate_music
+        fal = FalProvider()
+        litellm_p = LiteLLMProvider()
+
+        with pytest.raises(NotImplementedError, match="does not support music"):
+            import asyncio
+
+            asyncio.get_event_loop().run_until_complete(fal.generate_music("test"))
+
+        with pytest.raises(NotImplementedError, match="does not support music"):
+            import asyncio
+
+            asyncio.get_event_loop().run_until_complete(
+                litellm_p.generate_music("test")
+            )
+
+    @pytest.mark.asyncio
+    async def test_openrouter_generate_music_streams(self, monkeypatch):
+        """OpenRouterProvider.generate_music should parse SSE like generate_audio."""
+        chunk = base64.b64encode(b"music_data").decode()
+        events = [_audio_event(b64_chunk=chunk, transcript="Generated music")]
+        lines = _make_sse_lines(events)
+        fake_resp = _FakeStreamResponse(lines)
+        fake_session = _FakeSession(fake_resp)
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            result = await provider.generate_music(
+                prompt="jazz piano",
+                model="google/lyria-3-pro",
+                duration=30,
+            )
+
+        assert result.has_audio
+        assert result.audio.data == chunk
+        assert result.text == "Generated music"
+
+        # Verify duration was included in prompt
+        payload = fake_session._last_post_kwargs["json"]
+        assert "30 seconds" in payload["messages"][0]["content"]
+        assert payload["model"] == "google/lyria-3-pro"
+
+    @pytest.mark.asyncio
+    async def test_openrouter_generate_music_default_model(self, monkeypatch):
+        """generate_music should default to google/lyria-3-pro."""
+        events = [_audio_event(b64_chunk="AAAA")]
+        lines = _make_sse_lines(events)
+        fake_resp = _FakeStreamResponse(lines)
+        fake_session = _FakeSession(fake_resp)
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            await provider.generate_music(prompt="test")
+
+        payload = fake_session._last_post_kwargs["json"]
+        assert payload["model"] == "google/lyria-3-pro"
+
+    @pytest.mark.asyncio
+    async def test_openrouter_generate_music_strips_prefix(self, monkeypatch):
+        """openrouter/ prefix should be stripped from music model."""
+        events = [_audio_event(b64_chunk="AAAA")]
+        lines = _make_sse_lines(events)
+        fake_resp = _FakeStreamResponse(lines)
+        fake_session = _FakeSession(fake_resp)
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            await provider.generate_music(
+                prompt="test",
+                model="openrouter/google/lyria-3-pro",
+            )
+
+        payload = fake_session._last_post_kwargs["json"]
+        assert payload["model"] == "google/lyria-3-pro"
+
+
+# =============================================================================
+# supported_modalities tests
+# =============================================================================
+
+
+class TestSupportedModalities:
+    """Test supported_modalities property."""
+
+    def test_openrouter_includes_audio_and_music(self):
+        """OpenRouterProvider.supported_modalities should include audio and music."""
+        provider = OpenRouterProvider()
+        mods = provider.supported_modalities
+        assert "audio" in mods
+        assert "music" in mods
+        assert "image" in mods
+
+    def test_fal_modalities_unchanged(self):
+        """FalProvider modalities should still be image, audio, video."""
+        provider = FalProvider()
+        assert set(provider.supported_modalities) == {"image", "audio", "video"}
+
+    def test_litellm_modalities_unchanged(self):
+        """LiteLLMProvider modalities should still be image, audio."""
+        provider = LiteLLMProvider()
+        assert set(provider.supported_modalities) == {"image", "audio"}
+
+
+# =============================================================================
+# AgentAI.ai_generate_music tests
+# =============================================================================
+
+
+class TestAgentAIGenerateMusic:
+    """Tests for ai_generate_music convenience method."""
+
+    def test_method_exists(self):
+        """AgentAI should have ai_generate_music method."""
+        agent = StubAgent()
+        ai = AgentAI(agent)
+        assert hasattr(ai, "ai_generate_music")
+        assert callable(ai.ai_generate_music)
+
+    @pytest.mark.asyncio
+    async def test_ai_generate_music_delegates_to_provider(self, monkeypatch):
+        """ai_generate_music should delegate to OpenRouterProvider.generate_music."""
+        expected = MultimodalResponse(
+            text="music",
+            audio=AudioOutput(data="AAAA", format="wav"),
+            images=[],
+            files=[],
+        )
+        mock_generate = AsyncMock(return_value=expected)
+
+        with patch("agentfield.media_providers.OpenRouterProvider") as MockProvider:
+            mock_instance = MagicMock()
+            mock_instance.generate_music = mock_generate
+            MockProvider.return_value = mock_instance
+
+            agent = StubAgent()
+            ai = AgentAI(agent)
+            result = await ai.ai_generate_music(
+                prompt="jazz", model="google/lyria-3-pro", duration=15
+            )
+
+        mock_generate.assert_called_once_with(
+            prompt="jazz", model="google/lyria-3-pro", duration=15
+        )
+        assert result.has_audio


### PR DESCRIPTION
## Summary
- Implement `OpenRouterProvider.generate_audio()` with SSE streaming: parses `choices[0].delta.audio.data` base64 chunks and transcript text from OpenRouter chat completions API
- Add `generate_music()` to `MediaProvider` ABC (raises `NotImplementedError` by default) and implement in `OpenRouterProvider` using same SSE pattern with music-capable models (e.g. `google/lyria-3-pro`)
- Add `ai_generate_music()` convenience method to `AgentAI` mixin and `Agent` class
- Update `OpenRouterProvider.supported_modalities` to `["image", "audio", "music"]`

## Test plan
- [x] 18 new tests in `test_openrouter_audio.py` covering SSE parsing, chunk concatenation, transcript extraction, model prefix stripping, format/voice validation, error handling, ABC default behavior, modality checks, and AgentAI delegation
- [x] Updated existing `test_openrouter_audio_is_not_supported` to `test_openrouter_audio_requires_api_key`
- [x] Full test suite passes (0 failures)
- [x] `ruff check` and `ruff format` clean