### PR TITLE
fix: reject terminal-state regression on execution status writes

### DIFF
--- a/control-plane/internal/handlers/execute.go
+++ b/control-plane/internal/handlers/execute.go
@@ -534,6 +534,23 @@ func (c *executionController) handleStatusUpdate(ctx *gin.Context) {
 			}
 		}
 
+		// Terminal-state regression guard. Once an execution has reached
+		// a terminal state, reject any non-terminal write — otherwise a
+		// late /status callback (e.g. from a retried fire-and-forget update)
+		// can stomp the terminal status back to "running" and strand the
+		// caller's poll loop. Idempotent terminal→same-terminal updates
+		// are allowed so callers can retry their own callback safely.
+		if types.IsTerminalExecutionStatus(string(current.Status)) {
+			if !types.IsTerminalExecutionStatus(normalizedStatus) {
+				logger.Logger.Warn().
+					Str("execution_id", executionID).
+					Str("current_status", string(current.Status)).
+					Str("requested_status", normalizedStatus).
+					Msg("rejecting status update: execution is already in a terminal state")
+				return nil, fmt.Errorf("execution %s is already in terminal state '%s'; cannot transition to '%s'", executionID, current.Status, normalizedStatus)
+			}
+		}
+
 		current.Status = normalizedStatus
 		current.StatusReason = req.StatusReason
 		if len(resultBytes) > 0 {

--- a/control-plane/internal/handlers/execute_status_update_test.go
+++ b/control-plane/internal/handlers/execute_status_update_test.go
@@ -305,6 +305,91 @@ func TestUpdateExecutionStatusHandler_ProgressUpdate(t *testing.T) {
 	require.Nil(t, updated.CompletedAt)
 }
 
+// TestUpdateExecutionStatusHandler_TerminalRegression covers the case where a
+// late /status callback (e.g. from a retried fire-and-forget update) tries to
+// move a finished execution back to a non-terminal state. The handler must
+// reject the regression so callers polling /api/v1/executions/:id keep seeing
+// the correct terminal status. Pinned a real production incident where the
+// caller's app.call hung for 7200s because pr-af.review reported "failed" but
+// a later event had stomped the status back to "running".
+func TestUpdateExecutionStatusHandler_TerminalRegression(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	store := newTestExecutionStorage(nil)
+	payloads := services.NewFilePayloadStore(t.TempDir())
+
+	completed := time.Now().UTC().Add(-time.Minute)
+	execution := &types.Execution{
+		ExecutionID: "exec-terminal",
+		RunID:       "run-1",
+		Status:      types.ExecutionStatusFailed,
+		StartedAt:   time.Now().UTC().Add(-5 * time.Minute),
+		CompletedAt: &completed,
+		CreatedAt:   time.Now().UTC().Add(-5 * time.Minute),
+		UpdatedAt:   completed,
+	}
+	require.NoError(t, store.CreateExecutionRecord(context.Background(), execution))
+
+	router := gin.New()
+	router.PUT("/api/v1/executions/:execution_id/status", UpdateExecutionStatusHandler(store, payloads, nil, 90*time.Second))
+
+	// Late "running" update arrives — must be rejected.
+	reqBody := `{"status": "running"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/executions/exec-terminal/status", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusInternalServerError, resp.Code)
+
+	// DB must still show the original terminal status — no regression.
+	updated, err := store.GetExecutionRecord(context.Background(), "exec-terminal")
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	require.Equal(t, types.ExecutionStatusFailed, updated.Status)
+	require.NotNil(t, updated.CompletedAt)
+}
+
+// TestUpdateExecutionStatusHandler_TerminalIdempotent confirms the regression
+// guard still allows callers to re-deliver the SAME terminal status (e.g. when
+// the SDK's status-callback retry succeeds after a transient network blip). A
+// terminal→same-terminal POST must return 200 and remain idempotent.
+func TestUpdateExecutionStatusHandler_TerminalIdempotent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	store := newTestExecutionStorage(nil)
+	payloads := services.NewFilePayloadStore(t.TempDir())
+
+	completed := time.Now().UTC().Add(-time.Minute)
+	execution := &types.Execution{
+		ExecutionID: "exec-idempotent",
+		RunID:       "run-1",
+		Status:      types.ExecutionStatusFailed,
+		StartedAt:   time.Now().UTC().Add(-5 * time.Minute),
+		CompletedAt: &completed,
+		CreatedAt:   time.Now().UTC().Add(-5 * time.Minute),
+		UpdatedAt:   completed,
+	}
+	require.NoError(t, store.CreateExecutionRecord(context.Background(), execution))
+
+	router := gin.New()
+	router.PUT("/api/v1/executions/:execution_id/status", UpdateExecutionStatusHandler(store, payloads, nil, 90*time.Second))
+
+	reqBody := `{"status": "failed", "error": "redelivered"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/executions/exec-idempotent/status", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	updated, err := store.GetExecutionRecord(context.Background(), "exec-idempotent")
+	require.NoError(t, err)
+	require.Equal(t, types.ExecutionStatusFailed, updated.Status)
+}
+
 func TestWaitForExecutionCompletion_Success(t *testing.T) {
 	store := newTestExecutionStorage(nil)
 	controller := newExecutionController(store, nil, nil, 90*time.Second, "")

--- a/control-plane/internal/handlers/workflow_execution_events.go
+++ b/control-plane/internal/handlers/workflow_execution_events.go
@@ -128,7 +128,22 @@ func buildExecutionRecordFromEvent(req *WorkflowExecutionEventRequest, now time.
 }
 
 func applyEventToExecution(current *types.Execution, req *WorkflowExecutionEventRequest, now time.Time) {
-	current.Status = types.NormalizeExecutionStatus(req.Status)
+	incomingStatus := types.NormalizeExecutionStatus(req.Status)
+
+	// Terminal-state regression guard. Fire-and-forget workflow events from
+	// the SDK are not strictly ordered — a late "running" event can race past
+	// a "failed"/"succeeded" event for the same execution_id (e.g. when the
+	// outer reasoner errors while inner reasoners are still emitting). Once
+	// an execution has reached a terminal state, treat the row as immutable
+	// for status/result/error/completion purposes; the UI and callers polling
+	// /api/v1/executions/:id will keep seeing the correct terminal status
+	// instead of a phantom "running".
+	if types.IsTerminalExecutionStatus(current.Status) {
+		current.UpdatedAt = now
+		return
+	}
+
+	current.Status = incomingStatus
 	current.UpdatedAt = now
 
 	if current.StartedAt.IsZero() {
@@ -164,11 +179,11 @@ func applyEventToExecution(current *types.Execution, req *WorkflowExecutionEvent
 	if req.Error != "" {
 		errCopy := req.Error
 		current.ErrorMessage = &errCopy
-	} else if types.NormalizeExecutionStatus(req.Status) == string(types.ExecutionStatusSucceeded) {
+	} else if incomingStatus == string(types.ExecutionStatusSucceeded) {
 		current.ErrorMessage = nil
 	}
 
-	if types.IsTerminalExecutionStatus(req.Status) {
+	if types.IsTerminalExecutionStatus(incomingStatus) {
 		completed := now
 		current.CompletedAt = &completed
 	}

--- a/control-plane/internal/handlers/workflow_execution_events_test.go
+++ b/control-plane/internal/handlers/workflow_execution_events_test.go
@@ -89,3 +89,67 @@ func TestWorkflowExecutionEventHandler_CreateAndUpdate(t *testing.T) {
 	require.NotNil(t, exec.DurationMS)
 	assert.Equal(t, duration, *exec.DurationMS)
 }
+
+// TestWorkflowExecutionEventHandler_TerminalRegression covers the case where
+// fire-and-forget workflow events from the SDK arrive out of order — e.g. an
+// outer reasoner emits "failed" while an inner reasoner emits a delayed
+// "running" with the same execution_id (or a retried event lands after the
+// terminal one). The handler must NOT regress a terminal status back to a
+// non-terminal one. Pinned the production hang where pr-af.review reported
+// "failed" but a later workflow event flipped the row back to "running",
+// stranding github-buddy's poll loop until its 7200s wall-clock timeout.
+func TestWorkflowExecutionEventHandler_TerminalRegression(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	storage := newTestExecutionStorage(&types.AgentNode{ID: "agent"})
+	handler := WorkflowExecutionEventHandler(storage)
+
+	// Seed the execution as already failed.
+	failPayload := WorkflowExecutionEventRequest{
+		ExecutionID: "exec_late_running",
+		RunID:       "run_1",
+		ReasonerID:  "review",
+		AgentNodeID: "agent",
+		Status:      "failed",
+		Error:       "Budget exhausted",
+	}
+	body, err := json.Marshal(failPayload)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/workflow/executions/events", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	handler(c)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	exec, err := storage.GetExecutionRecord(context.Background(), "exec_late_running")
+	require.NoError(t, err)
+	require.Equal(t, string(types.ExecutionStatusFailed), exec.Status)
+	require.NotNil(t, exec.CompletedAt)
+	originalCompletedAt := *exec.CompletedAt
+
+	// A late "running" event arrives. The handler must accept the request
+	// (200) but must NOT regress the status — the row should remain failed
+	// and CompletedAt should be unchanged.
+	latePayload := WorkflowExecutionEventRequest{
+		ExecutionID: "exec_late_running",
+		RunID:       "run_1",
+		ReasonerID:  "review",
+		AgentNodeID: "agent",
+		Status:      "running",
+	}
+	body, err = json.Marshal(latePayload)
+	require.NoError(t, err)
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/workflow/executions/events", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	handler(c)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	exec, err = storage.GetExecutionRecord(context.Background(), "exec_late_running")
+	require.NoError(t, err)
+	assert.Equal(t, string(types.ExecutionStatusFailed), exec.Status, "terminal status must not regress to running")
+	require.NotNil(t, exec.CompletedAt)
+	assert.True(t, exec.CompletedAt.Equal(originalCompletedAt), "CompletedAt must not be cleared by a regressing event")
+}


### PR DESCRIPTION
## Summary

Two execution-status write paths on the control plane could silently regress an already-finished execution from a terminal state (`failed`/`succeeded`/`cancelled`/`timeout`) back to a non-terminal one (`running`/`queued`/`pending`). When that happens, callers polling `/api/v1/executions/:id` for completion see the row flip back to "running" and never observe the terminal status — their `app.call` hangs until its own wall-clock timeout fires, and the workflow appears stuck in the UI for hours after it actually finished.

This PR adds the missing guard on both write paths:

1. **`POST /api/v1/workflow/executions/events`** — `applyEventToExecution` was unconditionally writing whatever status arrived. The Python SDK fires these events fire-and-forget from `notify_call_start` / `notify_call_complete` / `notify_call_error`, and the calls aren't strictly ordered (a late "running" can land after "failed" for the same `execution_id`, especially when retries are in play or when an outer reasoner errors while inner reasoners are still emitting). Now: once a row is terminal, the handler still returns 200 (so the SDK's fire-and-forget retry doesn't trip) but skips status / result / error / completion mutations entirely.
2. **`POST /api/v1/executions/:id/status`** — the existing transition guard only covered the `waiting` state. Now any non-terminal write against an already-terminal record returns 500 with a descriptive error, so the SDK's `_post_execution_status` retry loop sees a hard failure rather than silently stomping the row. Same-terminal writes are still accepted to keep at-least-once status delivery idempotent.

## Production incident this fixes

A real PR review on the Railway test deployment hung in the UI for 12+ hours despite the underlying `pr-af.review` reasoner having raised `BudgetExhaustedError` ~6 minutes in. The pr-af SDK successfully POSTed `{"status": "failed"}` to `/api/v1/executions/exec_…lyjqfh97/status` at `03:09:07 UTC` (control plane returned 200), but a subsequent unguarded write reverted the row to `running`. github-buddy's `app.call` poll loop kept seeing `status: running`, eventually timed out at its own `default_execution_timeout=7200s`, and the workflow row stayed in `running` state in the UI — observed live by querying `GET /api/v1/executions/exec_…lyjqfh97` 10 hours later: `status: running`. After this PR, that regression is impossible regardless of which writer raced.

## Test plan

- [x] `go build ./...` — clean.
- [x] `go test ./internal/handlers/... -count=1` — all existing tests still pass (107s + the smaller suites).
- [x] New tests pin the guard behavior:
  - `TestUpdateExecutionStatusHandler_TerminalRegression` — late `running` write against a `failed` row → 500, row unchanged.
  - `TestUpdateExecutionStatusHandler_TerminalIdempotent` — `failed`→`failed` redelivery → 200.
  - `TestWorkflowExecutionEventHandler_TerminalRegression` — late `running` event against a `failed` row → 200 (fire-and-forget) but row + `CompletedAt` unchanged.

## Notes for reviewers

- The two commits are split by write path so each guard is reviewable on its own.
- I deliberately return 500 (not 409) on `/executions/:id/status` regression because the existing handler returns 500 for the analogous waiting-state guard; matching the local convention. Happy to switch to 409 if you'd prefer.
- The `/workflow/executions/events` handler keeps its 200 response on regression because the SDK call site is fire-and-forget — surfacing 4xx/5xx there would put backpressure on the agent process and trigger needless retry storms. The early-return is silent on purpose; observability is via the unchanged DB row and the existing log-execution stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)