### PR TITLE
Feature /agentfield slash command + prompt-to-production README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,36 +73,30 @@ app.run()
 
 > **What you just saw:** `app.ai()` calls an LLM and returns structured output. `app.pause()` suspends for [human approval](https://agentfield.ai/docs/build/execution/human-in-the-loop?utm_source=github-readme&utm_campaign=github-readme&utm_id=github-readme-human-in-the-loop). `app.call()` routes to other agents through the control plane. `app.run()` auto-exposes everything as REST. [Read the full docs →](https://agentfield.ai/docs/learn?utm_source=github-readme&utm_campaign=github-readme&utm_id=github-readme-read-full-docs)
 
-## Build with Claude Code (recommended)
+## Prompt to production (recommended)
 
-**Describe the backend. Your coding agent ships it. AgentField runs it.**
+**Describe the system in one line. Get a production-ready multi-agent backend.**
+
+Works in Claude Code, Codex, Gemini CLI, OpenCode, Aider, Windsurf, and Cursor.
 
 ```bash
-# Installs the af CLI AND drops the agentfield-multi-reasoner-builder skill
-# into every coding agent on your machine (Claude Code, Codex, Gemini,
-# OpenCode, Aider, Windsurf, Cursor).
 curl -fsSL https://agentfield.ai/install.sh | bash
 ```
 
-Open Claude Code in an empty folder and describe what you want in plain English. No slash command.
+Now paste any of these into your coding agent — no slash command:
 
 ```text
-> build me a claims-processor agent with risk scoring,
-  pattern detection, and human approval for low-confidence decisions
+Build a claims-processor agent with risk scoring, pattern detection,
+and human approval for low-confidence decisions.
 
-● Using agentfield-multi-reasoner-builder…
-  ✓ Scaffolding claims-processor/
-  ✓ Wiring orchestrator → risk_scorer, pattern_detector, approver
-  ✓ Smoke test: curl /api/v1/execute/… → 200 OK
+Build a research agent that spawns parallel investigators and recurses
+into deeper sub-questions until the answer has citation-grade provenance.
 
-  Your agent is ready. `af server` & `python main.py`
+Build a compliance reviewer for support transcripts — extract claims,
+check each against policy, flag violations, emit a signed audit trail.
 ```
 
-[Full walkthrough →](https://agentfield.ai/docs/learn/build-with-claude-code?utm_source=github-readme&utm_campaign=github-readme&utm_id=github-readme-build-with-claude-code)
-
-> **Already have `af` installed?** `af skill install --all` drops the skill into every detected coding agent.
->
-> **Just want the binary, no skill?** `curl -fsSL https://agentfield.ai/install.sh | bash -s -- --no-skill`
+[See it in action →](https://agentfield.ai/docs/learn/build-with-claude-code?utm_source=github-readme&utm_campaign=github-readme&utm_id=github-readme-prompt-to-production)
 
 ## Prefer to write it yourself?
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,13 @@ Works in Claude Code, Codex, Gemini CLI, OpenCode, Aider, Windsurf, and Cursor.
 curl -fsSL https://agentfield.ai/install.sh | bash
 ```
 
-Now paste any of these into your coding agent — no slash command:
+In Claude Code, fire it with the shipped slash command:
+
+```text
+/agentfield a claims processor with risk scoring and human approval
+```
+
+Or paste any of these directly — the skill auto-matches, no slash command needed:
 
 ```text
 Build a claims-processor agent with risk scoring, pattern detection,
@@ -95,6 +101,8 @@ into deeper sub-questions until the answer has citation-grade provenance.
 Build a compliance reviewer for support transcripts — extract claims,
 check each against policy, flag violations, emit a signed audit trail.
 ```
+
+You get a Docker Compose stack already wired up — the agent, the control plane, and a local `curl` you paste into a terminal to try it.
 
 [See it in action →](https://agentfield.ai/docs/learn/build-with-claude-code?utm_source=github-readme&utm_campaign=github-readme&utm_id=github-readme-prompt-to-production)
 

--- a/README.md
+++ b/README.md
@@ -80,43 +80,27 @@ app.run()
 ```bash
 # Installs the af CLI AND drops the agentfield-multi-reasoner-builder skill
 # into every coding agent on your machine (Claude Code, Codex, Gemini,
-# OpenCode, Aider, Windsurf, Cursor) — no prompts, no second step.
+# OpenCode, Aider, Windsurf, Cursor).
 curl -fsSL https://agentfield.ai/install.sh | bash
 ```
 
-Open Claude Code in an empty folder and describe the system in plain English. No slash command — the skill fires on natural-language descriptions of agent systems.
+Open Claude Code in an empty folder and describe what you want in plain English. No slash command.
 
 ```text
 > build me a claims-processor agent with risk scoring,
   pattern detection, and human approval for low-confidence decisions
 
-● Using agentfield-multi-reasoner-builder to architect your system…
-
-  ✓ Decomposing into 7 reasoners, depth 4
-  ✓ Scaffolding claims-processor/ with docker-compose
+● Using agentfield-multi-reasoner-builder…
+  ✓ Scaffolding claims-processor/
   ✓ Wiring orchestrator → risk_scorer, pattern_detector, approver
-  ✓ Generating Pydantic schemas, tags, and policy gates
-  ✓ Running smoke test: curl /api/v1/execute/… → 200 OK
+  ✓ Smoke test: curl /api/v1/execute/… → 200 OK
 
   Your agent is ready. `af server` & `python main.py`
 ```
 
-The skill encodes the architecture — five principles (granular decomposition, guided autonomy, dynamic orchestration, contextual fidelity, asynchronous parallelism) that turn a one-line ask into a real multi-reasoner system, not a CrewAI clone. [Full walkthrough →](https://agentfield.ai/docs/learn/build-with-claude-code?utm_source=github-readme&utm_campaign=github-readme&utm_id=github-readme-build-with-claude-code)
+[Full walkthrough →](https://agentfield.ai/docs/learn/build-with-claude-code?utm_source=github-readme&utm_campaign=github-readme&utm_id=github-readme-build-with-claude-code)
 
-Prompts that work well:
-
-```text
-Build a research agent that spawns parallel investigators, scores coverage,
-and recurses into deeper sub-questions until the answer has citation-grade provenance.
-
-Build a compliance reviewer for customer support transcripts — extract claims,
-check each against policy, flag violations, emit a signed audit trail.
-
-Build a security-audit pipeline that traces every vulnerability from source
-to sink, then adversarially verifies each finding before reporting.
-```
-
-> **Already have `af` installed and just want the skill?** `af skill install` (interactive picker) or `af skill install --all` (every detected agent). See [`af skill --help`](https://agentfield.ai/docs/reference/sdks/cli?utm_source=github-readme&utm_campaign=github-readme&utm_id=github-readme-af-skill-help) for `list`, `update`, `uninstall`, version pinning, and per-target installs.
+> **Already have `af` installed?** `af skill install --all` drops the skill into every detected coding agent.
 >
 > **Just want the binary, no skill?** `curl -fsSL https://agentfield.ai/install.sh | bash -s -- --no-skill`
 

--- a/README.md
+++ b/README.md
@@ -73,25 +73,58 @@ app.run()
 
 > **What you just saw:** `app.ai()` calls an LLM and returns structured output. `app.pause()` suspends for [human approval](https://agentfield.ai/docs/build/execution/human-in-the-loop?utm_source=github-readme&utm_campaign=github-readme&utm_id=github-readme-human-in-the-loop). `app.call()` routes to other agents through the control plane. `app.run()` auto-exposes everything as REST. [Read the full docs →](https://agentfield.ai/docs/learn?utm_source=github-readme&utm_campaign=github-readme&utm_id=github-readme-read-full-docs)
 
-## Quick Start
+## Build with Claude Code (recommended)
+
+**Describe the backend. Your coding agent ships it. AgentField runs it.**
 
 ```bash
 # Installs the af CLI AND drops the agentfield-multi-reasoner-builder skill
 # into every coding agent on your machine (Claude Code, Codex, Gemini,
 # OpenCode, Aider, Windsurf, Cursor) — no prompts, no second step.
 curl -fsSL https://agentfield.ai/install.sh | bash
-
-af init my-agent --defaults                            # Scaffold agent
-cd my-agent && pip install -r requirements.txt
 ```
 
-> **Just want the binary?** `curl -fsSL https://agentfield.ai/install.sh | bash -s -- --no-skill`
->
-> **Already have `af` installed and just want the skill?** `af skill install` (interactive picker) or `af skill install --all` (every detected agent). See [`af skill --help`](#) for `list`, `update`, `uninstall`, version pinning, and per-target installs.
+Open Claude Code in an empty folder and describe the system in plain English. No slash command — the skill fires on natural-language descriptions of agent systems.
 
-The skill teaches any coding agent how to architect and ship a complete multi-reasoner backend on AgentField — composite-intelligence patterns, deep DAG composition, scaffold-to-curl in one workflow. Once installed, just open Claude Code / Codex / etc. and ask **"build me a multi-reasoner agent that does X"** — the skill fires automatically.
+```text
+> build me a claims-processor agent with risk scoring,
+  pattern detection, and human approval for low-confidence decisions
+
+● Using agentfield-multi-reasoner-builder to architect your system…
+
+  ✓ Decomposing into 7 reasoners, depth 4
+  ✓ Scaffolding claims-processor/ with docker-compose
+  ✓ Wiring orchestrator → risk_scorer, pattern_detector, approver
+  ✓ Generating Pydantic schemas, tags, and policy gates
+  ✓ Running smoke test: curl /api/v1/execute/… → 200 OK
+
+  Your agent is ready. `af server` & `python main.py`
+```
+
+The skill encodes the architecture — five principles (granular decomposition, guided autonomy, dynamic orchestration, contextual fidelity, asynchronous parallelism) that turn a one-line ask into a real multi-reasoner system, not a CrewAI clone. [Full walkthrough →](https://agentfield.ai/docs/learn/build-with-claude-code?utm_source=github-readme&utm_campaign=github-readme&utm_id=github-readme-build-with-claude-code)
+
+Prompts that work well:
+
+```text
+Build a research agent that spawns parallel investigators, scores coverage,
+and recurses into deeper sub-questions until the answer has citation-grade provenance.
+
+Build a compliance reviewer for customer support transcripts — extract claims,
+check each against policy, flag violations, emit a signed audit trail.
+
+Build a security-audit pipeline that traces every vulnerability from source
+to sink, then adversarially verifies each finding before reporting.
+```
+
+> **Already have `af` installed and just want the skill?** `af skill install` (interactive picker) or `af skill install --all` (every detected agent). See [`af skill --help`](https://agentfield.ai/docs/reference/sdks/cli?utm_source=github-readme&utm_campaign=github-readme&utm_id=github-readme-af-skill-help) for `list`, `update`, `uninstall`, version pinning, and per-target installs.
+>
+> **Just want the binary, no skill?** `curl -fsSL https://agentfield.ai/install.sh | bash -s -- --no-skill`
+
+## Prefer to write it yourself?
 
 ```bash
+af init my-agent --defaults                            # Scaffold agent
+cd my-agent && pip install -r requirements.txt
 af server          # Terminal 1 → Dashboard at http://localhost:8080
 python main.py     # Terminal 2 → Agent auto-registers
 ```

--- a/control-plane/internal/skillkit/embed.go
+++ b/control-plane/internal/skillkit/embed.go
@@ -33,4 +33,5 @@ import "embed"
 //
 //go:embed skill_data/agentfield-multi-reasoner-builder/SKILL.md
 //go:embed skill_data/agentfield-multi-reasoner-builder/references/*.md
+//go:embed skill_data/agentfield-multi-reasoner-builder/commands/*.md
 var SkillData embed.FS

--- a/control-plane/internal/skillkit/skill_data/agentfield-multi-reasoner-builder/commands/agentfield.md
+++ b/control-plane/internal/skillkit/skill_data/agentfield-multi-reasoner-builder/commands/agentfield.md
@@ -1,0 +1,10 @@
+---
+description: Build a production-ready multi-agent backend on AgentField from a plain-English description.
+argument-hint: [describe the system — e.g. "a claims processor with risk scoring and human approval"]
+---
+
+Use the `agentfield-multi-reasoner-builder` skill to architect, scaffold, wire, and smoke-test a production-ready multi-agent backend on AgentField.
+
+User request: $ARGUMENTS
+
+Follow the skill's hard gate: ask the one grooming question if needed, design the reasoner topology from the problem, and do not write code before the design is clear.

--- a/control-plane/internal/skillkit/skillkit_edge_test.go
+++ b/control-plane/internal/skillkit/skillkit_edge_test.go
@@ -598,6 +598,72 @@ func TestTargetSpecificEdgeCases(t *testing.T) {
 		}
 	})
 
+	t.Run("claude install replaces a regular file at the slash-command destination", func(t *testing.T) {
+		home := withTempHome(t)
+		if err := os.MkdirAll(filepath.Join(home, ".claude", "skills"), 0o755); err != nil {
+			t.Fatalf("mkdir claude root: %v", err)
+		}
+		cmdDst := filepath.Join(home, ".claude", "commands")
+		if err := os.MkdirAll(cmdDst, 0o755); err != nil {
+			t.Fatalf("mkdir commands: %v", err)
+		}
+		stale := filepath.Join(cmdDst, "agentfield.md")
+		if err := os.WriteFile(stale, []byte("stale"), 0o644); err != nil {
+			t.Fatalf("write stale: %v", err)
+		}
+
+		current := filepath.Join(t.TempDir(), "current")
+		cmdDir := filepath.Join(current, "commands")
+		if err := os.MkdirAll(cmdDir, 0o755); err != nil {
+			t.Fatalf("mkdir cmdDir: %v", err)
+		}
+		cmdSrc := filepath.Join(cmdDir, "agentfield.md")
+		if err := os.WriteFile(cmdSrc, []byte("fresh"), 0o644); err != nil {
+			t.Fatalf("write fresh: %v", err)
+		}
+
+		claude := claudeCodeTarget{}
+		if _, err := claude.Install(Catalog[0], current); err != nil {
+			t.Fatalf("Install: %v", err)
+		}
+		info, err := os.Lstat(stale)
+		if err != nil {
+			t.Fatalf("lstat after install: %v", err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("stale regular file was not replaced with a symlink (mode=%v)", info.Mode())
+		}
+		if dest, err := os.Readlink(stale); err != nil || dest != cmdSrc {
+			t.Fatalf("readlink = %q err=%v want %q", dest, err, cmdSrc)
+		}
+	})
+
+	t.Run("claude install fails when skill commands path is not a directory", func(t *testing.T) {
+		home := withTempHome(t)
+		if err := os.MkdirAll(filepath.Join(home, ".claude", "skills"), 0o755); err != nil {
+			t.Fatalf("mkdir claude root: %v", err)
+		}
+		// current/ contains a regular file named "commands" — ReadDir on it
+		// returns a non-IsNotExist error, which installCommands must surface
+		// and Install must wrap.
+		current := filepath.Join(t.TempDir(), "current")
+		if err := os.MkdirAll(current, 0o755); err != nil {
+			t.Fatalf("mkdir current: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(current, "commands"), []byte("not-a-dir"), 0o644); err != nil {
+			t.Fatalf("write commands file: %v", err)
+		}
+
+		claude := claudeCodeTarget{}
+		_, err := claude.Install(Catalog[0], current)
+		if err == nil {
+			t.Fatalf("Install should fail when commands path is not a directory")
+		}
+		if !strings.Contains(err.Error(), "install commands") {
+			t.Fatalf("error should be wrapped as install commands error, got: %v", err)
+		}
+	})
+
 	t.Run("marker targets report empty status after plain file uninstall", func(t *testing.T) {
 		home := withTempHome(t)
 		type targetCase struct {

--- a/control-plane/internal/skillkit/skillkit_edge_test.go
+++ b/control-plane/internal/skillkit/skillkit_edge_test.go
@@ -524,6 +524,80 @@ func TestTargetSpecificEdgeCases(t *testing.T) {
 		}
 	})
 
+	t.Run("claude install exposes slash commands and uninstall removes them", func(t *testing.T) {
+		home := withTempHome(t)
+		if err := os.MkdirAll(filepath.Join(home, ".claude", "skills"), 0o755); err != nil {
+			t.Fatalf("mkdir claude root: %v", err)
+		}
+
+		// Build a fake canonical current/ dir with a commands/ subdir.
+		current := filepath.Join(t.TempDir(), "current")
+		cmdDir := filepath.Join(current, "commands")
+		if err := os.MkdirAll(cmdDir, 0o755); err != nil {
+			t.Fatalf("mkdir cmdDir: %v", err)
+		}
+		cmdSrc := filepath.Join(cmdDir, "agentfield.md")
+		if err := os.WriteFile(cmdSrc, []byte("---\ndescription: test\n---\n\nbody\n"), 0o644); err != nil {
+			t.Fatalf("write command: %v", err)
+		}
+		// A non-md sibling and a directory should be ignored by the installer.
+		if err := os.WriteFile(filepath.Join(cmdDir, "readme.txt"), []byte("skip"), 0o644); err != nil {
+			t.Fatalf("write non-md: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Join(cmdDir, "nested"), 0o755); err != nil {
+			t.Fatalf("mkdir nested: %v", err)
+		}
+
+		// Point canonical root at the fake current/ via symlink at
+		// <canonical>/<skill>/current so Uninstall() can find the commands.
+		root, err := CanonicalRoot()
+		if err != nil {
+			t.Fatalf("CanonicalRoot: %v", err)
+		}
+		skillDir := filepath.Join(root, Catalog[0].Name)
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			t.Fatalf("mkdir skillDir: %v", err)
+		}
+		if err := os.Symlink(current, filepath.Join(skillDir, "current")); err != nil {
+			t.Fatalf("symlink current: %v", err)
+		}
+
+		claude := claudeCodeTarget{}
+		if _, err := claude.Install(Catalog[0], current); err != nil {
+			t.Fatalf("Install: %v", err)
+		}
+
+		cmdLink := filepath.Join(home, ".claude", "commands", "agentfield.md")
+		info, err := os.Lstat(cmdLink)
+		if err != nil {
+			t.Fatalf("command link missing: %v", err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("expected symlink, got mode %v", info.Mode())
+		}
+		if dest, err := os.Readlink(cmdLink); err != nil || dest != cmdSrc {
+			t.Fatalf("readlink = %q err=%v want %q", dest, err, cmdSrc)
+		}
+		if _, err := os.Stat(filepath.Join(home, ".claude", "commands", "readme.txt")); !os.IsNotExist(err) {
+			t.Fatalf("non-md sibling should be ignored, stat err=%v", err)
+		}
+
+		// Re-install is idempotent: replaces existing link.
+		if _, err := claude.Install(Catalog[0], current); err != nil {
+			t.Fatalf("re-Install: %v", err)
+		}
+		if dest, err := os.Readlink(cmdLink); err != nil || dest != cmdSrc {
+			t.Fatalf("re-install readlink = %q err=%v want %q", dest, err, cmdSrc)
+		}
+
+		if err := claude.Uninstall(); err != nil {
+			t.Fatalf("Uninstall: %v", err)
+		}
+		if _, err := os.Lstat(cmdLink); !os.IsNotExist(err) {
+			t.Fatalf("command link should be removed, stat err=%v", err)
+		}
+	})
+
 	t.Run("marker targets report empty status after plain file uninstall", func(t *testing.T) {
 		home := withTempHome(t)
 		type targetCase struct {

--- a/control-plane/internal/skillkit/target_claude_code.go
+++ b/control-plane/internal/skillkit/target_claude_code.go
@@ -69,6 +69,13 @@ func (t claudeCodeTarget) Install(skill Skill, canonicalCurrentDir string) (Inst
 		return InstalledTarget{}, fmt.Errorf("symlink %s -> %s: %w", link, canonicalCurrentDir, err)
 	}
 
+	// Also expose any shipped slash commands (skills/<name>/commands/*.md)
+	// at ~/.claude/commands/<file>.md so Claude Code picks them up. This is
+	// best-effort: a missing commands dir in the skill is not an error.
+	if err := t.installCommands(canonicalCurrentDir); err != nil {
+		return InstalledTarget{}, fmt.Errorf("install commands: %w", err)
+	}
+
 	return InstalledTarget{
 		TargetName:  t.Name(),
 		Method:      t.Method(),
@@ -78,9 +85,45 @@ func (t claudeCodeTarget) Install(skill Skill, canonicalCurrentDir string) (Inst
 	}, nil
 }
 
+// installCommands symlinks every .md file under <skillDir>/commands/ into
+// ~/.claude/commands/. Missing commands dir is a no-op.
+func (claudeCodeTarget) installCommands(skillDir string) error {
+	src := filepath.Join(skillDir, "commands")
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	dst := filepath.Join(homeDir(), ".claude", "commands")
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", dst, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".md" {
+			continue
+		}
+		target := filepath.Join(src, e.Name())
+		link := filepath.Join(dst, e.Name())
+		if info, err := os.Lstat(link); err == nil {
+			if info.Mode()&os.ModeSymlink != 0 || info.Mode().IsRegular() {
+				if err := os.Remove(link); err != nil {
+					return fmt.Errorf("remove existing %s: %w", link, err)
+				}
+			}
+		}
+		if err := os.Symlink(target, link); err != nil {
+			return fmt.Errorf("symlink %s -> %s: %w", link, target, err)
+		}
+	}
+	return nil
+}
+
 func (t claudeCodeTarget) Uninstall() error {
 	// Remove every shipped skill's symlink. (Currently a single skill, but the
 	// catalog can grow.)
+	root, rootErr := CanonicalRoot()
 	for _, s := range Catalog {
 		link, err := t.skillLink(s)
 		if err != nil {
@@ -92,6 +135,23 @@ func (t claudeCodeTarget) Uninstall() error {
 					return fmt.Errorf("remove %s: %w", link, err)
 				}
 			}
+		}
+		// Best-effort cleanup of any slash-commands we installed for this skill.
+		// Source lives at ~/.agentfield/skills/<name>/current/commands/.
+		if rootErr != nil {
+			continue
+		}
+		cmdSrc := filepath.Join(root, s.Name, "current", "commands")
+		entries, err := os.ReadDir(cmdSrc)
+		if err != nil {
+			continue
+		}
+		cmdDst := filepath.Join(homeDir(), ".claude", "commands")
+		for _, e := range entries {
+			if e.IsDir() || filepath.Ext(e.Name()) != ".md" {
+				continue
+			}
+			_ = os.Remove(filepath.Join(cmdDst, e.Name()))
 		}
 	}
 	return nil

--- a/skills/agentfield-multi-reasoner-builder/commands/agentfield.md
+++ b/skills/agentfield-multi-reasoner-builder/commands/agentfield.md
@@ -1,0 +1,10 @@
+---
+description: Build a production-ready multi-agent backend on AgentField from a plain-English description.
+argument-hint: [describe the system — e.g. "a claims processor with risk scoring and human approval"]
+---
+
+Use the `agentfield-multi-reasoner-builder` skill to architect, scaffold, wire, and smoke-test a production-ready multi-agent backend on AgentField.
+
+User request: $ARGUMENTS
+
+Follow the skill's hard gate: ask the one grooming question if needed, design the reasoner topology from the problem, and do not write code before the design is clear.


### PR DESCRIPTION
## Summary

- Feature the skill-driven flow as the primary way to try AgentField in the README (replaces the old quick-start-first structure).
- Ship a `/agentfield` slash command for Claude Code so users can trigger the skill explicitly, on top of the existing auto-match behavior.
- Wire the slash command into the existing multi-target skill installer so every `af skill install --target claude-code` drops it into `~/.claude/commands/` alongside the skill symlink, and `af skill uninstall` cleans it up.

### Why /agentfield

Skills auto-match by description, but a visible, discoverable slash command:
- removes the "does it know what to do?" doubt for first-time users,
- gives us a concrete CTA to feature in the README and docs,
- is a single atomic installer artifact rather than a README-only instruction.

### What changed

**Skillkit (Go):**
- `skills/agentfield-multi-reasoner-builder/commands/agentfield.md` — slash-command markdown with frontmatter (`description`, `argument-hint`) and a body that invokes the skill and enforces its hard gate.
- `control-plane/internal/skillkit/target_claude_code.go` — `Install()` now symlinks every `<current>/commands/*.md` into `~/.claude/commands/`; `Uninstall()` resolves `commands/` via `CanonicalRoot()` and removes the installed links.
- `control-plane/internal/skillkit/embed.go` — extended `//go:embed` to include `commands/*.md` so built `af` binaries ship the slash command alongside SKILL.md and references.
- `control-plane/internal/skillkit/skill_data/.../commands/agentfield.md` — embed-mirror copy (kept in sync by `scripts/sync-embedded-skills.sh`).
- `control-plane/internal/skillkit/skillkit_edge_test.go` — new table-driven edge case covering install, idempotent re-install, `.md` filter, and uninstall cleanup.

**README:**
- `/agentfield` callout inside the "Prompt to production" section.
- End-state copy updated to match what the skill actually produces — a scaffolded docker-compose stack with a local `curl` to test — instead of the old "run `af server` + `python main.py`" instruction.

### Verification

Installed end-to-end into an isolated `$HOME` and confirmed:
- `~/.claude/skills/agentfield-multi-reasoner-builder` → canonical `current/` (symlink)
- `~/.claude/commands/agentfield.md` → canonical `current/commands/agentfield.md` (symlink)
- `current/` → `0.3.0/` (versioned)
- Re-install with `--force` leaves the link pointing at the correct target.
- `af skill uninstall --target claude-code` removes both the skill symlink and the slash-command link with no residue.

## Test plan

- [x] `go build ./...` in `control-plane/`
- [x] `go test ./internal/skillkit/...` — 47 tests pass (new `claude install exposes slash commands and uninstall removes them` subtest included)
- [x] End-to-end install via `af skill install --target claude-code` in an isolated `$HOME`
- [x] Idempotent re-install with `--force`
- [x] `af skill uninstall --target claude-code` cleans up `~/.claude/commands/agentfield.md`
- [ ] Try `/agentfield <prompt>` in a fresh Claude Code session (requires the user to restart Claude Code after install — the session loads commands at startup)