### PR TITLE
security: fix SSRF in serverless agent discovery (CodeQL alert #32)

### DIFF
--- a/control-plane/internal/handlers/nodes_register.go
+++ b/control-plane/internal/handlers/nodes_register.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 
@@ -211,47 +212,94 @@ func resolveCallbackCandidates(rawCandidates []string, defaultPort string) (stri
 	return normalized[0], normalized, nil
 }
 
+// normalizeServerlessDiscoveryURL validates the caller-supplied invocation URL
+// and rebuilds it from a restricted set of components. The returned URL carries
+// only literal scheme values ("http"/"https"), a host whose hostname has been
+// matched against an allowlist, an optional validated port, and a sanitized
+// path — no user-info, query, or fragment is ever propagated. This breaks the
+// request-forgery (SSRF) taint flow from user input into the outbound HTTP
+// request, and defends against path-traversal sequences in the supplied path.
 func normalizeServerlessDiscoveryURL(rawURL string, allowedHosts []string) (string, error) {
+	safeURL, err := parseServerlessDiscoveryURL(rawURL, allowedHosts)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(safeURL.String(), "/"), nil
+}
+
+// parseServerlessDiscoveryURL performs the same validation as
+// normalizeServerlessDiscoveryURL and returns a freshly constructed *url.URL
+// assembled from validated components, so callers can compose a request URL
+// (e.g. appending "/discover") without re-introducing untrusted data.
+func parseServerlessDiscoveryURL(rawURL string, allowedHosts []string) (*url.URL, error) {
 	parsedURL, err := url.Parse(strings.TrimSpace(rawURL))
 	if err != nil {
-		return "", fmt.Errorf("invalid invocation_url format: %w", err)
+		return nil, fmt.Errorf("invalid invocation_url format: %w", err)
 	}
 
-	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		return "", fmt.Errorf("invocation_url must use http or https")
+	// Reject opaque URLs (e.g. "mailto:..."), which have no host component.
+	if parsedURL.Opaque != "" {
+		return nil, fmt.Errorf("invocation_url must not be opaque")
+	}
+
+	// Only accept literal http/https schemes so the scheme placed on the
+	// reconstructed URL cannot be influenced by user input.
+	var scheme string
+	switch parsedURL.Scheme {
+	case "http":
+		scheme = "http"
+	case "https":
+		scheme = "https"
+	default:
+		return nil, fmt.Errorf("invocation_url must use http or https")
 	}
 
 	if parsedURL.User != nil {
-		return "", fmt.Errorf("invocation_url must not include user info")
+		return nil, fmt.Errorf("invocation_url must not include user info")
 	}
 
 	if parsedURL.Host == "" {
-		return "", fmt.Errorf("invocation_url must include a host")
+		return nil, fmt.Errorf("invocation_url must include a host")
 	}
 
 	if parsedURL.RawQuery != "" || parsedURL.Fragment != "" {
-		return "", fmt.Errorf("invocation_url must not include query parameters or fragments")
+		return nil, fmt.Errorf("invocation_url must not include query parameters or fragments")
 	}
 
 	hostname := parsedURL.Hostname()
 	if hostname == "" {
-		return "", fmt.Errorf("invocation_url must include a host")
+		return nil, fmt.Errorf("invocation_url must include a host")
 	}
 
+	// Treat wildcard bind addresses as loopback so developer workflows work.
 	if hostname == "0.0.0.0" || hostname == "::" {
 		hostname = "localhost"
-		if port := parsedURL.Port(); port != "" {
-			parsedURL.Host = net.JoinHostPort(hostname, port)
-		} else {
-			parsedURL.Host = hostname
-		}
 	}
 
 	if !isServerlessDiscoveryHostAllowed(hostname, allowedHosts) {
-		return "", fmt.Errorf("invocation_url host %q is not allowlisted for server-side discovery; configure agentfield.registration.serverless_discovery_allowed_hosts or AGENTFIELD_REGISTRATION_SERVERLESS_DISCOVERY_ALLOWED_HOSTS", hostname)
+		return nil, fmt.Errorf("invocation_url host %q is not allowlisted for server-side discovery; configure agentfield.registration.serverless_discovery_allowed_hosts or AGENTFIELD_REGISTRATION_SERVERLESS_DISCOVERY_ALLOWED_HOSTS", hostname)
 	}
 
-	return strings.TrimSuffix(parsedURL.String(), "/"), nil
+	host := hostname
+	if port := parsedURL.Port(); port != "" {
+		host = net.JoinHostPort(hostname, port)
+	}
+
+	// path.Clean collapses any "." / ".." segments so a validated host cannot
+	// be combined with a traversal path to reach unintended endpoints.
+	cleanedPath := ""
+	if parsedURL.Path != "" {
+		cleanedPath = path.Clean("/" + strings.TrimPrefix(parsedURL.Path, "/"))
+		if cleanedPath == "/" {
+			cleanedPath = ""
+		}
+	}
+
+	return &url.URL{
+		Scheme: scheme,
+		Host:   host,
+		Path:   cleanedPath,
+	}, nil
 }
 
 func isServerlessDiscoveryHostAllowed(host string, allowedHosts []string) bool {
@@ -680,7 +728,11 @@ func RegisterServerlessAgentHandler(storageProvider storage.StorageProvider, uiS
 			return
 		}
 
-		normalizedURL, err := normalizeServerlessDiscoveryURL(req.InvocationURL, allowedDiscoveryHosts)
+		// Validate the user-provided invocation URL and rebuild it (plus the
+		// discovery endpoint URL) from checked components so no tainted string
+		// flows into http.NewRequestWithContext — this is the SSRF sanitizer
+		// boundary.
+		safeInvocation, err := parseServerlessDiscoveryURL(req.InvocationURL, allowedDiscoveryHosts)
 		if err != nil {
 			logger.Logger.Warn().Err(err).Msgf("❌ Rejected serverless discovery URL: %s", req.InvocationURL)
 			c.JSON(http.StatusBadRequest, gin.H{
@@ -690,10 +742,14 @@ func RegisterServerlessAgentHandler(storageProvider storage.StorageProvider, uiS
 			return
 		}
 
-		logger.Logger.Info().Msgf("🔍 Discovering serverless agent at: %s", normalizedURL)
+		normalizedURL := strings.TrimSuffix(safeInvocation.String(), "/")
+		discoveryURL := (&url.URL{
+			Scheme: safeInvocation.Scheme,
+			Host:   safeInvocation.Host,
+			Path:   path.Clean(safeInvocation.Path + "/discover"),
+		}).String()
 
-		// Call the discovery endpoint using normalized URL
-		discoveryURL := strings.TrimSuffix(normalizedURL, "/") + "/discover"
+		logger.Logger.Info().Msgf("🔍 Discovering serverless agent at: %s", normalizedURL)
 
 		client := &http.Client{
 			Timeout: 10 * time.Second,

--- a/control-plane/internal/handlers/nodes_serverless_ssrf_test.go
+++ b/control-plane/internal/handlers/nodes_serverless_ssrf_test.go
@@ -1,0 +1,214 @@
+package handlers
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise the SSRF hardening added for the
+// parseServerlessDiscoveryURL / RegisterServerlessAgentHandler pair:
+// the discovery URL must be reconstructed from validated components, so that
+// scheme, host and path are all known-safe before an outbound HTTP request
+// is issued (see CodeQL go/request-forgery, CWE-918).
+
+func TestParseServerlessDiscoveryURL_RebuildsFromValidatedComponents(t *testing.T) {
+	t.Parallel()
+
+	safe, err := parseServerlessDiscoveryURL("https://agents.internal/invoke", []string{"agents.internal"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "https", safe.Scheme)
+	assert.Equal(t, "agents.internal", safe.Host)
+	assert.Equal(t, "/invoke", safe.Path)
+	assert.Nil(t, safe.User)
+	assert.Equal(t, "", safe.RawQuery)
+	assert.Equal(t, "", safe.Fragment)
+	assert.Equal(t, "", safe.Opaque)
+}
+
+func TestNormalizeServerlessDiscoveryURL_CleansPathTraversal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		rawURL  string
+		allowed []string
+		want    string
+	}{
+		{
+			name:    "dot segments collapsed",
+			rawURL:  "http://localhost:9000/a/./b/../invoke",
+			allowed: nil,
+			want:    "http://localhost:9000/a/invoke",
+		},
+		{
+			name:    "parent traversal clamped to root",
+			rawURL:  "http://localhost:9000/../../../etc/passwd",
+			allowed: nil,
+			want:    "http://localhost:9000/etc/passwd",
+		},
+		{
+			name:    "trailing slash stripped after cleaning",
+			rawURL:  "http://localhost:9000/invoke/",
+			allowed: nil,
+			want:    "http://localhost:9000/invoke",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := normalizeServerlessDiscoveryURL(tc.rawURL, tc.allowed)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestNormalizeServerlessDiscoveryURL_RejectsOpaqueURL(t *testing.T) {
+	t.Parallel()
+
+	_, err := normalizeServerlessDiscoveryURL("http:foo.example.com/path", []string{"foo.example.com"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be opaque")
+}
+
+func TestNormalizeServerlessDiscoveryURL_NormalizesIPv6ZeroHost(t *testing.T) {
+	t.Parallel()
+
+	got, err := normalizeServerlessDiscoveryURL("http://[::]:9000/invoke", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost:9000/invoke", got)
+}
+
+func TestNormalizeServerlessDiscoveryURL_IgnoresQueryAndFragmentInPath(t *testing.T) {
+	t.Parallel()
+
+	// A valid-shaped URL whose path tries to carry a query-like suffix must
+	// still succeed — the query is part of the path, not a real query string.
+	got, err := normalizeServerlessDiscoveryURL("http://localhost:7000/inv%3Fstrange", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost:7000/inv%3Fstrange", got)
+}
+
+// TestRegisterServerlessAgentHandler_DiscoverySanitizedFunctional is the SSRF
+// functional test: it verifies that (1) URLs whose host is not loopback and
+// not on the allowlist are rejected before any HTTP request goes out, and
+// (2) when a valid-but-path-traversal-shaped URL is submitted the handler's
+// outbound request lands on the allowlisted server at a sanitized path —
+// both of which are the properties CodeQL rule go/request-forgery asks the
+// code to uphold.
+func TestRegisterServerlessAgentHandler_DiscoverySanitizedFunctional(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var allowedHits int32
+	sawSanitizedPath := make(chan string, 4)
+
+	discoveryPayload := `{
+		"node_id":"serverless-ok",
+		"version":"v1",
+		"reasoners":[{"id":"r1","input_schema":{"type":"object"},"output_schema":{"type":"object"}}],
+		"skills":[{"id":"s1","input_schema":{"type":"object"}}]
+	}`
+
+	allowedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&allowedHits, 1)
+		select {
+		case sawSanitizedPath <- r.URL.Path:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(discoveryPayload))
+	}))
+	defer allowedServer.Close()
+
+	allowedURL, err := url.Parse(allowedServer.URL)
+	require.NoError(t, err)
+	_, _, err = net.SplitHostPort(allowedURL.Host)
+	require.NoError(t, err)
+
+	// Allowlist the loopback (default) plus a fake external host we can
+	// assert against without risking real network egress.
+	allowedHosts := []string{"127.0.0.1", "localhost"}
+
+	t.Run("rejects non-loopback host outside allowlist", func(t *testing.T) {
+		router := gin.New()
+		router.POST("/serverless/register",
+			RegisterServerlessAgentHandler(&nodeRESTStorageStub{}, nil, nil, nil, nil, allowedHosts),
+		)
+
+		// evil.example.com is neither a loopback address nor in the allow
+		// list, so the handler must reject this synchronously — no outbound
+		// request, no DNS, no socket.
+		body := `{"invocation_url":"https://evil.example.com/invoke"}`
+		req := httptest.NewRequest(http.MethodPost, "/serverless/register", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+
+		require.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Contains(t, resp.Body.String(), "Invalid invocation_url")
+		assert.Contains(t, resp.Body.String(), "not allowlisted")
+	})
+
+	t.Run("outbound request uses only validated components", func(t *testing.T) {
+		atomic.StoreInt32(&allowedHits, 0)
+
+		// The attacker-shaped path contains ".." traversal segments. After
+		// normalization the handler must contact the allowlisted server at
+		// the collapsed path — specifically, "/discover" (since "/a/./b/../.."
+		// collapses to "/" and "/" + "/discover" cleans to "/discover").
+		body := fmt.Sprintf(`{"invocation_url":"http://%s/a/./b/../.."}`, allowedURL.Host)
+		router := gin.New()
+		router.POST("/serverless/register",
+			RegisterServerlessAgentHandler(&nodeRESTStorageStub{}, nil, nil, nil, nil, allowedHosts),
+		)
+		req := httptest.NewRequest(http.MethodPost, "/serverless/register", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+
+		assert.GreaterOrEqual(t, atomic.LoadInt32(&allowedHits), int32(1),
+			"allowed host should receive the discovery request; response was: %s", resp.Body.String())
+
+		select {
+		case got := <-sawSanitizedPath:
+			// The path seen by the allowlisted server must be a literal,
+			// sanitized "/discover" — never "/a/./b/../../discover" and never
+			// anything outside the "/discover" endpoint.
+			assert.Equal(t, "/discover", got,
+				"discovery request must target the sanitized /discover path")
+		default:
+			t.Fatalf("expected an inbound request on the allowlisted discovery server")
+		}
+	})
+
+	t.Run("rejects opaque URL before any network call", func(t *testing.T) {
+		atomic.StoreInt32(&allowedHits, 0)
+
+		router := gin.New()
+		router.POST("/serverless/register",
+			RegisterServerlessAgentHandler(&nodeRESTStorageStub{}, nil, nil, nil, nil, allowedHosts),
+		)
+
+		// "http:foo" is parsed as an opaque URL (no "//", no host).
+		req := httptest.NewRequest(http.MethodPost, "/serverless/register",
+			strings.NewReader(`{"invocation_url":"http:opaque/content"}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+
+		require.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Contains(t, resp.Body.String(), "Invalid invocation_url")
+		assert.Equal(t, int32(0), atomic.LoadInt32(&allowedHits))
+	})
+}


### PR DESCRIPTION
## Summary
- Fixes CodeQL [go/request-forgery alert #32](https://github.com/Agent-Field/agentfield/security/code-scanning/32) (CWE-918) on `RegisterServerlessAgentHandler`.
- Splits `normalizeServerlessDiscoveryURL` into a parse helper that returns a freshly constructed `*url.URL` (validated scheme literal, allowlisted host, `path.Clean`-ed path — no user-info / query / fragment ever propagated).
- Handler now builds `discoveryURL` from those sanitized components rather than string-concatenating the caller-supplied value, so no tainted string flows into `http.NewRequestWithContext`.
- Also rejects opaque URLs (e.g. `http:foo/path`).

## Test plan
- [x] `go test ./control-plane/internal/handlers/...` — full suite green (69.7s)
- [x] New unit tests in `nodes_serverless_ssrf_test.go`:
  - Path-traversal cleaning (`./`, `../`, trailing slashes)
  - Rebuilds from validated components (no `User`/`RawQuery`/`Fragment`/`Opaque`)
  - Rejects opaque URLs
  - Normalizes IPv6 zero-host `[::]` to `localhost`
- [x] New functional test `TestRegisterServerlessAgentHandler_DiscoverySanitizedFunctional`:
  - Non-loopback host outside allowlist is rejected without any outbound network call
  - End-to-end: handler contacts the allowlisted server only on the sanitized `/discover` path even when input contains `./` and `../` segments
  - Opaque URL rejected before any network call
- [x] Coverage on touched symbols: `normalizeServerlessDiscoveryURL` 100%, `parseServerlessDiscoveryURL` 90.6%, `RegisterServerlessAgentHandler` 79.2%
- [x] `go vet ./control-plane/internal/handlers/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)