### PR TITLE
feat(skillkit,doctor): GitHub Copilot CLI target + doctor probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 <!-- changelog:entries -->
 
+## [Unreleased]
+
+### Added
+
+- feat(skillkit,doctor): GitHub Copilot CLI as a first-class skill-install target.
+  `af skill install --target copilot` symlinks skills into `~/.copilot/skills/`,
+  auto-detected when `~/.copilot/` exists or the `copilot` binary is on PATH.
+  `af doctor` (+ `--json`) reports Copilot presence, config dir, detected auth
+  sources (`COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN` / `gh auth`),
+  and the last logged-in user, with an explicit disclaimer that presence of a
+  source is not proof of a valid login.
+
 ## [0.1.70] - 2026-04-20
 
 ## [0.1.70-rc.3] - 2026-04-20

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ app.run()
 
 ```bash
 # Installs the af CLI AND drops the agentfield-multi-reasoner-builder skill
-# into every coding agent on your machine (Claude Code, Codex, Gemini,
-# OpenCode, Aider, Windsurf, Cursor) — no prompts, no second step.
+# into every coding agent on your machine (Claude Code, GitHub Copilot CLI,
+# Codex, Gemini, OpenCode, Aider, Windsurf, Cursor) — no prompts, no second step.
 curl -fsSL https://agentfield.ai/install.sh | bash
 
 af init my-agent --defaults                            # Scaffold agent

--- a/control-plane/internal/cli/doctor.go
+++ b/control-plane/internal/cli/doctor.go
@@ -26,6 +26,7 @@ type DoctorReport struct {
 	Docker          ToolStatus              `json:"docker"`
 	HarnessProviders map[string]ToolStatus  `json:"harness_providers"`
 	ProviderKeys    map[string]ProviderKey  `json:"provider_keys"`
+	Copilot         CopilotStatus           `json:"copilot"`
 	ControlPlane    ControlPlaneStatus      `json:"control_plane"`
 	Recommendation  Recommendation          `json:"recommendation"`
 }
@@ -52,6 +53,20 @@ type ControlPlaneStatus struct {
 	HealthStatus       string `json:"health_status,omitempty"`
 	DockerImageName    string `json:"docker_image_name"`
 	DockerImageLocal   bool   `json:"docker_image_local"`
+}
+
+// CopilotStatus reports what Copilot CLI auth *sources* are present. It
+// intentionally does NOT claim the user is "authenticated" — Copilot rejects
+// classic ghp_ PATs and requires a fine-grained PAT with the "Copilot
+// Requests" permission. Presence of a source only means the SDK will attempt
+// to use it; the user may still need to run `copilot --login` to verify.
+type CopilotStatus struct {
+	Binary           ToolStatus `json:"binary"`
+	ConfigDirPresent bool       `json:"config_dir_present"` // ~/.copilot exists
+	LoggedInUser     string     `json:"logged_in_user,omitempty"`
+	AuthEnvSources   []string   `json:"auth_env_sources"`    // names of env vars set (never values)
+	GhCliAuthSource  bool       `json:"gh_cli_auth_source"`  // `gh auth status` exits 0
+	Disclaimer       string     `json:"disclaimer"`
 }
 
 // Recommendation tells the caller (a skill or a coding agent) what to default to,
@@ -174,6 +189,9 @@ func buildDoctorReport(controlPlaneURL string) DoctorReport {
 	// Control plane
 	report.ControlPlane = checkControlPlane(controlPlaneURL)
 
+	// Copilot CLI
+	report.Copilot = checkCopilot()
+
 	// Recommendation
 	notes := []string{}
 	if chosenProvider == "" {
@@ -227,6 +245,51 @@ func checkTool(bin, versionFlag string) ToolStatus {
 		first := strings.SplitN(strings.TrimSpace(string(out)), "\n", 2)[0]
 		status.Version = first
 	}
+	return status
+}
+
+// checkCopilot inspects the environment for Copilot CLI auth *sources*. It
+// does not validate them; `copilot --login` is the only way to confirm the
+// user is actually authenticated (fine-grained PATs must have the "Copilot
+// Requests" permission; classic ghp_ tokens are rejected by the backend).
+func checkCopilot() CopilotStatus {
+	status := CopilotStatus{
+		Binary:         checkTool("copilot", "--version"),
+		AuthEnvSources: []string{},
+		Disclaimer:     "Auth sources detected are attempts, not proof of a working login. Copilot requires a fine-grained PAT with the 'Copilot Requests' permission (or an interactive `copilot --login`); classic ghp_* tokens will be rejected.",
+	}
+
+	home, err := os.UserHomeDir()
+	if err == nil && home != "" {
+		configDir := home + "/.copilot"
+		if info, err := os.Stat(configDir); err == nil && info.IsDir() {
+			status.ConfigDirPresent = true
+			// Best-effort read of config.json for the last logged-in user.
+			if data, err := os.ReadFile(configDir + "/config.json"); err == nil {
+				var cfg struct {
+					LastLoggedInUser string `json:"lastLoggedInUser"`
+				}
+				if json.Unmarshal(data, &cfg) == nil {
+					status.LoggedInUser = cfg.LastLoggedInUser
+				}
+			}
+		}
+	}
+
+	for _, v := range []string{"COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"} {
+		if strings.TrimSpace(os.Getenv(v)) != "" {
+			status.AuthEnvSources = append(status.AuthEnvSources, v)
+		}
+	}
+
+	if _, err := exec.LookPath("gh"); err == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if err := exec.CommandContext(ctx, "gh", "auth", "status").Run(); err == nil {
+			status.GhCliAuthSource = true
+		}
+	}
+
 	return status
 }
 
@@ -313,6 +376,28 @@ func printDoctorReport(r DoctorReport) {
 		c = green
 	}
 	c.Printf("  %s (%s)\n", mark, r.ControlPlane.DockerImageName)
+	fmt.Println()
+
+	bold.Println("GitHub Copilot CLI")
+	printToolLine("copilot", r.Copilot.Binary, green, yellow)
+	if r.Copilot.ConfigDirPresent {
+		green.Printf("  ✓ ~/.copilot config dir present")
+		if r.Copilot.LoggedInUser != "" {
+			fmt.Printf(" (last user: %s)", r.Copilot.LoggedInUser)
+		}
+		fmt.Println()
+	} else {
+		yellow.Println("  • ~/.copilot config dir not found — run `copilot --login` to initialize")
+	}
+	if len(r.Copilot.AuthEnvSources) > 0 {
+		green.Printf("  ✓ auth env sources present: %s\n", strings.Join(r.Copilot.AuthEnvSources, ", "))
+	} else {
+		yellow.Println("  • no auth env vars set (COPILOT_GITHUB_TOKEN / GH_TOKEN / GITHUB_TOKEN)")
+	}
+	if r.Copilot.GhCliAuthSource {
+		green.Println("  ✓ gh CLI auth source present")
+	}
+	fmt.Printf("  • %s\n", r.Copilot.Disclaimer)
 	fmt.Println()
 
 	bold.Println("Recommendation")

--- a/control-plane/internal/skillkit/skillkit_test.go
+++ b/control-plane/internal/skillkit/skillkit_test.go
@@ -301,7 +301,7 @@ func TestHelpersAndTargets(t *testing.T) {
 	for _, target := range AllTargets() {
 		targetNames[target.Name()] = true
 	}
-	for _, name := range []string{"aider", "claude-code", "codex", "cursor", "gemini", "opencode", "windsurf"} {
+	for _, name := range []string{"aider", "claude-code", "codex", "copilot", "cursor", "gemini", "opencode", "windsurf"} {
 		if !targetNames[name] {
 			t.Fatalf("missing registered target %q", name)
 		}
@@ -467,11 +467,15 @@ func TestHelpersAndTargets(t *testing.T) {
 		t.Fatalf("windsurf uninstall: %v", err)
 	}
 
+	if err := os.MkdirAll(filepath.Join(home, ".copilot"), 0o755); err != nil {
+		t.Fatalf("mkdir copilot dir: %v", err)
+	}
+
 	detected := map[string]bool{}
 	for _, target := range DetectedTargets() {
 		detected[target.Name()] = true
 	}
-	for _, name := range []string{"aider", "claude-code", "codex", "gemini", "opencode", "windsurf"} {
+	for _, name := range []string{"aider", "claude-code", "codex", "copilot", "gemini", "opencode", "windsurf"} {
 		if !detected[name] {
 			t.Fatalf("DetectedTargets missing %q: %+v", name, detected)
 		}

--- a/control-plane/internal/skillkit/target_copilot.go
+++ b/control-plane/internal/skillkit/target_copilot.go
@@ -1,0 +1,136 @@
+package skillkit
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// copilotTarget installs the skill into GitHub Copilot CLI via
+// ~/.copilot/skills/<name>/ using a symlink to the canonical versioned-store
+// location. Copilot CLI natively reads SKILL.md files from that directory and
+// the symlink ensures updates to the canonical store flow through
+// automatically. This mirrors the claudeCodeTarget approach.
+//
+// Note on deduplication: Copilot CLI auto-discovers skills from both
+// ~/.copilot/skills/ and ~/.claude/skills/ (when the Claude Code config is
+// present). If both targets have installed the same skill, Copilot sees it
+// twice at discovery time but dedupes internally by skill name. We still
+// create the symlink so the integration is explicit; a one-line warning is
+// printed to stderr to surface the overlap to the user.
+type copilotTarget struct{}
+
+func init() { RegisterTarget(copilotTarget{}) }
+
+func (copilotTarget) Name() string        { return "copilot" }
+func (copilotTarget) DisplayName() string { return "GitHub Copilot CLI" }
+func (copilotTarget) Method() string      { return "symlink" }
+
+func (copilotTarget) Detected() bool {
+	if dirExists(filepath.Join(homeDir(), ".copilot")) {
+		return true
+	}
+	return commandAvailable("copilot")
+}
+
+func (copilotTarget) TargetPath() (string, error) {
+	h := homeDir()
+	if h == "" {
+		return "", errors.New("could not resolve home directory")
+	}
+	return filepath.Join(h, ".copilot", "skills"), nil
+}
+
+func (t copilotTarget) skillLink(skill Skill) (string, error) {
+	root, err := t.TargetPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, skill.Name), nil
+}
+
+func (t copilotTarget) Install(skill Skill, canonicalCurrentDir string) (InstalledTarget, error) {
+	root, err := t.TargetPath()
+	if err != nil {
+		return InstalledTarget{}, err
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return InstalledTarget{}, fmt.Errorf("create %s: %w", root, err)
+	}
+	link, err := t.skillLink(skill)
+	if err != nil {
+		return InstalledTarget{}, err
+	}
+
+	// Warn if the same skill is already installed into ~/.claude/skills/ —
+	// Copilot CLI reads from both locations and the duplicate symlinks, while
+	// harmless (Copilot dedupes by name), may confuse users grepping for where
+	// the skill came from.
+	if h := homeDir(); h != "" {
+		claudeLink := filepath.Join(h, ".claude", "skills", skill.Name)
+		if info, err := os.Lstat(claudeLink); err == nil && info.Mode()&os.ModeSymlink != 0 {
+			fmt.Fprintf(os.Stderr, "note: skill %q is also installed into ~/.claude/skills/; Copilot CLI reads both locations and will dedupe by name.\n", skill.Name)
+		}
+	}
+
+	// Remove any existing entry (regular dir, file, or symlink). Copilot reads
+	// symlinks transparently, so we always replace with a fresh link to the
+	// canonical current/ directory.
+	if info, err := os.Lstat(link); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || info.IsDir() || info.Mode().IsRegular() {
+			if err := os.RemoveAll(link); err != nil {
+				return InstalledTarget{}, fmt.Errorf("remove existing %s: %w", link, err)
+			}
+		}
+	}
+
+	if err := os.Symlink(canonicalCurrentDir, link); err != nil {
+		return InstalledTarget{}, fmt.Errorf("symlink %s -> %s: %w", link, canonicalCurrentDir, err)
+	}
+
+	return InstalledTarget{
+		TargetName:  t.Name(),
+		Method:      t.Method(),
+		Path:        link,
+		Version:     skill.Version,
+		InstalledAt: time.Now().UTC(),
+	}, nil
+}
+
+func (t copilotTarget) Uninstall() error {
+	for _, s := range Catalog {
+		link, err := t.skillLink(s)
+		if err != nil {
+			continue
+		}
+		if info, err := os.Lstat(link); err == nil {
+			if info.Mode()&os.ModeSymlink != 0 || info.IsDir() || info.Mode().IsRegular() {
+				if err := os.RemoveAll(link); err != nil {
+					return fmt.Errorf("remove %s: %w", link, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (t copilotTarget) Status() (bool, string, error) {
+	link, err := t.skillLink(Catalog[0])
+	if err != nil {
+		return false, "", err
+	}
+	info, err := os.Lstat(link)
+	if err != nil {
+		return false, "", nil
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return true, "manual", nil
+	}
+	dest, err := os.Readlink(link)
+	if err != nil {
+		return false, "", nil
+	}
+	return true, filepath.Base(dest), nil
+}

--- a/control-plane/internal/skillkit/target_copilot_test.go
+++ b/control-plane/internal/skillkit/target_copilot_test.go
@@ -1,0 +1,107 @@
+package skillkit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopilotTarget(t *testing.T) {
+	home := withTempHome(t)
+
+	cp := copilotTarget{}
+	if cp.Name() != "copilot" || cp.DisplayName() != "GitHub Copilot CLI" || cp.Method() != "symlink" {
+		t.Fatalf("unexpected copilot metadata: %q %q %q", cp.Name(), cp.DisplayName(), cp.Method())
+	}
+
+	// Not detected before ~/.copilot exists and the copilot binary is not on
+	// PATH (withTempHome sets PATH to an empty bin dir).
+	if cp.Detected() {
+		t.Fatal("copilot target should not be detected in empty temp home")
+	}
+
+	if err := os.MkdirAll(filepath.Join(home, ".copilot"), 0o755); err != nil {
+		t.Fatalf("mkdir copilot dir: %v", err)
+	}
+	if !cp.Detected() {
+		t.Fatal("copilot target should be detected once ~/.copilot exists")
+	}
+
+	skill := Catalog[0]
+	canonicalCurrentDir := filepath.Join(home, "canonical", "current")
+	if err := os.MkdirAll(canonicalCurrentDir, 0o755); err != nil {
+		t.Fatalf("mkdir canonical current: %v", err)
+	}
+
+	inst, err := cp.Install(skill, canonicalCurrentDir)
+	if err != nil {
+		t.Fatalf("copilot install: %v", err)
+	}
+	if inst.Method != "symlink" || inst.TargetName != "copilot" {
+		t.Fatalf("unexpected install record: %+v", inst)
+	}
+
+	link := filepath.Join(home, ".copilot", "skills", skill.Name)
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat symlink: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("expected symlink at %s", link)
+	}
+	dest, err := os.Readlink(link)
+	if err != nil || dest != canonicalCurrentDir {
+		t.Fatalf("readlink = %q err=%v", dest, err)
+	}
+
+	installed, version, err := cp.Status()
+	if err != nil || !installed || version != "current" {
+		t.Fatalf("copilot status = %v %q %v", installed, version, err)
+	}
+
+	// Re-install should be idempotent (replaces existing symlink cleanly).
+	if _, err := cp.Install(skill, canonicalCurrentDir); err != nil {
+		t.Fatalf("copilot reinstall: %v", err)
+	}
+
+	if err := cp.Uninstall(); err != nil {
+		t.Fatalf("copilot uninstall: %v", err)
+	}
+	if installed, _, _ := cp.Status(); installed {
+		t.Fatal("copilot should not be installed after uninstall")
+	}
+}
+
+func TestCopilotTargetReplacesRegularDir(t *testing.T) {
+	home := withTempHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".copilot"), 0o755); err != nil {
+		t.Fatalf("mkdir copilot dir: %v", err)
+	}
+
+	skill := Catalog[0]
+	link := filepath.Join(home, ".copilot", "skills", skill.Name)
+	if err := os.MkdirAll(link, 0o755); err != nil {
+		t.Fatalf("mkdir pre-existing skill dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(link, "stray.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write stray: %v", err)
+	}
+
+	canonicalCurrentDir := filepath.Join(home, "canonical", "current")
+	if err := os.MkdirAll(canonicalCurrentDir, 0o755); err != nil {
+		t.Fatalf("mkdir canonical: %v", err)
+	}
+
+	cp := copilotTarget{}
+	if _, err := cp.Install(skill, canonicalCurrentDir); err != nil {
+		t.Fatalf("copilot install over regular dir: %v", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat after install: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("expected symlink after install-over-dir")
+	}
+}

--- a/research/docs/2026-04-20-auth-model.md
+++ b/research/docs/2026-04-20-auth-model.md
@@ -1,0 +1,329 @@
+---
+date: "2026-04-20"
+researcher: "codebase-analyzer (auth-model)"
+git_commit: "0f42e612"
+branch: "copilot-cli-support"
+repository: "agentfield"
+topic: "AgentField authentication and external credential model"
+tags: [research, codebase, auth, did-vc, credentials]
+status: complete
+last_updated: "2026-04-20"
+last_updated_by: "codebase-analyzer"
+---
+
+## Analysis: AgentField Authentication & External Credential System
+
+### Overview
+
+AgentField uses a layered authentication architecture. The control plane enforces a single static **API key** on all HTTP routes and optionally an **Ed25519 DID-based signature** scheme for caller identity. Agents register with the control plane at startup by POSTing their metadata (node ID, reasoners, skills, callback URL) to `/api/v1/nodes/register` carrying that API key. The control plane then issues each agent a **W3C Verifiable Credential identity package** (a set of Ed25519 key pairs encoded as `did:key` or `did:web` DIDs, one per agent, reasoner, and skill) which the agent caches locally to sign subsequent requests. There is no dedicated secrets store; external API keys (e.g., OpenAI) are read from the **agent process's own environment variables** by LiteLLM and are never sent to or stored by the control plane.
+
+---
+
+### 1. Control-Plane Authentication Middleware
+
+#### 1a. API Key Auth (`control-plane/internal/server/middleware/auth.go`)
+
+The primary gate is `APIKeyAuth` (`auth.go:18`). It is applied as a global Gin middleware at `server.go:979`:
+
+```go
+s.Router.Use(middleware.APIKeyAuth(middleware.AuthConfig{
+    APIKey:    s.config.API.Auth.APIKey,
+    SkipPaths: s.config.API.Auth.SkipPaths,
+}))
+```
+
+**Token extraction order** (`auth.go:71–87`):
+1. `X-API-Key` header
+2. `Authorization: Bearer <token>` header
+3. `?api_key=` query parameter
+
+**Bypass rules** (no token required — `auth.go:38–69`):
+- `/api/v1/health`, `/health`, `/metrics` — health/metrics
+- Paths starting with `/ui` or exactly `/` — UI static files
+- `GET /api/v1/did/document/` and `/api/v1/did/resolve/` — public DID resolution (W3C spec)
+- `GET /api/v1/agentic/kb/` — public knowledge base
+- `POST /api/v1/connector/` — handled by `ConnectorTokenAuth` separately
+
+Comparison is constant-time (`crypto/subtle.ConstantTimeCompare` at `auth.go:89`). Failed auth sets `auth_level=public` (`auth.go:91`) and returns `HTTP 401`.
+
+The API key is sourced from `AGENTFIELD_API_KEY` env var (applied in `config.go:367`) or `agentfield.yaml` under `api.auth.api_key` (`config.go:311`). It is empty by default, which disables all auth (`auth.go:26–29`).
+
+#### 1b. Admin Token Auth (`middleware/auth.go:115–134`)
+
+A separate `AdminTokenAuth` middleware requires the `X-Admin-Token` header for admin routes. Mounted at `server.go:1686`:
+
+```go
+adminGroup.Use(middleware.AdminTokenAuth(s.config.Features.DID.Authorization.AdminToken))
+```
+
+Configured via `AGENTFIELD_AUTHORIZATION_ADMIN_TOKEN` (`config.go:489`) or `features.did.authorization.admin_token` in YAML. The default in `agentfield.yaml:99` is `"admin-secret"`.
+
+#### 1c. Connector Token Auth (`middleware/connector_auth.go`)
+
+The connector subsystem uses its own token scheme (`connector_auth.go:13`). All `/api/v1/connector/` routes are skipped by the global API key middleware (`auth.go:66–69`) and instead gated by `ConnectorTokenAuth`, which checks the `X-Connector-Token` header (`connector_auth.go:23`). Additionally it injects audit headers `X-Command-ID` and `X-Command-Source` into the Gin context (`connector_auth.go:33–39`). Per-route capability enforcement is done by `ConnectorCapabilityCheck` middleware (`connector_capability.go:14`), which reads `config.ConnectorCapability.Enabled` and `ReadOnly` flags.
+
+The connector token comes from `features.connector.token` in YAML (`config.go:191`) or `AGENTFIELD_AUTHORIZATION_INTERNAL_TOKEN` (this env var sets the *internal* token, not the connector token directly).
+
+#### 1d. gRPC Admin Auth (`middleware/grpc_auth.go`)
+
+An admin gRPC server runs on port `cfg.AgentField.Port + 100` (default 8180). The `APIKeyUnaryInterceptor` interceptor checks `x-api-key` metadata or `Authorization: Bearer` metadata (`grpc_auth.go:27–36`). Installed at `server.go:603–608`:
+
+```go
+grpc.UnaryInterceptor(middleware.APIKeyUnaryInterceptor(s.config.API.Auth.APIKey))
+```
+
+#### 1e. DID Auth Middleware (`middleware/did_auth.go`)
+
+`DIDAuthMiddleware` is an **optional** layer mounted only when `features.did.authorization.did_auth_enabled=true` (`server.go:988`, default `false` per `agentfield.yaml:95`). When active, it runs after the API key middleware.
+
+**Flow** (`did_auth.go:156–308`):
+1. If `X-Caller-DID` header is absent → skip, set `did_auth_skipped=true` (`did_auth.go:179–183`)
+2. If present, require `X-DID-Signature` and `X-DID-Timestamp` headers (`did_auth.go:195–202`)
+3. Parse timestamp and reject if outside ±300s window (`did_auth.go:204–222`, configurable via `timestamp_window_seconds`)
+4. Read and restore request body up to 1 MB (`did_auth.go:225–241`)
+5. Build verification payload: `"{timestamp}:{nonce}:{sha256(body)}"` (or `"{timestamp}:{sha256(body)}"` if no nonce) (`did_auth.go:246–252`)
+6. Base64-decode signature (`did_auth.go:255–261`)
+7. Replay protection: SHA256 the signature bytes and check global `signatureCache` (`did_auth.go:265–273`); the cache has a TTL equal to `TimestampWindowSeconds`
+8. Call `didService.VerifyDIDOwnership(ctx, callerDID, payload, sigBytes)` to verify against the DID document's Ed25519 public key (`did_auth.go:276–302`)
+9. On success, store verified DID in Gin context under `"verified_caller_did"` (`did_auth.go:306`)
+
+---
+
+### 2. DID/VC Identity System
+
+#### DID Service Initialization (`control-plane/internal/services/did_service.go`)
+
+On server startup, when `features.did.enabled=true`, the following initialization chain runs (`server.go:188–263`):
+
+1. `KeystoreService` is created from `features.did.keystore` config (`server.go:204`). It stores encrypted key files at `cfg.Path` (default `./data/keys`) using AES-GCM with a session-ephemeral random key (`keystore_service.go:25–49`).
+
+2. A `DIDRegistry` is created with `storage.StorageProvider`, and if `keystore.encryption_passphrase` is set, an `EncryptionService` is wired in (`server.go:211–213`). The `EncryptionService` uses AES-256-GCM with PBKDF2 (600,000 rounds) key derivation (`encryption.go:37–38`). Encrypted blobs are prefixed with `"AFENC2"` and versioned as `"v2:<base64>"` (`encryption.go:19–22`, `115–127`).
+
+3. `DIDService` is initialized with a server ID derived from `AGENTFIELD_HOME` (`server.go:234`). On first run, it generates a 32-byte random master seed (`did_service.go:57–59`), derives a root DID at BIP32 path `m/44'/0'` (`did_service.go:63`), and stores the `DIDRegistry` struct persistently (`did_service.go:69–81`).
+
+#### Agent DID Registration (`did_service.go:150–205`)
+
+When an agent registers at `POST /api/v1/did/register` (handler: `did_handlers.go:92`), `DIDService.RegisterAgent` is called. For a new agent:
+
+- **Agent DID**: derived at path `m/44'/{serverHash}'/{agentIndex}'` (`did_service.go:235`)
+- **Reasoner DIDs**: `m/44'/{serverHash}'/{agentIndex}'/0'/{reasonerIndex}'` (`did_service.go:258`)
+- **Skill DIDs**: `m/44'/{serverHash}'/{agentIndex}'/1'/{skillIndex}'` (`did_service.go:304`)
+
+Key generation uses HKDF over the master seed (`did_service.go` imports `golang.org/x/crypto/hkdf`), producing Ed25519 key pairs. Each DID is encoded as `did:key:z6Mk...` (multibase-encoded public key). The private keys are returned in the response's `IdentityPackage` as JWK objects with `"kty":"OKP"`, `"crv":"Ed25519"`, `"d":"<base64url>"`, `"x":"<base64url>"`.
+
+If the agent already exists, a differential analysis compares known reasoner/skill IDs with the new request and only generates keys for new components (`did_service.go:182–201`).
+
+#### DID/VC Endpoints (`did_handlers.go:532–548`)
+
+Registered under `/api/v1/did/`:
+
+| Endpoint | Handler | Notes |
+|---|---|---|
+| `POST /api/v1/did/register` | `RegisterAgent` | Issues identity package |
+| `GET /api/v1/did/resolve/:did` | `ResolveDID` | Resolves `did:web` (DB) or `did:key` (memory) |
+| `POST /api/v1/did/verify` | `VerifyVC` | Verifies a VC document |
+| `POST /api/v1/did/verify-audit` | `VerifyAuditBundle` | Verifies exported provenance JSON |
+| `GET /api/v1/did/workflow/:id/vc-chain` | `GetWorkflowVCChain` | Chains execution VCs |
+| `POST /api/v1/did/workflow/:id/vc` | `CreateWorkflowVC` | Creates workflow-level VC |
+| `GET /api/v1/did/status` | `GetDIDStatus` | Returns `"active"` |
+| `GET /api/v1/did/export/vcs` | `ExportVCs` | Exports all VCs |
+| `GET /api/v1/did/document/:did` | `GetDIDDocument` | Returns W3C DID document |
+| `POST /api/v1/execution/vc` | `CreateExecutionVC` | Creates per-execution VC |
+
+W3C `did:web` resolution paths are also mounted at `/.well-known/did.json` (server DID) and `/agents/:agentID/did.json` (per-agent DID) (`server.go:1012–1013`).
+
+#### VC Generation
+
+VCs are W3C Verifiable Credentials. The `VCService.GenerateExecutionVC` creates a credential that records `issuer_did`, `target_did`, `caller_did`, `input_hash`, `output_hash`, `status`, `duration_ms`, and a signature (`vc_service.go`). These are stored in the control-plane database. The `EncryptConfigurationValues` / `DecryptConfigurationValues` methods on `EncryptionService` (`encryption.go:163–211`) can encrypt specific fields in config maps, used to protect the master seed at rest.
+
+---
+
+### 3. Agent Registration Flow
+
+#### Python SDK (`sdk/python/agentfield/`)
+
+**Init** (`agent.py:464–709`):
+1. The control-plane URL is resolved: explicit `agentfield_server` param → `AGENTFIELD_SERVER` env var → `AGENTFIELD_SERVER_URL` env var → `"http://localhost:8080"` (`agent.py:556–558`)
+2. `AgentFieldClient` is instantiated with `base_url` and `api_key` (`agent.py:606–608`). The `api_key` is stored and later injected as `X-API-Key` on every request (`client.py:220–222`)
+3. If `enable_did=True` (the default), `DIDManager(agentfield_server, node_id, api_key)` and `VCGenerator(agentfield_server, api_key)` are created (`agent.py:1149–1167`)
+
+**Registration** (`agent_field_handler.py:41–184`):
+1. `AgentFieldClient.register_agent()` is called with node ID, reasoner/skill schemas, `base_url`, and `tags` (`client.py:630–711`)
+2. The POST goes to `/api/v1/nodes/register` with `X-API-Key` in headers (`client.py:690–695`)
+3. On success, if `did_manager` exists, `_register_agent_with_did()` is called (`agent_field_handler.py:159`)
+4. `_register_agent_with_did()` calls `did_manager.register_agent(reasoner_defs, skill_defs)` which POSTs to `/api/v1/did/register` (`did_manager.py:100`, `agent.py:1578`)
+5. The returned `identity_package` is stored in `did_manager.identity_package`; the agent DID and private key JWK are extracted and passed to `client.set_did_credentials(did, private_key_jwk)` (`agent.py:1585–1592`), which wires them into `DIDAuthenticator` for request signing
+
+**Heartbeat** (`agent_field_handler.py:226–247`):
+- POST to `/api/v1/nodes/{node_id}/heartbeat` with `X-API-Key` header every 30 seconds
+
+#### Go SDK (`sdk/go/agent/agent.go`, `sdk/go/client/client.go`)
+
+**Init** (`agent.go:353–427`):
+1. `Config.AgentFieldURL` and `Config.Token` are set by the caller (no automatic env var lookup in the Go SDK for the URL)
+2. `client.New(cfg.AgentFieldURL, client.WithBearerToken(cfg.Token))` is called (`agent.go:415`)
+3. If `cfg.DID != ""` and `cfg.PrivateKeyJWK != ""`, `client.WithDIDAuth(cfg.DID, cfg.PrivateKeyJWK)` is also passed (`agent.go:416–418`)
+
+**HTTP client `do()` method** (`client.go:178–253`):
+- Sets `Authorization: Bearer <token>` if `c.token != ""` (`client.go:212–214`)
+- Sets `X-API-Key: <key>` if `c.apiKey != ""` (`client.go:215–217`)
+- Calls `c.didAuthenticator.SignRequest(bodyBytes)` and adds the resulting headers if DID auth is configured (`client.go:220–225`)
+
+**DID request signing** (`client/did_auth.go:60–93`):
+1. Generate Unix timestamp (`did_auth.go:66`)
+2. Generate 16-byte random nonce hex-encoded (`did_auth.go:70–74`)
+3. SHA256 the body (`did_auth.go:77`)
+4. Build payload: `"{timestamp}:{nonce}:{bodyHash}"` (`did_auth.go:80`)
+5. Sign with Ed25519 (`did_auth.go:83`)
+6. Set headers `X-Caller-DID`, `X-DID-Signature` (base64), `X-DID-Timestamp`, `X-DID-Nonce` (`did_auth.go:88–93`)
+
+**Incoming request auth (RequireOriginAuth)** (`agent.go:949–982`):
+- When `RequireOriginAuth=true`, the `originAuthMiddleware` checks that `Authorization: Bearer <InternalToken>` matches (`agent.go:973–974`). `/health` and `/discover` are exempt (`agent.go:968`).
+- `InternalToken` falls back to `Token` if empty (`agent.go:949–951`)
+
+**Registered endpoints** (`agent.go:940`):
+- `POST /execute/{reasoner}` — main invocation path
+- `POST /reasoners/{reasoner}` — alternate invocation path
+- `GET /health` — health check (no auth)
+- `GET /discover` — capability discovery (no auth)
+
+---
+
+### 4. Secrets / External Credentials Storage
+
+AgentField has **no secrets store** for external service credentials. There is no per-agent secrets API, no way to upload a GitHub token or OpenAI key to the control plane, and no mechanism to forward env vars from the control plane to agents.
+
+**Config-level encrypted storage** (`encryption.go`):
+
+The `EncryptionService` (`encryption.go:26`) can be used to encrypt/decrypt arbitrary strings with AES-256-GCM + PBKDF2. It is wired exclusively to protect the DID registry's **master seed** at rest (`server.go:211–213`). The `EncryptConfigurationValues` (`encryption.go:163`) and `DecryptConfigurationValues` (`encryption.go:188`) methods exist to encrypt named fields in `map[string]interface{}` config payloads, but there is no handler that accepts external service credentials through this path.
+
+**Config storage API** (`handlers/config_storage.go`):
+Routes `GET/PUT/DELETE /api/v1/configs/:key` store arbitrary key/value YAML strings in the database (`config_storage.go:30–36`). These are generic config blobs (not encrypted). There is no special handling for secrets here.
+
+**Per-agent memory** (`agent/memory.go`, `sdk/python/agentfield/memory.py`):
+The memory system stores scoped key/value data per execution/session/workflow/agent scope. It is not used as a secrets channel.
+
+---
+
+### 5. External AI Credentials (OpenAI/Anthropic)
+
+#### Python SDK `AIConfig` (`sdk/python/agentfield/types.py`)
+
+`AIConfig` (`types.py:313`) delegates entirely to **LiteLLM** for API key management:
+
+- `api_key` field (`types.py:458`): if set explicitly, it is passed as `params["api_key"]` to `litellm.acompletion()` via `get_litellm_params()` (`types.py:644`)
+- `api_base` field (`types.py:461`): custom base URL (e.g., for a proxy)
+- If `api_key` is not set, LiteLLM reads provider-specific env vars automatically (per docstring `types.py:318–320`): `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `AZURE_OPENAI_API_KEY`, etc. — these are **read directly from the agent process environment**
+- `fal_api_key` field (`types.py:380`): for Fal.ai media generation; if unset, Fal reads `FAL_KEY` env var
+
+`AIConfig.from_env()` (`types.py:692`) simply calls `cls(**overrides)` — it does not read any env var itself; it relies entirely on LiteLLM's own env var handling at call time.
+
+The `AgentAI` class (`agent_ai.py:143`) uses the agent's `ai_config` lazily; when `ai()` is called, it ultimately calls `litellm.acompletion()` with the parameters from `get_litellm_params()`.
+
+**OpenAI direct mode** (`agent_ai.py:1294`): when `mode="openai_direct"` is passed, the code reads `config.get("api_key")` from the call-specific config and passes it to `openai.OpenAI(api_key=api_key)` (`agent_ai.py:1329–1335`).
+
+#### Go SDK `ai.Config` (`sdk/go/ai/`)
+
+The Go AI client is configured via `ai.Config` passed to `agent.Config.AIConfig`. The API key is stored in the config struct and passed directly to the AI provider calls (no env var auto-read visible in the harness path; each provider CLI subprocess inherits the parent process environment via `os.Environ()` in `harness/cli.go:55`).
+
+---
+
+### 6. Harness / External Coding Agent Credentials
+
+The harness system (`sdk/go/harness/`, `sdk/python/agentfield/harness/`) dispatches prompts to CLI-based coding agents (`claude-code`, `codex`, `opencode`, `gemini`) by spawning subprocesses.
+
+**Environment variable pass-through** (`harness/cli.go:47–71`):
+```go
+// Merge environment: empty values unset the variable.
+for _, entry := range os.Environ() { ... }  // inherits ALL parent env vars
+for k, v := range env {
+    if v != "" {
+        mergedEnv = append(mergedEnv, k+"="+v)
+    }
+}
+c.Env = mergedEnv
+```
+
+The subprocess inherits **all** env vars from the agent process. The `Options.Env` map (`harness/provider.go:43`) can override or unset specific vars (empty string value = unset). This means that if `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GITHUB_TOKEN` are set in the agent process environment, they are transparently forwarded to the CLI subprocess.
+
+**Claude Code** (`harness/claudecode.go:70–78`): builds an env override with `env["CLAUDECODE"] = ""` to unset the variable that prevents nested Claude Code sessions. All other env vars (including API keys) are inherited.
+
+**`Options.Env` field** (`provider.go:43`): callers can inject per-call env vars. For example, to pass a `GITHUB_TOKEN` to a coding agent, the caller would set `Options.Env["GITHUB_TOKEN"] = "<token>"`. There is no special handling for this; the token arrives in the subprocess's environment.
+
+---
+
+### 6. Search Results for "GITHUB_TOKEN", "github", "oauth", "bearer", "copilot"
+
+**In source code (`.go`, `.py`, `.ts`, `.yaml`):**
+
+- No occurrences of `GITHUB_TOKEN`, `github_token`, `copilot`, or `oauth` appear in any Go, Python, TypeScript, or YAML source file. The grep returned zero results (`bash` command output above).
+
+**In CI/CD workflows (`.github/workflows/`):**
+- `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` appears in `release.yml:248`, `coverage-report.yml:25`, `coverage-badge.yml:117`, `memory-metrics-report.yml:27` — these are standard GitHub Actions automation tokens, not part of the AgentField application itself.
+- The AI detection label workflow (`ai-label.yml:74`) contains a regex pattern that checks PR descriptions for references to `github.com/features/copilot` — this is used to auto-label AI-assisted PRs, not a credential.
+
+**Bearer in source code:**
+- `"Authorization: Bearer "` pattern is used in:
+  - `auth.go:79` — control plane extracts from incoming `Authorization: Bearer` header
+  - `grpc_auth.go:32` — gRPC interceptor extracts from `authorization` metadata
+  - `client.go:213` — Go SDK client sets `Authorization: Bearer <token>` on outbound requests
+  - `execute.go:1238` — control plane sets `Authorization: Bearer <internalToken>` when forwarding to agents
+  - `agent.go:973`, `1028` — Go agent validates incoming `Authorization: Bearer <internalToken>`
+  - `client.py` (implicitly, via `_get_auth_headers` setting `X-API-Key` — the Python SDK uses `X-API-Key`, not `Bearer`, by default)
+
+---
+
+### Data Flow Summary
+
+```
+1. Agent Process Startup
+   └─ Python: reads AGENTFIELD_SERVER / AGENTFIELD_SERVER_URL env var (agent.py:557-558)
+   └─ Go: AgentFieldURL / Token set explicitly in Config struct (agent.go:181-202)
+
+2. Control-Plane Registration
+   └─ POST /api/v1/nodes/register
+       ├─ Header: X-API-Key (Python) or Authorization: Bearer (Go)
+       └─ Body: {id, base_url, reasoners[], skills[], tags[], ...}
+
+3. DID Registration (after node registration succeeds)
+   └─ POST /api/v1/did/register
+       ├─ Header: X-API-Key
+       └─ Body: {agent_node_id, reasoners[], skills[]}
+   └─ Response: {identity_package: {agent_did: {did, private_key_jwk, public_key_jwk, ...},
+                                     reasoner_dids: {...}, skill_dids: {...}}}
+   └─ Agent caches private_key_jwk → wired into DIDAuthenticator for future requests
+
+4. Agent-to-Agent Execution (via control plane)
+   └─ Caller POSTs to /api/v1/execute/{target}
+       ├─ Header: X-API-Key (control-plane auth)
+       ├─ Header: X-Caller-DID, X-DID-Signature, X-DID-Timestamp, X-DID-Nonce (optional DID auth)
+   └─ Control plane validates API key + optional DID signature
+   └─ Control plane forwards to target agent:
+       ├─ Header: Authorization: Bearer <InternalToken>
+       ├─ Header: X-Caller-DID, X-Target-DID (from DID auth)
+       └─ Body: original execution payload
+
+5. External AI Calls (within agent process)
+   └─ OPENAI_API_KEY / ANTHROPIC_API_KEY / FAL_KEY read from agent's own process env
+   └─ Passed to litellm.acompletion() (Python) or subprocess env (Go harness)
+   └─ Never sent to / stored by the control plane
+```
+
+---
+
+### Configuration: All Auth-Related Env Vars
+
+| Env Var | Effect | Set In |
+|---|---|---|
+| `AGENTFIELD_SERVER` | Agent's control-plane URL (Python SDK) | `agent.py:557` |
+| `AGENTFIELD_SERVER_URL` | Fallback control-plane URL (Python SDK) | `agent.py:558` |
+| `AGENTFIELD_API_KEY` | Control-plane API key (server-side) | `config.go:367` |
+| `AGENTFIELD_API_AUTH_API_KEY` | Same, alternate path | `config.go:371` |
+| `AGENTFIELD_AUTHORIZATION_ADMIN_TOKEN` | Admin routes token | `config.go:489` |
+| `AGENTFIELD_AUTHORIZATION_INTERNAL_TOKEN` | Token CP sends to agents | `config.go:493` |
+| `AGENTFIELD_AUTHORIZATION_DID_AUTH_ENABLED` | Enable DID middleware | `config.go:483` |
+| `AGENTFIELD_AUTHORIZATION_DOMAIN` | Domain for `did:web` DIDs | `config.go:486` |
+| `AGENT_CALLBACK_URL` | Agent's public callback URL | `agent.py:293` |
+| `OPENAI_API_KEY` | OpenAI key (LiteLLM auto-reads) | agent process env |
+| `ANTHROPIC_API_KEY` | Anthropic key (LiteLLM auto-reads) | agent process env |
+| `FAL_KEY` | Fal.ai key | agent process env |

--- a/research/docs/2026-04-20-copilot-cli-external-research.md
+++ b/research/docs/2026-04-20-copilot-cli-external-research.md
@@ -1,0 +1,695 @@
+---
+date: "2026-04-20"
+researcher: "codebase-online-researcher"
+topic: "GitHub Copilot CLI — Programmatic Invocation, Auth, Extensions, MCP, and Integration Patterns"
+tags: [research, external, copilot-cli]
+status: complete
+local_binary: "/home/eioannidis/.local/bin/copilot"
+local_version: "GitHub Copilot CLI 1.0.34"
+---
+
+# GitHub Copilot CLI — External Research Report
+
+> **Scope**: Wrapping Copilot CLI as an agent inside an orchestrator (AgentField), shipping Copilot
+> "skills" alongside an installer, and reusing Copilot CLI authentication. Research combines live
+> `copilot --help` output (v1.0.34 on this machine), local config inspection, and official
+> [docs.github.com](https://docs.github.com/en/copilot/how-tos/copilot-cli) documentation.
+
+---
+
+## 1. Programmatic / Non-Interactive Invocation
+
+**Official docs**: [About GitHub Copilot CLI — Programmatic interface](https://docs.github.com/en/copilot/concepts/agents/copilot-cli/about-copilot-cli#programmatic-interface) · [CLI command reference](https://docs.github.com/en/free-pro-team@latest/copilot/reference/copilot-cli-reference/cli-command-reference)
+
+### 1.1 The `-p` / `--prompt` Flag
+
+The primary mechanism for non-interactive one-shot use is the `-p` / `--prompt` flag:
+
+```bash
+copilot -p "Fix the bug in main.js" --allow-all-tools
+```
+
+> "Execute a prompt in non-interactive mode (exits after completion)"
+> — `copilot --help` (v1.0.34), confirmed by [official docs](https://docs.github.com/en/copilot/concepts/agents/copilot-cli/about-copilot-cli#programmatic-interface)
+
+Key companion flags for scripting:
+
+| Flag | Effect |
+|------|--------|
+| `-p` / `--prompt <text>` | Execute prompt non-interactively and exit |
+| `--allow-all-tools` | Pre-approve every tool (required for unattended use); env: `COPILOT_ALLOW_ALL=true` |
+| `--allow-all` / `--yolo` | Equivalent to `--allow-all-tools --allow-all-paths --allow-all-urls` |
+| `-s` / `--silent` | Output only the agent response (no stats); **use with `-p` for scripting** |
+| `--output-format json` | Emit JSONL (one JSON object per line) instead of human-readable text |
+| `--no-ask-user` | Disable the `ask_user` tool; agent works fully autonomously |
+| `--stream on\|off` | Enable/disable streaming mode |
+| `--no-color` | Disable ANSI colour (useful in CI log parsers) |
+| `--no-auto-update` | Disable automatic self-update (auto-disabled when `CI` env var is detected) |
+
+### 1.2 Minimal One-Shot Invocations
+
+```bash
+# Simplest possible: read-only task
+copilot -p "Summarise git log --oneline -10" --allow-tool='shell(git:*)'
+
+# Full agentic: can edit files and run anything
+copilot -p "Refactor foo.py to use dataclasses" --allow-all
+
+# JSONL output — parse with jq
+copilot -p "List open issues" --allow-all --output-format json | jq .
+
+# Silent for piping to downstream tools
+copilot -p "Generate a changelog entry" --allow-all --silent
+
+# Per-session MCP config override (no config file edit required)
+copilot -p "Run playwright tests" \
+  --additional-mcp-config '{"mcpServers":{"pw":{"type":"stdio","command":"npx","args":["@playwright/mcp@latest"]}}}' \
+  --allow-all
+```
+
+### 1.3 Piping Options
+
+The `--help` output documents a second invocation pattern — piping shell-script-generated options:
+
+```bash
+./script-outputting-options.sh | copilot
+```
+
+This allows dynamic construction of flags from a parent process. ([Official docs](https://docs.github.com/en/copilot/concepts/agents/copilot-cli/about-copilot-cli#programmatic-interface))
+
+### 1.4 Autopilot Mode
+
+`--autopilot` (or `--mode autopilot`) starts Copilot in full autopilot mode where it continues working with minimal interruption. Combine with `--max-autopilot-continues <count>` to cap the number of continuation rounds:
+
+```bash
+copilot --autopilot --max-autopilot-continues 20 -p "Implement the TODO items in src/" --allow-all
+```
+
+### 1.5 Agent Client Protocol (`--acp`)
+
+`--acp` starts Copilot as an **Agent Client Protocol server**, a structured machine-readable interface designed for orchestrator-to-agent communication. This is the native "wrap as an agent" entry point:
+
+```bash
+copilot --acp
+```
+
+> The ACP flag surfaces from `copilot --help` (v1.0.34). As of this writing the ACP specification
+> is not fully documented on docs.github.com; it is an experimental interface. Use `--experimental`
+> to ensure experimental features are on.
+
+### 1.6 Session Resume
+
+Copilot stores session state in `~/.copilot/session-state/` (1279 session dirs observed locally) and a SQLite store at `~/.copilot/session-store.db`. Sessions can be resumed:
+
+```bash
+copilot --continue                          # resume most recent session
+copilot --resume                            # interactive session picker
+copilot --resume=0cb916d                    # by 7+ hex-char prefix
+copilot --resume=<full-uuid>                # by full UUID
+```
+
+### 1.7 CI / Automation Behaviour
+
+Copilot CLI auto-detects CI environments via the `CI`, `BUILD_NUMBER`, `RUN_ID`, or `SYSTEM_COLLECTIONURI` environment variables and disables auto-update. The `--no-auto-update` flag achieves the same effect explicitly. ([`copilot help environment`])
+
+---
+
+## 2. Authentication Model
+
+**Official docs**: [Authenticating GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/authenticate-copilot-cli) · [Installing GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli#authenticating-with-copilot-cli)
+
+### 2.1 Authentication Methods (Priority Order)
+
+Copilot CLI checks for credentials in this **exact order** ([official docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/authenticate-copilot-cli#about-authentication)):
+
+1. `COPILOT_GITHUB_TOKEN` environment variable
+2. `GH_TOKEN` environment variable
+3. `GITHUB_TOKEN` environment variable
+4. OAuth token from the OS keychain (service name `copilot-cli`)
+5. `gh auth token` — GitHub CLI token fallback (lowest priority)
+
+### 2.2 Supported Token Types
+
+| Token type | Prefix | Supported | Notes |
+|-----------|--------|-----------|-------|
+| OAuth device-flow token | `gho_` | ✅ | Default via `copilot login` |
+| Fine-grained PAT | `github_pat_` | ✅ | Must include "Copilot Requests" permission |
+| GitHub App user-to-server | `ghu_` | ✅ | Via environment variable |
+| Classic PAT | `ghp_` | ❌ | **Not supported** |
+
+([Official supported token types table](https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/authenticate-copilot-cli#supported-token-types))
+
+### 2.3 OS Keychain Storage
+
+| Platform | Keychain |
+|---------|---------|
+| macOS | Keychain Access |
+| Windows | Credential Manager |
+| Linux | libsecret (GNOME Keyring / KWallet) |
+
+Fallback when keychain unavailable (headless server): plaintext token stored in **`~/.copilot/config.json`** (confirmed locally — `copilotTokens` field). ([Official docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/authenticate-copilot-cli#how-copilot-cli-stores-credentials))
+
+### 2.4 Config File (Local Observation)
+
+`~/.copilot/config.json` was observed locally and contains:
+
+- `loggedInUsers` — array of `{host, login}` objects
+- `lastLoggedInUser` — `{host, login}`
+- `copilotTokens` — **redacted in this report**
+- `trustedFolders` — list of pre-approved paths
+- `installedPlugins` — array of installed plugin manifests
+- `disabledSkills` — list of skill IDs to suppress
+- `model` — last selected model identifier
+- Various UI preferences (`theme`, `renderMarkdown`, etc.)
+
+### 2.5 Subprocess Auth Inheritance
+
+A subprocess that inherits `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` will authenticate automatically without any stored credentials. This is the **recommended pattern for AgentField orchestration**:
+
+```bash
+# Parent process sets the token; child Copilot CLI inherits it
+export COPILOT_GITHUB_TOKEN="github_pat_..."
+copilot -p "do task" --allow-all --silent
+```
+
+> "An environment variable silently overrides a stored OAuth token." — [official docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/authenticate-copilot-cli)
+
+### 2.6 BYOK / No-Auth Mode
+
+If `COPILOT_PROVIDER_BASE_URL` is set, GitHub authentication is **not required**. Copilot CLI routes model calls to the custom provider instead. The following features are **unavailable without GitHub auth**: `/delegate`, GitHub MCP server, GitHub Code Search. ([Official docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/authenticate-copilot-cli#unauthenticated-use))
+
+Fully air-gapped mode: `COPILOT_OFFLINE=true` disables all network access including telemetry. ([`copilot help environment`])
+
+### 2.7 GitHub Enterprise Cloud (Data Residency)
+
+```bash
+copilot login --host https://example.ghe.com
+GH_HOST=mycompany.ghe.com copilot ...
+```
+
+---
+
+## 3. Extensions / Skills / Plugins
+
+**Official docs**: [About agent skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills) · [Adding agent skills](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-skills) · [About CLI plugins](https://docs.github.com/en/copilot/concepts/agents/copilot-cli/about-cli-plugins) · [Creating a plugin](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-creating) · [Plugin reference](https://docs.github.com/en/copilot/reference/cli-plugin-reference)
+
+### 3.1 Skills
+
+Skills are the primary extensibility mechanism — folders containing a `SKILL.md` specification file that Copilot loads when relevant ([about agent skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills)). The Agent Skills specification is an [open standard](https://github.com/agentskills/agentskills).
+
+#### Skill Discovery Locations (searched automatically)
+
+| Scope | Paths searched |
+|-------|---------------|
+| **Personal** (cross-project) | `~/.copilot/skills/`, `~/.claude/skills/`, `~/.agents/skills/` |
+| **Project** (repo-specific) | `.github/skills/`, `.claude/skills/`, `.agents/skills/` |
+
+Additional directories via env: `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` (comma-separated).
+
+**Locally observed**: `~/.copilot/skills/` contains 47 skill subdirectories including `playwright-cli`, `pdf`, `docx`, `research-codebase`, `semantic-code-search`, `test-generation`, etc.
+
+#### `SKILL.md` Schema
+
+```yaml
+---
+name: my-skill              # required; kebab-case; unique identifier
+description: "..."          # required; when Copilot should use this skill
+license: MIT                # optional
+allowed-tools: shell        # optional; pre-approves tools (use with caution)
+---
+
+# Skill instructions in Markdown...
+```
+
+([Official SKILL.md schema](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-skills#example-skillmd-file))
+
+> ⚠️ Only add `shell` to `allowed-tools` for fully trusted skills — it removes confirmation prompts for arbitrary shell execution.
+
+#### Skill Management Commands
+
+```bash
+/skills list                    # list all loaded skills
+/skills info <name>             # inspect skill + file location
+/skills reload                  # hot-reload after adding/editing skills
+/skills                         # toggle skills on/off interactively
+```
+
+Via CLI: `copilot --available-tools=...` to restrict which tools (and by extension skills) are exposed.
+
+#### Shipping Skills with an Installer
+
+To ship skills with AgentField's installer, place skill directories in one of these locations:
+
+- **Per-user (recommended)**: `~/.copilot/skills/<skill-name>/SKILL.md`
+- **Per-repo**: `.github/skills/<skill-name>/SKILL.md`
+- **In a plugin** (see §3.2): `plugin.json` → `"skills": ["skills/"]`
+
+The `--config-dir <directory>` flag overrides `~/.copilot/` entirely, allowing isolated installer-managed configs. The `COPILOT_HOME` env var achieves the same.
+
+### 3.2 Plugins
+
+Plugins are distributable packages that bundle agents, skills, hooks, MCP configs, and LSP configs into a single installable unit. ([About CLI plugins](https://docs.github.com/en/copilot/concepts/agents/copilot-cli/about-cli-plugins))
+
+#### Install Sources
+
+```bash
+copilot plugin install spark@copilot-plugins      # from registered marketplace
+copilot plugin install owner/repo                  # GitHub repo (root)
+copilot plugin install owner/repo:plugins/mypkg   # GitHub repo subdirectory
+copilot plugin install https://github.com/o/r.git # git URL
+copilot plugin install ./my-plugin                 # local directory
+```
+
+([Plugin install docs](https://docs.github.com/en/copilot/reference/cli-plugin-reference#plugin-specification-for-install-command))
+
+The `--plugin-dir <directory>` global flag loads a plugin for the current session only (without persisting to config):
+
+```bash
+copilot --plugin-dir ./agentfield-skills-plugin -p "do task" --allow-all
+```
+
+#### Plugin Directory Structure
+
+```
+my-plugin/
+├── plugin.json           # required manifest
+├── agents/               # *.agent.md files
+│   └── helper.agent.md
+├── skills/               # skill subdirectories with SKILL.md
+│   └── deploy/
+│       └── SKILL.md
+├── hooks.json            # event handlers
+└── .mcp.json             # MCP server config
+```
+
+([Plugin structure docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-creating#plugin-structure))
+
+#### `plugin.json` Schema
+
+```json
+{
+  "name": "agentfield-skills",
+  "description": "AgentField orchestrator skills for Copilot CLI",
+  "version": "1.0.0",
+  "author": { "name": "AgentField", "email": "team@example.com" },
+  "license": "MIT",
+  "agents": "agents/",
+  "skills": ["skills/"],
+  "hooks": "hooks.json",
+  "mcpServers": ".mcp.json"
+}
+```
+
+([`plugin.json` reference](https://docs.github.com/en/copilot/reference/cli-plugin-reference#pluginjson))
+
+#### Local Plugin Install Path
+
+Observed locally at `~/.copilot/installed-plugins/`:
+
+```
+~/.copilot/installed-plugins/
+├── _direct/                      # directly-installed from GitHub repos
+│   └── FStarLang--proof-copilot/
+└── superpowers-marketplace/
+    └── superpowers/
+```
+
+#### Default Marketplaces
+
+| Marketplace | GitHub Repo |
+|------------|------------|
+| `copilot-plugins` | [github/copilot-plugins](https://github.com/github/copilot-plugins) |
+| `awesome-copilot` | [github/awesome-copilot](https://github.com/github/awesome-copilot) |
+
+([Marketplace docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-marketplace))
+
+#### Custom Agents
+
+Agents are `*.agent.md` files in `~/.copilot/agents/` or `agents/` in a plugin:
+
+```yaml
+---
+name: my-agent
+description: Helps with specific tasks
+tools: ["bash", "edit", "view"]
+---
+
+You are a specialized assistant that...
+```
+
+Locally observed: `~/.copilot/agents/` contains 18 `.md` files including `orchestrator.md`, `worker.md`, `planner.md`, `reviewer.md`, `agentic-workflows.agent.md`, `DeepTest.agent.md`.
+
+Select an agent at startup: `copilot --agent orchestrator`
+
+---
+
+## 4. Installation
+
+**Official docs**: [Installing GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli)
+
+### 4.1 Install Methods
+
+| Method | Command | Platform |
+|--------|---------|---------|
+| **npm** | `npm install -g @github/copilot` (Node.js 22+ required) | All |
+| **WinGet** | `winget install GitHub.Copilot` | Windows |
+| **Homebrew** | `brew install copilot-cli` | macOS, Linux |
+| **Install script** | `curl -fsSL https://gh.io/copilot-install \| bash` | macOS, Linux |
+| **Direct download** | [github/copilot-cli/releases](https://github.com/github/copilot-cli/releases/) | All |
+
+Pre-release variant: append `@prerelease` (npm), `.Prerelease` (WinGet), `@prerelease` (Homebrew).
+
+Custom install dir (install script): `PREFIX=$HOME/.local curl -fsSL https://gh.io/copilot-install | bash`
+
+### 4.2 Binary Details (Locally Observed)
+
+| Property | Value |
+|---------|-------|
+| Binary name | `copilot` |
+| Install path (this machine) | `/home/eioannidis/.local/bin/copilot` |
+| Binary size | 139 MB (single self-contained ELF x86-64 executable) |
+| Format | ELF 64-bit LSB, dynamically linked |
+| Version command | `copilot --version` or `copilot version` |
+| Current version | `GitHub Copilot CLI 1.0.34` |
+| Config dir | `~/.copilot/` (override: `COPILOT_HOME` or `--config-dir`) |
+| Log dir | `~/.copilot/logs/` (override: `--log-dir`) |
+
+### 4.3 Config Dir Override (Isolation Pattern)
+
+For AgentField spawning multiple isolated Copilot instances:
+
+```bash
+COPILOT_HOME=/var/agentfield/instances/agent-001/.copilot \
+  copilot -p "do task" --allow-all --silent
+```
+
+Or:
+```bash
+copilot --config-dir /var/agentfield/instances/agent-001 -p "do task" --allow-all --silent
+```
+
+---
+
+## 5. MCP Server Configuration
+
+**Official docs**: [Adding MCP servers for GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers)
+
+### 5.1 Config File Locations (Priority / Sources)
+
+MCP configuration is loaded from multiple sources, shown in `copilot mcp --help` ([v1.0.34]):
+
+| Source | Location |
+|--------|---------|
+| **User** (persistent) | `~/.copilot/mcp-config.json` |
+| **Workspace** | `.mcp.json` in current working directory |
+| **Plugin** | `.mcp.json` or `.github/mcp.json` in installed plugin |
+| **Builtin** | GitHub MCP server (pre-installed, cannot be removed but can be disabled) |
+
+### 5.2 `mcp-config.json` Schema
+
+Locally observed at `~/.copilot/mcp-config.json`:
+
+```json
+{
+  "mcpServers": {
+    "fstar": {
+      "type": "stdio",
+      "command": "/home/eioannidis/fstar-mcp/target/release/fstar-mcp",
+      "tools": ["*"],
+      "args": ["--log", "/tmp/fstar-mcp.log"]
+    }
+  }
+}
+```
+
+Full schema from [official docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers#editing-the-configuration-file):
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "type": "local",
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"],
+      "env": {},
+      "tools": ["*"]
+    },
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": { "CONTEXT7_API_KEY": "YOUR-API-KEY" },
+      "tools": ["*"]
+    }
+  }
+}
+```
+
+Transport types: `stdio` / `local`, `http` (Streamable HTTP), `sse` (legacy Server-Sent Events).
+
+### 5.3 CLI Commands for MCP Management
+
+```bash
+copilot mcp add context7 -- npx -y @upstash/context7-mcp    # add stdio server
+copilot mcp add --transport http notion https://mcp.notion.com/mcp  # add HTTP server
+copilot mcp list                                              # list all servers (all sources)
+copilot mcp list --json                                       # machine-readable list
+copilot mcp get <name>                                        # show server details
+copilot mcp remove <name>                                     # remove server
+```
+
+Interactive slash commands: `/mcp show`, `/mcp add`, `/mcp edit <name>`, `/mcp delete <name>`, `/mcp disable <name>`, `/mcp enable <name>`
+
+### 5.4 Per-Session MCP Override (No Config File Edit)
+
+```bash
+copilot --additional-mcp-config '{"mcpServers":{"myserver":{"type":"stdio","command":"my-mcp-server"}}}' \
+  -p "do task" --allow-all
+```
+
+Or via file reference:
+```bash
+copilot --additional-mcp-config @/path/to/session-mcp.json -p "do task" --allow-all
+```
+
+The `--additional-mcp-config` flag can be repeated and **augments** (does not replace) `~/.copilot/mcp-config.json`. ([v1.0.34 `--help`])
+
+### 5.5 Built-in GitHub MCP Server
+
+The GitHub MCP server ships built-in and is available without configuration. It can be disabled:
+
+```bash
+copilot --disable-builtin-mcps -p "offline task" --allow-all
+copilot --disable-mcp-server github-mcp-server -p "partial task" --allow-all
+```
+
+To expand the default GitHub MCP toolset:
+```bash
+copilot --add-github-mcp-tool my_tool -p "..."
+copilot --add-github-mcp-toolset all -p "..."       # all toolsets
+copilot --enable-all-github-mcp-tools -p "..."      # all tools
+```
+
+### 5.6 AgentField Control Plane as MCP Server
+
+To expose AgentField's control plane as an MCP server consumed by Copilot CLI:
+
+```json
+{
+  "mcpServers": {
+    "agentfield": {
+      "type": "http",
+      "url": "http://localhost:8080/mcp",
+      "headers": {
+        "Authorization": "Bearer ${AGENTFIELD_TOKEN}"
+      },
+      "tools": ["*"]
+    }
+  }
+}
+```
+
+Or via stdio, wrapping the `af` CLI:
+```json
+{
+  "mcpServers": {
+    "agentfield": {
+      "type": "stdio",
+      "command": "af",
+      "args": ["mcp", "serve"],
+      "tools": ["*"]
+    }
+  }
+}
+```
+
+The control plane's `internal/mcp/` package (see `CLAUDE.md`) provides the MCP integration layer. Toolsets AgentField could expose include: workflow execution, agent registry queries, skill dispatch, memory read/write, DID/VC audit queries.
+
+---
+
+## 6. Rate Limits, Session State, and CWD Handling
+
+### 6.1 Rate Limits
+
+**No public documentation found** on specific rate limits for Copilot CLI. Rate limits are governed by the user's Copilot subscription plan. GitHub's general [Copilot API rate limiting](https://docs.github.com/en/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-github-copilot-features-in-your-organization/managing-policies-for-copilot-in-your-organization) documentation does not specify per-process or per-minute limits for CLI use. For orchestration scenarios spawning many parallel instances, plan limits should be tested empirically.
+
+### 6.2 Session State
+
+Session state is persisted between calls:
+
+| Artifact | Path |
+|---------|------|
+| Session state dirs | `~/.copilot/session-state/<uuid>/` (1279 observed) |
+| Session SQLite store | `~/.copilot/session-store.db` (48 MB observed) |
+| Command history | `~/.copilot/command-history-state.json` |
+| Embedding cache | `~/.copilot/embedding-cache.db` |
+| Logs | `~/.copilot/logs/` |
+
+Isolate sessions by overriding `COPILOT_HOME` or `--config-dir` per subprocess instance.
+
+### 6.3 CWD Handling
+
+Copilot CLI **defaults to the current working directory** for file access. This is critical for AgentField's orchestrator spawning Copilot subprocesses — each subprocess should be launched with `cwd` set to the target repository:
+
+```python
+subprocess.run(
+    ["copilot", "-p", "Fix the bug", "--allow-all", "--silent"],
+    cwd="/path/to/target/repo",
+    env={**os.environ, "COPILOT_GITHUB_TOKEN": token},
+)
+```
+
+Path access rules:
+- Default: CWD + subdirectories + system temp dir
+- `--add-dir <directory>`: expand allowed paths (repeatable)
+- `--allow-all-paths`: disable path verification entirely
+- `--disallow-temp-dir`: remove automatic temp dir access
+
+In-session CWD changes: `/cwd /path`, `/cd /path` (does **not** change the spawning process's CWD).
+
+Trust prompt: on first run in a new directory, Copilot prompts to trust the folder. Pre-populate `trustedFolders` in `~/.copilot/config.json` to suppress this in automation:
+
+```json
+{
+  "trustedFolders": ["/path/to/workspace"]
+}
+```
+
+### 6.4 Output Formats
+
+| Flag | Output |
+|------|--------|
+| *(default)* | Human-readable text with ANSI colours, stats |
+| `--silent` / `-s` | Agent response only; no stats |
+| `--output-format json` | JSONL — one JSON object per line |
+| `--no-color` | Plain text without ANSI codes |
+| `--plain-diff` | Plain diff (no syntax highlighting) |
+
+The `--output-format json` flag is the preferred interface for structured parsing in an orchestrator. Output is JSONL (newline-delimited JSON), one object per message/event.
+
+### 6.5 OpenTelemetry / Observability
+
+Full OTel support for tracing every LLM call and tool execution ([`copilot help monitoring`]):
+
+```bash
+# Export traces to a local Jaeger collector
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
+  copilot -p "do task" --allow-all
+
+# Write JSONL traces to file (no collector required)
+COPILOT_OTEL_FILE_EXPORTER_PATH=/var/log/copilot-otel.jsonl \
+  copilot -p "do task" --allow-all
+```
+
+Trace hierarchy: `invoke_agent → chat <model> → execute_tool <tool>`
+
+Metrics exported: `gen_ai.client.operation.duration`, `gen_ai.client.token.usage`, `github.copilot.tool.call.count`, `github.copilot.tool.call.duration`, `github.copilot.agent.turn.count`
+
+---
+
+## 7. Summary Table: Key Flags for Orchestration
+
+| Use Case | Command Pattern |
+|---------|----------------|
+| One-shot non-interactive | `copilot -p "task" --allow-all --silent` |
+| JSON output for parsing | `copilot -p "task" --allow-all --output-format json` |
+| Pre-authorized token (CI) | `COPILOT_GITHUB_TOKEN=<token> copilot -p "task" --allow-all` |
+| Isolated config per agent | `COPILOT_HOME=~/.copilot-agent-N copilot -p "task" --allow-all` |
+| Custom MCP per session | `copilot --additional-mcp-config @session.json -p "task" --allow-all` |
+| ACP protocol server | `copilot --acp` |
+| Ship skills in installer | Place `SKILL.md` under `~/.copilot/skills/<name>/` |
+| Ship skills as plugin | `copilot plugin install ./agentfield-plugin` or `--plugin-dir` |
+| BYOK (no GitHub auth) | `COPILOT_PROVIDER_BASE_URL=... COPILOT_MODEL=... copilot -p "task" --allow-all` |
+| Full offline mode | `COPILOT_OFFLINE=true COPILOT_PROVIDER_BASE_URL=... copilot -p "task" --allow-all` |
+| Resume previous session | `copilot --resume=<session-id> --allow-all -p "continue task"` |
+
+---
+
+## 8. Additional Resources
+
+- [GitHub Copilot CLI home page](https://docs.github.com/en/copilot/how-tos/copilot-cli)
+- [About GitHub Copilot CLI](https://docs.github.com/en/copilot/concepts/agents/copilot-cli/about-copilot-cli)
+- [CLI command reference](https://docs.github.com/en/free-pro-team@latest/copilot/reference/copilot-cli-reference/cli-command-reference)
+- [Authenticating GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/authenticate-copilot-cli)
+- [Adding agent skills](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-skills)
+- [About agent skills (open standard)](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills)
+- [Agent Skills open standard (GitHub)](https://github.com/agentskills/agentskills)
+- [About CLI plugins](https://docs.github.com/en/copilot/concepts/agents/copilot-cli/about-cli-plugins)
+- [Creating a plugin](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-creating)
+- [Plugin reference](https://docs.github.com/en/copilot/reference/cli-plugin-reference)
+- [Adding MCP servers](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers)
+- [Installing Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli)
+- [Copilot CLI releases (binary downloads)](https://github.com/github/copilot-cli/releases/)
+- [Awesome Copilot (community skills/plugins)](https://github.com/github/awesome-copilot)
+- [Copilot-plugins marketplace](https://github.com/github/copilot-plugins)
+
+---
+
+## 9. Gaps and Limitations
+
+1. **ACP (`--acp`) protocol specification**: The Agent Client Protocol flag is present in v1.0.34 but the full wire protocol is not publicly documented on docs.github.com as of 2026-04-20. Test empirically.
+
+2. **Rate limits**: No public per-CLI-invocation or per-minute rate limit figures are documented. Use exponential backoff and respect `429` HTTP responses.
+
+3. **JSONL schema**: The exact schema of objects emitted by `--output-format json` is not documented. Must be inferred from empirical testing.
+
+4. **Session isolation in parallel instances**: When running multiple Copilot CLI subprocesses in parallel, use separate `COPILOT_HOME` dirs to prevent config/session-store contention. This is inferred from the file-based session storage model, not explicitly documented.
+
+5. **Token lifetime / expiry**: Token expiry for OAuth tokens from `copilot login` is not documented — depends on organization OAuth policy settings.
+
+6. **Plugin update in non-interactive mode**: `copilot plugin update` may require a TTY. Test in CI before assuming it works headlessly.
+
+---
+
+*Research conducted 2026-04-20 using: local `copilot` binary v1.0.34, config at `~/.copilot/`, and live fetches from docs.github.com. All `--help` output is from the locally installed binary.*
+```
+
+---
+
+## Summary of Findings
+
+Here is a digest of the most actionable facts for AgentField:
+
+### (a) Wrapping Copilot CLI as an Agent in AgentField's Orchestrator
+
+- **One-shot invocation**: `copilot -p "<task>" --allow-all --silent --output-format json`
+- **No interactive TTY needed**; the binary exits after completing the prompt
+- **ACP server mode** (`--acp`) is the native orchestrator interface — starts Copilot as an Agent Client Protocol server; wire protocol not yet publicly documented
+- **Auth inheritance**: set `COPILOT_GITHUB_TOKEN` in the subprocess environment; it takes precedence over everything else
+- **Isolate state** per agent: `COPILOT_HOME=/path/to/agent-N-home` or `--config-dir`
+- **`cwd`** the subprocess to the target repository directory — Copilot restricts file access to CWD by default
+- **OTel tracing** (`OTEL_EXPORTER_OTLP_ENDPOINT` or `COPILOT_OTEL_FILE_EXPORTER_PATH`) gives full observability into LLM calls and tool use from the orchestrator
+
+### (b) Shipping Copilot "Skills" with the AgentField Installer
+
+- Drop skill directories under **`~/.copilot/skills/<name>/SKILL.md`** (user-level, cross-project)
+- Or bundle as a **plugin** (`plugin.json` + `skills/` + optionally `agents/`, `hooks.json`, `.mcp.json`) and run `copilot plugin install ./agentfield-skills-plugin`
+- The `--plugin-dir ./agentfield-skills-plugin` flag loads a plugin for a single session without persisting it — useful for controlled orchestrator invocations
+- Skill files follow the [Agent Skills open standard](https://github.com/agentskills/agentskills): YAML frontmatter (`name`, `description`) + Markdown body
+
+### (c) Reusing Copilot CLI Authentication
+
+- **Env var pattern** (recommended for CI/automation): `COPILOT_GITHUB_TOKEN > GH_TOKEN > GITHUB_TOKEN`
+- Fine-grained PAT with **"Copilot Requests" permission** is the correct token type
+- Classic PATs (`ghp_`) are **not supported**
+- If `gh` CLI is authenticated on the machine, Copilot CLI will use its token as a fallback automatically — no extra setup needed
+- Tokens stored in OS keychain (service name `copilot-cli`) or `~/.copilot/config.json` fallback

--- a/research/docs/2026-04-20-copilot-cli-support.md
+++ b/research/docs/2026-04-20-copilot-cli-support.md
@@ -1,0 +1,299 @@
+---
+date: "2026-04-20 22:30:00 UTC"
+researcher: "Copilot CLI"
+git_commit: "0f42e612"
+branch: "copilot-cli-support"
+repository: "agentfield"
+topic: "Adding GitHub Copilot CLI support to AgentField"
+tags: [research, codebase, copilot-cli, sdk, skillkit, auth]
+status: complete
+last_updated: "2026-04-20"
+last_updated_by: "Copilot CLI"
+---
+
+# Research — Adding GitHub Copilot CLI Support to AgentField
+
+## Research Question
+
+> Create a new branch `copilot-cli-support`, research and figure out how to add support for GitHub Copilot CLI.
+>
+> Clarified scope (via ask_user):
+> 1. **Wrap Copilot CLI as an AgentField agent** — Copilot becomes a reasoner/skill callable by the control plane.
+> 2. Ship **Copilot skills** as part of the AgentField installer.
+> 3. Ensure **Copilot CLI authentication** works with AgentField.
+
+This document is intentionally a *documentation-of-current-state* plus an integration map. No code has been written; follow-up work will produce a spec/plan and then an implementation PR.
+
+---
+
+## Summary
+
+AgentField already has every primitive needed to wrap GitHub Copilot CLI as an agent, ship Copilot-facing skill packets through its installer, and share authentication with the host user's `copilot` invocation — **without any new architecture**. Specifically:
+
+- **(a) Copilot-as-agent** maps cleanly onto the existing Python/Go SDK pattern: one agent node, one or more reasoners, each of which shells out to `copilot -p "<prompt>" --allow-all-tools --log-level none` (one-shot mode) and returns structured output. The SDK's `@app.reasoner()` decorator and `RegisterReasoner` already support subprocess wrapping; `ExecutionContext` lets us propagate `X-Run-ID` / `X-Session-ID` so each AgentField run gets a dedicated Copilot `--session-id` or `COPILOT_HOME`. See [§2.1](#21-copilot-as-agent).
+- **(b) Skillkit integration** is a drop-in: AgentField's skillkit already writes a canonical `SKILL.md` into per-tool target dirs (`~/.claude/skills/…`, `~/.codex/AGENTS.override.md`, etc.). Copilot CLI looks for skills at `~/.copilot/skills/<name>/SKILL.md` — the exact same shape. Adding Copilot as a **new target** under `control-plane/internal/skillkit/target_copilot.go` plus one entry in `detectedTargets` is the full footprint. See [§2.2](#22-skills-installation).
+- **(c) Authentication reuse** works through env var inheritance: Copilot CLI honors `COPILOT_GITHUB_TOKEN > GH_TOKEN > GITHUB_TOKEN` (in that precedence) and falls back to the `gh` CLI's stored token. AgentField already lets agents read their own env, so `af run copilot` can inherit the user's Copilot auth with zero extra plumbing. For stronger isolation we can spawn Copilot with `COPILOT_HOME=$AGENTFIELD_HOME/copilot-<node>` to sandbox state. See [§2.3](#23-authentication-reuse).
+
+MCP is *not* a viable integration path today: all AgentField MCP code was removed in commit `f732ed5e` (2026-04-07). The integration must go through the SDK/HTTP surface, not MCP.
+
+There is currently **one trivial mention** of "GitHub Copilot" in the repo (`docs/CONTRIBUTING.md:101`, a list of AI tools contributors may use). No Copilot-specific code exists.
+
+---
+
+## Detailed Findings
+
+### 1. Current state of AgentField (as of `0f42e612`)
+
+#### 1.1 SDK agent shape (target surface for Copilot-as-agent)
+
+**Python SDK** ([`sdk/python/agentfield/agent.py`](../../sdk/python/agentfield/agent.py)): `Agent` is a FastAPI subclass. `@app.reasoner()` (`agent.py:~1693`) registers a function and auto-mounts `POST /reasoners/<id>`. `ExecutionContext.from_request()` at `agent.py:1843` parses correlation headers (`X-Run-ID`, `X-Execution-ID`, `X-Session-ID`, `X-Parent-Execution-ID`, `X-Workflow-ID`, `X-Actor-ID`, plus DID headers) into a context object that can be injected into handlers by declaring a parameter `execution_context: ExecutionContext`. Control-plane URL resolution order (`agent.py:556-558`): explicit `agentfield_server` arg → `AGENTFIELD_SERVER` → `AGENTFIELD_SERVER_URL` → `http://localhost:8080`. On `serve()` the server binds to `PORT` (injected by `af run`).
+
+Minimal Python agent (verbatim shape from research):
+```python
+from agentfield import Agent
+
+app = Agent(node_id="copilot", agentfield_server=os.getenv("AGENTFIELD_SERVER"))
+
+@app.reasoner()
+async def run_command(prompt: str, execution_context) -> dict:
+    # shell out to `copilot -p prompt …`
+    ...
+
+if __name__ == "__main__":
+    app.serve()
+```
+
+**Go SDK** ([`sdk/go/agent/agent.go`](../../sdk/go/agent/agent.go)): `agent.New(Config{...})` + `app.RegisterReasoner(name, handler, opts...)` (`agent.go:~522`). Handler signature is `func(ctx context.Context, input map[string]any) (any, error)`; retrieve `ExecutionContext` via `agent.ExecutionContextFrom(ctx)` (`agent.go:2042`). `agent.Call(ctx, "other-node.reasoner", input)` (`agent.go:1570`) forwards all correlation + DID headers automatically.
+
+> See [`research/docs/2026-04-20-sdk-patterns.md`](2026-04-20-sdk-patterns.md) for a complete walk-through of both SDKs, `af init` templates, and `af run` env-var injection.
+
+#### 1.2 `af init` templates
+
+Located at `control-plane/internal/templates/{python,go,typescript}/`. `templates.go:52-61` lists the template files. Each shipped template already includes an `echo` reasoner. For Copilot we can either:
+- Provide a fourth template (`control-plane/internal/templates/copilot/`) generated by `af init my-copilot --language=copilot`, **or**
+- Ship a standalone built-in agent node definition that the server registers automatically (similar to how the server already provides `/api/v1/nodes/register` and the Go SDK can register itself on startup).
+
+The simpler ergonomics are "`af init copilot-agent`" → generates a ready-to-run Python project that wraps `copilot -p`.
+
+#### 1.3 Skillkit — the right hook for "ship Copilot skills with AgentField"
+
+AgentField's skillkit ([`control-plane/internal/skillkit/`](../../control-plane/internal/skillkit/)) is explicitly an **install-time Markdown distribution mechanism**. `Skill` struct at `skillkit/catalog.go:13-19`:
+
+```go
+type Skill struct {
+    Name        string  // e.g. "agentfield-multi-reasoner-builder"
+    Version     string
+    Description string
+    EmbedRoot   string  // "skill_data/<name>"
+    EntryFile   string  // "SKILL.md"
+}
+```
+
+Install pipeline (`skillkit/install.go:47-153`):
+1. Resolve skill from `Catalog` by name.
+2. `writeCanonical()` extracts embedded files to `~/.agentfield/skills/<name>/<version>/`.
+3. `updateCurrentLink()` creates `~/.agentfield/skills/<name>/current → ./<version>/`.
+4. For each selected target, call `t.Install(skill, currentLink)`.
+5. Persist `~/.agentfield/skills/.state.json`.
+
+Target implementations (one file each under `control-plane/internal/skillkit/`):
+- `target_claude_code.go` — symlinks `~/.claude/skills/<name>` → canonical `current/`.
+- `target_codex.go` — appends a `<!-- agentfield-skill:<name> -->` marker block to `~/.codex/AGENTS.override.md`.
+- `target_gemini.go`, `target_opencode.go`, `target_aider.go`, `target_windsurf.go` — marker-block variants.
+- `target_cursor.go` — "manual" mode: prints paste-in instructions.
+
+CLI surface for skills is already complete (`control-plane/internal/cli/skill.go`):
+
+| Command | Behavior |
+|---|---|
+| `af skill install [name]` | `--skill`, `--version`, `--target`, `--all`, `--all-targets`, `--force`, `--dry-run` |
+| `af skill list` | Read `.state.json` |
+| `af skill update [name]` | Re-install at embedded version with `Force: true` |
+| `af skill uninstall [name]` | `--remove-canonical` also deletes `~/.agentfield/skills/<name>/` |
+| `af skill print [name]` | Stdout the `SKILL.md` |
+| `af skill path` | Print `~/.agentfield/skills` |
+| `af skill catalog` | List skills embedded in the binary |
+
+The installer's Phase-2 hook (`scripts/install.sh:536-568`) already calls `"$af_bin" skill install --all-targets` — adding Copilot to `detectedTargets()` means it ships automatically.
+
+Currently only one skill is embedded: `skills/agentfield-multi-reasoner-builder/` (with `SKILL.md` and `references/*.md`). Adding new skills requires (a) `skills/<name>/`, (b) running `scripts/sync-embedded-skills.sh` (which uses `rsync --delete`), (c) adding a `go:embed` directive in `skillkit/embed.go`, (d) adding a `Catalog` entry.
+
+> See [`research/docs/2026-04-20-install-skills.md`](2026-04-20-install-skills.md) *(also captured inline in the install-skills-flow sub-agent report — see [§5](#5-agent-reports) below)*.
+
+#### 1.4 Authentication model
+
+**Control-plane auth** ([`control-plane/internal/server/middleware/auth.go`](../../control-plane/internal/server/middleware/auth.go), full walk-through in `research/docs/2026-04-20-auth-model.md`):
+- Single static API key on all routes; accepted as `X-API-Key`, `Authorization: Bearer`, or `?api_key=`.
+- Empty key disables auth (`auth.go:26-29`). Sourced from `AGENTFIELD_API_KEY` or `api.auth.api_key` YAML.
+- Optional DID-based signature layer (`DIDAuthMiddleware`, off by default).
+
+**Agent → control-plane** (Python `agent.py:606-608`, Go `agent.go:415`): agent registers with `X-API-Key` on startup, receives an `IdentityPackage` (Ed25519 JWK) from `POST /api/v1/did/register`, then signs subsequent requests with `X-Caller-DID` + `X-DID-Signature` headers.
+
+**No external secrets store exists.** External creds (OpenAI, GitHub, Copilot) are consumed by agent processes directly from **their own environment variables** — which is exactly how Copilot CLI expects to find `COPILOT_GITHUB_TOKEN` / `GH_TOKEN`. This is the integration surface for auth reuse.
+
+`af run <agent>` injects a minimal env (`agent_service.go:452`: `PORT`, `AGENTFIELD_SERVER_URL`, and inherits parent env). So the Copilot agent, when launched by `af run`, will naturally inherit the host user's `GH_TOKEN` / `COPILOT_GITHUB_TOKEN` / `gh` cached auth.
+
+#### 1.5 MCP — removed
+
+`control-plane/internal/mcp/` and all related SDK modules were removed in commit `f732ed5e` (2026-04-07, "refactor: remove all MCP code from codebase (#359)"). The `test-mcp-endpoints.sh` scripts at `control-plane/scripts/` reference endpoints that no longer exist. **Do not plan any Copilot integration via MCP.**
+
+---
+
+### 2. GitHub Copilot CLI surface (external)
+
+Full report with inline doc links: [`research/docs/2026-04-20-copilot-cli-external-research.md`](2026-04-20-copilot-cli-external-research.md). Verified against `copilot --help` v1.0.34 installed at `~/.local/bin/copilot`.
+
+Key facts that shape the integration:
+
+| Facet | Mechanism | Docs |
+|---|---|---|
+| **One-shot invocation** | `copilot -p "<prompt>" --allow-all-tools --log-level none` prints model output to stdout and exits 0. Stdin mode: `cat prompt.md \| copilot -p -`. | [programmatic interface](https://docs.github.com/en/copilot/concepts/agents/copilot-cli/about-copilot-cli#programmatic-interface) |
+| **JSON output** | `--json` flag emits a single NDJSON stream (turns, tool calls, token usage). | [CLI reference](https://docs.github.com/en/free-pro-team@latest/copilot/reference/copilot-cli-reference/cli-command-reference) |
+| **Auth precedence** | `COPILOT_GITHUB_TOKEN` > `GH_TOKEN` > `GITHUB_TOKEN` > `gh` CLI cache > OS keychain entry `copilot-cli` > `~/.copilot/config.json`. | see external report §2 |
+| **Token type** | Fine-grained PAT with **"Copilot Requests"** permission. Classic `ghp_` tokens **not supported**. | ibid |
+| **State dir** | `COPILOT_HOME` (default `~/.copilot/`) contains `config.json`, `sessions/`, `skills/`, `plugins/`. `--config-dir` is an alias. | ibid |
+| **Skills** | User-level skills: `~/.copilot/skills/<name>/SKILL.md` with YAML frontmatter (`name`, `description`). Same open-standard shape as Claude Code. | [agentskills spec](https://github.com/agentskills/agentskills) |
+| **Plugins** | `copilot plugin install <dir>`; a plugin is `plugin.json` + optional `skills/`, `agents/`, `hooks.json`, `.mcp.json`. One-shot alternative: `copilot --plugin-dir ./pkg`. | ibid |
+| **Sandboxing** | Copilot restricts file writes to its `--cwd` (default: process cwd). Pass `--cwd /agent/workdir`. | ibid |
+| **Observability** | `OTEL_EXPORTER_OTLP_ENDPOINT` or `COPILOT_OTEL_FILE_EXPORTER_PATH` emit OTel spans for every LLM call and tool use. | ibid |
+
+---
+
+### 3. Integration design
+
+### 2.1 Copilot-as-agent
+
+**Goal:** a new agent node `copilot` (language: Python, bundled) exposing reasoners such as `ask`, `review`, `plan`, `run_task` that are thin wrappers around `copilot -p`.
+
+**Directory (proposed):** `examples/copilot-agent/` scaffolded by `af init copilot-agent` *or* a first-party tree at `sdk/python/examples/copilot/`. Code shape:
+
+```python
+# main.py (illustrative)
+import asyncio, json, os, shlex, subprocess
+from agentfield import Agent, ExecutionContext
+
+app = Agent(
+    node_id=os.getenv("AGENT_NODE_ID", "copilot"),
+    agentfield_server=os.getenv("AGENTFIELD_SERVER", "http://localhost:8080"),
+)
+
+COPILOT_BIN = os.getenv("COPILOT_BIN", "copilot")
+
+async def _run_copilot(prompt: str, cwd: str, ctx: ExecutionContext) -> dict:
+    # Per-run state isolation → own COPILOT_HOME keyed on run_id.
+    home = os.path.join(os.getenv("AGENTFIELD_HOME", "~/.agentfield"),
+                        "copilot-home", ctx.run_id or "default")
+    os.makedirs(home, exist_ok=True)
+    env = {**os.environ, "COPILOT_HOME": home}
+    # Token inheritance: COPILOT_GITHUB_TOKEN > GH_TOKEN > GITHUB_TOKEN > gh auth cache.
+    cmd = [COPILOT_BIN, "-p", prompt, "--allow-all-tools",
+           "--log-level", "none", "--json", "--cwd", cwd]
+    proc = await asyncio.create_subprocess_exec(
+        *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        env=env)
+    out, err = await proc.communicate()
+    turns = [json.loads(l) for l in out.splitlines() if l.strip()]
+    return {"turns": turns, "exit_code": proc.returncode,
+            "stderr": err.decode("utf-8", "replace")}
+
+@app.reasoner()
+async def ask(prompt: str, cwd: str = None,
+              execution_context: ExecutionContext = None) -> dict:
+    return await _run_copilot(prompt, cwd or os.getcwd(), execution_context)
+
+# Additional thin wrappers: review(diff), plan(task), run_task(task), apply_patch(...)
+```
+
+Key design points:
+- **Session-per-run**: set `COPILOT_HOME=$AGENTFIELD_HOME/copilot-home/<run_id>` so concurrent runs don't trample each other's `sessions/` dir.
+- **CWD discipline**: pass `--cwd` from input; never inherit the agent-server cwd.
+- **Output shape**: return the raw NDJSON turns so upstream workflows can do their own summarization. Add a `summary` field by joining assistant text.
+- **Timeouts / cancel**: implement a `timeout` input (default 300 s); use `asyncio.wait_for`.
+- **DID-signed cross-agent calls**: automatic — the SDK injects headers; Copilot calls itself via `agent.Call("copilot.ask", ...)`.
+
+Alternative surface: a **Go** implementation under `sdk/go/examples/copilot/` for users who want a single static binary. Same shape (`RegisterReasoner`, `os/exec`).
+
+### 2.2 Skills installation
+
+**Goal:** when users run `curl ... install.sh | bash`, the AgentField `SKILL.md` for "multi-reasoner builder" (and any future agent-facing skills) gets installed into Copilot CLI alongside Claude Code / Codex / Gemini.
+
+**Change set (illustrative):**
+
+1. **New target** at `control-plane/internal/skillkit/target_copilot.go`:
+   - Detection: `~/.copilot/` exists *or* `copilot` binary on PATH (`exec.LookPath("copilot")`).
+   - Install method: symlink `~/.copilot/skills/<name>` → canonical `~/.agentfield/skills/<name>/current/`. This is the cleanest option because Copilot treats `~/.copilot/skills/*/SKILL.md` as first-class user skills.
+   - State: record `method: "symlink"`, `path: "~/.copilot/skills/<name>"` in `.state.json`.
+2. **Register target** in `skillkit/install.go` (the `detectedTargets` / target registry).
+3. **Doctor probe**: add a `copilot` CLI entry to `control-plane/internal/cli/doctor.go:90-133` so `af doctor --json` tells consumers whether Copilot is present.
+4. **Install script**: no change needed — `scripts/install.sh:556` already runs `af skill install --all-targets`.
+
+Plugin option (future): bundle AgentField's skills as a Copilot CLI *plugin* at `~/.agentfield/copilot-plugin/` (`plugin.json` + symlinks into canonical skill dirs) and run `copilot plugin install ~/.agentfield/copilot-plugin` from the target handler. Gives us one registration point rather than N per-skill symlinks, and a clean uninstall (`copilot plugin uninstall agentfield`).
+
+### 2.3 Authentication reuse
+
+**Default path (zero config):** Copilot CLI already checks `COPILOT_GITHUB_TOKEN > GH_TOKEN > GITHUB_TOKEN`, and falls back to `gh` CLI's stored token. `af run copilot` spawns the agent as a child process which inherits the user's env, so any of those is picked up automatically.
+
+**Enhanced path (explicit, per-agent):** allow the Copilot agent's config (or `af run copilot --env COPILOT_GITHUB_TOKEN=…`) to set a dedicated token without leaking it to sibling agents. Concretely, extend `af run` (`control-plane/internal/services/agent_service.go:452`) to accept `--env KEY=VAL` pass-through flags (the spec work should confirm this doesn't already exist in some form).
+
+**Explicit non-goal:** storing Copilot tokens inside AgentField. The research confirms there is no secrets store, and design philosophy (`research/docs/2026-04-20-auth-model.md`) keeps external creds in the agent's env. We should preserve that invariant.
+
+**Doctor integration:** `af doctor` already probes `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, etc. Extend it to report:
+- Whether `copilot` is on PATH and its version (`copilot --version`).
+- Whether `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN` is set, *or* whether `gh auth status` reports an authenticated user.
+- Location of `~/.copilot/config.json` and whether it contains a `lastLoggedInUser`.
+
+---
+
+## Code References
+
+- [`control-plane/internal/skillkit/catalog.go:13-19`](../../control-plane/internal/skillkit/catalog.go) — `Skill` struct (target for Copilot target additions)
+- [`control-plane/internal/skillkit/install.go:47-153`](../../control-plane/internal/skillkit/install.go) — install pipeline; add `target_copilot` to registry
+- `control-plane/internal/skillkit/target_claude_code.go` — reference pattern for a new `target_copilot.go`
+- `control-plane/internal/skillkit/target_codex.go` — alternative (marker-block) pattern
+- `control-plane/internal/skillkit/embed.go:34-36` — `go:embed` entries for skill data
+- [`control-plane/internal/cli/skill.go:23-57`](../../control-plane/internal/cli/skill.go) — CLI surface (no changes needed; generic over targets)
+- [`control-plane/internal/cli/doctor.go:90-133`](../../control-plane/internal/cli/doctor.go) — add Copilot probes
+- [`scripts/install.sh:536-568`](../../scripts/install.sh) — Phase-2 skill install hook (no changes needed)
+- [`scripts/sync-embedded-skills.sh:26-28`](../../scripts/sync-embedded-skills.sh) — `SKILLS=(…)` list, add new skills here
+- `skills/agentfield-multi-reasoner-builder/SKILL.md` — existing skill format reference
+- [`sdk/python/agentfield/agent.py:1693,1843,606-608`](../../sdk/python/agentfield/agent.py) — `@app.reasoner()`, `ExecutionContext.from_request`, URL resolution
+- [`sdk/go/agent/agent.go:~522,2042,1570`](../../sdk/go/agent/agent.go) — `RegisterReasoner`, `ExecutionContextFrom`, `Call`
+- [`control-plane/internal/templates/python/`](../../control-plane/internal/templates/python/) — add `copilot/` sibling if we want `af init --language=copilot`
+- [`control-plane/internal/services/agent_service.go:452`](../../control-plane/internal/services/agent_service.go) — env-var injection point for `af run`
+- [`control-plane/internal/server/middleware/auth.go:26-29,38-69`](../../control-plane/internal/server/middleware/auth.go) — API-key auth, no changes needed
+- `docs/CONTRIBUTING.md:101` — the only pre-existing mention of Copilot
+
+## Architecture Documentation
+
+- **SDK convention:** reasoners are pure async functions; subprocess wrapping is already the pattern for anything that isn't a network call. See `sdk/python/agentfield/ai/` (LLM helpers) for the precedent of shelling out to external services.
+- **Skillkit convention:** each target is a separate Go file implementing the `Target` interface; state is a JSON blob at `~/.agentfield/skills/.state.json` with per-skill per-target records. Adding Copilot is additive and follows the existing pattern exactly.
+- **No-secrets-store invariant:** external credentials are *always* read from the agent process's env. Anything proposing to store Copilot tokens inside AgentField is off-pattern.
+- **MCP is gone:** do not plan integration through MCP; it was removed in `f732ed5e`.
+- **Doctor is machine-consumable:** `af doctor --json` is the probe layer; new capabilities should have a doctor entry.
+
+## Historical Context (from research/)
+
+- [`research/docs/2026-04-20-sdk-patterns.md`](2026-04-20-sdk-patterns.md) — deep-dive on Python + Go agent construction, `af init` templates, `af run` env injection.
+- [`research/docs/2026-04-20-auth-model.md`](2026-04-20-auth-model.md) — full auth layering (API key, DID/VC, connector token, admin token) and confirmation of the no-secrets-store design.
+- [`research/docs/2026-04-20-copilot-cli-external-research.md`](2026-04-20-copilot-cli-external-research.md) — GitHub Copilot CLI v1.0.34 surface: `-p`, `--json`, `COPILOT_HOME`, plugins, skills, auth precedence, OTel hooks.
+- **install-skills-flow** sub-agent report (content in §5 below, not yet materialized as a separate file) — skillkit internals and CLI surface.
+
+## Open Questions
+
+1. **Distribution of the Copilot agent**: first-party tree under `sdk/python/examples/copilot/`, or a separate repo (e.g. `agentfield-copilot-agent`), or a new `af init --language=copilot` template, or a bundled node auto-registered by the server? The repo seems to prefer `examples/` for third-party/user-facing flows and `sdk/.../examples/` for SDK showcases. Recommend: **both** — a scaffold template for local authoring, and an optional built-in mode.
+2. **Session continuity across calls**: Copilot CLI supports `--resume <session-id>` in v1.0.34. Should we bind `ExecutionContext.SessionID` → Copilot `--resume`? That would give us multi-turn reasoning per AgentField session. Needs verification against the `--help` output (the external report notes it, but we should confirm the flag name).
+3. **Per-skill vs per-plugin install strategy for Copilot target**: per-skill symlinks are simpler; a single plugin is more discoverable. Choose after a quick prototype.
+4. **Output schema stability**: Copilot's `--json` NDJSON format isn't versioned. Do we want to post-process into a stable AgentField-native schema (e.g. `{turns, summary, usage, tool_calls}`) and keep the raw NDJSON as a side channel? Recommend: yes, add a versioned adapter.
+5. **OTel pass-through**: AgentField's control plane has its own execution tracing. Should Copilot's OTel traces be ingested (via `OTEL_EXPORTER_OTLP_ENDPOINT` pointed at the control plane), or kept separate? Out of scope for first integration.
+6. **Does `af run` currently accept `--env KEY=VAL` pass-through?** The research didn't verify this; the spec/plan stage should check `control-plane/internal/cli/commands/run.go`.
+
+---
+
+## 5. Agent reports
+
+Full sub-agent outputs for reference:
+
+- [`research/docs/2026-04-20-copilot-cli-external-research.md`](2026-04-20-copilot-cli-external-research.md) — external (Copilot CLI).
+- [`research/docs/2026-04-20-sdk-patterns.md`](2026-04-20-sdk-patterns.md) — SDK agent patterns.
+- [`research/docs/2026-04-20-auth-model.md`](2026-04-20-auth-model.md) — auth model.
+- Install / skills flow details are folded into this synthesis (§1.3 and Code References); if a standalone file is desired later, the raw content is reproducible from the `install-skills-flow` sub-agent.

--- a/research/docs/2026-04-20-sdk-patterns.md
+++ b/research/docs/2026-04-20-sdk-patterns.md
@@ -1,0 +1,631 @@
+---
+date: "2026-04-20"
+researcher: "codebase-analyzer (sdk-patterns)"
+git_commit: "0f42e612"
+branch: "copilot-cli-support"
+repository: "agentfield"
+topic: "AgentField SDK agent patterns (Python, Go, templates, af run)"
+tags: [research, codebase, sdk, python-sdk, go-sdk, templates]
+status: complete
+last_updated: "2026-04-20"
+last_updated_by: "codebase-analyzer"
+---
+
+## Analysis: Building an AgentField Agent — Python SDK, Go SDK, `af init` Templates, `af run`, and ExecutionContext
+
+---
+
+### Overview
+
+An AgentField agent is a small HTTP server (FastAPI in Python, `net/http` in Go) that registers its callable functions ("reasoners" or "skills") with a central control-plane server. Reasoners are exposed as individual `POST` endpoints; the control plane routes execution requests to those endpoints and propagates a correlation-header bundle (`X-Run-ID`, `X-Execution-ID`, etc.) as the `ExecutionContext`. The `af init` scaffolding tool generates the minimal directory with one ready-to-run echo reasoner, and `af run` / `af dev` launch the resulting `main.py` or Go binary while injecting `PORT` and `AGENTFIELD_SERVER_URL` into the process environment.
+
+---
+
+### Part 1 — Python SDK
+
+#### 1.1 The `Agent` Class
+
+**File:** `sdk/python/agentfield/agent.py`
+
+`Agent` subclasses `FastAPI` directly (`agent.py:419`). Construction signature (`agent.py:464–484`):
+
+```python
+Agent(
+    node_id: str,                        # required — unique registration key
+    agentfield_server: Optional[str],    # control-plane URL; falls back to
+                                         # AGENTFIELD_SERVER / AGENTFIELD_SERVER_URL / "http://localhost:8080"
+    version: str = "1.0.0",
+    ai_config: Optional[AIConfig] = None,
+    dev_mode: bool = False,
+    callback_url: Optional[str] = None,  # explicit callback URL the CP uses to reach this agent
+    vc_enabled: Optional[bool] = True,
+    api_key: Optional[str] = None,
+    enable_did: bool = True,
+    ...
+)
+```
+
+`agentfield_server` resolution order (`agent.py:555–558`):
+1. Explicit parameter
+2. `AGENTFIELD_SERVER` env var
+3. `AGENTFIELD_SERVER_URL` env var
+4. Literal `"http://localhost:8080"`
+
+After `super().__init__()`, the constructor stores `node_id` and `agentfield_server` as instance attributes (`agent.py:563–564`), constructs an `AgentFieldClient` (`agent.py:606–607`), initialises in-memory `_reasoner_registry` and `_skill_registry` dicts (`agent.py:572–573`), and creates `workflow_handler`, `agentfield_handler`, and `agent_server` helpers.
+
+#### 1.2 The `@app.reasoner()` Decorator
+
+**File:** `sdk/python/agentfield/agent.py:1615–1829`
+
+The decorator can be applied directly (`@app.reasoner`) or with keyword options:
+
+| Option | Purpose |
+|---|---|
+| `path` | Override the default `/reasoners/<name>` endpoint path |
+| `name` | Override the registration ID (defaults to `func.__name__`) |
+| `tags` | List of organizational tags sent at registration |
+| `vc_enabled` | Override per-reasoner VC generation |
+| `require_realtime_validation` | Force CP-side verification instead of local |
+
+What the decorator does step by step (`agent.py:1649–1829`):
+1. Derives `reasoner_id` from `name` or `func.__name__` (`agent.py:1652`).
+2. Derives `endpoint_path` as `/reasoners/<reasoner_id>` (or custom path) (`agent.py:1653–1660`).
+3. Inspects parameter type hints to build `input_fields` dict mapping param-name → `(type, default)` (`agent.py:1667–1676`).
+4. Registers a FastAPI `POST` handler at `endpoint_path` (`agent.py:1693–1744`).
+5. Creates a `tracked_func` wrapper that routes through `workflow_handler.execute_with_tracking` when a context is present (`agent.py:1753–1776`).
+6. Stores the entry in `_reasoner_registry[reasoner_id]` (`agent.py:1798–1804`).
+7. Calls `workflow_handler.replace_function_references(original_func, tracked_func, func_name)` so intra-module direct calls also go through tracking (`agent.py:1812`).
+
+#### 1.3 The `AgentFieldHandler` and Registration
+
+**File:** `sdk/python/agentfield/agent_field_handler.py`
+
+`AgentFieldHandler` owns two concerns:
+
+- **Registration** (`agent_field_handler.py:41–~200`): `register_with_agentfield_server(port)` resolves the callback URL the control plane should use to reach the agent, then `POST`s the node manifest (node_id, version, reasoners list, base_url) to the control plane.
+- **Heartbeat** (`agent_field_handler.py`): starts a background thread that `PUT`s a heartbeat every `heartbeat_interval` seconds (default 2 s) to keep the CP lease alive.
+
+#### 1.4 How Reasoners Become HTTP Endpoints
+
+**File:** `sdk/python/agentfield/agent_server.py`
+
+`AgentServer.setup_agentfield_routes()` (`agent_server.py:37`) registers platform-level routes on the `Agent` FastAPI app:
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/health` | Health probe (`agent_server.py:133`) |
+| `GET` | `/reasoners` | List all registered reasoners (`agent_server.py:144`) |
+| `GET` | `/skills` | List skills (`agent_server.py:148`) |
+| `GET` | `/status` | Detailed status + resource usage (`agent_server.py:224`) |
+| `GET` | `/info` | Node metadata (`agent_server.py:285`) |
+| `POST` | `/shutdown` | Graceful stop (`agent_server.py:152`) |
+| `GET` | `/agentfield/v1/logs` | NDJSON log stream (`agent_server.py:43`) |
+| `POST` | `/webhooks/approval` | Approval-decision callback (`agent_server.py:301`) |
+
+Each `@app.reasoner()` call also registers a `POST /reasoners/<id>` endpoint via `@self.post(endpoint_path)` (`agent.py:1693`).
+
+#### 1.5 The FastAPI Endpoint Handler Flow (per request)
+
+**File:** `sdk/python/agentfield/agent.py:1694–1744` and `agent.py:1831–1960`
+
+1. The POST body is parsed to JSON (`agent.py:1697–1701`).
+2. Input is runtime-validated against `handler_input_fields` via `_validate_handler_input` (`agent.py:1705–1713`).
+3. If `X-Execution-ID` header is present and the agent is connected to a CP, the call is promoted to an **async fire-and-forget** task that calls back the CP with the result; the endpoint immediately returns `HTTP 202` with `{"status":"processing","execution_id":"..."}` (`agent.py:1724–1742`).
+4. Otherwise it is a **synchronous** call: `_execute_reasoner_endpoint` is awaited in-place (`agent.py:1744`).
+
+Inside `_execute_reasoner_endpoint` (`agent.py:1831–1960`):
+1. `ExecutionContext.from_request(request, self.node_id)` is called to extract correlation headers (`agent.py:1843`).
+2. `workflow_handler.notify_call_start(...)` fires (`agent.py:1850–1858`).
+3. Pydantic args conversion via `convert_function_args` if applicable (`agent.py:1880–1898`).
+4. If the function signature includes `execution_context`, it is injected automatically (`agent.py:1900–1901`).
+5. `func(*args, **kwargs)` is awaited or called (`agent.py:1903–1906`).
+6. `workflow_handler.notify_call_complete(...)` fires (`agent.py:1930–1940`).
+
+#### 1.6 `AgentRouter` — Grouping Reasoners
+
+**File:** `sdk/python/agentfield/router.py`
+
+`AgentRouter(prefix="demo", tags=["example"])` collects reasoners before they are attached to an `Agent`:
+
+```python
+reasoners_router = AgentRouter(prefix="demo", tags=["example"])
+
+@reasoners_router.reasoner()
+async def echo(message: str) -> dict:
+    ...
+
+app.include_router(reasoners_router)   # agent.py:2666
+```
+
+`AgentRouter.reasoner()` (`router.py:28`) stores `{"func": func, "wrapper": wrapper, "path": ..., "tags": ...}` in `self.reasoners`. `_attach_agent` (`router.py:218`) links the router back to the agent so that `reasoners_router.ai(...)` and other agent methods work through `__getattr__` delegation (`router.py:131–163`). After `include_router`, the path for the echo reasoner above becomes `/reasoners/demo_echo` (prefix + name joined with `_`).
+
+#### 1.7 The `@reasoner` Standalone Decorator
+
+**File:** `sdk/python/agentfield/decorators.py`
+
+`@reasoner` / `@reasoner(track_workflow=True)` can be applied to functions **not** registered on an `Agent`. It sets `wrapper._is_reasoner = True` and other metadata attributes (`decorators.py:71–83`). When called, it enters `_execute_with_tracking` (`decorators.py:96`), which:
+- Gets the current `ExecutionContext` via `get_current_context()` (`decorators.py:109`)
+- Creates a root or child context (`decorators.py:126–141`)
+- Calls `workflow_handler._ensure_execution_registered(...)` (`decorators.py:151–154`)
+- Fires start/completion/error notifications to the workflow handler (`decorators.py:262–307`)
+
+#### 1.8 Minimal Python Agent Shape
+
+Based on `sdk/python/agentfield/agent.py` and templates:
+
+```python
+# main.py
+import os
+from agentfield import Agent, AIConfig
+from reasoners import reasoners_router
+
+app = Agent(
+    node_id=os.getenv("AGENT_NODE_ID", "copilot-agent"),
+    agentfield_server=os.getenv("AGENTFIELD_SERVER", "http://localhost:8080"),
+    version="1.0.0",
+    dev_mode=True,
+)
+app.include_router(reasoners_router)
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.getenv("PORT", "8001")), auto_port=False)
+
+# reasoners.py
+import subprocess
+from agentfield import AgentRouter
+
+reasoners_router = AgentRouter(prefix="copilot", tags=["cli"])
+
+@reasoners_router.reasoner()
+async def run_command(prompt: str) -> dict:
+    result = subprocess.run(
+        ["copilot", "--prompt", prompt],
+        capture_output=True, text=True
+    )
+    return {"stdout": result.stdout, "returncode": result.returncode}
+```
+
+*All inputs arrive as keyword arguments matching the function signature; `execution_context: ExecutionContext` can be added as an extra parameter and it will be injected automatically.*
+
+#### 1.9 `serve()` / `run()` — Server Start
+
+**File:** `sdk/python/agentfield/agent_server.py:617–800`, `sdk/python/agentfield/agent.py:4350–4418`
+
+`app.run(**serve_kwargs)` (`agent.py:4350`) inspects `sys.argv[1]`; if it's one of `["call", "list", "shell", "help"]` it enters CLI mode, otherwise it calls `app.serve(...)` (`agent.py:4413–4418`).
+
+`serve()` port selection priority (`agent_server.py:657–714`):
+1. Explicit `port` argument
+2. `PORT` env var (set by `af run` / `af dev`)
+3. `AGENTFIELD_AUTO_PORT=true` or `auto_port=True` → `get_free_port()`
+4. Default: 8001 if free, otherwise next free port
+
+`serve()` also reads `AGENT_CALLBACK_URL` to set `base_url` for CP-side reverse routing (`agent_server.py:721–742`).
+
+---
+
+### Part 2 — Go SDK
+
+#### 2.1 `Config` Struct
+
+**File:** `sdk/go/agent/agent.go:167–300`
+
+```go
+type Config struct {
+    NodeID               string        // required
+    Version              string        // required
+    AgentFieldURL        string        // control-plane URL (empty = offline / CLI-only)
+    ListenAddress        string        // default ":8001"
+    PublicURL            string        // URL reported to CP; default "http://localhost" + ListenAddress
+    Token                string        // Bearer token for CP auth
+    InternalToken        string        // token validated on *inbound* execution requests
+    DeploymentType       string        // "long_running" (default) or "serverless"
+    LeaseRefreshInterval time.Duration // default 2m
+    DisableLeaseLoop     bool
+    RequireOriginAuth    bool          // validate inbound requests carry InternalToken
+    LocalVerification    bool          // verify DID sigs locally, skipping CP per-call
+    MemoryBackend        MemoryBackend // nil = in-process map
+    AIConfig             *ai.Config
+    CLIConfig            *CLIConfig
+    Tags                 []string
+    EnableDID            bool
+    VCEnabled            bool
+    Logger               *log.Logger
+    HarnessConfig        *HarnessConfig
+}
+```
+
+Defaults applied by `New()` (`agent.go:353–401`): `TeamID → "default"`, `ListenAddress → ":8001"`, `PublicURL → "http://localhost:8001"`, `DeploymentType → "long_running"`, `LeaseRefreshInterval → 2m`.
+
+#### 2.2 `RegisterReasoner`
+
+**File:** `sdk/go/agent/agent.go:522–551`
+
+```go
+func (a *Agent) RegisterReasoner(name string, handler HandlerFunc, opts ...ReasonerOption)
+```
+
+`HandlerFunc` (`agent.go:57`):
+```go
+type HandlerFunc func(ctx context.Context, input map[string]any) (any, error)
+```
+
+`RegisterReasoner` creates a `Reasoner` struct, applies `ReasonerOption` functions, and stores it in `a.reasoners[name]`. Available options:
+
+| Option function | What it sets |
+|---|---|
+| `WithInputSchema(json.RawMessage)` | Override auto-generated JSON schema (`agent.go:63`) |
+| `WithOutputSchema(json.RawMessage)` | Override output schema (`agent.go:72`) |
+| `WithCLI()` | Mark as CLI-accessible (`agent.go:81`) |
+| `WithDefaultCLI()` | Designate as the default CLI entry point (`agent.go:87`) |
+| `WithCLIFormatter(func)` | Custom output formatter for CLI (`agent.go:96`) |
+| `WithDescription(string)` | Human-readable description (`agent.go:103`) |
+| `WithVCEnabled(bool)` | Per-reasoner VC override (`agent.go:132`) |
+| `WithReasonerTags(...string)` | Tags for tag-based authorization (`agent.go:139`) |
+| `WithRequireRealtimeValidation()` | Force CP verification (`agent.go:147`) |
+
+#### 2.3 HTTP Routing (`handler()`)
+
+**File:** `sdk/go/agent/agent.go:932–959`
+
+```go
+mux.HandleFunc("/health",              a.healthHandler)
+mux.HandleFunc("/discover",            a.handleDiscover)
+mux.HandleFunc("/agentfield/v1/logs",  a.handleAgentfieldLogs)
+mux.HandleFunc("/execute",             a.handleExecute)
+mux.HandleFunc("/execute/",            a.handleExecute)
+mux.HandleFunc("/reasoners/",          a.handleReasoner)
+```
+
+Middleware is conditionally wrapped: `localVerificationMiddleware` when `LocalVerification=true` (`agent.go:944–947`), `originAuthMiddleware` when `RequireOriginAuth=true` (`agent.go:950–957`).
+
+#### 2.4 `handleExecute` — Request-to-Handler Path
+
+**File:** `sdk/go/agent/agent.go:1154–1241`
+
+1. `targetName` is extracted from the URL path after `/execute/` (`agent.go:1160–1161`).
+2. JSON body is decoded to `payload map[string]any` (`agent.go:1163–1170`).
+3. `reasonerName` resolved from path, then from `payload["reasoner"|"target"|"skill"]` (`agent.go:1175–1183`).
+4. `extractInputFromServerless(payload)` isolates the user input under the `"input"` key, or filters out control fields (`agent.go:1191`, `1243–1265`).
+5. `buildExecutionContextFromServerless(r, payload, reasonerName)` reads HTTP headers into an `ExecutionContext` (`agent.go:1192`, `1267–1308`).
+6. `ExecutionContext` is stored on `ctx` via `contextWithExecution` (`agent.go:1194`).
+7. `reasoner.Handler(ctx, input)` is called directly (`agent.go:1201`).
+8. Result written as JSON with `writeJSON` (`agent.go:1240`).
+
+#### 2.5 `ExecutionContext` (Go)
+
+**File:** `sdk/go/agent/agent.go:32–50`
+
+```go
+type ExecutionContext struct {
+    RunID             string
+    ExecutionID       string
+    ParentExecutionID string
+    SessionID         string
+    ActorID           string
+    WorkflowID        string
+    ParentWorkflowID  string
+    RootWorkflowID    string
+    Depth             int
+    AgentNodeID       string
+    ReasonerName      string
+    StartedAt         time.Time
+    CallerDID         string
+    TargetDID         string
+    AgentNodeDID      string
+}
+```
+
+Retrieved inside a handler via `agent.ExecutionContextFrom(ctx)` (`agent.go:2042`), which reads the value stored by `contextWithExecution`.
+
+`ChildContext(agentNodeID, reasonerName)` (`agent.go:444–479`) creates a derived context for local nested calls, incrementing `Depth` and setting `ParentExecutionID`.
+
+#### 2.6 `Run()` / `Serve()` / `Initialize()`
+
+**File:** `sdk/go/agent/agent.go:616–660`
+
+- `Run(ctx)` (`agent.go:616`): checks `os.Args[1:]`; if no args and no CLI-enabled reasoners, calls `Serve(ctx)`; if `args[0] == "serve"`, calls `Serve(ctx)`; otherwise dispatches to `runCLI(ctx, args)`.
+- `Serve(ctx)` (`agent.go:630`): calls `Initialize(ctx)` then `startServer()`, then blocks on `ctx.Done()` or OS signal.
+- `Initialize(ctx)` (`agent.go:554`): calls `registerNode(ctx)` (POST to CP with all reasoners listed), optionally `initializeDIDSystem`, then `markReady` and `startLeaseLoop()`.
+
+Node registration payload (`agent.go:680–706`):
+```go
+types.NodeRegistrationRequest{
+    ID:        cfg.NodeID,
+    BaseURL:   cfg.PublicURL,
+    Version:   cfg.Version,
+    Reasoners: []types.ReasonerDefinition{...},  // one per registered reasoner
+    CommunicationConfig: types.CommunicationConfig{
+        Protocols:         ["http"],
+        HeartbeatInterval: ...,
+    },
+}
+```
+
+#### 2.7 `Call()` — Cross-Agent Invocation
+
+**File:** `sdk/go/agent/agent.go:1570–~1680`
+
+`Call(ctx, "other-node.some_reasoner", input)` (`agent.go:1570`) POSTs to `<AgentFieldURL>/api/v1/execute/<target>`, forwarding `X-Run-ID`, `X-Parent-Execution-ID`, `X-Workflow-ID`, `X-Session-ID`, `X-Actor-ID`, and DID headers extracted from the current `ExecutionContext` (`agent.go:1606–1628`).
+
+#### 2.8 Memory (Go)
+
+**File:** `sdk/go/agent/memory.go`
+
+`agent.Memory()` returns `*Memory` (`agent.go:2059`). Default scope methods use `ScopeSession`, deriving the scope-ID from `ctx` via `ExecutionContextFrom(ctx).SessionID` (falling back to `RunID`) (`memory.go:80–85`). Explicit scopes via:
+
+| Method | Scope | Scope-ID source |
+|---|---|---|
+| `Memory().Set/Get(ctx, key)` | `ScopeSession` | `execCtx.SessionID` or `RunID` |
+| `Memory().WorkflowScope()` | `ScopeWorkflow` | `execCtx.WorkflowID` or `RunID` (`memory.go:196–207`) |
+| `Memory().SessionScope()` | `ScopeSession` | `execCtx.SessionID` (`memory.go:212`) |
+| `Memory().UserScope()` | `ScopeUser` | `execCtx.ActorID` |
+| `Memory().GlobalScope()` | `ScopeGlobal` | `"global"` |
+| `Memory().Scoped(scope, id)` | explicit | explicit (`memory.go:101`) |
+
+`MemoryBackend` is pluggable (`agent.go:238`). The built-in is `InMemoryBackend`. A `ControlPlaneMemoryBackend` that proxies to the CP's `/memory/set` and `/memory/get` endpoints is available separately (`control_plane_memory_backend.go`).
+
+#### 2.9 Minimal Go Agent Shape
+
+Based on `control-plane/internal/templates/go/main.go.tmpl` and `reasoners.go.tmpl`:
+
+```go
+// main.go
+package main
+
+import (
+    "context"
+    "log"
+    "os/exec"
+    "github.com/Agent-Field/agentfield/sdk/go/agent"
+)
+
+func main() {
+    cfg := agent.Config{
+        NodeID:        "copilot-agent",
+        Version:       "1.0.0",
+        AgentFieldURL: "http://localhost:8080",
+        ListenAddress: ":8001",
+    }
+    app, err := agent.New(cfg)
+    if err != nil { log.Fatal(err) }
+
+    app.RegisterReasoner("run_command", func(ctx context.Context, input map[string]any) (any, error) {
+        prompt, _ := input["prompt"].(string)
+        out, err := exec.CommandContext(ctx, "copilot", "--prompt", prompt).Output()
+        if err != nil {
+            return nil, err
+        }
+        return map[string]any{"stdout": string(out)}, nil
+    }, agent.WithDescription("Shell out to copilot CLI"))
+
+    log.Fatal(app.Run(context.Background()))
+}
+```
+
+*`input` is always `map[string]any`. The `ctx` carries the full `ExecutionContext`; retrieve it with `agent.ExecutionContextFrom(ctx)` if needed.*
+
+---
+
+### Part 3 — `af init` Templates
+
+#### 3.1 Files Generated for Python
+
+**Directory:** `control-plane/internal/templates/python/`
+
+Template files and their output names after stripping `.tmpl` (`templates.go:52–61`):
+
+| Template | Output file |
+|---|---|
+| `python/main.py.tmpl` | `main.py` |
+| `python/reasoners.py.tmpl` | `reasoners.py` |
+| `python/requirements.txt.tmpl` | `requirements.txt` |
+| `python/.env.example.tmpl` | `.env.example` |
+| `python/.gitignore.tmpl` | `.gitignore` |
+| `python/README.md.tmpl` | `README.md` |
+
+`requirements.txt.tmpl` contains a single line: `agentfield` (`requirements.txt.tmpl:1`).
+
+`.env.example.tmpl` contains: `AGENTFIELD_CONTROL_PLANE_URL=http://localhost:8080` (`python/.env.example.tmpl:1`).
+
+Generated `main.py` (`main.py.tmpl:1–32`):
+- Constructs `Agent(node_id=..., agentfield_server=os.getenv("AGENTFIELD_SERVER", "http://localhost:8080"), ...)` where `node_id` comes from `AGENT_NODE_ID` env var or the baked-in `{{.NodeID}}` value.
+- Calls `app.include_router(reasoners_router)` linking the generated `reasoners.py`.
+- Entry: `app.run(host="0.0.0.0", port=int(os.getenv("PORT", "8001")), auto_port=False)`.
+
+Generated `reasoners.py` (`reasoners.py.tmpl:1–57`):
+- Creates `reasoners_router = AgentRouter(prefix="demo", tags=["example"])`.
+- Registers one `@reasoners_router.reasoner()` function named `echo(message: str) -> dict` that returns `{"original": message, "echoed": message, "length": len(message)}`.
+
+#### 3.2 Files Generated for Go
+
+**Directory:** `control-plane/internal/templates/go/`
+
+| Template | Output file |
+|---|---|
+| `go/main.go.tmpl` | `main.go` |
+| `go/reasoners.go.tmpl` | `reasoners.go` |
+| `go/go.mod.tmpl` | `go.mod` |
+| `go/.env.example.tmpl` | `.env.example` |
+| `go/.gitignore.tmpl` | `.gitignore` |
+| `go/README.md.tmpl` | `README.md` |
+
+Generated `main.go` (`main.go.tmpl:1–41`):
+- `agent.Config{NodeID: "{{.NodeID}}", Version: "1.0.0", AgentFieldURL: "http://localhost:8080", ListenAddress: ":0"}` — port `0` means the OS assigns any free port.
+- `agent.New(cfg)` → `registerReasoners(app)` → `app.Run(context.Background())`.
+
+Generated `reasoners.go` (`reasoners.go.tmpl:1–49`):
+- `func registerReasoners(app *agent.Agent)` calls `app.RegisterReasoner("echo", ...)` with the same echo logic.
+
+#### 3.3 Optional Docker Scaffold (`--docker` flag)
+
+If `af init --docker` is used, `GetDockerTemplateFiles(language)` (`templates.go:92–103`) also produces:
+- `docker-compose.yml`
+- `.env.example` (overwritten)
+- `.dockerignore`
+- `Dockerfile` (Python only)
+
+#### 3.4 `TemplateData` Fields
+
+**File:** `control-plane/internal/templates/templates.go:15–29`
+
+`{{.ProjectName}}`, `{{.NodeID}}`, `{{.GoModule}}`, `{{.AuthorName}}`, `{{.AuthorEmail}}`, `{{.CurrentYear}}`, `{{.CreatedAt}}`, `{{.Language}}`, `{{.ControlPlaneImage}}`, `{{.ControlPlanePort}}`, `{{.AgentPort}}`, `{{.DefaultModel}}`.
+
+`NodeID` is derived from `ProjectName` by lowercasing, replacing `_` → `-`, and collapsing multiple hyphens (`init.go:526–532`).
+
+#### 3.5 `af init` Command
+
+**File:** `control-plane/internal/cli/init.go:204–511`
+
+Interactive TUI (Bubble Tea) with 4 steps: project-name → language selection → author name → author email. Non-interactive via `--non-interactive` / `--defaults` flags. `--language` / `-l` accepts `python`, `go`, `typescript` (with aliases `py`, `ts`, `golang`, etc.) (`init.go:558–569`).
+
+---
+
+### Part 4 — `af run` Discovery and Execution
+
+#### 4.1 `af run <agent-name>`
+
+**File:** `control-plane/internal/cli/commands/run.go:36–127`, `control-plane/internal/core/services/agent_service.go:51–136`
+
+`RunCommand.execute(name, port, detach, verbose)` (`run.go:69`) calls `cmd.Services.AgentService.RunAgent(name, options)`.
+
+`DefaultAgentService.RunAgent` (`agent_service.go:51`):
+1. Loads `~/.agentfield/installed.yaml` registry (`agent_service.go:55–64`).
+2. Finds the agent entry, reconciles stale PID state.
+3. Calls `portManager.FindFreePort(8001)` for port `8001+` if none given (`agent_service.go:87–93`).
+4. Calls `buildProcessConfig(agentNode, port)` (`agent_service.go:448–525`) which:
+   - Sets `env PORT=<port>` (`agent_service.go:451`).
+   - Sets `env AGENTFIELD_SERVER_URL=<resolved-url>` (`agent_service.go:452`).
+   - Loads `.env` from the package directory (`agent_service.go:455–460`).
+   - Resolves Python path: `<pkg>/venv/bin/python` → `<pkg>/venv/Scripts/python.exe` → system `python` (`agent_service.go:463–516`).
+   - Returns `ProcessConfig{Command: pythonPath, Args: ["main.py"], WorkDir: agentNode.Path}`.
+5. Starts the process and polls `http://localhost:<port>/health` every 500 ms until `HTTP 200` within 10 s (`agent_service.go:104–111`, `528–546`).
+6. Updates `installed.yaml` with PID + port + started-at (`agent_service.go:116`).
+
+#### 4.2 `af dev [path]`
+
+**File:** `control-plane/internal/cli/commands/dev.go`, `control-plane/internal/core/services/dev_service.go`
+
+`DevService.RunInDevMode(path, options)` (`dev_service.go:40`) checks for `agentfield.yaml` in the target directory (`dev_service.go:49`), then calls `runDev(absPath, options)`.
+
+`startDevProcess` (`dev_service.go:183`) sets the same env vars (`PORT`, `AGENTFIELD_SERVER_URL`, `AGENTFIELD_DEV_MODE=true`), runs `python main.py` with stdout/stderr piped to the terminal, and does **not** detach.
+
+`discoverAgentPort` (`dev_service.go:242`) polls `http://localhost:<n>/health` for ports 8001–8999 with 2 s per-request timeout up to the overall timeout (120 s default) (`dev_service.go:260–267`).
+
+The old `packages/runner.go` path (`runner.go:112`) does the same: sets `PORT`, `AGENTFIELD_SERVER_URL`, runs `python main.py`.
+
+#### 4.3 Key Environment Variables Consumed by the Agent
+
+| Variable | Set by | Consumed at |
+|---|---|---|
+| `PORT` | `af run` / `af dev` | `agent_server.py:659` (Python); agent uses it as the listen port |
+| `AGENTFIELD_SERVER` | user / `.env` | `agent.py:556` (Python `agentfield_server` default) |
+| `AGENTFIELD_SERVER_URL` | `af run` / `af dev` (`agent_service.go:452`) | Same fallback as above |
+| `AGENT_NODE_ID` | user | `main.py.tmpl:16` — overrides the baked-in node ID |
+| `AGENT_CALLBACK_URL` | user / container env | `agent_server.py:721` — the URL the CP uses to call back |
+| `AGENTFIELD_AUTO_PORT` | user | `agent_server.py:678` — triggers auto-port mode |
+
+For the Go SDK, the go template uses `AGENTFIELD_URL` (`go_agent_nodes/main.go:21`) and `AGENT_NODE_ID` (`main.go:15`), `AGENT_LISTEN_ADDR` (`main.go:22`), `AGENT_PUBLIC_URL` (`main.go:26`), `AGENTFIELD_TOKEN` (`main.go:35`).
+
+#### 4.4 `af install` — Package Registry
+
+Before `af run` can find an agent, it must be installed via `af install <source>`, which:
+- Validates presence of `agentfield-package.yaml` and `main.py` in the source (`installer.go:392–406`).
+- Reads `agentfield-package.yaml` fields: `name`, `version`, `description`, `main` (default `"main.py"`), `agent_node.node_id`, `dependencies.python[]` (`installer.go:32–69`).
+- Copies the package directory to `~/.agentfield/packages/<name>/` and installs Python dependencies into `<pkg>/venv/`.
+- Writes an entry into `~/.agentfield/installed.yaml`.
+
+---
+
+### Part 5 — Memory Scopes and `ExecutionContext` at Runtime
+
+#### 5.1 Python `ExecutionContext`
+
+**File:** `sdk/python/agentfield/execution_context.py`
+
+`@dataclass ExecutionContext` fields:
+
+| Field | Type | Source |
+|---|---|---|
+| `run_id` | `str` | `X-Run-ID` header or generated |
+| `execution_id` | `str` | `X-Execution-ID` header or generated |
+| `agent_instance` | `Any` | set to current `Agent` from registry |
+| `reasoner_name` | `str` | set by endpoint handler |
+| `agent_node_id` | `Optional[str]` | `agent.node_id` |
+| `parent_execution_id` | `Optional[str]` | `X-Parent-Execution-ID` header |
+| `depth` | `int` | incremented for child contexts |
+| `session_id` | `Optional[str]` | `X-Session-ID` header |
+| `actor_id` | `Optional[str]` | `X-Actor-ID` header |
+| `caller_did` | `Optional[str]` | `X-Caller-DID` header |
+| `target_did` | `Optional[str]` | `X-Target-DID` header |
+| `agent_node_did` | `Optional[str]` | `X-Agent-Node-DID` header |
+| `workflow_id` | `Optional[str]` | `X-Workflow-ID` header; defaults to `run_id` |
+| `parent_workflow_id` | `Optional[str]` | `X-Parent-Workflow-ID` |
+| `root_workflow_id` | `Optional[str]` | `X-Root-Workflow-ID` |
+| `registered` | `bool` | `True` when built from request headers |
+
+**Construction:**
+- From HTTP request: `ExecutionContext.from_request(request, agent_node_id)` (`execution_context.py:174`).
+- Fresh root: `ExecutionContext.new_root(agent_node_id, reasoner_name)` (`execution_context.py:223`).
+- Child: `ctx.child_context()` / `ctx.create_child_context()` (`execution_context.py:136–168`).
+
+**Context-var propagation:** A module-level `contextvars.ContextVar` (`execution_context.py:259`) stores the current context. `set_execution_context(ctx)` sets it and returns a token; `reset_execution_context(token)` restores previous value. The decorator system sets/resets this around every reasoner call (`decorators.py:228`, `311`).
+
+**Injection into reasoner:** If the decorated function declares `execution_context` as a parameter, it is passed in automatically (`decorators.py:231–232`, `agent.py:1900–1901`).
+
+**Header forwarding:** `ctx.to_headers()` (`execution_context.py:56`) returns the dict of correlation headers to send on downstream calls:
+```
+X-Run-ID, X-Workflow-ID, X-Parent-Execution-ID, X-Execution-ID,
+X-Workflow-Run-ID, X-Agent-Node-ID, X-Session-ID, X-Actor-ID,
+X-Parent-Workflow-ID, X-Root-Workflow-ID, X-Caller-DID, X-Target-DID, X-Agent-Node-DID
+```
+
+#### 5.2 Python Memory Scopes
+
+**File:** `sdk/python/agentfield/memory.py:1–99` (docstring) and `memory.py:100+` (implementation)
+
+Four scopes, resolved from the `ExecutionContext` at call time:
+
+| Scope name | Retention | Scope-ID source | Access pattern |
+|---|---|---|---|
+| `global` | Until explicitly deleted | `"global"` literal | `agent.memory.global_scope.set(key, value)` |
+| `session` | Until session ends | `execution_context.session_id` | `agent.memory.session(session_id).set(key, value)` |
+| `actor` | Across sessions per actor | `execution_context.actor_id` | `agent.memory.actor(actor_id).set(key, value)` |
+| `workflow` | Until run completes | `execution_context.workflow_id` | `agent.memory.workflow(workflow_id).set(key, value)` |
+
+Hierarchical lookup (`memory.py:45–56`): `agent.memory.get(key)` without an explicit scope resolves `workflow → session → actor → global`, returning the first match.
+
+The `MemoryClient._build_headers()` (`memory.py:149–168`) merges `execution_context.to_headers()` with scope-override headers before POSTing to `<agentfield_server>/memory/set` or `.../memory/get`.
+
+#### 5.3 Go Memory Scopes
+
+**File:** `sdk/go/agent/memory.go`
+
+```go
+const (
+    ScopeWorkflow MemoryScope = "workflow"
+    ScopeSession  MemoryScope = "session"
+    ScopeUser     MemoryScope = "user"
+    ScopeGlobal   MemoryScope = "global"
+)
+```
+
+Default `Memory.Set/Get(ctx, key)` uses `ScopeSession` with scope-ID = `ExecutionContextFrom(ctx).SessionID` (fallback: `RunID`) (`memory.go:80–86`).
+
+Explicit scoped accessors:
+- `Memory().WorkflowScope()` → `ScopeWorkflow`, ID from `execCtx.WorkflowID` or `RunID` (`memory.go:196–207`).
+- `Memory().SessionScope()` → `ScopeSession` (`memory.go:212`).
+- `Memory().UserScope()` → `ScopeUser`, ID from `execCtx.ActorID`.
+- `Memory().GlobalScope()` → `ScopeGlobal`, fixed ID `"global"`.
+
+The `ControlPlaneMemoryBackend` (`control_plane_memory_backend.go`) forwards each call as an HTTP request to the CP's `/memory/set` and `/memory/get`, attaching `X-Workflow-ID`, `X-Session-ID`, `X-Actor-ID`, and `X-Agent-Node-ID` headers to scope the data (`control_plane_memory_backend.go:357–385`).
+
+---
+
+### Key Patterns Summary
+
+- **Agent = FastAPI app (Python) / `http.ServeMux` wrapper (Go)**: the same binary serves both the reasoner POST endpoints and the platform routes (`/health`, `/discover`, `/reasoners`, etc.).
+- **`@reasoner` or `RegisterReasoner` = route registration + CP metadata**: each call both adds an HTTP route and registers schema metadata that the CP receives at node-registration time.
+- **`ExecutionContext` flows via HTTP headers**: the CP injects `X-Run-ID`, `X-Execution-ID`, etc. on inbound calls; the agent rebuilds the context from those headers and propagates them on outbound `Call()` / cross-agent requests.
+- **`af run` = `python main.py` with `PORT` and `AGENTFIELD_SERVER_URL` injected**: discovery of the agent's actual port is done by polling `http://localhost:<n>/health`.
+- **Memory scopes are header-driven**: the scope-ID for session, actor, and workflow memory is read from the same execution-context headers, so the CP can route storage to the correct shard without the agent needing to carry explicit scope IDs.
+- **CLI-wrapping pattern**: a reasoner that shells out to an external CLI tool (`subprocess.run` / `exec.CommandContext`) fits naturally — the `input` dict carries the CLI arguments, `subprocess.run` is called synchronously inside the async handler, and the captured stdout/returncode are returned as the reasoner's output dict.


### PR DESCRIPTION
# Summary

Adds **GitHub Copilot CLI** as a first-class skill-install target plus `af doctor` probes, so `af skill install` covers Copilot the same way it covers Claude Code.

**Track B of the two-PR Copilot integration** (Track A is #492, the example agent — independent of this PR).

What this PR lands:

- **`control-plane/internal/skillkit/target_copilot.go`** — new `copilotTarget` that symlinks `<canonical current>/` into `~/.copilot/skills/<skill>/`. Auto-registers via `init()`, mirrors `target_claude_code.go` exactly. Detects the target when `~/.copilot/` exists **or** the `copilot` binary is on PATH. Warns on stderr if the same skill is also symlinked into `~/.claude/skills/` (Copilot reads both and dedupes by name).
- **`control-plane/internal/cli/doctor.go`** — new `CopilotStatus` block in the doctor report. Reports: copilot binary + version, `~/.copilot` config-dir presence, last logged-in user, detected auth env-source names (`COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN` — names only, never values), and whether `gh auth status` exits 0. Ships with an explicit disclaimer that "sources present" ≠ "authenticated" — Copilot rejects classic `ghp_*` PATs and requires a fine-grained PAT with the "Copilot Requests" permission.
- **`README.md`** — lists "GitHub Copilot CLI" in the Quick Start skill-install target list.
- **`research/docs/2026-04-20-*.md`** — four research docs recording the integration and SDK findings (including the PyPI/repo drift where v0.2.2 doesn't expose `AssistantMessageData` etc.).

No behaviour change for existing targets; no SDK/server wire changes; no dependencies added.

## Testing

- [x] `./scripts/test-all.sh` — skipped (no Go/Python SDK surface changed). Ran the scoped tests instead:
- [x] Additional verification:
  - `go test ./control-plane/internal/skillkit/...` — pass (includes new `TestCopilotTarget` covering detect / install / uninstall / status / symlink redirection).
  - `go test ./control-plane/internal/cli/ -run 'Doctor|Helper'` — pass.
  - `af doctor --json | jq .copilot` smoke-tested on dev machine; reports binary + config-dir state correctly.

## Checklist

- [x] I updated documentation where applicable. (README Quick Start + four `research/docs/2026-04-20-*.md` docs.)
- [x] I added or updated tests. (`control-plane/internal/skillkit/target_copilot_test.go` + `copilot` added to the detected/registered lists in `skillkit_test.go`.)
- [x] I updated `CHANGELOG.md` — new `[Unreleased]` entry under `### Added`.

## Screenshots (if UI-related)

Not UI-related.

## Related issues

Pairs with #492 (Copilot example agent, independent — merge in either order).
