### PR TITLE
feat(runs): bottom-up cancel-tree endpoint and UI guard fix

### DIFF
--- a/control-plane/internal/handlers/execute_cancel_tree.go
+++ b/control-plane/internal/handlers/execute_cancel_tree.go
@@ -1,0 +1,315 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Agent-Field/agentfield/control-plane/internal/events"
+	"github.com/Agent-Field/agentfield/control-plane/internal/logger"
+	"github.com/Agent-Field/agentfield/control-plane/internal/storage"
+	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
+
+	"github.com/gin-gonic/gin"
+)
+
+// cancel-tree exists because per-execution cancel cannot reach a run whose
+// root execution has already terminated but whose children are still flagged
+// non-terminal (zombied workers, fan-out reasoners that finished before
+// their dispatched siblings, etc.). The user-facing model is "cancel the
+// run" — this endpoint walks the DAG bottom-up and cancels every
+// non-terminal execution under the run, leaving terminal ones alone.
+
+type cancelTreeRequest struct {
+	Reason string `json:"reason"`
+}
+
+type cancelTreeNodeResult struct {
+	ExecutionID    string `json:"execution_id"`
+	AgentNodeID    string `json:"agent_node_id,omitempty"`
+	ReasonerID     string `json:"reasoner_id,omitempty"`
+	WorkflowDepth  int    `json:"workflow_depth"`
+	PreviousStatus string `json:"previous_status"`
+	Status         string `json:"status"`
+	SkipReason     string `json:"skip_reason,omitempty"`
+}
+
+type cancelTreeResponse struct {
+	RunID          string                 `json:"run_id"`
+	TotalNodes     int                    `json:"total_nodes"`
+	CancelledCount int                    `json:"cancelled_count"`
+	SkippedCount   int                    `json:"skipped_count"`
+	ErrorCount     int                    `json:"error_count"`
+	Nodes          []cancelTreeNodeResult `json:"nodes"`
+	CancelledAt    string                 `json:"cancelled_at"`
+}
+
+// errAlreadyTerminal signals the storage update saw a terminal status under
+// the lock — distinguished from a generic update failure so we can report
+// it as a clean skip rather than an error.
+var errAlreadyTerminal = errors.New("execution already terminal")
+
+// CancelWorkflowTreeHandler cancels every non-terminal execution belonging
+// to a run. Order is bottom-up by computed depth so leaves transition first
+// and parents observe a consistent post-state before they themselves get
+// cancelled. Already-terminal executions are left untouched.
+func CancelWorkflowTreeHandler(store storage.StorageProvider) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		runID := strings.TrimSpace(c.Param("workflowId"))
+		if runID == "" {
+			runID = strings.TrimSpace(c.Param("workflow_id"))
+		}
+		if runID == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "workflowId is required"})
+			return
+		}
+
+		var req cancelTreeRequest
+		if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid request body: %v", err)})
+			return
+		}
+		reason := strings.TrimSpace(req.Reason)
+		var reasonPtr *string
+		if reason != "" {
+			reasonPtr = &reason
+		}
+
+		ctx := c.Request.Context()
+
+		executions, err := store.QueryExecutionRecords(ctx, types.ExecutionFilter{
+			RunID:          &runID,
+			SortBy:         "started_at",
+			SortDescending: false,
+		})
+		if err != nil {
+			logger.Logger.Error().Err(err).Str("run_id", runID).Msg("cancel-tree: failed to load run executions")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load run"})
+			return
+		}
+		if len(executions) == 0 {
+			c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("run %s not found", runID)})
+			return
+		}
+
+		ordered, depthByID := orderExecutionsLeafFirst(executions)
+
+		now := time.Now().UTC()
+		results := make([]cancelTreeNodeResult, 0, len(ordered))
+		var cancelledCount, skippedCount, errorCount int
+
+		for _, exec := range ordered {
+			if exec == nil {
+				continue
+			}
+			depth := depthByID[exec.ExecutionID]
+			result := cancelTreeNodeResult{
+				ExecutionID:    exec.ExecutionID,
+				AgentNodeID:    exec.AgentNodeID,
+				ReasonerID:     exec.ReasonerID,
+				WorkflowDepth:  depth,
+				PreviousStatus: exec.Status,
+			}
+
+			if types.IsTerminalExecutionStatus(exec.Status) {
+				result.Status = exec.Status
+				result.SkipReason = "terminal"
+				results = append(results, result)
+				skippedCount++
+				continue
+			}
+
+			updated, previousStatus, cancelErr := cancelOneExecution(ctx, store, exec.ExecutionID, reasonPtr, now, reason)
+			switch {
+			case errors.Is(cancelErr, errAlreadyTerminal):
+				result.Status = "skipped"
+				result.SkipReason = "raced_to_terminal"
+				results = append(results, result)
+				skippedCount++
+			case cancelErr != nil:
+				logger.Logger.Error().Err(cancelErr).Str("execution_id", exec.ExecutionID).Msg("cancel-tree: failed to cancel execution")
+				result.Status = "error"
+				result.SkipReason = cancelErr.Error()
+				results = append(results, result)
+				errorCount++
+			default:
+				if updated != nil {
+					result.PreviousStatus = previousStatus
+					result.Status = types.ExecutionStatusCancelled
+				}
+				results = append(results, result)
+				cancelledCount++
+			}
+		}
+
+		c.JSON(http.StatusOK, cancelTreeResponse{
+			RunID:          runID,
+			TotalNodes:     len(executions),
+			CancelledCount: cancelledCount,
+			SkippedCount:   skippedCount,
+			ErrorCount:     errorCount,
+			Nodes:          results,
+			CancelledAt:    now.Format(time.RFC3339),
+		})
+	}
+}
+
+// cancelOneExecution applies the same status transition + sibling-table
+// sync + event publishing as the per-execution cancel handler. Kept as a
+// local helper rather than a refactor of execute_cancel.go to keep this
+// PR's blast radius small. Returns errAlreadyTerminal if the execution
+// raced to a terminal state under the storage lock.
+func cancelOneExecution(
+	ctx context.Context,
+	store storage.StorageProvider,
+	executionID string,
+	reasonPtr *string,
+	now time.Time,
+	reasonRaw string,
+) (*types.Execution, string, error) {
+	wfExec, err := store.GetWorkflowExecution(ctx, executionID)
+	if err != nil {
+		logger.Logger.Warn().Err(err).Str("execution_id", executionID).Msg("cancel-tree: workflow execution lookup failed (non-fatal)")
+	}
+
+	var previousStatus string
+	updated, err := store.UpdateExecutionRecord(ctx, executionID, func(current *types.Execution) (*types.Execution, error) {
+		if current == nil {
+			return nil, fmt.Errorf("execution %s not found", executionID)
+		}
+		if types.IsTerminalExecutionStatus(current.Status) {
+			return nil, errAlreadyTerminal
+		}
+		previousStatus = current.Status
+		current.Status = types.ExecutionStatusCancelled
+		if reasonPtr != nil {
+			current.StatusReason = reasonPtr
+		}
+		return current, nil
+	})
+	if err != nil {
+		return nil, previousStatus, err
+	}
+
+	if wfExec != nil {
+		if updateErr := store.UpdateWorkflowExecution(ctx, executionID, func(current *types.WorkflowExecution) (*types.WorkflowExecution, error) {
+			if current == nil {
+				return nil, fmt.Errorf("execution %s not found", executionID)
+			}
+			current.Status = types.ExecutionStatusCancelled
+			if reasonPtr != nil {
+				current.StatusReason = reasonPtr
+			}
+			return current, nil
+		}); updateErr != nil {
+			logger.Logger.Warn().Err(updateErr).Str("execution_id", executionID).Msg("cancel-tree: failed to sync workflow_executions (non-fatal)")
+		}
+	}
+
+	events.PublishExecutionCancelled(updated.ExecutionID, updated.RunID, updated.AgentNodeID, map[string]interface{}{
+		"reason": reasonRaw,
+		"source": "cancel_tree",
+	})
+
+	payload, marshalErr := json.Marshal(map[string]interface{}{
+		"reason": reasonRaw,
+		"source": "cancel_tree",
+	})
+	if marshalErr != nil {
+		payload = json.RawMessage(`{"reason":"","source":"cancel_tree"}`)
+	}
+
+	workflowID := updated.RunID
+	runIDForEvent := &updated.RunID
+	if wfExec != nil {
+		workflowID = wfExec.WorkflowID
+		runIDForEvent = wfExec.RunID
+	}
+	cancelledStatus := types.ExecutionStatusCancelled
+	if eventErr := store.StoreWorkflowExecutionEvent(ctx, &types.WorkflowExecutionEvent{
+		ExecutionID:  updated.ExecutionID,
+		WorkflowID:   workflowID,
+		RunID:        runIDForEvent,
+		EventType:    "execution.cancelled",
+		Status:       &cancelledStatus,
+		StatusReason: reasonPtr,
+		Payload:      payload,
+		EmittedAt:    now,
+	}); eventErr != nil {
+		logger.Logger.Warn().Err(eventErr).Str("execution_id", updated.ExecutionID).Msg("cancel-tree: failed to store event (non-fatal)")
+	}
+
+	return updated, previousStatus, nil
+}
+
+// orderExecutionsLeafFirst returns executions sorted by depth descending so
+// leaves are processed before their ancestors. Stable secondary order is
+// most-recently-started first so older parents fall to the end.
+func orderExecutionsLeafFirst(executions []*types.Execution) ([]*types.Execution, map[string]int) {
+	depths := computeExecutionDepths(executions)
+
+	ordered := make([]*types.Execution, 0, len(executions))
+	for _, e := range executions {
+		if e == nil {
+			continue
+		}
+		ordered = append(ordered, e)
+	}
+	sort.SliceStable(ordered, func(i, j int) bool {
+		di, dj := depths[ordered[i].ExecutionID], depths[ordered[j].ExecutionID]
+		if di != dj {
+			return di > dj
+		}
+		return ordered[i].StartedAt.After(ordered[j].StartedAt)
+	})
+	return ordered, depths
+}
+
+// computeExecutionDepths walks parent_execution_id chains to assign each
+// execution a depth from the run's root. Cycle-safe; orphan parents (parent
+// id present but missing from the slice) are treated as depth 0.
+func computeExecutionDepths(executions []*types.Execution) map[string]int {
+	execMap := make(map[string]*types.Execution, len(executions))
+	for _, e := range executions {
+		if e == nil {
+			continue
+		}
+		execMap[e.ExecutionID] = e
+	}
+	depths := make(map[string]int, len(executions))
+	computing := make(map[string]bool)
+
+	var compute func(e *types.Execution) int
+	compute = func(e *types.Execution) int {
+		if e == nil {
+			return 0
+		}
+		if d, ok := depths[e.ExecutionID]; ok {
+			return d
+		}
+		if computing[e.ExecutionID] {
+			return 0
+		}
+		computing[e.ExecutionID] = true
+		defer delete(computing, e.ExecutionID)
+
+		d := 0
+		if e.ParentExecutionID != nil && *e.ParentExecutionID != "" {
+			if parent, ok := execMap[*e.ParentExecutionID]; ok {
+				d = compute(parent) + 1
+			}
+		}
+		depths[e.ExecutionID] = d
+		return d
+	}
+	for _, e := range executions {
+		compute(e)
+	}
+	return depths
+}

