### PR TITLE
perf(harness): stop retrying on timeout, repair JSON cheaply, raise opencode caps

### DIFF
--- a/sdk/python/agentfield/harness/_runner.py
+++ b/sdk/python/agentfield/harness/_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import random
@@ -26,8 +27,11 @@ TRANSIENT_PATTERNS = {
     "rate limit",
     "rate_limit",
     "overloaded",
-    "timeout",
-    "timed out",
+    # Note: "timeout" / "timed out" are intentionally NOT here. The opencode
+    # provider's wall-clock timeout (default 30 min) is the cap on a *single*
+    # subprocess; if that hits, the prompt or model is wrong and re-running
+    # the entire 30-min subprocess won't fix it. Real network blips that
+    # surface as "connection reset" / "503" still trigger retry.
     "connection reset",
     "connection refused",
     "temporarily unavailable",
@@ -41,10 +45,100 @@ TRANSIENT_PATTERNS = {
 
 DEFAULT_SCHEMA_RETRIES = 2
 
+# Wall-clock cap on a single AI-based JSON repair call. The repair is one
+# LLM call with no tools, no repo access — it should finish in seconds.
+# If it doesn't, fall through to the existing harness retry path.
+_SCHEMA_REPAIR_TIMEOUT_SECONDS = 90
+
 
 def _is_transient(error_str: str) -> bool:
     lower = error_str.lower()
     return any(pattern in lower for pattern in TRANSIENT_PATTERNS)
+
+
+async def _ai_schema_repair(
+    text: str,
+    schema: Any,
+    options: Dict[str, Any],
+) -> Optional[Any]:
+    """Try to coerce raw text into a valid pydantic schema instance via ONE LLM call.
+
+    The harness's older fallback for schema-validation failures was to re-run the
+    *entire* opencode subprocess (30-minute wall-clock, full repo browsing) hoping
+    the model re-emitted something parseable. That's wildly expensive when the
+    actual problem is just "the JSON closes with an extra trailing comma" or
+    similar surface-level malformation — the model already produced the correct
+    information, it just didn't structure it cleanly.
+
+    This helper attempts cheap repair instead: take the existing text + the
+    pydantic schema, ask a fresh LLM call to re-emit valid JSON conforming to
+    the schema, and parse. No tools, no exploration, just reformatting.
+
+    Returns the parsed instance on success, None on any failure (caller falls
+    through to the existing retry-with-harness path). Skipped entirely when
+    `text` is empty — there's nothing to repair from in that case, and a real
+    rerun is the only option.
+    """
+    if not text or not text.strip():
+        # Nothing to repair from. The user explicitly called out this case:
+        # "if it actually failed and there was no output, then we can't do
+        # an AI-based JSON repair." Fall through to existing retry path.
+        return None
+
+    try:
+        import litellm  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+
+    schema_json: Optional[Dict[str, Any]] = None
+    try:
+        if hasattr(schema, "model_json_schema"):
+            schema_json = schema.model_json_schema()
+    except Exception:
+        schema_json = None
+
+    schema_section = (
+        f"Target JSON schema:\n```json\n{json.dumps(schema_json, indent=2)}\n```\n\n"
+        if schema_json is not None
+        else ""
+    )
+
+    repair_prompt = (
+        "The text below was produced as the answer to a structured-output task, "
+        "but it did not parse as valid JSON conforming to the expected schema. "
+        "Re-emit the SAME content as valid JSON matching the schema. Preserve "
+        "every fact and finding from the original text — do NOT invent new "
+        "information or drop fields. Output ONLY the JSON object, no surrounding "
+        "prose, no markdown code fences, no commentary.\n\n"
+        f"{schema_section}"
+        f"Original text:\n{text}"
+    )
+
+    model = options.get("model")
+    if not model:
+        # No model configured — caller's harness call should have set one.
+        # Bail rather than guess; the existing retry path will handle this.
+        return None
+
+    try:
+        response = await asyncio.wait_for(
+            litellm.acompletion(
+                model=str(model),
+                messages=[{"role": "user", "content": repair_prompt}],
+                temperature=0.0,
+                response_format={"type": "json_object"},
+            ),
+            timeout=_SCHEMA_REPAIR_TIMEOUT_SECONDS,
+        )
+        content = response.choices[0].message.content  # type: ignore[union-attr]
+    except Exception as exc:
+        logger.info("AI schema repair: LLM call failed (%s); falling through to harness retry", exc)
+        return None
+
+    if not content:
+        return None
+
+    return try_parse_from_text(content, schema)
 
 
 def _resolve_options(
@@ -261,6 +355,17 @@ class HarnessRunner:
             validated = try_parse_from_text(initial_raw.result, schema)
             if validated is not None:
                 logger.info("Stdout fallback succeeded")
+
+        # Cheap-repair tier: if we have non-empty text but still no valid
+        # parse, try one focused LLM call that just reformats the text into
+        # valid JSON. This is dramatically cheaper than the retry loop below
+        # (which spawns a whole new opencode subprocess), so we prefer it
+        # whenever there's text to work with.
+        if validated is None and initial_raw.result and initial_raw.result.strip():
+            logger.info("Attempting AI-based JSON repair before harness retry")
+            validated = await _ai_schema_repair(initial_raw.result, schema, options)
+            if validated is not None:
+                logger.info("AI schema repair succeeded — skipped harness retry")
 
         if validated is not None:
             elapsed = int((time.monotonic() - start_time) * 1000)

--- a/sdk/python/agentfield/harness/providers/opencode.py
+++ b/sdk/python/agentfield/harness/providers/opencode.py
@@ -54,8 +54,17 @@ class OpenCodeProvider:
     # processes from overwhelming the LLM API with concurrent requests.
     # Each opencode run spawns a full subprocess (pyright, DB migration, etc.)
     # so unbounded concurrency causes rate-limiting and transient failures.
-    _MAX_CONCURRENT: ClassVar[int] = int(os.environ.get("OPENCODE_MAX_CONCURRENT", "3"))
+    # Default raised 3 → 10 to match the typical pr-af review fan-out
+    # (~6–8 review_dimension phases + 3 meta-lenses); OpenRouter handles
+    # this comfortably on Kimi K2.6. Lower via OPENCODE_MAX_CONCURRENT if
+    # your provider has tighter per-key rate limits.
+    _MAX_CONCURRENT: ClassVar[int] = int(os.environ.get("OPENCODE_MAX_CONCURRENT", "10"))
     _concurrency_sem: ClassVar[Optional[asyncio.Semaphore]] = None
+
+    # Shared XDG_DATA_HOME across calls when opt-in is enabled. SQLite
+    # migrations only run once per process instead of per-call. None means
+    # "fresh tempdir per call" (current default).
+    _shared_data_dir: ClassVar[Optional[str]] = None
 
     def __init__(self, bin_path: str = "opencode"):
         self._bin = bin_path
@@ -120,15 +129,46 @@ class OpenCodeProvider:
 
         cwd: Optional[str] = None
 
-        temp_data_dir = tempfile.mkdtemp(prefix=".secaf-opencode-data-")
-        env["XDG_DATA_HOME"] = temp_data_dir
+        # Per-call XDG_DATA_HOME by default — guarantees session isolation.
+        # AGENTFIELD_OPENCODE_REUSE_DATA_DIR=true reuses one dir across calls
+        # in this process so SQLite migrations only run once. Opt-in because
+        # the implications vary by container layout (read-only /tmp, multi-
+        # tenant deployments, etc.) — default behavior is unchanged.
+        reuse_data_dir = os.environ.get(
+            "AGENTFIELD_OPENCODE_REUSE_DATA_DIR", "false"
+        ).strip().lower() in ("1", "true", "yes")
+
+        temp_data_dir: Optional[str] = None
+        if reuse_data_dir:
+            if type(self)._shared_data_dir is None or not os.path.isdir(
+                type(self)._shared_data_dir or ""
+            ):
+                type(self)._shared_data_dir = tempfile.mkdtemp(
+                    prefix=".secaf-opencode-data-shared-"
+                )
+            data_dir = type(self)._shared_data_dir
+        else:
+            temp_data_dir = tempfile.mkdtemp(prefix=".secaf-opencode-data-")
+            data_dir = temp_data_dir
+        env["XDG_DATA_HOME"] = data_dir
+
+        # Wall-clock cap for ONE opencode subprocess. Default 1800s (30min):
+        # Kimi K2.6 on a complex review can need 20+ minutes; cutting at 600s
+        # (the previous default) was killing slow-but-progressing calls and
+        # then re-running them from scratch via the runner's transient retry
+        # path. If a call doesn't finish in 30 min, the prompt or the model
+        # is wrong — re-running won't help — so we let it fail cleanly.
+        # Override via AGENTFIELD_HARNESS_TIMEOUT_SECONDS for tighter caps.
+        timeout_seconds = int(
+            os.environ.get("AGENTFIELD_HARNESS_TIMEOUT_SECONDS", "1800")
+        )
 
         start_api = time.monotonic()
 
         try:
             try:
                 stdout, stderr, returncode = await run_cli(
-                    cmd, env=env, cwd=cwd, timeout=600
+                    cmd, env=env, cwd=cwd, timeout=timeout_seconds
                 )
             except FileNotFoundError:
                 return RawResult(
@@ -148,7 +188,10 @@ class OpenCodeProvider:
                     metrics=Metrics(),
                 )
         finally:
-            shutil.rmtree(temp_data_dir, ignore_errors=True)
+            # Only clean up the per-call tempdir; the shared one outlives the
+            # call by design (skip the SQLite migration on the next call).
+            if temp_data_dir is not None:
+                shutil.rmtree(temp_data_dir, ignore_errors=True)
 
         api_ms = int((time.monotonic() - start_api) * 1000)
         result_text = stdout.strip() if stdout.strip() else None

--- a/sdk/python/tests/test_harness_ai_schema_repair.py
+++ b/sdk/python/tests/test_harness_ai_schema_repair.py
@@ -1,0 +1,176 @@
+"""Regression tests for AI-based schema repair in the harness runner.
+
+Background
+----------
+Before this change, when an opencode harness call produced text output that
+didn't validate against the requested pydantic schema, the runner would
+retry the *entire* opencode subprocess — re-running the full agentic loop,
+re-reading the repo, etc. — just to coerce the output into valid JSON.
+On a real review that's a 30-minute round-trip for a problem that's
+typically "the model produced a valid answer but with a stray trailing
+comma."
+
+`_ai_schema_repair` short-circuits that: when the harness call did produce
+non-empty text but it didn't validate, we make ONE cheap LLM call (no
+tools, no repo) that just reformats the existing text into valid JSON.
+That's seconds vs. tens of minutes.
+
+These tests pin the load-bearing invariants:
+  - empty output → repair is skipped (the user's explicit guidance: if
+    there's no output we can't repair from nothing)
+  - non-empty malformed output → repair is attempted and, on success,
+    avoids the expensive harness retry path
+  - repair failure → falls through to the existing harness retry path
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from pydantic import BaseModel
+
+from agentfield.harness._runner import _ai_schema_repair
+
+
+class _Schema(BaseModel):
+    name: str
+    count: int
+
+
+def _make_litellm_response(content: str):
+    """Minimal stand-in for a litellm.acompletion response."""
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+
+@pytest.mark.asyncio
+async def test_ai_schema_repair_skips_when_text_is_empty():
+    """Empty text = nothing to reformat — must NOT call the LLM.
+
+    User's explicit constraint: 'if it actually failed and there was no
+    output, then we can't do an AI-based JSON repair.' Important to pin
+    because calling the LLM with empty content would (a) waste a request,
+    and (b) risk the model hallucinating fake data.
+    """
+    options = {"model": "openrouter/moonshotai/kimi-k2.6"}
+
+    # If litellm gets called, this fixture would record it. Instead we
+    # patch acompletion to raise — if it's reached, the test fails loud.
+    async def _explode(*args, **kwargs):
+        raise AssertionError("litellm must NOT be called for empty input")
+
+    with patch("litellm.acompletion", side_effect=_explode):
+        result = await _ai_schema_repair("", _Schema, options)
+
+    assert result is None, "empty text must short-circuit to None without LLM call"
+
+
+@pytest.mark.asyncio
+async def test_ai_schema_repair_skips_when_text_is_whitespace_only():
+    """Whitespace-only counts as empty. Same reasoning."""
+    options = {"model": "openrouter/moonshotai/kimi-k2.6"}
+
+    async def _explode(*args, **kwargs):
+        raise AssertionError("litellm must NOT be called for whitespace input")
+
+    with patch("litellm.acompletion", side_effect=_explode):
+        result = await _ai_schema_repair("   \n\t  ", _Schema, options)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_ai_schema_repair_skips_when_no_model_configured():
+    """No model = no idea what to call. Bail rather than guess.
+
+    The harness retry path is the safety net for this case; we don't want
+    to silently route to a default model that the caller hasn't authorized.
+    """
+    options: dict = {}  # no "model" key
+
+    async def _explode(*args, **kwargs):
+        raise AssertionError("litellm must NOT be called without a model")
+
+    with patch("litellm.acompletion", side_effect=_explode):
+        result = await _ai_schema_repair("some text here", _Schema, options)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_ai_schema_repair_succeeds_on_valid_json_response():
+    """Happy path: text was malformed, the repair LLM returns valid JSON,
+    the result parses against the schema. This is the case that saves the
+    30-minute harness retry."""
+    options = {"model": "openrouter/moonshotai/kimi-k2.6"}
+
+    async def _fake_acompletion(*args, **kwargs):
+        # The repair call returns a clean JSON object matching _Schema.
+        return _make_litellm_response('{"name": "test", "count": 42}')
+
+    with patch("litellm.acompletion", side_effect=_fake_acompletion):
+        result = await _ai_schema_repair(
+            "name: test, count: 42 (this was malformed)", _Schema, options
+        )
+
+    assert result is not None
+    assert result.name == "test"
+    assert result.count == 42
+
+
+@pytest.mark.asyncio
+async def test_ai_schema_repair_returns_none_when_llm_fails():
+    """LLM exception → None, so the caller falls through to the existing
+    harness retry path. Repair is best-effort — we never let it block the
+    fallback flow."""
+    options = {"model": "openrouter/moonshotai/kimi-k2.6"}
+
+    async def _fail(*args, **kwargs):
+        raise RuntimeError("simulated litellm failure")
+
+    with patch("litellm.acompletion", side_effect=_fail):
+        result = await _ai_schema_repair("some text", _Schema, options)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_ai_schema_repair_returns_none_when_repair_output_unparseable():
+    """If the repair LLM itself returns garbage that doesn't parse against
+    the schema, we return None — same fall-through behavior as a hard
+    failure. We don't recurse repair-on-repair."""
+    options = {"model": "openrouter/moonshotai/kimi-k2.6"}
+
+    async def _bad_response(*args, **kwargs):
+        # Repair LLM returns something that doesn't match the schema at all.
+        return _make_litellm_response("this is just prose, no JSON")
+
+    with patch("litellm.acompletion", side_effect=_bad_response):
+        result = await _ai_schema_repair("some text", _Schema, options)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_ai_schema_repair_respects_timeout():
+    """A wedged repair call must NOT block the harness indefinitely.
+    The internal _SCHEMA_REPAIR_TIMEOUT_SECONDS cap is the safety valve;
+    if it fires, we return None and fall through.
+    """
+    options = {"model": "openrouter/moonshotai/kimi-k2.6"}
+
+    async def _hang(*args, **kwargs):
+        await asyncio.sleep(3600)  # would hang for an hour
+
+    # Patch the module-level timeout to something the test can wait for.
+    with patch(
+        "agentfield.harness._runner._SCHEMA_REPAIR_TIMEOUT_SECONDS", 0.1
+    ):
+        with patch("litellm.acompletion", side_effect=_hang):
+            result = await _ai_schema_repair("some text", _Schema, options)
+
+    assert result is None


### PR DESCRIPTION
## Why

Production traces from pr-af reviews showed individual phases burning **30+ minutes apiece**, even though Kimi K2.6 is fast per-turn. Profiling traced this to three orthogonal problems in the harness layer that compound:

1. **`timeout=600` on opencode** kills slow-but-progressing calls. Kimi K2.6 on a complex review legitimately needs more than 10 minutes.
2. **`TRANSIENT_PATTERNS` includes `"timeout"` / `"timed out"`**. So when (1) fires, the runner classifies it as transient and reruns the *entire* opencode subprocess up to 3 more times. One phase that should have been one 12-min call becomes **four 10-min restarts (40 min wall, ~3-4× the tokens) for the same deterministic outcome.** Live trace from a recent review: `meta_systemic` at **35m 57s ≈ exactly 3.5 timeouts**.
3. **Schema-validation failures rerun the entire opencode subprocess** (same 30-min agentic loop) just to coerce the output into valid JSON — when the actual problem is usually "the model produced a correct answer but with a stray comma." The model already did the work; we just needed a parser.

Plus a side-effect: `OPENCODE_MAX_CONCURRENT` defaulted to 3, silently gating Agent-Field/pr-af#19's bump to `max_concurrent_reviewers=10`. Two semaphores in series both at 3 = throughput of either one at 3.

## Changes

### `harness/providers/opencode.py`

- **Per-call timeout 600s → 1800s** (env-overridable as `AGENTFIELD_HARNESS_TIMEOUT_SECONDS`). Rationale: if a single opencode subprocess can't finish in 30 min, the prompt or model is wrong and rerunning won't fix it. Fail loud rather than burn another half-hour.
- **`OPENCODE_MAX_CONCURRENT` default 3 → 10.** Unblocks pr-af's reviewer fan-out; OpenRouter Kimi K2.6 handles 10 concurrent comfortably. Lower via env if your provider has tighter per-key limits.
- **Opt-in `XDG_DATA_HOME` reuse** via `AGENTFIELD_OPENCODE_REUSE_DATA_DIR=true`. SQLite migrations only run once per process instead of per-call. Default off because container layouts vary (read-only `/tmp`, multi-tenant, etc.) — opting in is the deployment's call.

### `harness/_runner.py`

- **Dropped `"timeout"` / `"timed out"` from `TRANSIENT_PATTERNS`.** A wall-clock timeout now fails immediately; only genuine transient errors (502/503/rate-limit/connection-reset) still trigger retry. The 30-min cap is now an actual cap.
- **New `_ai_schema_repair()`** — when the harness call produced non-empty text but it didn't validate, ONE focused LLM call (no tools, no repo, 90s wall-clock) reformats the existing text into valid JSON conforming to the schema. Skipped when text is empty (per user requirement: *"if no output, can't repair"*). Wired into `_handle_schema_with_retry` so it runs **before** the existing retry-via-harness loop. On failure, falls through to the unchanged retry path — best-effort, never blocking.

## Pairs with

[pr-af PR #20](https://github.com/Agent-Field/pr-af/pull/20) — softens the meta-phase prompts so the model can answer from the diff in 2 turns instead of 30. The two PRs are orthogonal:
- pr-af #20 reduces the *count* of opencode turns per phase
- this PR stops the harness from compounding *retries* of those turns

Together: typical review wall time should drop from 60–110+ min to comfortably under an hour. Each PR alone is meaningful; both is the goal.

## Test plan

- [x] **7 new regression tests** in `test_harness_ai_schema_repair.py`:
  - empty text → no LLM call (the explicit user constraint)
  - whitespace-only → no LLM call
  - no model configured → no LLM call
  - valid JSON response → parses, returns instance
  - LLM exception → returns None, caller falls through
  - repair output unparseable → returns None, caller falls through
  - repair timeout (90s wall-clock) → returns None, caller falls through
- [x] Full SDK suite green: 1451 passed, 4 env-skipped, 0 failures
- [x] `ruff check .` clean
- [ ] After merge: roll out to pr-af deployment and compare per-phase wall time on the same PR against pre-merge baseline (`anatomy_phase` 903s, `meta_systemic` 2157s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)