### PR TITLE
fix(examples/init-example): pin Railway build to local Dockerfile

### DIFF
--- a/examples/ts-node-examples/init-example/railway.json
+++ b/examples/ts-node-examples/init-example/railway.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "npm start",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}


### PR DESCRIPTION
## Summary
- The Railway "example node" service in the `github-buddy` project (rootDirectory `examples/ts-node-examples/init-example/`) has been failing on every deploy with `failed to compute cache key: "/control-plane/web/client": not found`.
- Root cause: with no railway config inside the example dir, Railway falls back to the repo-root [`railway.json`](../blob/main/railway.json), which builds [`deployments/docker/Dockerfile.control-plane`](../blob/main/deployments/docker/Dockerfile.control-plane). That Dockerfile expects the repo root as its build context (`COPY control-plane/web/client/...`), but Railway scopes the context to the service's rootDirectory — where `control-plane/` doesn't exist.
- Fix: drop a local `railway.json` into the example pinning the build to the local `Dockerfile` (the simple `node:20-alpine` + `npm start` image already in the directory). This decouples the agent example from the control-plane template config.

## Test plan
- [ ] Trigger a Railway deploy of the `example node` service in `github-buddy` against this branch and confirm the build uses `examples/ts-node-examples/init-example/Dockerfile` and succeeds.
- [ ] Confirm the agent comes up healthy and registers with the control plane.