### PR TITLE
fix(harness/opencode): surface stderr Error: lines on exit 0

### DIFF
--- a/sdk/python/agentfield/harness/providers/opencode.py
+++ b/sdk/python/agentfield/harness/providers/opencode.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import shutil
 import tempfile
 import time
@@ -14,6 +15,36 @@ from agentfield.harness._cli import estimate_cli_cost, run_cli, strip_ansi
 from agentfield.harness._result import FailureType, Metrics, RawResult
 
 logger = logging.getLogger("agentfield.harness.opencode")
+
+# opencode CLI sometimes prints a hard error to stderr but exits 0
+# (notably "Model not found", auth errors, schema validation failures).
+# These patterns mark stderr as containing a real failure, not just noise
+# like the one-time SQLite migration prelude.
+_OPENCODE_STDERR_ERROR_PATTERNS = (
+    re.compile(r"^Error:", re.MULTILINE),
+    re.compile(r"\bModel not found\b"),
+    re.compile(r"\bAuthenticationError\b"),
+    re.compile(r"\bUnauthorized\b"),
+    re.compile(r"\bAPIError\b"),
+)
+
+
+def _extract_opencode_error(stderr: str) -> str:
+    """Pull the meaningful failure line(s) out of opencode stderr.
+
+    opencode's stderr typically opens with the SQLite migration prelude
+    ("Performing one time database migration…") followed by the real error.
+    Naively truncating the first 800 chars hides the part that matters,
+    so prefer the line carrying the error marker plus a small window of
+    context around it.
+    """
+    lines = stderr.splitlines()
+    for i, line in enumerate(lines):
+        for pat in _OPENCODE_STDERR_ERROR_PATTERNS:
+            if pat.search(line):
+                window = lines[max(0, i - 1) : i + 5]
+                return "\n".join(window).strip()[:1000]
+    return stderr[:1000]
 
 
 class OpenCodeProvider:
@@ -144,10 +175,22 @@ class OpenCodeProvider:
             failure_type = FailureType.CRASH
             is_error = True
             error_message = (
-                clean_stderr[:1000]
+                _extract_opencode_error(clean_stderr)
                 if clean_stderr
                 else (f"Process exited with code {returncode} and produced no output.")
             )
+        elif (
+            result_text is None
+            and clean_stderr
+            and any(pat.search(clean_stderr) for pat in _OPENCODE_STDERR_ERROR_PATTERNS)
+        ):
+            # opencode sometimes exits 0 even on hard failures like
+            # "Model not found" — surface the real error from stderr instead
+            # of silently returning empty output that downstream callers
+            # interpret as "agent failed to produce a valid result".
+            failure_type = FailureType.CRASH
+            is_error = True
+            error_message = _extract_opencode_error(clean_stderr)
         else:
             failure_type = FailureType.NONE
             is_error = False

