### PR TITLE
fix(sdk): don't fall back to sync when the reasoner already ran

### DIFF
--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -3791,6 +3791,33 @@ class Agent(FastAPI):
                         if _err_status in (401, 403):
                             raise async_error
 
+                        # Never fall back when the failure happened AFTER the
+                        # reasoner already ran. ExecutionFailedError means
+                        # the call reached the reasoner, the work executed,
+                        # and the reasoner returned an error — retrying
+                        # via sync would burn the same budget for the same
+                        # outcome. ExecutionTimeoutError means the work has
+                        # already used (or exceeded) its timeout budget on
+                        # the agent side; firing the same call again wastes
+                        # another full budget. Both classes surface as
+                        # subclasses of AgentFieldError so a local import
+                        # is safe even with the legacy AgentFieldClientError
+                        # catch path some callers depend on.
+                        from agentfield.exceptions import (
+                            ExecutionFailedError,
+                            ExecutionTimeoutError,
+                        )
+                        if isinstance(
+                            async_error,
+                            (ExecutionFailedError, ExecutionTimeoutError),
+                        ):
+                            if self.dev_mode:
+                                log_debug(
+                                    f"Skipping sync fallback for {type(async_error).__name__}: "
+                                    f"reasoner already ran; retry would re-burn the budget"
+                                )
+                            raise async_error
+
                         if not self.async_config.fallback_to_sync:
                             raise async_error
 

--- a/sdk/python/agentfield/async_execution_manager.py
+++ b/sdk/python/agentfield/async_execution_manager.py
@@ -18,7 +18,11 @@ import aiohttp
 
 from .async_config import AsyncConfig
 from .execution_state import ExecuteError, ExecutionPriority, ExecutionState, ExecutionStatus
-from .exceptions import AgentFieldClientError, ExecutionTimeoutError
+from .exceptions import (
+    AgentFieldClientError,
+    ExecutionFailedError,
+    ExecutionTimeoutError,
+)
 from .http_connection_manager import ConnectionManager
 from .logger import get_logger
 from .result_cache import ResultCache
@@ -551,7 +555,16 @@ class AsyncExecutionManager:
                             )
                         return execution.result
                     elif execution.status == ExecutionStatus.FAILED:
-                        raise AgentFieldClientError(
+                        # The reasoner ran and explicitly returned a failed
+                        # result. Surface as ExecutionFailedError (a subclass
+                        # of AgentFieldClientError, kept for backward compat)
+                        # so Agent.call can skip the sync fallback path: the
+                        # reasoner's already done its work, retrying with the
+                        # same input would burn the same budget for the same
+                        # outcome. Transient transport / submission errors
+                        # still surface as plain AgentFieldClientError and
+                        # remain retry-eligible.
+                        raise ExecutionFailedError(
                             f"Execution failed: {execution.error_message}"
                         )
                     elif execution.status == ExecutionStatus.CANCELLED:

--- a/sdk/python/agentfield/exceptions.py
+++ b/sdk/python/agentfield/exceptions.py
@@ -14,6 +14,25 @@ class AgentFieldClientError(AgentFieldError):
     pass
 
 
+class ExecutionFailedError(AgentFieldClientError):
+    """The remote reasoner ran and explicitly returned a failed status.
+
+    Distinct from a transport / submission / network failure (plain
+    ``AgentFieldClientError``): the call reached the reasoner, the work
+    ran, and the reasoner returned an error. Retrying via the sync
+    fallback path would re-run the same reasoner with the same input,
+    burn the same budget, and produce the same failure — so the SDK's
+    ``Agent.call`` skips the sync fallback when this is raised.
+
+    Inherits from ``AgentFieldClientError`` for backward compatibility:
+    callers that catch ``AgentFieldClientError`` still see this. New
+    callers that want to distinguish "the work ran and failed" from
+    "the call never reached the reasoner" should catch this directly.
+    """
+
+    pass
+
+
 class ExecutionTimeoutError(AgentFieldError):
     """Execution timed out waiting for completion."""
 
@@ -41,6 +60,7 @@ class ValidationError(AgentFieldError):
 __all__ = [
     "AgentFieldError",
     "AgentFieldClientError",
+    "ExecutionFailedError",
     "ExecutionTimeoutError",
     "MemoryAccessError",
     "RegistrationError",

--- a/sdk/python/tests/test_agent_call.py
+++ b/sdk/python/tests/test_agent_call.py
@@ -96,3 +96,162 @@ async def test_call_raises_when_agentfield_disconnected():
             await agent.call("other.reasoner", 1)
     finally:
         clear_current_agent()
+
+
+# ---------------------------------------------------------------------------
+# fallback_to_sync — must NOT fire on ExecutionFailedError / ExecutionTimeoutError.
+#
+# Background: a remote reasoner that returns an explicit failed status
+# means the work already ran. Re-running it through the sync fallback path
+# burns the same per-call budget for the same deterministic outcome — and
+# can show up in production as 2× cost on every failed cross-agent call
+# (see github-buddy → pr-af.review where pr-af raises BudgetExhaustedError
+# and the SDK silently retries it). The fix is to skip the sync fallback
+# for these two specific terminal-failure exceptions while keeping it
+# enabled for transient transport errors.
+# ---------------------------------------------------------------------------
+
+
+def _make_agent_with_async_path():
+    """Build a minimal Agent wired for the async-then-fallback path.
+
+    The async submission succeeds, but the configured async manager raises
+    on `wait_for_execution_result`. Whether app.call retries via sync depends
+    on the exception class — that's what these tests pin.
+    """
+    agent = object.__new__(Agent)
+    agent.node_id = "node"
+    agent.agentfield_connected = True
+    agent.dev_mode = False
+    agent.async_config = SimpleNamespace(
+        enable_async_execution=True,
+        fallback_to_sync=True,  # ON — but the new code must skip it for these errors
+    )
+    agent._async_execution_manager = None
+    agent._current_execution_context = None
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_call_skips_sync_fallback_on_execution_failed_error():
+    """ExecutionFailedError = the reasoner ran and returned an error; the SDK
+    must NOT retry via sync (which would re-run the same reasoner and burn
+    the same budget for the same outcome)."""
+    from agentfield.exceptions import ExecutionFailedError
+
+    agent = _make_agent_with_async_path()
+
+    sync_calls = 0
+
+    async def fake_execute_async(target, input_data, headers, timeout=None):
+        return "exec_xyz"
+
+    async def fake_wait_for_execution_result(execution_id, timeout=None):
+        # Reasoner ran and returned failed.
+        raise ExecutionFailedError("Execution failed: budget exhausted")
+
+    async def fake_execute(target, input_data, headers):
+        # If this fires, the SDK incorrectly retried via sync — counts the failure.
+        nonlocal sync_calls
+        sync_calls += 1
+        return {"result": {"never_reached": True}}
+
+    agent.client = SimpleNamespace(
+        execute=fake_execute,
+        execute_async=fake_execute_async,
+        wait_for_execution_result=fake_wait_for_execution_result,
+    )
+
+    set_current_agent(agent)
+    try:
+        with pytest.raises(ExecutionFailedError):
+            await agent.call("other.reasoner", 1)
+    finally:
+        clear_current_agent()
+
+    assert sync_calls == 0, (
+        "ExecutionFailedError must NOT trigger sync fallback — "
+        "the reasoner already ran and failed deterministically; "
+        "retrying just doubles the cost."
+    )
+
+
+@pytest.mark.asyncio
+async def test_call_skips_sync_fallback_on_execution_timeout_error():
+    """ExecutionTimeoutError = the wait deadline hit; the work either is
+    still running on the agent side or already burned its budget. Either
+    way, retrying via sync just stacks another full-budget invocation."""
+    from agentfield.exceptions import ExecutionTimeoutError
+
+    agent = _make_agent_with_async_path()
+
+    sync_calls = 0
+
+    async def fake_execute_async(target, input_data, headers, timeout=None):
+        return "exec_xyz"
+
+    async def fake_wait_for_execution_result(execution_id, timeout=None):
+        raise ExecutionTimeoutError("Execution exec_xyz exceeded timeout")
+
+    async def fake_execute(target, input_data, headers):
+        nonlocal sync_calls
+        sync_calls += 1
+        return {"result": {"never_reached": True}}
+
+    agent.client = SimpleNamespace(
+        execute=fake_execute,
+        execute_async=fake_execute_async,
+        wait_for_execution_result=fake_wait_for_execution_result,
+    )
+
+    set_current_agent(agent)
+    try:
+        with pytest.raises(ExecutionTimeoutError):
+            await agent.call("other.reasoner", 1)
+    finally:
+        clear_current_agent()
+
+    assert sync_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_call_still_falls_back_on_transport_errors():
+    """Plain AgentFieldClientError (transport / submission / network) MUST
+    still trigger the sync fallback. Only post-execution errors are skipped.
+    Pin so the fix doesn't accidentally disable retry-on-transport-error."""
+    from agentfield.exceptions import AgentFieldClientError
+
+    agent = _make_agent_with_async_path()
+
+    sync_calls = 0
+
+    async def fake_execute_async(target, input_data, headers, timeout=None):
+        return "exec_xyz"
+
+    async def fake_wait_for_execution_result(execution_id, timeout=None):
+        # Generic transport failure — the kind retry was designed for.
+        raise AgentFieldClientError("connection reset by peer")
+
+    async def fake_execute(target, input_data, headers):
+        nonlocal sync_calls
+        sync_calls += 1
+        return {"result": {"recovered": True}}
+
+    agent.client = SimpleNamespace(
+        execute=fake_execute,
+        execute_async=fake_execute_async,
+        wait_for_execution_result=fake_wait_for_execution_result,
+    )
+
+    set_current_agent(agent)
+    try:
+        result = await agent.call("other.reasoner", 1)
+    finally:
+        clear_current_agent()
+
+    assert sync_calls == 1, (
+        "AgentFieldClientError without an execution-side cause must STILL "
+        "trigger the sync fallback — that's the recovery path for transport "
+        "blips and 502/503s."
+    )
+    assert result == {"recovered": True}


### PR DESCRIPTION
## Summary

`Agent.call`'s async-then-sync-fallback was retrying **any** non-401/403 exception from the async path. That includes the case where the call reached the reasoner, the work ran, and the reasoner explicitly returned a failed status — at which point retrying via the sync path just runs the same reasoner again with the same input, burns the same budget, and produces the same deterministic failure.

**Observed in production**: github-buddy → `pr-af.review` fails with `pr_af.orchestrator.BudgetExhaustedError`; the SDK silently retries via sync 1 ms later (look for "Falling back to sync execution for target" in the calling agent's logs); pr-af runs intake + anatomy from scratch, hits the budget again, double-billed. The same pattern applies to any deterministic 5xx surface (validation errors, malformed input, exhausted quotas) — one logical failure, two charges.

## Fix

A new `ExecutionFailedError(AgentFieldClientError)` exception distinguishes "the work ran and failed" from "the call never reached the reasoner":

- `async_execution_manager.wait_for_result` now raises `ExecutionFailedError` instead of plain `AgentFieldClientError` when the polled execution status is `FAILED`. **Backward-compatible**: `ExecutionFailedError` inherits from `AgentFieldClientError`, so callers catching the parent still see it; new callers can catch the subclass directly to distinguish post-execution errors from transport errors.
- `Agent.call`'s exception handler skips the sync fallback when the async exception is `ExecutionFailedError` **or** `ExecutionTimeoutError` — both mean the work has already used (or exceeded) its budget on the agent side. Plain `AgentFieldClientError` (transport / submission / network) continues to fall back via sync, preserving the recovery path `fallback_to_sync` was designed for.

The behaviour is asymmetric on purpose: retry remains **on** for transient transport failures (the legitimate use case), but is now **off** for post-execution failures (the wasteful case). No new config knob — this is the right default, and an opt-in env override would invite future regressions.

## Test plan

`tests/test_agent_call.py` adds three pinning tests:

- `test_call_skips_sync_fallback_on_execution_failed_error` — verifies `ExecutionFailedError` does **not** trigger the sync fallback.
- `test_call_skips_sync_fallback_on_execution_timeout_error` — same for `ExecutionTimeoutError`.
- `test_call_still_falls_back_on_transport_errors` — regression guard: plain `AgentFieldClientError` (e.g. "connection reset by peer") **must** still trigger sync fallback.

All 65 tests pass across the affected files (`test_agent_call.py`, `test_agent_core.py`, `test_async_execution_manager_comprehensive.py`, `test_async_execution_manager_final90.py`, `test_client_laser_push.py`, `test_client_bigfiles_coverage.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)