### PR TITLE
test(sdk-go): fix flaky DurationMS assertion in runner test

### DIFF
--- a/sdk/go/harness/coverage_branches_test.go
+++ b/sdk/go/harness/coverage_branches_test.go
@@ -92,7 +92,7 @@ func TestRunnerRun_SuccessBranches(t *testing.T) {
 		require.NotNil(t, result)
 		assert.False(t, result.IsError)
 		assert.Equal(t, "stub opencode result", strings.TrimSpace(result.Result))
-		assert.Positive(t, result.DurationMS)
+		assert.GreaterOrEqual(t, result.DurationMS, 0)
 	})
 
 	t.Run("schema + project dir uses temp output dir and parses file", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- `TestRunnerRun_SuccessBranches/no_schema_returns_provider_result` is flaky on fast CI runners
- The stub `opencode` provider returns in well under 1ms, and [runner.go:86](sdk/go/harness/runner.go#L86) computes `int(time.Since(start).Milliseconds())`, which truncates to 0 — failing `assert.Positive`
- Switched to `assert.GreaterOrEqual(t, result.DurationMS, 0)`. The real invariant is that the duration is non-negative; sub-ms timing precision was never the contract being tested
- Caught blocking #481 — see [job log](https://github.com/Agent-Field/agentfield/actions/runs/24620303159/job/72126072105)

## Test plan
- [x] `go test -run TestRunnerRun_SuccessBranches -count=10 ./harness/...` passes locally
- [ ] CI green