### PR TITLE
fix(web-ui): clear sidebar-close timeout on unmount

### DIFF
--- a/control-plane/web/client/src/components/WorkflowDAG/index.tsx
+++ b/control-plane/web/client/src/components/WorkflowDAG/index.tsx
@@ -768,10 +768,26 @@ function WorkflowDAGViewerInner({
   );
 
   // Handle sidebar close
+  const closeSidebarTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
   const handleCloseSidebar = useCallback(() => {
     setSidebarOpen(false);
-    // Optionally clear selected node after animation
-    setTimeout(() => setSelectedNode(null), 300);
+    if (closeSidebarTimeoutRef.current) {
+      clearTimeout(closeSidebarTimeoutRef.current);
+    }
+    // Clear selected node after animation
+    closeSidebarTimeoutRef.current = setTimeout(() => {
+      setSelectedNode(null);
+      closeSidebarTimeoutRef.current = null;
+    }, 300);
+  }, []);
+  useEffect(() => {
+    return () => {
+      if (closeSidebarTimeoutRef.current) {
+        clearTimeout(closeSidebarTimeoutRef.current);
+      }
+    };
   }, []);
 
   // Handle agent filter - optimized to avoid dependency on nodes array

--- a/control-plane/web/client/src/test/components/WorkflowDAG/workflowDagSupplemental.test.tsx
+++ b/control-plane/web/client/src/test/components/WorkflowDAG/workflowDagSupplemental.test.tsx
@@ -576,4 +576,51 @@ describe("WorkflowDAGViewer supplemental coverage", () => {
     warnSpy.mockRestore();
     setItemSpy.mockRestore();
   });
+
+  it("clears the pending sidebar-close timer when the sidebar is reopened and reclosed, and lets the timer fire safely", async () => {
+    const { WorkflowDAGViewer } = await import("@/components/WorkflowDAG");
+    state.getWorkflowDAG.mockResolvedValue({
+      lightweight: true,
+      workflow_name: "Reopen Workflow",
+      nodes: [
+        {
+          workflow_id: "wf-reopen",
+          execution_id: "exec-reopen",
+          agent_node_id: "agent-reopen",
+          reasoner_id: "task_reopen",
+          status: "succeeded",
+          started_at: "2026-04-09T10:00:00Z",
+          workflow_depth: 1,
+          task_name: "task_reopen",
+          agent_name: "Reopen Agent",
+        },
+      ],
+    });
+
+    const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+    render(<WorkflowDAGViewer workflowId="wf-reopen" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("nodes:1")).toBeInTheDocument();
+    });
+
+    // Open then close — schedules the deferred clear, no prior handle to cancel.
+    fireEvent.click(screen.getByRole("button", { name: "click-node" }));
+    expect(screen.getByText("sidebar:exec-reopen")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "sidebar-close" }));
+
+    // Re-open and close again before the deferred clear fires —
+    // exercises the clearTimeout branch on the prior pending handle.
+    clearSpy.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: "click-node" }));
+    expect(screen.getByText("sidebar:exec-reopen")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "sidebar-close" }));
+    expect(clearSpy).toHaveBeenCalled();
+
+    // Let the deferred clear actually run so the setTimeout body executes.
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    expect(screen.getByText("sidebar:closed")).toBeInTheDocument();
+
+    clearSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- `handleCloseSidebar` in [WorkflowDAG/index.tsx:771](control-plane/web/client/src/components/WorkflowDAG/index.tsx#L771) scheduled a 300ms `setTimeout(() => setSelectedNode(null))` to clear the selected node *after* the slide-out animation, but never tracked the handle
- If the component unmounted inside the 300ms window — routine in tests — the timer still fired, called `setState` on an unmounted component, and React's internals threw `ReferenceError: window is not defined` after the vitest env was torn down
- Surfaced as a flaky `coverage (web-ui)` job; example failure on #481 [here](https://github.com/Agent-Field/agentfield/actions/runs/24667653506/job/72129448263). Tests themselves all passed (583/583); the unhandled error is what failed the job
- Fix: track the timeout handle in a ref, clear it on re-invocation, and clear it on unmount via a `useEffect` cleanup

## Test plan
- [x] `npm test -- --run src/test/components/WorkflowDAG/workflowDagSupplemental.test.tsx` passes with no unhandled errors
- [x] Full `WorkflowDAG/` test directory: pre-existing TZ-dependent failure in `workflowDagNodeWrapperLine.test.tsx` reproduces on clean `main` and is unrelated
- [ ] CI green on `coverage (web-ui)`