--- a/sdk/python/tests/test_harness_provider_opencode.py
+++ b/sdk/python/tests/test_harness_provider_opencode.py
@@ -216,6 +216,88 @@ async def test_opencode_uses_project_dir_when_no_cwd(
 
 
 @pytest.mark.asyncio
+async def test_opencode_exit0_with_error_stderr_is_treated_as_failure(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Regression test: opencode prints hard errors to stderr but exits 0.
+
+    Symptom seen in production: an invalid model string ("minimax/minimax-m2.5"
+    instead of "openrouter/minimax/minimax-m2.5") makes opencode print
+    'Error: Model not found: …' to stderr and exit 0. Without this guard the
+    harness sees empty stdout + clean exit and reports success with no
+    output, which downstream surfaces as 'agent failed to produce a valid
+    result' — hiding the real cause.
+    """
+    stderr_with_real_error = (
+        "Performing one time database migration, may take a few minutes...\n"
+        "sqlite-migration:done\n"
+        "Database migration complete.\n"
+        "\n"
+        "Error: Model not found: minimax/minimax-m2.5.\n"
+    )
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        return "", stderr_with_real_error, 0
+
+    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
+
+    provider = OpenCodeProvider()
+    raw = await provider.execute("hello", {"model": "minimax/minimax-m2.5"})
+
+    assert raw.is_error is True
+    assert raw.failure_type.name == "CRASH"
+    assert raw.error_message is not None
+    # The real error must be surfaced — not buried under the migration prelude.
+    assert "Model not found" in raw.error_message
+    assert "minimax/minimax-m2.5" in raw.error_message
+
+
+@pytest.mark.asyncio
+async def test_opencode_exit0_with_only_migration_stderr_is_success(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Migration prelude on stderr without an Error: line should NOT be a failure."""
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        return (
+            "actual model output\n",
+            "Performing one time database migration, may take a few minutes...\n"
+            "Database migration complete.\n",
+            0,
+        )
+
+    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
+
+    provider = OpenCodeProvider()
+    raw = await provider.execute("hello", {})
+
+    assert raw.is_error is False
+    assert raw.result == "actual model output"
+
+
+@pytest.mark.asyncio
+async def test_opencode_exit_nonzero_uses_extracted_error_not_truncated_prelude(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Non-zero exit + long migration prelude in stderr should still surface
+    the real Error: line, not just the first 1000 chars of the prelude."""
+    long_prelude = ("Performing one time database migration line\n" * 30)
+    stderr = long_prelude + "Error: AuthenticationError: bad key\n"
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        return "", stderr, 1
+
+    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
+
+    provider = OpenCodeProvider()
+    raw = await provider.execute("hello", {})
+
+    assert raw.is_error is True
+    assert raw.error_message is not None
+    assert "AuthenticationError" in raw.error_message
+
+
+@pytest.mark.asyncio
 async def test_opencode_v14_cli_shape_no_deprecated_flags(
     monkeypatch: pytest.MonkeyPatch,
 ):


### PR DESCRIPTION
## Summary

The `opencode` CLI sometimes prints a hard error to stderr but exits **0** — notably:

- `Error: Model not found: …` (invalid model id)
- `AuthenticationError` (bad/missing key)
- `APIError` (provider failure)

`OpenCodeProvider._execute_impl` only flagged failures on non-zero exit, so these cases returned `RawResult(is_error=False, result=None)` — silently empty output. Downstream callers (the schema-output retry loop in `agentfield.harness._runner`) then surface the failure as the much less useful "agent failed to produce a valid result".

The bug is doubly hidden because `clean_stderr` is logged truncated to 800 chars, but opencode opens stderr with the SQLite migration prelude (`Performing one time database migration…`), pushing the real `Error:` line off the end of the truncation window. Operators saw the prelude in logs and assumed migration was the issue, not the model id.

This was the proximate cause of the SWE-AF Railway run `run_1777925624226_f5a637ae` failing every `run_product_manager` and `run_git_init` invocation in 8–10s with no useful diagnostic. A separate companion PR (`Agent-Field/SWE-AF#55`) fixes the upstream model-string bug; this PR ensures opencode failures of this shape are never invisible again.

## Changes

- `sdk/python/agentfield/harness/providers/opencode.py`
  - New `_OPENCODE_STDERR_ERROR_PATTERNS` and `_extract_opencode_error()` helper that pulls the meaningful failure line + a small context window out of opencode stderr, skipping the migration prelude.
  - Adds an explicit branch for `returncode == 0 and result_text is None and stderr matches an error pattern` → returns `is_error=True, failure_type=CRASH` with the extracted error message.
  - The existing non-zero-exit branch now uses `_extract_opencode_error()` too, so log truncation can no longer hide the cause there either.

- `sdk/python/tests/test_harness_provider_opencode.py` — three new regression tests:
  1. `Model not found` exit 0 → is_error=True with the model id in the message.
  2. Migration-only stderr + real stdout → is_error=False (no false positive).
  3. Long migration prelude + AuthenticationError on non-zero exit → AuthenticationError surfaces (no truncation).

## Test plan

- [x] `pytest tests/test_harness_provider_opencode.py tests/test_harness_factory.py tests/test_harness_runner.py` — 48/48 pass.
- [ ] Bump SWE-AF's `agentfield` requirement to whatever version this lands in, redeploy, re-trigger `github buddy implement` on `Agent-Field/github-buddy#22`, confirm any future opencode misconfiguration shows up with the actual error in the Railway logs (not buried under the migration prelude).

## Companion PR

`Agent-Field/SWE-AF#55` — fixes the upstream cause (default model id was missing the `openrouter/` provider prefix). Both PRs are needed to fully unblock the github-buddy → SWE-AF delegation flow on Railway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)