### PR TITLE
feat(workers): cancel-signal transport via HTTP callback

### DIFF
--- a/control-plane/internal/server/server.go
+++ b/control-plane/internal/server/server.go
@@ -457,7 +457,9 @@ func NewAgentFieldServer(cfg *config.Config) (*AgentFieldServer, error) {
 	triggerHandlers := handlers.NewTriggerHandlers(storageProvider, triggerDispatcher, sourceManager)
 	handlers.SetTriggerSourceManager(sourceManager)
 
-	cancelDispatcher := services.NewCancelDispatcher(storageProvider, services.CancelDispatcherConfig{})
+	cancelDispatcher := services.NewCancelDispatcher(storageProvider, services.CancelDispatcherConfig{
+		InternalToken: cfg.Features.DID.Authorization.InternalToken,
+	})
 
 	return &AgentFieldServer{
 		storage:                storageProvider,

--- a/control-plane/internal/server/server.go
+++ b/control-plane/internal/server/server.go
@@ -84,6 +84,10 @@ type AgentFieldServer struct {
 	triggerDispatcher *services.TriggerDispatcher
 	sourceManager     *services.SourceManager
 	triggerHandlers   *handlers.TriggerHandlers
+	// cancelDispatcher forwards execution-cancelled events to remote SDK
+	// workers so they can cooperatively short-circuit in-flight reasoner
+	// code (raise CancelledError / abort signals / cancel contexts).
+	cancelDispatcher *services.CancelDispatcher
 	// Agentic API
 	apiCatalog *apicatalog.Catalog
 	kb         *knowledgebase.KB
@@ -453,6 +457,8 @@ func NewAgentFieldServer(cfg *config.Config) (*AgentFieldServer, error) {
 	triggerHandlers := handlers.NewTriggerHandlers(storageProvider, triggerDispatcher, sourceManager)
 	handlers.SetTriggerSourceManager(sourceManager)
 
+	cancelDispatcher := services.NewCancelDispatcher(storageProvider, services.CancelDispatcherConfig{})
+
 	return &AgentFieldServer{
 		storage:                storageProvider,
 		cache:                  cacheProvider,
@@ -486,6 +492,7 @@ func NewAgentFieldServer(cfg *config.Config) (*AgentFieldServer, error) {
 		triggerDispatcher:      triggerDispatcher,
 		sourceManager:          sourceManager,
 		triggerHandlers:        triggerHandlers,
+		cancelDispatcher:       cancelDispatcher,
 		apiCatalog:             initAPICatalog(),
 		kb:                     initKnowledgeBase(),
 	}, nil
@@ -560,6 +567,13 @@ func (s *AgentFieldServer) Start() error {
 	if err := s.cleanupService.Start(ctx); err != nil {
 		logger.Logger.Error().Err(err).Msg("Failed to start execution cleanup service")
 		// Don't fail server startup if cleanup service fails to start
+	}
+
+	// Start cancel dispatcher: forwards bus ExecutionCancelledEvent to
+	// remote workers via HTTP callback. Best-effort; missing endpoint on
+	// older SDKs is treated as a no-op.
+	if s.cancelDispatcher != nil {
+		s.cancelDispatcher.Start(ctx)
 	}
 
 	// Start OpenTelemetry execution tracer in background
@@ -684,6 +698,11 @@ func (s *AgentFieldServer) Stop() error {
 		if err := s.cleanupService.Stop(); err != nil {
 			logger.Logger.Error().Err(err).Msg("Failed to stop execution cleanup service")
 		}
+	}
+
+	// Stop cancel dispatcher
+	if s.cancelDispatcher != nil {
+		s.cancelDispatcher.Stop()
 	}
 
 	if s.registryWatcherCancel != nil {

--- a/control-plane/internal/services/cancel_dispatcher.go
+++ b/control-plane/internal/services/cancel_dispatcher.go
@@ -38,10 +38,11 @@ import (
 // Missed deliveries fall back to the existing behaviour (in-flight work
 // finishes naturally and its output is discarded).
 type CancelDispatcher struct {
-	store      storage.StorageProvider
-	bus        *events.ExecutionEventBus
-	httpClient *http.Client
-	cancelPath string
+	store         storage.StorageProvider
+	bus           *events.ExecutionEventBus
+	httpClient    *http.Client
+	cancelPath    string
+	internalToken string
 
 	subscriberID string
 
@@ -66,6 +67,10 @@ type CancelDispatcherConfig struct {
 	// SubscriberID identifies this dispatcher's subscription on the bus.
 	// Defaults to "cancel-dispatcher".
 	SubscriberID string
+	// InternalToken is sent as Authorization: Bearer on the cancel
+	// callback so workers running with RequireOriginAuth=true accept it.
+	// Matches the existing reasoner-dispatch auth contract.
+	InternalToken string
 }
 
 // NewCancelDispatcher constructs a dispatcher with sensible defaults.
@@ -87,11 +92,12 @@ func NewCancelDispatcher(store storage.StorageProvider, cfg CancelDispatcherConf
 		subscriberID = "cancel-dispatcher"
 	}
 	return &CancelDispatcher{
-		store:        store,
-		bus:          bus,
-		httpClient:   httpClient,
-		cancelPath:   path,
-		subscriberID: subscriberID,
+		store:         store,
+		bus:           bus,
+		httpClient:    httpClient,
+		cancelPath:    path,
+		subscriberID:  subscriberID,
+		internalToken: cfg.InternalToken,
 	}
 }
 
@@ -203,6 +209,9 @@ func (d *CancelDispatcher) dispatch(ctx context.Context, ev events.ExecutionEven
 	req.Header.Set("X-Execution-ID", executionID)
 	req.Header.Set("X-Workflow-ID", ev.WorkflowID)
 	req.Header.Set("X-AgentField-Source", "cancel-dispatcher")
+	if d.internalToken != "" {
+		req.Header.Set("Authorization", "Bearer "+d.internalToken)
+	}
 
 	resp, err := d.httpClient.Do(req)
 	if err != nil {

--- a/control-plane/internal/services/cancel_dispatcher.go
+++ b/control-plane/internal/services/cancel_dispatcher.go
@@ -1,0 +1,230 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Agent-Field/agentfield/control-plane/internal/events"
+	"github.com/Agent-Field/agentfield/control-plane/internal/logger"
+	"github.com/Agent-Field/agentfield/control-plane/internal/storage"
+)
+
+// CancelDispatcher is the bridge between the in-process execution event bus
+// and remote SDK workers. The control plane already publishes
+// ExecutionCancelledEvent on the bus whenever an execution is cancelled
+// (per-execution cancel handler, cancel-tree, future sources). This service
+// subscribes to that bus and POSTs a per-execution cancel notification to
+// the worker that owns the execution, giving the worker's SDK a chance to
+// raise CancelledError / abort an AbortController / cancel a context into
+// the user's still-running reasoner code.
+//
+// Transport choice: HTTP callback to a well-known path on the worker
+// (BaseURL/_internal/executions/:exec_id/cancel). Workers already expose
+// HTTP servers that the control plane dispatches into; reusing that channel
+// avoids a second long-lived connection per worker. Older SDK versions
+// without the cancel endpoint will return 404 — that's a no-op and
+// backwards-compatible.
+//
+// Best-effort delivery: short timeout, no retries. The control plane
+// already records the cancelled status in storage; the SDK callback only
+// exists to give the user's in-flight code a chance to short-circuit.
+// Missed deliveries fall back to the existing behaviour (in-flight work
+// finishes naturally and its output is discarded).
+type CancelDispatcher struct {
+	store      storage.StorageProvider
+	bus        *events.ExecutionEventBus
+	httpClient *http.Client
+	cancelPath string
+
+	subscriberID string
+
+	stopMu sync.Mutex
+	stopCh chan struct{}
+	wg     sync.WaitGroup
+}
+
+// CancelDispatcherConfig configures a CancelDispatcher.
+type CancelDispatcherConfig struct {
+	// Bus is the execution event bus to subscribe to. If nil, defaults to
+	// events.GlobalExecutionEventBus.
+	Bus *events.ExecutionEventBus
+	// HTTPClient is the client used to call worker cancel endpoints.
+	// If nil, a sane default with a short timeout is used.
+	HTTPClient *http.Client
+	// CancelPathTemplate is the worker-side path the dispatcher will POST
+	// to. The literal substring ":execution_id" is replaced with the actual
+	// execution id at dispatch time. Defaults to
+	// "/_internal/executions/:execution_id/cancel".
+	CancelPathTemplate string
+	// SubscriberID identifies this dispatcher's subscription on the bus.
+	// Defaults to "cancel-dispatcher".
+	SubscriberID string
+}
+
+// NewCancelDispatcher constructs a dispatcher with sensible defaults.
+func NewCancelDispatcher(store storage.StorageProvider, cfg CancelDispatcherConfig) *CancelDispatcher {
+	bus := cfg.Bus
+	if bus == nil {
+		bus = events.GlobalExecutionEventBus
+	}
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 5 * time.Second}
+	}
+	path := cfg.CancelPathTemplate
+	if strings.TrimSpace(path) == "" {
+		path = "/_internal/executions/:execution_id/cancel"
+	}
+	subscriberID := cfg.SubscriberID
+	if strings.TrimSpace(subscriberID) == "" {
+		subscriberID = "cancel-dispatcher"
+	}
+	return &CancelDispatcher{
+		store:        store,
+		bus:          bus,
+		httpClient:   httpClient,
+		cancelPath:   path,
+		subscriberID: subscriberID,
+	}
+}
+
+// Start begins consuming the event bus. It returns immediately after
+// launching the consumer goroutine; Stop() must be called for clean
+// shutdown. Calling Start twice without an intervening Stop is a no-op.
+func (d *CancelDispatcher) Start(ctx context.Context) {
+	d.stopMu.Lock()
+	if d.stopCh != nil {
+		d.stopMu.Unlock()
+		return
+	}
+	stop := make(chan struct{})
+	d.stopCh = stop
+	d.stopMu.Unlock()
+
+	ch := d.bus.Subscribe(d.subscriberID)
+
+	d.wg.Add(1)
+	go func() {
+		defer d.wg.Done()
+		defer d.bus.Unsubscribe(d.subscriberID)
+
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ctx.Done():
+				return
+			case ev, ok := <-ch:
+				if !ok {
+					return
+				}
+				if ev.Type != events.ExecutionCancelledEvent {
+					continue
+				}
+				d.dispatch(ctx, ev)
+			}
+		}
+	}()
+}
+
+// Stop tears down the subscription and waits for the consumer goroutine
+// to exit. Safe to call multiple times.
+func (d *CancelDispatcher) Stop() {
+	d.stopMu.Lock()
+	stop := d.stopCh
+	d.stopCh = nil
+	d.stopMu.Unlock()
+	if stop == nil {
+		return
+	}
+	close(stop)
+	d.wg.Wait()
+}
+
+// dispatch fires the cancel callback for a single execution. All errors
+// here are best-effort: we log and continue. The control plane's record
+// of the cancelled status is the source of truth — a failed callback
+// means the worker just doesn't get a chance to short-circuit.
+func (d *CancelDispatcher) dispatch(ctx context.Context, ev events.ExecutionEvent) {
+	executionID := strings.TrimSpace(ev.ExecutionID)
+	if executionID == "" {
+		return
+	}
+	agentNodeID := strings.TrimSpace(ev.AgentNodeID)
+	if agentNodeID == "" {
+		logger.Logger.Debug().Str("execution_id", executionID).Msg("cancel-dispatcher: event missing agent_node_id, skipping")
+		return
+	}
+
+	agent, err := d.store.GetAgent(ctx, agentNodeID)
+	if err != nil {
+		logger.Logger.Warn().Err(err).Str("agent_node_id", agentNodeID).Str("execution_id", executionID).Msg("cancel-dispatcher: failed to look up agent")
+		return
+	}
+	if agent == nil {
+		logger.Logger.Debug().Str("agent_node_id", agentNodeID).Str("execution_id", executionID).Msg("cancel-dispatcher: agent not registered, skipping")
+		return
+	}
+	baseURL := strings.TrimRight(strings.TrimSpace(agent.BaseURL), "/")
+	if baseURL == "" {
+		logger.Logger.Debug().Str("agent_node_id", agentNodeID).Str("execution_id", executionID).Msg("cancel-dispatcher: agent has no base_url (likely serverless), skipping")
+		return
+	}
+
+	// reason is best-effort metadata pulled from the publisher's data map.
+	reason := ""
+	if m, ok := ev.Data.(map[string]interface{}); ok {
+		if r, ok := m["reason"].(string); ok {
+			reason = r
+		}
+	}
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"execution_id": executionID,
+		"workflow_id":  ev.WorkflowID,
+		"reason":       reason,
+		"emitted_at":   ev.Timestamp.UTC().Format(time.RFC3339Nano),
+	})
+
+	url := baseURL + strings.ReplaceAll(d.cancelPath, ":execution_id", executionID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		logger.Logger.Warn().Err(err).Str("url", url).Msg("cancel-dispatcher: build request failed")
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Execution-ID", executionID)
+	req.Header.Set("X-Workflow-ID", ev.WorkflowID)
+	req.Header.Set("X-AgentField-Source", "cancel-dispatcher")
+
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		// Don't escalate timeouts/connection refused — the worker may have
+		// already exited or be unreachable. Workers reachable next time
+		// will pick up future events.
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			logger.Logger.Debug().Str("url", url).Msg("cancel-dispatcher: callback timed out")
+		} else {
+			logger.Logger.Debug().Err(err).Str("url", url).Msg("cancel-dispatcher: callback failed (best-effort)")
+		}
+		return
+	}
+	defer resp.Body.Close()
+
+	switch {
+	case resp.StatusCode == http.StatusNotFound:
+		// Worker doesn't speak the cancel protocol yet (older SDK). No-op.
+	case resp.StatusCode >= 400:
+		logger.Logger.Debug().Int("status", resp.StatusCode).Str("url", url).Msg("cancel-dispatcher: worker rejected cancel callback")
+	default:
+		logger.Logger.Debug().Int("status", resp.StatusCode).Str("execution_id", executionID).Msg("cancel-dispatcher: cancel callback delivered")
+	}
+}

--- a/control-plane/internal/services/cancel_dispatcher_test.go
+++ b/control-plane/internal/services/cancel_dispatcher_test.go
@@ -1,0 +1,210 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Agent-Field/agentfield/control-plane/internal/events"
+	"github.com/Agent-Field/agentfield/control-plane/internal/storage"
+	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeAgentStore implements just enough of storage.StorageProvider to
+// satisfy CancelDispatcher's lookups. Anything else panics so accidental
+// extra dependencies surface in tests.
+type fakeAgentStore struct {
+	storage.StorageProvider
+
+	mu     sync.Mutex
+	agents map[string]*types.AgentNode
+}
+
+func newFakeAgentStore() *fakeAgentStore {
+	return &fakeAgentStore{agents: make(map[string]*types.AgentNode)}
+}
+
+func (s *fakeAgentStore) seed(id, baseURL string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.agents[id] = &types.AgentNode{ID: id, BaseURL: baseURL}
+}
+
+func (s *fakeAgentStore) GetAgent(ctx context.Context, id string) (*types.AgentNode, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	a, ok := s.agents[id]
+	if !ok {
+		return nil, nil
+	}
+	clone := *a
+	return &clone, nil
+}
+
+func TestCancelDispatcher_DeliversCallback(t *testing.T) {
+	bus := events.NewExecutionEventBus()
+
+	var (
+		calls       int32
+		gotPath     string
+		gotBody     map[string]any
+		gotHeaders  http.Header
+		callDoneCh  = make(chan struct{}, 1)
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		gotPath = r.URL.Path
+		gotHeaders = r.Header.Clone()
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.WriteHeader(http.StatusOK)
+		select {
+		case callDoneCh <- struct{}{}:
+		default:
+		}
+	}))
+	defer srv.Close()
+
+	store := newFakeAgentStore()
+	store.seed("agent-1", srv.URL)
+
+	d := NewCancelDispatcher(store, CancelDispatcherConfig{
+		Bus:        bus,
+		HTTPClient: &http.Client{Timeout: 2 * time.Second},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d.Start(ctx)
+	defer d.Stop()
+
+	// Give the goroutine a beat to subscribe before we publish — the bus
+	// drops events when no subscriber is registered. Polling for the
+	// subscriber count avoids a flaky time.Sleep.
+	require.Eventually(t, func() bool {
+		return bus.GetSubscriberCount() >= 1
+	}, time.Second, 5*time.Millisecond, "dispatcher did not subscribe")
+
+	bus.Publish(events.ExecutionEvent{
+		Type:        events.ExecutionCancelledEvent,
+		ExecutionID: "exec-42",
+		WorkflowID:  "wf-1",
+		AgentNodeID: "agent-1",
+		Status:      "cancelled",
+		Timestamp:   time.Now().UTC(),
+		Data:        map[string]interface{}{"reason": "user clicked cancel"},
+	})
+
+	select {
+	case <-callDoneCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not receive cancel callback")
+	}
+
+	require.EqualValues(t, 1, atomic.LoadInt32(&calls))
+	require.Equal(t, "/_internal/executions/exec-42/cancel", gotPath)
+	require.Equal(t, "exec-42", gotHeaders.Get("X-Execution-ID"))
+	require.Equal(t, "wf-1", gotHeaders.Get("X-Workflow-ID"))
+	require.Equal(t, "cancel-dispatcher", gotHeaders.Get("X-AgentField-Source"))
+	require.Equal(t, "exec-42", gotBody["execution_id"])
+	require.Equal(t, "user clicked cancel", gotBody["reason"])
+}
+
+func TestCancelDispatcher_IgnoresNonCancelEvents(t *testing.T) {
+	bus := events.NewExecutionEventBus()
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	store := newFakeAgentStore()
+	store.seed("agent-1", srv.URL)
+
+	d := NewCancelDispatcher(store, CancelDispatcherConfig{Bus: bus})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d.Start(ctx)
+	defer d.Stop()
+
+	require.Eventually(t, func() bool { return bus.GetSubscriberCount() >= 1 }, time.Second, 5*time.Millisecond)
+
+	bus.Publish(events.ExecutionEvent{
+		Type:        events.ExecutionCompleted,
+		ExecutionID: "exec-99",
+		AgentNodeID: "agent-1",
+		Timestamp:   time.Now().UTC(),
+	})
+
+	// Briefly wait — there's no positive signal because we expect no call.
+	// 100ms is plenty for the dispatcher to drop the event on the floor.
+	time.Sleep(100 * time.Millisecond)
+	require.Zero(t, atomic.LoadInt32(&calls), "non-cancel event should not trigger callback")
+}
+
+func TestCancelDispatcher_HandlesUnregisteredAgent(t *testing.T) {
+	bus := events.NewExecutionEventBus()
+	store := newFakeAgentStore()
+	// No agent seeded — lookup returns (nil, nil).
+
+	d := NewCancelDispatcher(store, CancelDispatcherConfig{Bus: bus})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d.Start(ctx)
+	defer d.Stop()
+
+	require.Eventually(t, func() bool { return bus.GetSubscriberCount() >= 1 }, time.Second, 5*time.Millisecond)
+
+	// Should not panic, should not block the dispatcher.
+	bus.Publish(events.ExecutionEvent{
+		Type:        events.ExecutionCancelledEvent,
+		ExecutionID: "exec-orphan",
+		AgentNodeID: "agent-missing",
+		Timestamp:   time.Now().UTC(),
+	})
+
+	// Followup event still gets through.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	store.seed("agent-1", srv.URL)
+
+	delivered := make(chan struct{}, 1)
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		delivered <- struct{}{}
+	})
+
+	bus.Publish(events.ExecutionEvent{
+		Type:        events.ExecutionCancelledEvent,
+		ExecutionID: "exec-43",
+		AgentNodeID: "agent-1",
+		Timestamp:   time.Now().UTC(),
+	})
+
+	select {
+	case <-delivered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("dispatcher stopped processing after orphan event")
+	}
+}
+
+func TestCancelDispatcher_StopIsIdempotent(t *testing.T) {
+	bus := events.NewExecutionEventBus()
+	d := NewCancelDispatcher(newFakeAgentStore(), CancelDispatcherConfig{Bus: bus})
+	d.Start(context.Background())
+	d.Stop()
+	d.Stop() // second call must be a no-op
+}

