### PR TITLE
feat(sdk-go): cooperative cancel via /_internal/executions/:id/cancel

### DIFF
--- a/sdk/go/agent/agent.go
+++ b/sdk/go/agent/agent.go
@@ -498,6 +498,15 @@ type Agent struct {
 	leaseLoopOnce sync.Once
 
 	defaultCLIReasoner string
+
+	// cancelFuncs tracks the context.CancelFunc for every in-flight reasoner
+	// invocation, keyed by execution_id. The control plane's cancel
+	// dispatcher POSTs to /_internal/executions/:id/cancel and we look up
+	// the matching cancel func to short-circuit the reasoner's context.
+	// Reasoners are responsible for honoring ctx.Done() — most idiomatic
+	// Go code does this through net/http, database/sql, etc.
+	cancelMu    sync.Mutex
+	cancelFuncs map[string]context.CancelFunc
 }
 
 // New constructs an Agent.
@@ -550,6 +559,7 @@ func New(cfg Config) (*Agent, error) {
 		stopLease:                   make(chan struct{}),
 		logger:                      cfg.Logger,
 		realtimeValidationFunctions: make(map[string]struct{}),
+		cancelFuncs:                 make(map[string]context.CancelFunc),
 	}
 
 	// Initialize local verifier if enabled
@@ -785,6 +795,7 @@ func (a *Agent) handler() http.Handler {
 		mux.HandleFunc("/execute", a.handleExecute)
 		mux.HandleFunc("/execute/", a.handleExecute)
 		mux.HandleFunc("/reasoners/", a.handleReasoner)
+		mux.HandleFunc("/_internal/executions/", a.handleInternalCancel)
 
 		var handler http.Handler = mux
 
@@ -837,6 +848,13 @@ func (a *Agent) localVerificationMiddleware(next http.Handler) http.Handler {
 
 		// Only verify execution endpoints
 		if path == "/health" || path == "/discover" || path == "/agentfield/v1/logs" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		// /_internal/executions/.../cancel is a control-plane→worker
+		// notification, not a DID-signed user-initiated call. Bearer-token
+		// origin auth still applies via originAuthMiddleware.
+		if strings.HasPrefix(path, "/_internal/") {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -1038,7 +1056,9 @@ func (a *Agent) handleExecute(w http.ResponseWriter, r *http.Request) {
 	input := extractInputFromServerless(payload)
 	execCtx := a.buildExecutionContextFromServerless(r, payload, reasonerName)
 	a.fillDIDContext(&execCtx)
-	ctx := contextWithExecution(r.Context(), execCtx)
+	cancellableCtx, releaseCancel := a.registerCancellableExecution(r.Context(), execCtx.ExecutionID)
+	defer releaseCancel()
+	ctx := contextWithExecution(cancellableCtx, execCtx)
 
 	start := time.Now()
 	a.logExecutionInfo(ctx, "reasoner.invoke.start", "starting reasoner execution", map[string]any{
@@ -1214,11 +1234,14 @@ func (a *Agent) handleReasoner(w http.ResponseWriter, r *http.Request) {
 	}
 	a.fillDIDContext(&execCtx)
 
-	ctx := contextWithExecution(r.Context(), execCtx)
-
 	// In serverless mode we want a synchronous execution so the control plane can return
 	// the result immediately; skip the async path even if an execution ID is present.
 	if a.cfg.DeploymentType != "serverless" && execCtx.ExecutionID != "" && strings.TrimSpace(a.cfg.AgentFieldURL) != "" {
+		// Async dispatch — handleReasoner returns 202 immediately, the
+		// goroutine owns the lifetime. executeReasonerAsync registers its
+		// own cancellation hook against execution_id, so the cancel
+		// dispatcher can still reach this run.
+		ctx := contextWithExecution(r.Context(), execCtx)
 		a.logExecutionInfo(ctx, "reasoner.invoke.accepted", "accepted asynchronous execution request", map[string]any{
 			"reasoner_id": name,
 			"mode":        "async",
@@ -1232,6 +1255,15 @@ func (a *Agent) handleReasoner(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+
+	// Sync path — wrap r.Context() with a cancel hook keyed on
+	// execution_id so the control-plane cancel-dispatcher (POST
+	// /_internal/executions/:id/cancel) can short-circuit reasoner code
+	// that honors ctx.Done().
+	cancellableCtx, releaseCancel := a.registerCancellableExecution(r.Context(), execCtx.ExecutionID)
+	defer releaseCancel()
+
+	ctx := contextWithExecution(cancellableCtx, execCtx)
 
 	start := time.Now()
 	a.logExecutionInfo(ctx, "reasoner.invoke.start", "starting reasoner execution", map[string]any{
@@ -1282,7 +1314,12 @@ func (a *Agent) handleReasoner(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *Agent) executeReasonerAsync(reasoner *Reasoner, input map[string]any, execCtx ExecutionContext) {
-	ctx := contextWithExecution(context.Background(), execCtx)
+	// Register a cancel hook keyed on execution_id so a control-plane
+	// cancel reaches the still-running reasoner. release fires both on
+	// natural completion (deferred) and on cancel (via ctx.Done()).
+	cancellableCtx, release := a.registerCancellableExecution(context.Background(), execCtx.ExecutionID)
+	defer release()
+	ctx := contextWithExecution(cancellableCtx, execCtx)
 	start := time.Now()
 	a.logExecutionInfo(ctx, "reasoner.invoke.start", "starting asynchronous reasoner execution", map[string]any{
 		"reasoner_id": reasoner.Name,

--- a/sdk/go/agent/cancel.go
+++ b/sdk/go/agent/cancel.go
@@ -1,0 +1,107 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// registerCancellableExecution wraps `parent` with a child context that the
+// SDK can cancel out-of-band when the control plane's cancel dispatcher
+// fires. Returns the wrapped context and a release function that MUST be
+// deferred — release deregisters the execution and cancels the inner
+// context (no-op if cancel already fired). Empty executionID means
+// "untracked", in which case nothing is registered and the context is just
+// a cancellable wrapper of the parent.
+func (a *Agent) registerCancellableExecution(parent context.Context, executionID string) (context.Context, func()) {
+	ctx, cancel := context.WithCancel(parent)
+	executionID = strings.TrimSpace(executionID)
+	if executionID != "" {
+		a.cancelMu.Lock()
+		a.cancelFuncs[executionID] = cancel
+		a.cancelMu.Unlock()
+	}
+	released := false
+	release := func() {
+		if released {
+			return
+		}
+		released = true
+		if executionID != "" {
+			a.cancelMu.Lock()
+			// Only delete our entry — a racing cancel that already
+			// removed it shouldn't get a stale registration overwritten.
+			if existing, ok := a.cancelFuncs[executionID]; ok {
+				_ = existing
+				delete(a.cancelFuncs, executionID)
+			}
+			a.cancelMu.Unlock()
+		}
+		cancel()
+	}
+	return ctx, release
+}
+
+// CancelExecution cancels an in-flight reasoner invocation by execution_id
+// from inside the SDK. Mostly useful for tests and tools that drive the
+// SDK directly; the production trigger is the HTTP cancel endpoint.
+// Returns true if a matching execution was found and cancelled.
+func (a *Agent) CancelExecution(executionID string) bool {
+	executionID = strings.TrimSpace(executionID)
+	if executionID == "" {
+		return false
+	}
+	a.cancelMu.Lock()
+	cancel, ok := a.cancelFuncs[executionID]
+	if ok {
+		delete(a.cancelFuncs, executionID)
+	}
+	a.cancelMu.Unlock()
+	if !ok {
+		return false
+	}
+	cancel()
+	return true
+}
+
+// handleInternalCancel is the worker side of the cancel-signal transport
+// shipped by the control plane. The dispatcher POSTs:
+//
+//	POST /_internal/executions/:execution_id/cancel
+//
+// We look up the matching cancel func and fire it. Reasoner code that
+// honors ctx.Done() (idiomatic Go: net/http, database/sql, the official
+// Anthropic SDK, etc.) will short-circuit. Reasoner code that doesn't
+// honor cancellation finishes naturally and its output is discarded by
+// the control plane (existing behaviour).
+func (a *Agent) handleInternalCancel(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	// Path shape: /_internal/executions/{id}/cancel
+	rest := strings.TrimPrefix(r.URL.Path, "/_internal/executions/")
+	id := strings.TrimSuffix(rest, "/cancel")
+	id = strings.TrimSpace(id)
+	if id == "" || strings.Contains(id, "/") {
+		http.NotFound(w, r)
+		return
+	}
+
+	cancelled := a.CancelExecution(id)
+	status := http.StatusOK
+	body := map[string]any{
+		"cancelled":    cancelled,
+		"execution_id": id,
+	}
+	if !cancelled {
+		// Not active locally — could be already finished, or never
+		// dispatched here. 200 with the marker keeps the dispatcher's
+		// best-effort logic happy and avoids spurious warning logs.
+		body["reason"] = "execution_not_active"
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/sdk/go/agent/cancel_test.go
+++ b/sdk/go/agent/cancel_test.go
@@ -1,0 +1,235 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// newCancelAgent constructs a minimal Agent suitable for unit-testing the
+// cancel surface. Avoids the full New(cfg) bootstrap which drags in
+// memory backends, AI clients, and DID subsystems we don't need here.
+func newCancelAgent() *Agent {
+	return &Agent{
+		cancelFuncs: make(map[string]context.CancelFunc),
+	}
+}
+
+func TestCancelExecution_TriggersContextDone(t *testing.T) {
+	a := newCancelAgent()
+
+	ctx, release := a.registerCancellableExecution(context.Background(), "exec-1")
+	defer release()
+
+	if a.CancelExecution("exec-1") != true {
+		t.Fatal("CancelExecution returned false for active execution")
+	}
+
+	select {
+	case <-ctx.Done():
+		// expected — ctx cancelled
+	case <-time.After(time.Second):
+		t.Fatal("ctx was not cancelled")
+	}
+	if !errors.Is(ctx.Err(), context.Canceled) {
+		t.Fatalf("ctx.Err() = %v, want context.Canceled", ctx.Err())
+	}
+}
+
+func TestCancelExecution_UnknownIDReturnsFalse(t *testing.T) {
+	a := newCancelAgent()
+	if a.CancelExecution("never-registered") {
+		t.Fatal("CancelExecution returned true for unknown id")
+	}
+	if a.CancelExecution("") {
+		t.Fatal("CancelExecution returned true for empty id")
+	}
+}
+
+func TestRegisterCancellableExecution_ReleaseDeregisters(t *testing.T) {
+	a := newCancelAgent()
+	_, release := a.registerCancellableExecution(context.Background(), "exec-2")
+	release()
+
+	a.cancelMu.Lock()
+	_, present := a.cancelFuncs["exec-2"]
+	a.cancelMu.Unlock()
+	if present {
+		t.Fatal("release did not deregister cancel func")
+	}
+	if a.CancelExecution("exec-2") {
+		t.Fatal("CancelExecution returned true after release")
+	}
+}
+
+func TestRegisterCancellableExecution_EmptyExecutionIDIsUntracked(t *testing.T) {
+	a := newCancelAgent()
+	ctx, release := a.registerCancellableExecution(context.Background(), "")
+	defer release()
+	a.cancelMu.Lock()
+	registered := len(a.cancelFuncs)
+	a.cancelMu.Unlock()
+	if registered != 0 {
+		t.Fatalf("expected 0 registrations for empty id, got %d", registered)
+	}
+	// ctx is still cancellable via release.
+	release()
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("untracked ctx was not cancelled by release")
+	}
+}
+
+func TestHandleInternalCancel_CancelsActiveExecution(t *testing.T) {
+	a := newCancelAgent()
+	ctx, release := a.registerCancellableExecution(context.Background(), "exec-active")
+	defer release()
+
+	req := httptest.NewRequest(http.MethodPost, "/_internal/executions/exec-active/cancel", nil)
+	rr := httptest.NewRecorder()
+	a.handleInternalCancel(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := decodeJSON(t, rr.Body)
+	if body["cancelled"] != true {
+		t.Fatalf("body cancelled = %v, want true", body["cancelled"])
+	}
+	if body["execution_id"] != "exec-active" {
+		t.Fatalf("body execution_id = %v, want exec-active", body["execution_id"])
+	}
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("ctx not cancelled after HTTP cancel")
+	}
+}
+
+func TestHandleInternalCancel_UnknownExecutionReturns200WithReason(t *testing.T) {
+	a := newCancelAgent()
+	req := httptest.NewRequest(http.MethodPost, "/_internal/executions/exec-missing/cancel", nil)
+	rr := httptest.NewRecorder()
+	a.handleInternalCancel(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := decodeJSON(t, rr.Body)
+	if body["cancelled"] != false {
+		t.Fatalf("body cancelled = %v, want false", body["cancelled"])
+	}
+	if body["reason"] != "execution_not_active" {
+		t.Fatalf("body reason = %v, want execution_not_active", body["reason"])
+	}
+}
+
+func TestHandleInternalCancel_RejectsGet(t *testing.T) {
+	a := newCancelAgent()
+	req := httptest.NewRequest(http.MethodGet, "/_internal/executions/exec-1/cancel", nil)
+	rr := httptest.NewRecorder()
+	a.handleInternalCancel(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rr.Code)
+	}
+}
+
+func TestHandleInternalCancel_RejectsMalformedPath(t *testing.T) {
+	a := newCancelAgent()
+	cases := []string{
+		"/_internal/executions//cancel",
+		"/_internal/executions/has/slash/cancel",
+	}
+	for _, p := range cases {
+		req := httptest.NewRequest(http.MethodPost, p, nil)
+		rr := httptest.NewRecorder()
+		a.handleInternalCancel(rr, req)
+		if rr.Code != http.StatusNotFound {
+			t.Fatalf("path %q: status = %d, want 404", p, rr.Code)
+		}
+	}
+}
+
+// End-to-end: long-running reasoner gets cancelled via the HTTP endpoint.
+// Verifies the actual contract — the reasoner's ctx.Done() fires and the
+// handler returns the cancellation error path.
+func TestEndToEnd_HTTPCancelStopsLongRunningReasoner(t *testing.T) {
+	a := newCancelAgent()
+
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	a.cfg.Logger = nil
+
+	go func() {
+		ctx, release := a.registerCancellableExecution(context.Background(), "exec-long")
+		defer release()
+		close(started)
+		select {
+		case <-ctx.Done():
+			done <- ctx.Err()
+		case <-time.After(5 * time.Second):
+			done <- errors.New("reasoner finished without cancel — context never fired")
+		}
+	}()
+
+	<-started
+
+	req := httptest.NewRequest(http.MethodPost, "/_internal/executions/exec-long/cancel", nil)
+	rr := httptest.NewRecorder()
+	a.handleInternalCancel(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("cancel HTTP status = %d, want 200", rr.Code)
+	}
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("reasoner exited with %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("reasoner did not exit after cancel")
+	}
+}
+
+// Concurrent cancel/release: must not panic, must always end with the
+// registry empty.
+func TestRegisterCancellableExecution_ConcurrentReleaseAndCancel(t *testing.T) {
+	a := newCancelAgent()
+	const n = 50
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		id := strings.Repeat("a", i+1)
+		_, release := a.registerCancellableExecution(context.Background(), id)
+		wg.Add(2)
+		go func() { defer wg.Done(); release() }()
+		go func() { defer wg.Done(); a.CancelExecution(id) }()
+	}
+	wg.Wait()
+
+	a.cancelMu.Lock()
+	leftover := len(a.cancelFuncs)
+	a.cancelMu.Unlock()
+	if leftover != 0 {
+		t.Fatalf("leftover cancel registrations = %d, want 0", leftover)
+	}
+}
+
+func decodeJSON(t *testing.T, r io.Reader) map[string]any {
+	t.Helper()
+	var out map[string]any
+	if err := json.NewDecoder(r).Decode(&out); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
Add cooperative cancellation to the Go SDK. Workers now register a per-execution \`context.CancelFunc\` on incoming reasoner invocations and expose a \`POST /_internal/executions/:id/cancel\` endpoint that the control plane's cancel dispatcher (#538) calls into. Cancelling fires the matching context, which propagates into idiomatic Go code (\`net/http\`, \`database/sql\`, the Anthropic SDK, etc.) and short-circuits in-flight reasoner work.

Depends on #538 (cancel-signal transport). Functions correctly without it — the endpoint is just dormant.

## Changes
- \`agent/cancel.go\` — new \`registerCancellableExecution\`, \`CancelExecution\`, and \`handleInternalCancel\`.
- \`Agent\` struct — \`cancelMu\` + \`cancelFuncs map[string]context.CancelFunc\`.
- \`agent.go\`:
  - \`mux.HandleFunc(\"/_internal/executions/\", a.handleInternalCancel)\`
  - \`localVerificationMiddleware\` exempts \`/_internal/\` (DID verification doesn't apply to control-plane→worker notifications); \`originAuthMiddleware\` Bearer-token check still applies.
  - \`handleReasoner\` (sync), \`executeReasonerAsync\` (async), and \`handleExecute\` all wrap their context with the cancellation hook before invoking the user handler.
- \`agent/cancel_test.go\` — 10 tests: registry behaviour (register/release/empty-id/concurrent), HTTP handler (active/unknown/method/malformed-path), and an end-to-end test where a long-running reasoner exits cleanly via the cancel endpoint.

## Backwards compatibility
Purely additive. Reasoners that don't honor \`ctx.Done()\` continue to run to completion; their output is discarded by the control plane (existing per-execution cancel behaviour). Workers running without the cancel-dispatcher in front of them simply never see the cancel callback.

## Test plan
- [x] \`go build ./...\` from \`sdk/go/\`
- [x] \`go vet ./...\`
- [x] \`go test ./agent/ -run \"Cancel|HandleInternal|RegisterCancellable|EndToEnd_HTTPCancel\"\` (10/10 pass)
- [x] \`go test ./... -count=1\` (full SDK suite green)
- [ ] Manual: register a Go-SDK agent on the deployed control-plane, trigger a long-running reasoner, hit Cancel, observe the worker context fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)