--- a/control-plane/internal/handlers/execute_cancel_tree_test.go
+++ b/control-plane/internal/handlers/execute_cancel_tree_test.go
@@ -1,0 +1,258 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Agent-Field/agentfield/control-plane/internal/storage"
+	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// cancelTreeStorage embeds StorageProvider and overrides only the methods
+// the cancel-tree handler touches. Unimplemented methods will panic if
+// called — keeps the surface tight and surfaces accidental new dependencies.
+type cancelTreeStorage struct {
+	storage.StorageProvider
+
+	mu                 sync.Mutex
+	executionRecords   map[string]*types.Execution
+	workflowExecutions map[string]*types.WorkflowExecution
+	workflowEvents     []*types.WorkflowExecutionEvent
+}
+
+func newCancelTreeStorage() *cancelTreeStorage {
+	return &cancelTreeStorage{
+		executionRecords:   make(map[string]*types.Execution),
+		workflowExecutions: make(map[string]*types.WorkflowExecution),
+	}
+}
+
+func (s *cancelTreeStorage) seedExecution(execID, runID, status string, parentID *string, startOffsetMs int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now().UTC().Add(time.Duration(startOffsetMs) * time.Millisecond)
+	rid := runID
+	s.executionRecords[execID] = &types.Execution{
+		ExecutionID:       execID,
+		RunID:             runID,
+		AgentNodeID:       "agent-1",
+		ReasonerID:        "reasoner-1",
+		Status:            status,
+		StartedAt:         now,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+		ParentExecutionID: parentID,
+	}
+	s.workflowExecutions[execID] = &types.WorkflowExecution{
+		ExecutionID: execID,
+		WorkflowID:  "wf-" + runID,
+		RunID:       &rid,
+		AgentNodeID: "agent-1",
+		Status:      status,
+		StartedAt:   now,
+	}
+}
+
+func (s *cancelTreeStorage) GetExecutionRecord(ctx context.Context, executionID string) (*types.Execution, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	exec, ok := s.executionRecords[executionID]
+	if !ok {
+		return nil, nil
+	}
+	clone := *exec
+	return &clone, nil
+}
+
+func (s *cancelTreeStorage) GetWorkflowExecution(ctx context.Context, executionID string) (*types.WorkflowExecution, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	wfExec, ok := s.workflowExecutions[executionID]
+	if !ok {
+		return nil, nil
+	}
+	clone := *wfExec
+	return &clone, nil
+}
+
+func (s *cancelTreeStorage) UpdateExecutionRecord(ctx context.Context, executionID string, update func(*types.Execution) (*types.Execution, error)) (*types.Execution, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, ok := s.executionRecords[executionID]
+	if !ok {
+		return nil, fmt.Errorf("execution %s not found", executionID)
+	}
+	clone := *current
+	updated, err := update(&clone)
+	if err != nil {
+		return nil, err
+	}
+	if updated != nil {
+		clone = *updated
+	}
+	s.executionRecords[executionID] = &clone
+	out := clone
+	return &out, nil
+}
+
+func (s *cancelTreeStorage) UpdateWorkflowExecution(ctx context.Context, executionID string, updateFunc func(*types.WorkflowExecution) (*types.WorkflowExecution, error)) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, ok := s.workflowExecutions[executionID]
+	if !ok {
+		return fmt.Errorf("execution %s not found", executionID)
+	}
+	clone := *current
+	updated, err := updateFunc(&clone)
+	if err != nil {
+		return err
+	}
+	if updated != nil {
+		clone = *updated
+	}
+	s.workflowExecutions[executionID] = &clone
+	return nil
+}
+
+func (s *cancelTreeStorage) StoreWorkflowExecutionEvent(ctx context.Context, event *types.WorkflowExecutionEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.workflowEvents = append(s.workflowEvents, event)
+	return nil
+}
+
+func (s *cancelTreeStorage) QueryExecutionRecords(ctx context.Context, filter types.ExecutionFilter) ([]*types.Execution, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*types.Execution, 0, len(s.executionRecords))
+	for _, exec := range s.executionRecords {
+		if filter.RunID != nil && exec.RunID != *filter.RunID {
+			continue
+		}
+		clone := *exec
+		out = append(out, &clone)
+	}
+	return out, nil
+}
+
+func TestCancelWorkflowTreeHandler_HappyPath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Tree:
+	//   root (succeeded, depth 0)
+	//   ├─ child-a (running, depth 1)
+	//   │  └─ leaf-a (running, depth 2)
+	//   └─ child-b (failed, depth 1)
+	//      └─ leaf-b (succeeded, depth 2)
+	store := newCancelTreeStorage()
+	rootID := "root"
+	childA := "child-a"
+	leafA := "leaf-a"
+	childB := "child-b"
+	leafB := "leaf-b"
+	store.seedExecution(rootID, "run-1", types.ExecutionStatusSucceeded, nil, 0)
+	store.seedExecution(childA, "run-1", types.ExecutionStatusRunning, &rootID, 100)
+	store.seedExecution(leafA, "run-1", types.ExecutionStatusRunning, &childA, 200)
+	store.seedExecution(childB, "run-1", types.ExecutionStatusFailed, &rootID, 300)
+	store.seedExecution(leafB, "run-1", types.ExecutionStatusSucceeded, &childB, 400)
+
+	router := gin.New()
+	router.POST("/api/v1/workflows/:workflowId/cancel-tree", CancelWorkflowTreeHandler(store))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/workflows/run-1/cancel-tree", bytes.NewReader([]byte(`{"reason":"user clicked cancel"}`)))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var payload cancelTreeResponse
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &payload))
+	require.Equal(t, "run-1", payload.RunID)
+	require.Equal(t, 5, payload.TotalNodes)
+	require.Equal(t, 2, payload.CancelledCount, "exactly the two non-terminal nodes (child-a, leaf-a) should flip")
+	require.Equal(t, 3, payload.SkippedCount, "root, child-b, leaf-b are terminal and skipped")
+	require.Equal(t, 0, payload.ErrorCount)
+
+	// Verify storage state.
+	for _, id := range []string{childA, leafA} {
+		exec, err := store.GetExecutionRecord(context.Background(), id)
+		require.NoError(t, err)
+		require.Equal(t, types.ExecutionStatusCancelled, exec.Status, id)
+	}
+	for id, want := range map[string]string{
+		rootID: types.ExecutionStatusSucceeded,
+		childB: types.ExecutionStatusFailed,
+		leafB:  types.ExecutionStatusSucceeded,
+	} {
+		exec, err := store.GetExecutionRecord(context.Background(), id)
+		require.NoError(t, err)
+		require.Equal(t, want, exec.Status, id)
+	}
+
+	// Bottom-up: leaf-a (depth 2) appears before child-a (depth 1) in the
+	// node list. Find their indices and assert ordering.
+	indexOf := func(id string) int {
+		for i, n := range payload.Nodes {
+			if n.ExecutionID == id {
+				return i
+			}
+		}
+		return -1
+	}
+	require.Less(t, indexOf(leafA), indexOf(childA), "leaves must be processed before parents")
+}
+
+func TestCancelWorkflowTreeHandler_NotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := newCancelTreeStorage()
+	router := gin.New()
+	router.POST("/api/v1/workflows/:workflowId/cancel-tree", CancelWorkflowTreeHandler(store))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/workflows/missing-run/cancel-tree", bytes.NewReader(nil))
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusNotFound, resp.Code)
+}
+
+func TestCancelWorkflowTreeHandler_AllTerminal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := newCancelTreeStorage()
+	store.seedExecution("a", "run-2", types.ExecutionStatusSucceeded, nil, 0)
+	store.seedExecution("b", "run-2", types.ExecutionStatusFailed, strPtr("a"), 100)
+
+	router := gin.New()
+	router.POST("/api/v1/workflows/:workflowId/cancel-tree", CancelWorkflowTreeHandler(store))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/workflows/run-2/cancel-tree", bytes.NewReader(nil))
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+	var payload cancelTreeResponse
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &payload))
+	require.Equal(t, 0, payload.CancelledCount)
+	require.Equal(t, 2, payload.SkippedCount)
+}
+
+func TestComputeExecutionDepths_OrphanParent(t *testing.T) {
+	// Parent ID points to an execution outside the loaded slice — depth
+	// should fall back to 0 rather than crashing.
+	missing := "missing-parent"
+	executions := []*types.Execution{
+		{ExecutionID: "orphan", ParentExecutionID: &missing},
+	}
+	depths := computeExecutionDepths(executions)
+	require.Equal(t, 0, depths["orphan"])
+}
+

