### PR TITLE
feat(sdk-python): cooperative cancel via /_internal/executions/:id/cancel

### DIFF
--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -653,6 +653,21 @@ class Agent(FastAPI):
         # prevent GC of fire-and-forget async execution tasks
         self._background_tasks: set[asyncio.Task] = set()
 
+        # Cooperative cancel registry. The control plane's cancel dispatcher
+        # POSTs /_internal/executions/{id}/cancel to signal that the user's
+        # reasoner code should stop. We track the active asyncio.Task per
+        # execution_id so the cancel handler can call task.cancel() — that
+        # raises CancelledError into the user's coroutine, which any
+        # well-behaved async I/O (httpx, anthropic, openai) honors.
+        self._cancel_tasks: Dict[str, asyncio.Task] = {}
+        self._cancel_lock = asyncio.Lock()
+
+        # Install the /_internal/executions/{execution_id}/cancel route
+        # before any user-defined reasoners are registered so the path is
+        # always available for the control-plane callback.
+        from .cancel import install_cancel_route
+        install_cancel_route(self)
+
         # Initialize async execution manager (will be lazily created when needed)
         self._async_execution_manager: Optional[AsyncExecutionManager] = None
 
@@ -1841,6 +1856,12 @@ class Agent(FastAPI):
                     # prevent GC of fire-and-forget tasks
                     self._background_tasks.add(task)
                     task.add_done_callback(self._background_tasks.discard)
+                    # Register so the cancel callback can short-circuit
+                    # the still-running reasoner. The async path's
+                    # execute_async_with_callback handles its own
+                    # cancellation accounting on top of this.
+                    from .cancel import register_execution_task
+                    await register_execution_task(self, execution_id_header, task)
                     return JSONResponse(
                         status_code=202,
                         content={
@@ -1848,6 +1869,32 @@ class Agent(FastAPI):
                             "execution_id": execution_id_header,
                         },
                     )
+
+                # Sync path: wrap the coroutine in a Task so the cancel
+                # callback can call task.cancel() and have CancelledError
+                # propagate into the reasoner. Without this wrapping the
+                # await happens inside the FastAPI request handler frame
+                # directly and there's no Task handle to cancel.
+                if execution_id_header:
+                    from .cancel import (
+                        register_execution_task,
+                        deregister_execution,
+                    )
+                    sync_task = asyncio.create_task(run_reasoner())
+                    await register_execution_task(self, execution_id_header, sync_task)
+                    try:
+                        return await sync_task
+                    except asyncio.CancelledError:
+                        return JSONResponse(
+                            status_code=499,
+                            content={
+                                "status": "cancelled",
+                                "execution_id": execution_id_header,
+                                "reason": "cancelled_by_control_plane",
+                            },
+                        )
+                    finally:
+                        await deregister_execution(self, execution_id_header)
 
                 return await run_reasoner()
 
@@ -2300,6 +2347,20 @@ class Agent(FastAPI):
                 "reasoner": reasoner_name,
             }
             log_error(f"Execution {execution_id} timed out after {reasoner_timeout}s")
+        except asyncio.CancelledError:
+            # Cooperative cancel hit while the reasoner was awaiting.
+            # Report cancelled status so the control-plane sees a clean
+            # terminal transition rather than a generic failure.
+            payload = {
+                "status": "cancelled",
+                "error": "cancelled_by_control_plane",
+                "error_details": {"reason": "cancelled"},
+                "duration_ms": int((time.time() - start_time) * 1000),
+                "completed_at": datetime.now(timezone.utc).isoformat(),
+                "execution_id": execution_id,
+                "reasoner": reasoner_name,
+            }
+            log_info(f"Execution {execution_id} cancelled cooperatively")
         except Exception as exc:
             error_details = getattr(exc, "error_details", None)
             payload = {
@@ -2312,6 +2373,10 @@ class Agent(FastAPI):
                 "reasoner": reasoner_name,
             }
             log_error(f"Execution {execution_id} failed asynchronously: {exc}")