--- a/control-plane/internal/services/cancel_dispatcher_test.go
+++ b/control-plane/internal/services/cancel_dispatcher_test.go
@@ -201,6 +201,47 @@ func TestCancelDispatcher_HandlesUnregisteredAgent(t *testing.T) {
 	}
 }
 
+func TestCancelDispatcher_SendsAuthorizationHeader(t *testing.T) {
+	bus := events.NewExecutionEventBus()
+
+	gotAuth := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case gotAuth <- r.Header.Get("Authorization"):
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	store := newFakeAgentStore()
+	store.seed("agent-1", srv.URL)
+
+	d := NewCancelDispatcher(store, CancelDispatcherConfig{
+		Bus:           bus,
+		InternalToken: "secret-token-xyz",
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d.Start(ctx)
+	defer d.Stop()
+	require.Eventually(t, func() bool { return bus.GetSubscriberCount() >= 1 }, time.Second, 5*time.Millisecond)
+
+	bus.Publish(events.ExecutionEvent{
+		Type:        events.ExecutionCancelledEvent,
+		ExecutionID: "exec-1",
+		AgentNodeID: "agent-1",
+		Timestamp:   time.Now().UTC(),
+	})
+
+	select {
+	case auth := <-gotAuth:
+		require.Equal(t, "Bearer secret-token-xyz", auth)
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not receive cancel callback")
+	}
+}
+
 func TestCancelDispatcher_StopIsIdempotent(t *testing.T) {
 	bus := events.NewExecutionEventBus()
 	d := NewCancelDispatcher(newFakeAgentStore(), CancelDispatcherConfig{Bus: bus})


### PR DESCRIPTION
## Summary
Bridge between the in-process ExecutionEventBus (where the per-execution cancel handler and PR #536's cancel-tree handler already publish ExecutionCancelledEvent) and remote SDK workers, so cancellation can propagate into in-flight reasoner code rather than only updating storage state.

## Transport
- New service \`services.CancelDispatcher\` subscribes to \`events.GlobalExecutionEventBus\` on startup.
- On \`ExecutionCancelledEvent\`, looks up the agent by \`agent_node_id\`, resolves \`BaseURL\`, and POSTs:
  \`POST {BaseURL}/_internal/executions/:exec_id/cancel\`
  Body: \`{execution_id, workflow_id, reason, emitted_at}\`
  Headers: \`X-Execution-ID\`, \`X-Workflow-ID\`, \`X-AgentField-Source: cancel-dispatcher\`
- Reuses the existing dispatch HTTP channel — no second long-lived connection per worker, no auth changes (network trust matches the dispatch path).

## Behaviour
- **Best-effort:** 5s timeout, no retries. The control plane's storage record of \`cancelled\` is authoritative; the callback only exists so workers can short-circuit.
- **Backwards compatible:** workers running older SDKs without the cancel endpoint return 404, which is logged at debug and treated as a no-op.
- **Lifecycle:** Started in \`server.Start()\` after \`cleanupService\`, stopped from \`server.Stop()\`. Subscribes/unsubscribes cleanly on the bus.

## Why callback over SSE
Workers already expose HTTP servers that the control plane dispatches into. Reusing that channel is cheaper than maintaining a long-lived control-plane→worker SSE connection per registered agent. SSE would also need reconnection/resubscription logic on both sides; a one-shot POST is easier to reason about and easier to test.

## Test plan
- [x] \`go vet ./...\`
- [x] \`go test ./internal/services/ -run TestCancelDispatcher\` (4/4 pass)
- [x] \`go test ./internal/services/...\` (full suite green)
- [ ] Manual: deploy + verify cancel from UI triggers callback to a registered worker

## Follow-ups (separate PRs)
- PR 3 — Go SDK: register \`/_internal/executions/:id/cancel\` handler, derive per-execution \`context.Context\`, cancel on receipt
- PR 4 — Python SDK: same handler, wrap reasoner invocation in \`asyncio.Task\` and \`task.cancel()\` on receipt
- PR 5 — TypeScript SDK: same handler, per-execution \`AbortController\`, \`abort()\` on receipt

🤖 Generated with [Claude Code](https://claude.com/claude-code)