--- a/control-plane/internal/server/apicatalog/catalog_entries.go
+++ b/control-plane/internal/server/apicatalog/catalog_entries.go
@@ -78,6 +78,7 @@ func DefaultEntries() []EndpointEntry {
 		{Method: "POST", Path: "/api/v1/executions/:execution_id/cancel", Group: "executions", Summary: "Cancel a running execution", AuthLevel: "api_key", Tags: []string{"executions", "cancel"}},
 		{Method: "POST", Path: "/api/v1/executions/:execution_id/pause", Group: "executions", Summary: "Pause an execution", AuthLevel: "api_key", Tags: []string{"executions", "pause"}},
 		{Method: "POST", Path: "/api/v1/executions/:execution_id/resume", Group: "executions", Summary: "Resume a paused execution", AuthLevel: "api_key", Tags: []string{"executions", "resume"}},
+		{Method: "POST", Path: "/api/v1/workflows/:workflowId/cancel-tree", Group: "workflows", Summary: "Cancel every non-terminal execution in a run (bottom-up)", AuthLevel: "api_key", Tags: []string{"workflows", "executions", "cancel"}},
 
 		// --- Approval ---
 		{Method: "POST", Path: "/api/v1/executions/:execution_id/request-approval", Group: "approval", Summary: "Request approval for an execution", AuthLevel: "api_key", Tags: []string{"approval", "request"}},

--- a/control-plane/internal/server/routes_core.go
+++ b/control-plane/internal/server/routes_core.go
@@ -116,6 +116,7 @@ func (s *AgentFieldServer) registerCoreRoutes(agentAPI *gin.RouterGroup) {
 	agentAPI.POST("/executions/:execution_id/cancel", handlers.CancelExecutionHandler(s.storage))
 	agentAPI.POST("/executions/:execution_id/pause", handlers.PauseExecutionHandler(s.storage))
 	agentAPI.POST("/executions/:execution_id/resume", handlers.ResumeExecutionHandler(s.storage))
+	agentAPI.POST("/workflows/:workflowId/cancel-tree", handlers.CancelWorkflowTreeHandler(s.storage))
 
 	// Approval workflow endpoints — CP manages execution state only;
 	// agents handle external approval service communication directly.

--- a/control-plane/internal/server/routes_ui.go
+++ b/control-plane/internal/server/routes_ui.go
@@ -195,6 +195,7 @@ func (s *AgentFieldServer) registerUIAPI() {
 		workflows := uiAPI.Group("/workflows")
 		{
 			workflows.GET("/:workflowId/dag", handlers.GetWorkflowDAGHandler(s.storage))
+			workflows.POST("/:workflowId/cancel-tree", handlers.CancelWorkflowTreeHandler(s.storage))
 			workflows.DELETE("/:workflowId/cleanup", handlers.CleanupWorkflowHandler(s.storage))
 			didHandler := ui.NewDIDHandler(s.storage, s.didService, s.vcService, s.didWebService)
 			workflows.POST("/vc-status", didHandler.GetWorkflowVCStatusBatchHandler)

--- a/control-plane/web/client/src/components/runs/RunLifecycleMenu.tsx
+++ b/control-plane/web/client/src/components/runs/RunLifecycleMenu.tsx
@@ -78,18 +78,19 @@ export function RunLifecycleMenu({
   const [menuOpen, setMenuOpen] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
 
-  // Prefer the root execution status when available — that's the row the
-  // user actually controls. The aggregate `run.status` can stay 'running'
-  // even after the user paused the root because in-flight children keep
-  // going (see backend execute.go dispatch-time guard). Falling back to
-  // the aggregate keeps things working for older API responses.
-  const effectiveStatus = run.root_execution_status ?? run.status;
-  const isRunning = effectiveStatus === "running";
-  const isPaused = effectiveStatus === "paused";
-  const isTerminal = isTerminalStatus(effectiveStatus);
+  // Pause/Resume target the root execution — they're scoped operations on
+  // the row the user actually controls, and the aggregate `run.status` can
+  // stay 'running' even after the user paused the root because in-flight
+  // children keep going (see backend execute.go dispatch-time guard).
+  // Cancel targets the AGGREGATE status because a run with a terminated
+  // root and zombied children still has work that needs cancelling — the
+  // bulk-cancel path walks the whole DAG.
+  const rootStatus = run.root_execution_status ?? run.status;
+  const isRunning = rootStatus === "running";
+  const isPaused = rootStatus === "paused";
   const canPause = isRunning && Boolean(run.root_execution_id);
   const canResume = isPaused && Boolean(run.root_execution_id);
-  const canCancel = !isTerminal && Boolean(run.root_execution_id);
+  const canCancel = !isTerminalStatus(run.status);
   const hasAnyAction = canPause || canResume || canCancel;
 
   // Render an inert placeholder with the same footprint so the column

--- a/control-plane/web/client/src/hooks/queries/index.ts
+++ b/control-plane/web/client/src/hooks/queries/index.ts
@@ -11,6 +11,7 @@ export type {
 } from "./useSystemHealth";
 export {
   useCancelExecution,
+  useCancelWorkflowTree,
   usePauseExecution,
   useResumeExecution,
 } from "./useExecutionMutations";

--- a/control-plane/web/client/src/hooks/queries/useExecutionMutations.ts
+++ b/control-plane/web/client/src/hooks/queries/useExecutionMutations.ts
@@ -9,6 +9,8 @@ import type {
   PauseExecutionResponse,
   ResumeExecutionResponse,
 } from "../../services/executionsApi";
+import { cancelWorkflowTree } from "../../services/workflowsApi";
+import type { CancelWorkflowTreeResponse } from "../../services/workflowsApi";
 
 export function useCancelExecution() {
   const queryClient = useQueryClient();
@@ -25,6 +27,21 @@ export function usePauseExecution() {
   const queryClient = useQueryClient();
   return useMutation<PauseExecutionResponse, Error, string>({
     mutationFn: (executionId: string) => pauseExecution(executionId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["runs"] });
+      queryClient.invalidateQueries({ queryKey: ["run-dag"] });
+    },
+  });
+}
+
+export function useCancelWorkflowTree() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    CancelWorkflowTreeResponse,
+    Error,
+    { workflowId: string; reason?: string }
+  >({
+    mutationFn: ({ workflowId, reason }) => cancelWorkflowTree(workflowId, reason),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["runs"] });
       queryClient.invalidateQueries({ queryKey: ["run-dag"] });

--- a/control-plane/web/client/src/pages/RunDetailPage.tsx
+++ b/control-plane/web/client/src/pages/RunDetailPage.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate, Link } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   useRunDAG,
-  useCancelExecution,
+  useCancelWorkflowTree,
   usePauseExecution,
   useResumeExecution,
 } from "@/hooks/queries";
@@ -476,7 +476,7 @@ export function RunDetailPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { data: dag, isLoading, isError, error } = useRunDAG(runId);
-  const cancelMutation = useCancelExecution();
+  const cancelTreeMutation = useCancelWorkflowTree();
   const pauseMutation = usePauseExecution();
   const resumeMutation = useResumeExecution();
   const showRunNotification = useRunNotification();
@@ -853,24 +853,33 @@ export function RunDetailPage() {
             </DropdownMenuContent>
           </DropdownMenu>
 
-          {/* Lifecycle cluster — Pause / Resume / Cancel. Uses the ROOT
-              execution's own status (not the aggregated workflow status)
-              because that's the row the user controls. A run can be
-              aggregate-'running' while the root is already 'paused' if
-              in-flight children are still finishing. */}
+          {/* Lifecycle cluster — Pause / Resume / Cancel.
+              Pause/Resume still target the ROOT execution's own status
+              (a run can be aggregate-'running' while the root is already
+              'paused' because in-flight children keep going). Cancel
+              targets the AGGREGATE workflow status — when the root has
+              terminated but children are still flagged running (zombied
+              fan-out), the user still needs an escape hatch. The cancel
+              button hits a bottom-up cancel-tree endpoint that walks the
+              whole run rather than a single execution. */}
           {(() => {
             const rootNodeForStatus =
               dag.timeline.find((n) => n.workflow_depth === 0) ??
               dag.timeline[0];
-            const normalized = normalizeExecutionStatus(
+            const rootStatus = normalizeExecutionStatus(
               rootNodeForStatus?.status ?? dag.workflow_status,
             );
-            const isRunning = normalized === "running";
-            const isPaused = normalized === "paused";
-            if (isTerminalStatus(normalized)) return null;
-
+            const aggregateStatus = normalizeExecutionStatus(dag.workflow_status);
+            const isRunning = rootStatus === "running";
+            const isPaused = rootStatus === "paused";
+            // Cancel is allowed whenever there is anything left to cancel —
+            // i.e. the aggregate workflow has not reached a terminal state.
+            const showCancel = !isTerminalStatus(aggregateStatus);
+            // Pause/Resume require a live root execution.
             const rootExecId = rootNodeForStatus?.execution_id;
-            if (!rootExecId) return null;
+            const showPause = isRunning && !!rootExecId;
+            const showResume = isPaused && !!rootExecId;
+            if (!showCancel && !showPause && !showResume) return null;
 
             const busy = lifecycleBusy !== null;
 
@@ -882,6 +891,7 @@ export function RunDetailPage() {
             const runIdForNotif = runId ?? "";
 
             const handlePause = async () => {
+              if (!rootExecId) return;
               setLifecycleBusy("pause");
               try {
                 await pauseMutation.mutateAsync(rootExecId);
@@ -909,6 +919,7 @@ export function RunDetailPage() {
             };
 
             const handleResume = async () => {
+              if (!rootExecId) return;
               setLifecycleBusy("resume");
               try {
                 await resumeMutation.mutateAsync(rootExecId);
@@ -939,7 +950,7 @@ export function RunDetailPage() {
 
             return (
               <>
-                {isRunning ? (
+                {showPause ? (
                   <Button
                     variant="outline"
                     size="sm"
@@ -958,7 +969,7 @@ export function RunDetailPage() {
                     Pause
                   </Button>
                 ) : null}
-                {isPaused ? (
+                {showResume ? (
                   <Button
                     variant="outline"
                     size="sm"
@@ -977,20 +988,22 @@ export function RunDetailPage() {
                     Resume
                   </Button>
                 ) : null}
-                <Button
-                  variant="destructive"
-                  size="sm"
-                  className="h-8 gap-1.5 text-xs"
-                  disabled={busy}
-                  onClick={() => setCancelDialogOpen(true)}
-                >
-                  {lifecycleBusy === "cancel" ? (
-                    <Activity className="size-3.5 animate-spin" aria-hidden />
-                  ) : (
-                    <XCircle className="size-3.5" aria-hidden />
-                  )}
-                  Cancel
-                </Button>
+                {showCancel ? (
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    className="h-8 gap-1.5 text-xs"
+                    disabled={busy}
+                    onClick={() => setCancelDialogOpen(true)}
+                  >
+                    {lifecycleBusy === "cancel" ? (
+                      <Activity className="size-3.5 animate-spin" aria-hidden />
+                    ) : (
+                      <XCircle className="size-3.5" aria-hidden />
+                    )}
+                    Cancel
+                  </Button>
+                ) : null}
 
                 <AlertDialog
                   open={cancelDialogOpen}
@@ -1013,15 +1026,22 @@ export function RunDetailPage() {
                         disabled={busy}
                         className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                         onClick={async () => {
+                          if (!runId) return;
                           setCancelDialogOpen(false);
                           setLifecycleBusy("cancel");
                           try {
-                            await cancelMutation.mutateAsync(rootExecId);
+                            const result = await cancelTreeMutation.mutateAsync({
+                              workflowId: runId,
+                              reason: "user clicked cancel",
+                            });
                             showRunNotification({
                               type: "success",
                               eventKind: "cancel",
                               title: "Cancelled",
-                              message: `${runLabelForNotif} will stop after its current step finishes. In-flight work will be discarded.`,
+                              message:
+                                result.cancelled_count > 0
+                                  ? `${runLabelForNotif}: ${result.cancelled_count} ${result.cancelled_count === 1 ? "step" : "steps"} cancelled. In-flight work will finish and be discarded.`
+                                  : `${runLabelForNotif}: nothing left to cancel.`,
                               runId: runIdForNotif,
                               runLabel: runLabelForNotif,
                             });

--- a/control-plane/web/client/src/pages/RunsPage.tsx
+++ b/control-plane/web/client/src/pages/RunsPage.tsx
@@ -11,7 +11,7 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import {
   useRuns,
-  useCancelExecution,
+  useCancelWorkflowTree,
   usePauseExecution,
   useResumeExecution,
 } from "@/hooks/queries";
@@ -553,7 +553,7 @@ function RunsPaginationBar({
 export function RunsPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const cancelMutation = useCancelExecution();
+  const cancelTreeMutation = useCancelWorkflowTree();
   const pauseMutation = usePauseExecution();
   const resumeMutation = useResumeExecution();
   const showSuccess = useSuccessNotification();
@@ -655,16 +655,27 @@ export function RunsPage() {
 
   const handleCancelRun = useCallback(
     async (run: WorkflowSummary) => {
-      const execId = run.root_execution_id;
-      if (!execId) return;
-      markPending(execId);
+      // Use cancel-tree (bottom-up bulk cancel) rather than per-execution
+      // cancel — a run can have a terminated root with non-terminal
+      // children (zombied fan-out) and only the tree walk reaches them.
+      // Pending key is the root_execution_id when present (matches the
+      // existing optimistic-busy contract for the kebab spinner); falls
+      // back to run_id so we still spin when no root exec is recorded.
+      const pendingKey = run.root_execution_id ?? run.run_id;
+      markPending(pendingKey);
       try {
-        await cancelMutation.mutateAsync(execId);
+        const result = await cancelTreeMutation.mutateAsync({
+          workflowId: run.run_id,
+          reason: "user clicked cancel",
+        });
         showRunNotification({
           type: "success",
           eventKind: "cancel",
           title: "Cancelled",
-          message: `${runDisplayLabel(run)} will stop after its current step finishes. In-flight work will be discarded.`,
+          message:
+            result.cancelled_count > 0
+              ? `${runDisplayLabel(run)}: ${result.cancelled_count} ${result.cancelled_count === 1 ? "step" : "steps"} cancelled. In-flight work will finish and be discarded.`
+              : `${runDisplayLabel(run)}: nothing left to cancel.`,
           runId: run.run_id,
           runLabel: runDisplayLabel(run),
         });
@@ -678,10 +689,10 @@ export function RunsPage() {
           runLabel: runDisplayLabel(run),
         });
       } finally {
-        clearPending(execId);
+        clearPending(pendingKey);
       }
     },
-    [cancelMutation, showRunNotification, markPending, clearPending, runDisplayLabel],
+    [cancelTreeMutation, showRunNotification, markPending, clearPending, runDisplayLabel],
   );
 
   // Bulk confirmation dialog state — a single shared AlertDialog for the
@@ -1215,23 +1226,31 @@ export function RunsPage() {
               disabled={bulkBusy}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
               onClick={async () => {
+                // Bulk cancel uses cancel-tree per run — same reason as the
+                // per-row path: a run with a terminated root and zombied
+                // children needs the bottom-up walk to actually flip every
+                // execution. We gate inclusion on aggregate `r.status` being
+                // non-terminal (not the root's status) so users can sweep
+                // up zombies even when the root has succeeded.
                 const targets = [...selected]
                   .map((id) => filteredRuns.find((r) => r.run_id === id))
                   .filter(
                     (r): r is WorkflowSummary =>
-                      !!r &&
-                      !isTerminalStatus(r.root_execution_status ?? r.status) &&
-                      !!r.root_execution_id,
+                      !!r && !isTerminalStatus(r.status),
                   );
                 setBulkCancelOpen(false);
                 await runBulkMutation({
                   targets,
                   run: async (r) => {
-                    markPending(r.root_execution_id!);
+                    const pendingKey = r.root_execution_id ?? r.run_id;
+                    markPending(pendingKey);
                     try {
-                      await cancelMutation.mutateAsync(r.root_execution_id!);
+                      await cancelTreeMutation.mutateAsync({
+                        workflowId: r.run_id,
+                        reason: "user clicked bulk cancel",
+                      });
                     } finally {
-                      clearPending(r.root_execution_id!);
+                      clearPending(pendingKey);
                     }
                   },
                   verb: "cancelled",
@@ -1249,9 +1268,7 @@ export function RunsPage() {
                   .map((id) => filteredRuns.find((r) => r.run_id === id))
                   .filter(
                     (r): r is WorkflowSummary =>
-                      !!r &&
-                      !isTerminalStatus(r.root_execution_status ?? r.status) &&
-                      !!r.root_execution_id,
+                      !!r && !isTerminalStatus(r.status),
                   );
                 return CANCEL_RUN_COPY.confirmLabel(cancellable.length);
               })()}

--- a/control-plane/web/client/src/services/workflowsApi.ts
+++ b/control-plane/web/client/src/services/workflowsApi.ts
@@ -358,6 +358,44 @@ export async function getWorkflowDAGLightweight(
   });
 }
 
+export interface CancelWorkflowTreeNode {
+  execution_id: string;
+  agent_node_id?: string;
+  reasoner_id?: string;
+  workflow_depth: number;
+  previous_status: string;
+  status: string;
+  skip_reason?: string;
+}
+
+export interface CancelWorkflowTreeResponse {
+  run_id: string;
+  total_nodes: number;
+  cancelled_count: number;
+  skipped_count: number;
+  error_count: number;
+  nodes: CancelWorkflowTreeNode[];
+  cancelled_at: string;
+}
+
+// cancelWorkflowTree fans out cancel to every non-terminal execution in a
+// run, bottom-up. Use this in preference to per-execution cancel when the
+// user means "stop the whole run" — single-execution cancel can't reach
+// children of a root that already terminated.
+export async function cancelWorkflowTree(
+  workflowId: string,
+  reason?: string,
+): Promise<CancelWorkflowTreeResponse> {
+  return fetchWrapper<CancelWorkflowTreeResponse>(
+    `/workflows/${workflowId}/cancel-tree`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ reason: reason ?? "" }),
+    },
+  );
+}
+
 export async function getWorkflowRunDetail(
   runId: string,
   signal?: AbortSignal

--- a/control-plane/web/client/src/test/pages/RunDetailPage.test.tsx
+++ b/control-plane/web/client/src/test/pages/RunDetailPage.test.tsx
@@ -15,7 +15,7 @@ const state = vi.hoisted(() => ({
   },
   queryData: undefined as any,
   invalidateQueries: vi.fn<(args: unknown) => Promise<void>>(),
-  cancelMutateAsync: vi.fn<(executionId: string) => Promise<void>>(),
+  cancelTreeMutateAsync: vi.fn<(args: { workflowId: string; reason?: string }) => Promise<unknown>>(),
   pauseMutateAsync: vi.fn<(executionId: string) => Promise<void>>(),
   resumeMutateAsync: vi.fn<(executionId: string) => Promise<void>>(),
   showRunNotification: vi.fn<(message: string) => void>(),
@@ -48,7 +48,7 @@ vi.mock("@tanstack/react-query", () => ({
 
 vi.mock("@/hooks/queries", () => ({
   useRunDAG: () => state.runDag,
-  useCancelExecution: () => ({ mutateAsync: state.cancelMutateAsync, isPending: false }),
+  useCancelWorkflowTree: () => ({ mutateAsync: state.cancelTreeMutateAsync, isPending: false }),
   usePauseExecution: () => ({ mutateAsync: state.pauseMutateAsync, isPending: false }),
   useResumeExecution: () => ({ mutateAsync: state.resumeMutateAsync, isPending: false }),
 }));
@@ -330,7 +330,16 @@ describe("RunDetailPage", () => {
     };
     state.queryData = undefined;
     state.invalidateQueries.mockReset();
-    state.cancelMutateAsync.mockReset();
+    state.cancelTreeMutateAsync.mockReset();
+    state.cancelTreeMutateAsync.mockResolvedValue({
+      run_id: "run-1",
+      total_nodes: 1,
+      cancelled_count: 1,
+      skipped_count: 0,
+      error_count: 0,
+      nodes: [],
+      cancelled_at: new Date().toISOString(),
+    });
     state.pauseMutateAsync.mockReset();
     state.resumeMutateAsync.mockReset();
     state.showRunNotification.mockReset();
@@ -519,7 +528,7 @@ describe("RunDetailPage", () => {
       error: null,
     };
     state.pauseMutateAsync.mockResolvedValue(undefined);
-    state.cancelMutateAsync.mockRejectedValue(new Error("cancel exploded"));
+    state.cancelTreeMutateAsync.mockRejectedValue(new Error("cancel exploded"));
 
     const view = renderPage();
     expect(await screen.findByText("Run Alpha")).toBeInTheDocument();
@@ -535,7 +544,9 @@ describe("RunDetailPage", () => {
     fireEvent.click(screen.getByText("Cancel"));
     fireEvent.click(screen.getByRole("button", { name: "Cancel 1 run" }));
     await waitFor(() => {
-      expect(state.cancelMutateAsync).toHaveBeenCalledWith("exec-1");
+      expect(state.cancelTreeMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ workflowId: "run-1" }),
+      );
     });
     expect(state.showRunNotification).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/control-plane/web/client/src/test/pages/RunsPage.test.tsx
+++ b/control-plane/web/client/src/test/pages/RunsPage.test.tsx
@@ -8,7 +8,7 @@ const {
   navigateMock,
   searchParamsState,
   useRunsMock,
-  cancelMutationMock,
+  cancelTreeMutationMock,
   pauseMutationMock,
   resumeMutationMock,
   useQueryMock,
@@ -21,7 +21,7 @@ const {
   navigateMock: vi.fn(),
   searchParamsState: { value: new URLSearchParams() },
   useRunsMock: vi.fn(),
-  cancelMutationMock: vi.fn(),
+  cancelTreeMutationMock: vi.fn(),
   pauseMutationMock: vi.fn(),
   resumeMutationMock: vi.fn(),
   useQueryMock: vi.fn(),
@@ -47,7 +47,7 @@ vi.mock("@/services/executionsApi", () => ({
 
 vi.mock("@/hooks/queries", () => ({
   useRuns: useRunsMock,
-  useCancelExecution: () => ({ mutateAsync: cancelMutationMock }),
+  useCancelWorkflowTree: () => ({ mutateAsync: cancelTreeMutationMock }),
   usePauseExecution: () => ({ mutateAsync: pauseMutationMock }),
   useResumeExecution: () => ({ mutateAsync: resumeMutationMock }),
 }));
@@ -399,7 +399,7 @@ describe("RunsPage", () => {
     vi.useRealTimers();
     navigateMock.mockReset();
     useRunsMock.mockReset();
-    cancelMutationMock.mockReset();
+    cancelTreeMutationMock.mockReset();
     pauseMutationMock.mockReset();
     resumeMutationMock.mockReset();
     useQueryMock.mockReset();
@@ -411,7 +411,15 @@ describe("RunsPage", () => {
     searchParamsState.value = new URLSearchParams();
 
     useQueryMock.mockReturnValue({ data: undefined, isLoading: false });
-    cancelMutationMock.mockResolvedValue(undefined);
+    cancelTreeMutationMock.mockResolvedValue({
+      run_id: "run",
+      total_nodes: 1,
+      cancelled_count: 1,
+      skipped_count: 0,
+      error_count: 0,
+      nodes: [],
+      cancelled_at: new Date().toISOString(),
+    });
     pauseMutationMock.mockResolvedValue(undefined);
     resumeMutationMock.mockResolvedValue(undefined);
     useRunsMock.mockImplementation((filters?: Record<string, unknown>) => ({
@@ -516,10 +524,14 @@ describe("RunsPage", () => {
     await user.click(screen.getByRole("button", { name: "Cancel 2 runs" }));
 
     await waitFor(() => {
-      expect(cancelMutationMock).toHaveBeenCalledTimes(2);
+      expect(cancelTreeMutationMock).toHaveBeenCalledTimes(2);
     });
-    expect(cancelMutationMock).toHaveBeenCalledWith("exec-1");
-    expect(cancelMutationMock).toHaveBeenCalledWith("exec-2");
+    expect(cancelTreeMutationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ workflowId: "run-001-alpha" }),
+    );
+    expect(cancelTreeMutationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ workflowId: "run-002-beta" }),
+    );
     expect(showSuccessMock).toHaveBeenCalledWith(
       "2 runs cancelled",
       "All selected runs were cancelled successfully.",
@@ -615,10 +627,14 @@ describe("RunsPage", () => {
     await user.click(screen.getByRole("button", { name: "Cancel run" }));
 
     await waitFor(() => {
-      expect(cancelMutationMock).toHaveBeenCalledTimes(1);
+      expect(cancelTreeMutationMock).toHaveBeenCalledTimes(1);
     });
-    expect(cancelMutationMock).toHaveBeenCalledWith("exec-1");
-    expect(cancelMutationMock).not.toHaveBeenCalledWith("exec-3");
+    expect(cancelTreeMutationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ workflowId: "run-001-alpha" }),
+    );
+    expect(cancelTreeMutationMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ workflowId: "run-003-gamma" }),
+    );
     expect(showSuccessMock).toHaveBeenCalledWith("1 run cancelled", undefined);
   });
 
@@ -646,7 +662,15 @@ describe("RunsPage", () => {
     });
     pauseMutationMock.mockRejectedValueOnce(new Error("pause denied"));
     resumeMutationMock.mockResolvedValueOnce(undefined);
-    cancelMutationMock.mockResolvedValueOnce(undefined);
+    cancelTreeMutationMock.mockResolvedValueOnce({
+      run_id: "run-001-alpha",
+      total_nodes: 1,
+      cancelled_count: 1,
+      skipped_count: 0,
+      error_count: 0,
+      nodes: [],
+      cancelled_at: new Date().toISOString(),
+    });
 
     render(<RunsPage />);
 


### PR DESCRIPTION
## Summary
- Add `POST /workflows/:run_id/cancel-tree` that walks the run DAG and marks every non-terminal execution cancelled bottom-up. Reuses the existing per-execution cancel mechanics (status transition, sibling-table sync, event publishing) via a local helper to keep blast radius small.
- Relax UI guards in `RunDetailPage` and `RunLifecycleMenu` so the Cancel button shows whenever aggregate `workflow_status` is non-terminal — previously gated on the root execution's status, which hid Cancel for runs with a terminated root and zombied children (fan-out reasoners that finished before their dispatched siblings).
- Wire the run-detail header Cancel, the per-row kebab Cancel, and the bulk-cancel toolbar to the new `useCancelWorkflowTree` mutation. Pause/Resume are unchanged — they remain scoped to the root execution since that's the row the user controls.

## Why
A run with depth-0 root `status='succeeded'` but children still flagged `running` could not be cancelled — the Cancel button was hidden, and the per-execution cancel endpoint refused on terminal root. `cancel-tree` walks the whole run, so the user has an escape hatch even when the root has terminated.

## Changes
- **Backend** (`internal/handlers/execute_cancel_tree.go`):
  - `CancelWorkflowTreeHandler` loads all executions for the run via `QueryExecutionRecords`, computes depth from `parent_execution_id` chains, sorts deepest-first, and applies the per-execution cancel transition to each non-terminal execution.
  - Returns a per-node summary (`{cancelled_count, skipped_count, error_count, nodes: [...]}`) so the UI can render an accurate notification.
  - Mounted at `/api/v1/workflows/:workflowId/cancel-tree` and `/api/ui/v1/workflows/:workflowId/cancel-tree`.
- **Frontend**:
  - New `cancelWorkflowTree()` service method and `useCancelWorkflowTree()` mutation hook.
  - `RunDetailPage`: Cancel button gates on `!isTerminalStatus(dag.workflow_status)` instead of root status; calls cancel-tree and displays cancelled count in the success notification.
  - `RunLifecycleMenu`: same guard change for the per-row kebab.
  - `RunsPage`: per-row `handleCancelRun` and bulk cancel both switched to cancel-tree per run; bulk inclusion gate switched from `root_execution_status` to aggregate `r.status`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/handlers/...` (all pass)
- [x] `tsc --noEmit` (clean)
- [x] `vitest run` (124 files / 631 tests pass)
- [ ] Manual: open a zombied run on the deployed control-plane, confirm Cancel button appears and cancel-tree flips remaining non-terminal executions

## Backwards compatibility
Purely additive on the backend. Per-execution `POST /executions/:execution_id/cancel` is unchanged. Frontend Cancel surfaces all switch to cancel-tree, but the new endpoint subsumes the old behavior (a run with one non-terminal execution gets exactly that one cancelled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)