+        finally:
+            # Deregister the cancel hook regardless of outcome.
+            from .cancel import deregister_execution
+            await deregister_execution(self, execution_id)
         await self._post_execution_status(callback_url, payload, execution_id)
 
     async def _post_execution_status(

--- a/sdk/python/agentfield/cancel.py
+++ b/sdk/python/agentfield/cancel.py
@@ -1,0 +1,128 @@
+"""Cooperative cancellation glue between the control plane and reasoner code.
+
+The control plane's CancelDispatcher (Go service in
+control-plane/internal/services/cancel_dispatcher.go) POSTs to
+``/_internal/executions/{execution_id}/cancel`` whenever an execution
+flips to cancelled — from per-execution cancel, the bottom-up cancel-tree
+endpoint, or any future source publishing on the bus. This module wires
+that callback into the running asyncio.Task for the matching execution
+so ``CancelledError`` propagates into the user's reasoner coroutine.
+
+The contract for reasoner authors:
+- ``await``-based I/O (httpx, the official anthropic / openai SDKs,
+  database drivers like asyncpg) honors task cancellation natively. No
+  changes required.
+- Long synchronous CPU loops or ``time.sleep`` won't see the cancellation
+  until the next ``await`` checkpoint. For those, periodically check
+  ``execution_cancelled()`` (or the ``cancel_event`` on the execution
+  context) and bail.
+- ``except Exception`` around the entire reasoner body will swallow
+  ``CancelledError`` (which is a ``BaseException`` in 3.8+). Re-raise it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from fastapi import HTTPException, Request
+from fastapi.responses import JSONResponse
+
+if TYPE_CHECKING:
+    from .agent import Agent
+
+logger = logging.getLogger("agentfield.cancel")
+
+
+async def register_execution_task(
+    agent: "Agent", execution_id: str, task: asyncio.Task
+) -> None:
+    """Register an in-flight asyncio.Task against an execution_id.
+
+    Called from the FastAPI endpoint after the reasoner task is created
+    and before awaiting it. Idempotent: re-registering the same id replaces
+    the prior entry, which is the right behaviour for retried executions.
+    """
+    if not execution_id:
+        return
+    async with agent._cancel_lock:
+        agent._cancel_tasks[execution_id] = task
+
+
+async def deregister_execution(agent: "Agent", execution_id: str) -> None:
+    """Drop the registry entry for `execution_id`.
+
+    Safe to call multiple times. Always called from a `finally` after
+    the reasoner task completes (success, failure, or cancellation).
+    """
+    if not execution_id:
+        return
+    async with agent._cancel_lock:
+        agent._cancel_tasks.pop(execution_id, None)
+
+
+async def cancel_execution(agent: "Agent", execution_id: str) -> bool:
+    """Cancel the asyncio.Task registered for `execution_id`.
+
+    Returns True if a matching task was found and ``cancel()``-ed, False
+    if there was no active execution with that id (already finished, or
+    never dispatched here).
+    """
+    if not execution_id:
+        return False
+    async with agent._cancel_lock:
+        task = agent._cancel_tasks.get(execution_id)
+    if task is None or task.done():
+        return False
+    task.cancel()
+    return True
+
+
+def install_cancel_route(agent: "Agent") -> None:
+    """Register the ``POST /_internal/executions/{execution_id}/cancel``
+    handler on the agent's FastAPI app.
+
+    The route bypasses DID verification by way of its path prefix
+    (control-plane→worker notification, not a user-initiated DID-signed
+    call). Bearer-token origin auth, if configured on the agent, still
+    applies through the usual middleware path.
+    """
+
+    @agent.post("/_internal/executions/{execution_id}/cancel")
+    async def _cancel_execution(execution_id: str, request: Request):
+        # Path-level guards: HTTPException for shape errors so FastAPI
+        # produces the right JSON shape automatically.
+        if not execution_id or "/" in execution_id:
+            raise HTTPException(status_code=404, detail="invalid execution_id")
+
+        cancelled = await cancel_execution(agent, execution_id)
+        body = {"cancelled": cancelled, "execution_id": execution_id}
+        if not cancelled:
+            # 200 with the marker — don't generate an alarm log on the
+            # dispatcher side. The execution may have already finished
+            # naturally, or never landed on this worker.
+            body["reason"] = "execution_not_active"
+        else:
+            logger.info(
+                "cancel-callback fired for execution_id=%s (source=%s)",
+                execution_id,
+                request.headers.get("X-AgentField-Source", "unknown"),
+            )
+        return JSONResponse(status_code=200, content=body)
+
+
+def is_execution_cancelled(agent: "Agent", execution_id: Optional[str]) -> bool:
+    """Synchronous helper for reasoner code to poll cancellation status.
+
+    Useful inside CPU loops or sync blocks where ``CancelledError`` won't
+    fire until the next ``await``. Returns False if there's no live
+    registration (either never registered, or already cancelled and
+    cleaned up).
+    """
+    if not execution_id:
+        return False
+    task = agent._cancel_tasks.get(execution_id)
+    if task is None:
+        return False
+    return task.cancelled() or (task.done() and task.cancelling() > 0)

--- a/sdk/python/tests/test_cancel.py
+++ b/sdk/python/tests/test_cancel.py
@@ -1,0 +1,229 @@
+"""Tests for the cooperative-cancel transport on the Python SDK.
+
+The full Agent class drags in FastAPI middleware, AI clients, memory
+backends, and the registration loop — so we use a lightweight stand-in
+for unit-testing the cancel module in isolation. The contract tested is:
+
+  * register_execution_task / deregister_execution / cancel_execution
+    behave correctly under concurrency.
+  * cancel_execution raises CancelledError into the registered task.
+  * The HTTP route returns 200 with `cancelled: True/False` per state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agentfield.cancel import (
+    cancel_execution,
+    deregister_execution,
+    install_cancel_route,
+    is_execution_cancelled,
+    register_execution_task,
+)
+
+
+class _FakeAgent(FastAPI):
+    """Stand-in for Agent that satisfies the cancel module's contract.
+
+    The cancel module only touches three attributes (`_cancel_tasks`,
+    `_cancel_lock`) and the FastAPI `.post(...)` decorator. Subclassing
+    FastAPI gives us the route-registration plumbing for free.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._cancel_tasks: dict[str, asyncio.Task] = {}
+        self._cancel_lock = asyncio.Lock()
+
+
+@pytest.mark.asyncio
+async def test_cancel_execution_raises_into_task():
+    agent = _FakeAgent()
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def long_running() -> None:
+        started.set()
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    task = asyncio.create_task(long_running())
+    await register_execution_task(agent, "exec-1", task)
+    await started.wait()
+
+    assert await cancel_execution(agent, "exec-1") is True
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_cancel_execution_unknown_id_returns_false():
+    agent = _FakeAgent()
+    assert await cancel_execution(agent, "missing") is False
+    assert await cancel_execution(agent, "") is False
+
+
+@pytest.mark.asyncio
+async def test_deregister_execution_removes_entry():
+    agent = _FakeAgent()
+    task = asyncio.create_task(asyncio.sleep(0.01))
+    await register_execution_task(agent, "exec-2", task)
+    await deregister_execution(agent, "exec-2")
+    assert "exec-2" not in agent._cancel_tasks
+    assert await cancel_execution(agent, "exec-2") is False
+    await task  # let the sleep complete cleanly
+
+
+@pytest.mark.asyncio
+async def test_register_replaces_existing_id():
+    agent = _FakeAgent()
+    first = asyncio.create_task(asyncio.sleep(10))
+    second = asyncio.create_task(asyncio.sleep(10))
+    await register_execution_task(agent, "exec-3", first)
+    await register_execution_task(agent, "exec-3", second)
+    assert agent._cancel_tasks["exec-3"] is second
+
+    # Cancelling cleans up the second task; the first is still running.
+    assert await cancel_execution(agent, "exec-3") is True
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+    with pytest.raises(asyncio.CancelledError):
+        await second
+
+
+@pytest.mark.asyncio
+async def test_concurrent_register_and_cancel_settles_clean():
+    agent = _FakeAgent()
+    n = 20
+    tasks = [asyncio.create_task(asyncio.sleep(10)) for _ in range(n)]
+    register_jobs = [
+        register_execution_task(agent, f"exec-{i}", tasks[i]) for i in range(n)
+    ]
+    await asyncio.gather(*register_jobs)
+
+    cancel_jobs = [cancel_execution(agent, f"exec-{i}") for i in range(n)]
+    results = await asyncio.gather(*cancel_jobs)
+    assert all(results)
+
+    for task in tasks:
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+def test_cancel_route_returns_200_for_unknown_execution():
+    agent = _FakeAgent()
+    install_cancel_route(agent)
+    client = TestClient(agent)
+    resp = client.post("/_internal/executions/exec-missing/cancel")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {
+        "cancelled": False,
+        "execution_id": "exec-missing",
+        "reason": "execution_not_active",
+    }
+
+
+@pytest.mark.asyncio
+async def test_cancel_route_emits_info_log_on_active_cancel(caplog):
+    """The route logs a structured info line when it actually cancelled
+    something. We register the task and call the route handler directly
+    rather than via TestClient because TestClient creates a fresh event
+    loop per request, so a task registered in one request isn't visible
+    from the next.
+    """
+    agent = _FakeAgent()
+    install_cancel_route(agent)
+
+    async def long() -> None:
+        await asyncio.sleep(10)
+
+    task = asyncio.create_task(long())
+    await register_execution_task(agent, "exec-active", task)
+
+    # Find the route handler we just installed.
+    handler = None
+    for route in agent.router.routes:
+        if (
+            getattr(route, "path", "")
+            == "/_internal/executions/{execution_id}/cancel"
+        ):
+            handler = route.endpoint
+            break
+    assert handler is not None, "cancel route was not installed"
+
+    # Build a minimal request stand-in. The handler only reads one header.
+    class _Headers:
+        def __init__(self, h):
+            self._h = h
+
+        def get(self, name, default=None):
+            return self._h.get(name, default)
+
+    class _Request:
+        def __init__(self, headers):
+            self.headers = _Headers(headers)
+
+    with caplog.at_level(logging.INFO, logger="agentfield.cancel"):
+        resp = await handler(
+            execution_id="exec-active",
+            request=_Request({"X-AgentField-Source": "cancel-dispatcher"}),
+        )
+
+    # FastAPI JSONResponse — body is bytes, status is on the object.
+    import json as _json
+
+    assert resp.status_code == 200
+    body = _json.loads(resp.body.decode())
+    assert body == {"cancelled": True, "execution_id": "exec-active"}
+    assert any("cancel-callback fired" in rec.message for rec in caplog.records)
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+def test_cancel_route_rejects_path_with_slash():
+    agent = _FakeAgent()
+    install_cancel_route(agent)
+    client = TestClient(agent)
+    # FastAPI treats this as a missing route (path doesn't match the
+    # parameterized handler), so 404 from the framework rather than from
+    # our explicit guard. Either way the user-visible behaviour is "no
+    # match".
+    resp = client.post("/_internal/executions/has/extra/cancel")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_is_execution_cancelled_helper():
+    agent = _FakeAgent()
+    assert is_execution_cancelled(agent, None) is False
+    assert is_execution_cancelled(agent, "missing") is False
+
+    async def loop():
+        try:
+            while True:
+                await asyncio.sleep(0.01)
+        except asyncio.CancelledError:
+            raise
+
+    task = asyncio.create_task(loop())
+    await register_execution_task(agent, "exec-poll", task)
+    assert is_execution_cancelled(agent, "exec-poll") is False
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    # After natural cancellation the helper reflects it.
+    assert is_execution_cancelled(agent, "exec-poll") is True


### PR DESCRIPTION
## Summary
Add cooperative cancellation to the Python SDK. Workers now register an \`asyncio.Task\` per in-flight reasoner invocation and expose \`POST /_internal/executions/:id/cancel\`. The control plane's cancel dispatcher (#538) calls into the route, which calls \`task.cancel()\` — raising \`asyncio.CancelledError\` into the reasoner coroutine. Async I/O libs (httpx, the official anthropic and openai SDKs, asyncpg, etc.) honor task cancellation natively, so most reasoners get cooperative cancellation without source changes.

Depends on #538 (cancel-signal transport). Functions correctly without it — the route is just dormant.

## Changes
- \`agentfield/cancel.py\` — new module:
  - \`register_execution_task\` / \`deregister_execution\` / \`cancel_execution\`
  - \`install_cancel_route(agent)\` — registers the FastAPI POST route
  - \`is_execution_cancelled(agent, execution_id)\` — sync helper for CPU-loop polling
- \`Agent.__init__\`:
  - \`self._cancel_tasks: Dict[str, asyncio.Task]\` and \`self._cancel_lock\`
  - Calls \`install_cancel_route(self)\` so the path is always available
- \`Agent\` reasoner endpoint (sync path): wraps \`run_reasoner()\` in \`asyncio.create_task\`, registers, awaits, catches \`CancelledError\` → 499 \`{status: cancelled, ...}\` response
- \`_execute_async_with_callback\`: catches \`CancelledError\`, emits a \`status: cancelled\` payload to the control-plane callback, deregisters in \`finally\`

## Backwards compatibility
Purely additive. Reasoners that swallow \`CancelledError\` (\`except Exception\` in 3.8+ does *not* — \`CancelledError\` is a \`BaseException\`) or use blocking sync code continue to run; their output is discarded by the control plane (existing per-execution cancel behaviour). The \`/_internal/\` route is harmless when the dispatcher isn't running in front of the worker.

## Test plan
- [x] \`pytest tests/test_cancel.py\` (9/9 pass)
- [x] Targeted agent suites (core, lifecycle, serverless, decorators, registry, resilience, helpers): 74/74 pass
- [x] Workflow + parent-child + approval + reasoner-path + handler suites: 107/107 pass when isolated from a known pre-existing flaky-ordering issue in \`test_agent_workflow.py\` (unrelated to this PR — confirmed by running \`test_workflow_parent_child.py\` alone; passes 9/9)
- [ ] Manual: register a Python-SDK agent on the deployed control-plane, trigger a long-running reasoner (e.g. \`asyncio.sleep(60)\`), hit Cancel, observe \`CancelledError\` raised and \`status: cancelled\` reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)