### PR TITLE
ci(coverage): stop rerunning full pipeline on push to main

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -1,0 +1,143 @@
+name: Coverage Badge
+
+# Updates the README coverage badge gist after a merge to main, without
+# re-running the coverage pipeline. The coverage numbers that ship with main
+# are the ones computed on the PR's merge commit (coverage.yml runs on every
+# PR), so we just locate that PR's coverage-summary artifact and push it to
+# the gist.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Coverage Summary run ID to pull artifact from (optional; defaults to latest success on main)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  update-badge:
+    runs-on: ubuntu-latest
+    # Skip release automation commits — they don't change coverage.
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+    steps:
+      - name: Resolve Coverage Summary run ID for this merge
+        id: resolve
+        uses: actions/github-script@v7
+        env:
+          OVERRIDE_RUN_ID: ${{ github.event.inputs.run_id }}
+        with:
+          script: |
+            const override = process.env.OVERRIDE_RUN_ID;
+            if (override) {
+              core.info(`Using override run_id=${override}`);
+              core.setOutput('run_id', override);
+              return;
+            }
+
+            // Find the PR associated with the merge commit. Merge commits to
+            // main are produced by either squash/rebase (one PR) or a merge
+            // commit (one PR); the associated-PRs endpoint handles all three.
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            });
+
+            // Prefer a PR whose base is main and that is closed/merged.
+            const pr = prs.find(p => p.base && p.base.ref === 'main') || prs[0];
+            if (!pr) {
+              core.warning(`No PR associated with ${context.sha}; skipping badge update.`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            core.info(`Associated PR #${pr.number} head_sha=${pr.head.sha}`);
+
+            // Find the most recent successful Coverage Summary run whose head
+            // SHA matches the PR's head. That run's artifact reflects coverage
+            // against main at merge time.
+            const { data: runs } = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'coverage.yml',
+              head_sha: pr.head.sha,
+              status: 'success',
+              per_page: 10,
+            });
+
+            if (runs.workflow_runs.length === 0) {
+              core.warning(`No successful Coverage Summary run found for PR #${pr.number} (${pr.head.sha}); skipping badge update.`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            const run = runs.workflow_runs[0];
+            core.info(`Using Coverage Summary run ${run.id} (${run.html_url})`);
+            core.setOutput('run_id', run.id.toString());
+            core.setOutput('pr_number', pr.number.toString());
+
+      - name: Confirm artifact exists
+        if: steps.resolve.outputs.skip != 'true'
+        id: artifact
+        uses: actions/github-script@v7
+        env:
+          RUN_ID: ${{ steps.resolve.outputs.run_id }}
+        with:
+          script: |
+            const run_id = Number(process.env.RUN_ID);
+            const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id,
+            });
+            const artifact = data.artifacts.find(a => a.name === 'coverage-summary');
+            if (!artifact) {
+              core.warning(`Run ${run_id} has no coverage-summary artifact (likely a docs-only PR); skipping badge update.`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            if (artifact.expired) {
+              core.warning(`coverage-summary artifact on run ${run_id} has expired; skipping badge update.`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+      - name: Download coverage-summary artifact
+        if: steps.resolve.outputs.skip != 'true' && steps.artifact.outputs.skip != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-summary
+          run-id: ${{ steps.resolve.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: coverage
+
+      - name: Update coverage badge gist
+        # GitHub Actions does not allow secrets.* inside if: expressions, so
+        # surface them through env and gate on that to keep this a no-op on
+        # forks / repos without the secrets configured.
+        if: steps.resolve.outputs.skip != 'true' && steps.artifact.outputs.skip != 'true' && env.COVERAGE_GIST_ID != '' && env.GIST_TOKEN != ''
+        uses: actions/github-script@v7
+        env:
+          COVERAGE_GIST_ID: ${{ secrets.COVERAGE_GIST_ID }}
+          GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
+        with:
+          github-token: ${{ secrets.GIST_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const badge = fs.readFileSync('coverage/badge.json', 'utf8');
+            const summary = fs.readFileSync('coverage/summary.json', 'utf8');
+
+            await github.rest.gists.update({
+              gist_id: process.env.COVERAGE_GIST_ID,
+              files: {
+                'badge.json': { content: badge },
+                'coverage-summary.json': { content: summary },
+              },
+            });
+            core.info('Coverage badge gist updated.');

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,23 +3,6 @@ name: Coverage Summary
 on:
   merge_group:
   pull_request:
-  push:
-    branches: [main]
-    paths:
-      - "control-plane/**"
-      - "sdk/**"
-      - "scripts/test-all.sh"
-      - "scripts/coverage-summary.sh"
-      - "scripts/coverage-surface.sh"
-      - "scripts/coverage-aggregate.py"
-      - "scripts/coverage-gate.py"
-      - "scripts/patch-coverage-gate.sh"
-      - ".coverage-gate.toml"
-      - "coverage-baseline.json"
-      - ".github/workflows/coverage.yml"
-      - "docs/COVERAGE.md"
-      - "docs/DEVELOPMENT.md"
-      - ".github/BRANCH_PROTECTION.md"
   workflow_dispatch:
 
 permissions:
@@ -242,7 +225,10 @@ jobs:
         with:
           name: coverage-summary
           path: test-reports/coverage/
-          retention-days: 7
+          # Retention is long enough to cover the gap between a PR's last
+          # coverage run and the eventual merge to main, so coverage-badge.yml
+          # can still find the artifact when it runs post-merge.
+          retention-days: 30
 
       - name: Fail the job if any gate failed
         if: github.event_name != 'merge_group' && needs.changes.outputs.has_coverage_files == 'true' && (steps.gate.outcome == 'failure' || steps.patch_gate.outcome == 'failure')
@@ -250,26 +236,6 @@ jobs:
           echo "::error::Coverage gate failed. See the coverage report comment(s) on the PR for details and remediation steps."
           exit 1
 
-      - name: Update coverage badge gist
-        # NOTE: GitHub Actions does not allow `secrets.*` inside `if:` expressions
-        # (they evaluate to empty). We surface them through `env` and gate on that
-        # so the step silently skips on forks / PRs without the secret configured.
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && env.COVERAGE_GIST_ID != '' && env.GIST_TOKEN != ''
-        uses: actions/github-script@v7
-        env:
-          COVERAGE_GIST_ID: ${{ secrets.COVERAGE_GIST_ID }}
-          GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
-        with:
-          github-token: ${{ secrets.GIST_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const badge = fs.readFileSync('test-reports/coverage/badge.json', 'utf8');
-            const summary = fs.readFileSync('test-reports/coverage/summary.json', 'utf8');
-
-            await github.rest.gists.update({
-              gist_id: process.env.COVERAGE_GIST_ID,
-              files: {
-                'badge.json': { content: badge },
-                'coverage-summary.json': { content: summary },
-              },
-            });
+      # Badge gist updates on merge to main are handled by coverage-badge.yml,
+      # which reuses this workflow's coverage-summary artifact rather than
+      # recomputing coverage on every push to main.


### PR DESCRIPTION
## Problem

Every PR merge to main re-triggers the full Coverage Summary workflow: 5 per-surface matrix jobs + aggregation + gate. This is pure duplication — the same pipeline already ran on the PR against the same merge commit, and its result is authoritative.

The only thing that genuinely needed push-to-main was the README coverage badge gist update ([README.md:14](../blob/main/README.md#L14)). Everything else was wasted compute and an extra surface area for transient infrastructure failures (GitHub Actions download errors, cancelled runs on concurrency, etc.).

## Fix

Split the badge update out into a tiny new workflow that reuses the PR's coverage artifact instead of recomputing.

- **`coverage.yml`**: drop `push: branches: [main]` trigger, drop the badge update step. Bump `coverage-summary` artifact retention 7d → 30d so the badge updater can still find the artifact if a merge is delayed.
- **`coverage-badge.yml` (new)**: runs on push to main. Resolves the PR associated with the merge commit, finds its most recent successful Coverage Summary run, downloads that run's `coverage-summary` artifact, and pushes `badge.json` + `summary.json` to the gist. ~30 seconds total, no coverage recomputation.

The PR's Coverage Summary runs on the PR's merge commit (GitHub creates a synthetic merge with main), so its artifact already reflects the coverage of main post-merge. No new data is produced by re-running on main.

## Edge cases handled

- Docs-only / examples-only PRs produce no artifact → badge update skips cleanly with a warning.
- Release automation commits (`[skip ci]`) → skipped.
- Expired artifacts (e.g. very old PRs force-merged after retention window) → skipped with a warning.
- Forks without `COVERAGE_GIST_ID` / `GIST_TOKEN` secrets → step is a no-op.
- Manual re-run via `workflow_dispatch` with an optional `run_id` input for debugging.

## Scope

This PR only touches `coverage.yml`. The same redundant `push: branches: [main]` pattern exists in [control-plane.yml](../blob/main/.github/workflows/control-plane.yml), [sdk-go.yml](../blob/main/.github/workflows/sdk-go.yml), [sdk-python.yml](../blob/main/.github/workflows/sdk-python.yml), [sdk-typescript.yml](../blob/main/.github/workflows/sdk-typescript.yml), [docker.yml](../blob/main/.github/workflows/docker.yml), and [functional-tests.yml](../blob/main/.github/workflows/functional-tests.yml). Happy to sweep those in a follow-up if desired — none of them have a badge-update side effect, so each is a straightforward trigger removal.

## Test plan

- [ ] PR CI still runs Coverage Summary normally (this PR itself exercises that).
- [ ] After merging this PR, confirm `coverage-badge.yml` fires on the resulting push to main and the gist at `santoshkumarradha/433fb09c2d54c3c2589125cfd3eb14a2` gets a fresh timestamp.
- [ ] Confirm Coverage Summary does *not* run on the push-to-main event.
- [ ] README coverage badge still renders correctly after the update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)