### PR TITLE
feat(sdk-typescript): cooperative cancel via /_internal/executions/:id/cancel

### DIFF
--- a/sdk/typescript/src/agent/Agent.ts
+++ b/sdk/typescript/src/agent/Agent.ts
@@ -14,6 +14,7 @@ import type {
 } from '../types/agent.js';
 import { ReasonerRegistry } from './ReasonerRegistry.js';
 import { SkillRegistry } from './SkillRegistry.js';
+import { CancelRegistry, installCancelRoute } from './cancel.js';
 import { AgentRouter } from '../router/AgentRouter.js';
 import type { ReasonerHandler, ReasonerOptions } from '../types/reasoner.js';
 import type { SkillHandler, SkillOptions } from '../types/skill.js';
@@ -95,6 +96,11 @@ export class Agent {
   private readonly realtimeValidationFunctions = new Set<string>();
   private readonly processLogRing = new ProcessLogRing();
   private readonly executionLogger: ExecutionLogger;
+  /** Tracks an AbortController per in-flight execution_id so the
+   *  `/_internal/executions/:id/cancel` route can short-circuit reasoner
+   *  code that respects `signal.aborted` (fetch, anthropic SDK, openai
+   *  SDK, etc.). See ./cancel.ts. */
+  private readonly cancelRegistry = new CancelRegistry();
 
   constructor(config: AgentConfig) {
     this.config = {
@@ -137,6 +143,13 @@ export class Agent {
     this.registerDefaultRoutes();
     installStdioLogCapture(this.processLogRing);
     registerAgentfieldLogsRoute(this.app, this.processLogRing);
+    // Install the control-plane cancel callback route. Always-on so the
+    // dispatcher reaches the worker regardless of which routes the user
+    // has registered first.
+    installCancelRoute(this.app, this.cancelRegistry, {
+      info: (message, meta) =>
+        this.executionLogger.system('execution.cancel.received', message, meta ?? {})
+    });
   }
 
   reasoner<TInput = any, TOutput = any>(
@@ -1196,6 +1209,14 @@ export class Agent {
       agent: this
     });
 
+    // Register an AbortController for this execution so the control-plane
+    // cancel callback (POST /_internal/executions/:id/cancel) can abort
+    // in-flight `fetch` / Anthropic SDK / OpenAI SDK requests bound to
+    // ctx.signal. release() is always called, even on throw.
+    const { controller, release } = this.cancelRegistry.register(
+      executionMetadata.executionId
+    );
+
     return ExecutionContext.run(execCtx, async () => {
       this.executionLogger.system('execution.started', 'Execution started', {
         target: params.targetName,
@@ -1234,7 +1255,8 @@ export class Agent {
           aiClient: this.aiClient,
           memory: this.getMemoryInterface(executionMetadata),
           workflow: this.getWorkflowReporter(executionMetadata),
-          did: this.getDidInterface(executionMetadata, params.input, params.targetName)
+          did: this.getDidInterface(executionMetadata, params.input, params.targetName),
+          signal: controller.signal
         });
 
         const result = await reasoner.handler(ctx);
@@ -1296,6 +1318,8 @@ export class Agent {
           return;
         }
         throw err;
+      } finally {
+        release();
       }
     });
   }
@@ -1326,6 +1350,10 @@ export class Agent {
       res,
       agent: this
     });
+
+    const { controller, release } = this.cancelRegistry.register(
+      executionMetadata.executionId
+    );
 
     return ExecutionContext.run(execCtx, async () => {
       this.executionLogger.system('execution.started', 'Execution started', {
@@ -1358,7 +1386,8 @@ export class Agent {
           logger: this.executionLogger,
           memory: this.getMemoryInterface(executionMetadata),
           workflow: this.getWorkflowReporter(executionMetadata),
-          did: this.getDidInterface(executionMetadata, params.input, params.targetName)
+          did: this.getDidInterface(executionMetadata, params.input, params.targetName),
+          signal: controller.signal
         });
 
         const result = await skill.handler(ctx);
@@ -1420,6 +1449,8 @@ export class Agent {
           return;
         }
         throw err;
+      } finally {
+        release();
       }
     });
   }

--- a/sdk/typescript/src/agent/cancel.ts
+++ b/sdk/typescript/src/agent/cancel.ts
@@ -1,0 +1,134 @@
+import type express from 'express';
+
+// Minimal structural type — we just need to log info-level messages on
+// successful cancel. Using a structural type keeps cancel.ts independent
+// of whatever logger the agent uses today.
+type CancelLogger = { info(message: string, meta?: Record<string, unknown>): void };
+
+/**
+ * Cooperative cancellation registry.
+ *
+ * The control plane's cancel dispatcher (control-plane/internal/services/
+ * cancel_dispatcher.go) POSTs to `/_internal/executions/:execution_id/cancel`
+ * whenever an execution flips to cancelled — from per-execution cancel,
+ * the bottom-up cancel-tree endpoint, or any future source publishing on
+ * the bus. This module holds an `AbortController` per in-flight reasoner
+ * invocation; the cancel route looks up the controller and calls
+ * `.abort()`, which surfaces as `signal.aborted === true` and rejects any
+ * pending `fetch()` / Anthropic-SDK / OpenAI-SDK request bound to that
+ * signal.
+ *
+ * Reasoner-author contract:
+ *   - `await fetch(url, { signal: ctx.signal })` — aborts mid-flight.
+ *   - The official @anthropic-ai/sdk and openai clients accept
+ *     `{ signal }` in their request options. Pass `ctx.signal` through.
+ *   - For CPU loops or pure-JS work, periodically check
+ *     `ctx.signal.aborted` and throw if true.
+ *
+ * Backwards compatible: reasoners that ignore `signal` finish naturally
+ * and their output is discarded by the control plane (existing per-
+ * execution cancel behaviour). Workers running without a dispatcher in
+ * front of them simply never see the cancel callback.
+ */
+export class CancelRegistry {
+  private readonly controllers = new Map<string, AbortController>();
+
+  /**
+   * Register a fresh AbortController against an execution_id. Returns the
+   * controller and a `release()` cleanup function that must be called on
+   * completion (success, failure, or cancellation) to drop the entry.
+   * Empty `executionId` produces a controller that is NOT registered,
+   * so callers always get a usable signal even outside the control-plane
+   * dispatch path (e.g. local manual invocations).
+   */
+  register(executionId: string | undefined): {
+    controller: AbortController;
+    release: () => void;
+  } {
+    const controller = new AbortController();
+    if (!executionId) {
+      return { controller, release: () => {} };
+    }
+    this.controllers.set(executionId, controller);
+    let released = false;
+    const release = () => {
+      if (released) return;
+      released = true;
+      // Only delete our own entry — a racing register() that replaced
+      // us shouldn't get its registration clobbered.
+      const current = this.controllers.get(executionId);
+      if (current === controller) {
+        this.controllers.delete(executionId);
+      }
+    };
+    return { controller, release };
+  }
+
+  /**
+   * Cancel the AbortController registered for `executionId`. Returns
+   * true if a matching controller was found and aborted, false if there
+   * was no active execution (already finished, or never dispatched here).
+   */
+  cancel(executionId: string, reason?: string): boolean {
+    if (!executionId) return false;
+    const controller = this.controllers.get(executionId);
+    if (!controller) return false;
+    if (controller.signal.aborted) {
+      // Already aborted by something else; treat as a no-op success so
+      // double-cancels are idempotent.
+      return true;
+    }
+    controller.abort(reason ?? 'cancelled_by_control_plane');
+    this.controllers.delete(executionId);
+    return true;
+  }
+
+  /** Number of in-flight registrations. Useful for tests. */
+  size(): number {
+    return this.controllers.size;
+  }
+}
+
+/**
+ * Install the `POST /_internal/executions/:execution_id/cancel` route on
+ * the agent's Express app. The route bypasses path-based DID verification
+ * by way of its prefix (control-plane→worker notification, not a
+ * DID-signed user-initiated call). Bearer-token origin auth, when
+ * configured, still applies through the existing middleware path.
+ */
+export function installCancelRoute(
+  app: express.Express,
+  registry: CancelRegistry,
+  logger?: CancelLogger
+): void {
+  app.post(
+    '/_internal/executions/:executionId/cancel',
+    (req: express.Request, res: express.Response) => {
+      const executionId = (req.params.executionId ?? '').trim();
+      if (!executionId) {
+        res.status(404).json({ error: 'invalid execution_id' });
+        return;
+      }
+      const cancelled = registry.cancel(
+        executionId,
+        typeof req.body?.reason === 'string' ? req.body.reason : undefined
+      );
+      if (cancelled) {
+        logger?.info('cancel-callback fired', {
+          executionId,
+          source: req.headers['x-agentfield-source'] ?? 'unknown'
+        });
+        res.status(200).json({ cancelled: true, execution_id: executionId });
+      } else {
+        // 200 with the marker keeps the dispatcher's best-effort logic
+        // happy and avoids spurious warning logs. The execution may
+        // have already finished naturally, or never landed here.
+        res.status(200).json({
+          cancelled: false,
+          execution_id: executionId,
+          reason: 'execution_not_active'
+        });
+      }
+    }
+  );
+}

--- a/sdk/typescript/src/context/ReasonerContext.ts
+++ b/sdk/typescript/src/context/ReasonerContext.ts
@@ -31,6 +31,15 @@ export class ReasonerContext<TInput = any> {
   readonly memory: MemoryInterface;
   readonly workflow: WorkflowReporter;
   readonly did: DidInterface;
+  /**
+   * AbortSignal that fires when the control plane cancels this execution
+   * (per-execution cancel, the bottom-up cancel-tree endpoint, or any
+   * future source that flips the bus). Pass it through to `fetch`, the
+   * @anthropic-ai/sdk, the openai SDK, or anywhere that accepts
+   * `{ signal }` to short-circuit in-flight work mid-call. For pure-JS
+   * CPU loops, check `ctx.signal.aborted` periodically and throw.
+   */
+  readonly signal: AbortSignal;
 
   constructor(params: {
     input: TInput;
@@ -53,6 +62,7 @@ export class ReasonerContext<TInput = any> {
     memory: MemoryInterface;
     workflow: WorkflowReporter;
     did: DidInterface;
+    signal?: AbortSignal;
   }) {
     this.input = params.input;
     this.executionId = params.executionId;
@@ -74,6 +84,9 @@ export class ReasonerContext<TInput = any> {
     this.memory = params.memory;
     this.workflow = params.workflow;
     this.did = params.did;
+    // Default to a never-aborted signal when none provided so existing
+    // call sites (tests, manual invocations) continue to work.
+    this.signal = params.signal ?? new AbortController().signal;
   }
 
   ai<T>(prompt: string, options: AIRequestOptions & { schema: ZodSchema<T> }): Promise<T>;

--- a/sdk/typescript/src/context/SkillContext.ts
+++ b/sdk/typescript/src/context/SkillContext.ts
@@ -23,6 +23,8 @@ export class SkillContext<TInput = any> {
   readonly memory: MemoryInterface;
   readonly workflow: WorkflowReporter;
   readonly did: DidInterface;
+  /** AbortSignal — see ReasonerContext for usage. */
+  readonly signal: AbortSignal;
 
   constructor(params: {
     input: TInput;
@@ -40,6 +42,7 @@ export class SkillContext<TInput = any> {
     memory: MemoryInterface;
     workflow: WorkflowReporter;
     did: DidInterface;
+    signal?: AbortSignal;
   }) {
     this.input = params.input;
     this.executionId = params.executionId;
@@ -56,6 +59,7 @@ export class SkillContext<TInput = any> {
     this.memory = params.memory;
     this.workflow = params.workflow;
     this.did = params.did;
+    this.signal = params.signal ?? new AbortController().signal;
   }
 
   discover(options?: DiscoveryOptions) {

--- a/sdk/typescript/tests/cancel.test.ts
+++ b/sdk/typescript/tests/cancel.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import http from 'node:http';
+
+import { Agent } from '../src/agent/Agent.js';
+import { CancelRegistry, installCancelRoute } from '../src/agent/cancel.js';
+
+/**
+ * Lightweight stand-in for supertest. Boots an Express app on an ephemeral
+ * port, fires a single request, returns parsed JSON body + status.
+ */
+async function postJson(
+  app: express.Express,
+  path: string,
+  body: unknown = {},
+  headers: Record<string, string> = {}
+): Promise<{ status: number; body: any }> {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+  const port = (server.address() as { port: number }).port;
+  try {
+    const payload = JSON.stringify(body);
+    const resp = await new Promise<{ status: number; body: any }>((resolve, reject) => {
+      const req = http.request(
+        {
+          host: '127.0.0.1',
+          port,
+          path,
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'content-length': Buffer.byteLength(payload).toString(),
+            ...headers
+          }
+        },
+        (res) => {
+          let data = '';
+          res.setEncoding('utf8');
+          res.on('data', (chunk) => (data += chunk));
+          res.on('end', () => {
+            const status = res.statusCode ?? 0;
+            try {
+              resolve({ status, body: data ? JSON.parse(data) : {} });
+            } catch {
+              resolve({ status, body: data });
+            }
+          });
+        }
+      );
+      req.on('error', reject);
+      req.write(payload);
+      req.end();
+    });
+    return resp;
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+describe('CancelRegistry', () => {
+  it('register returns a fresh AbortController each time', () => {
+    const reg = new CancelRegistry();
+    const a = reg.register('exec-1');
+    const b = reg.register('exec-2');
+    expect(a.controller).not.toBe(b.controller);
+    expect(a.controller.signal.aborted).toBe(false);
+    expect(reg.size()).toBe(2);
+  });
+
+  it('cancel aborts the registered controller and removes it', () => {
+    const reg = new CancelRegistry();
+    const { controller } = reg.register('exec-1');
+    expect(reg.cancel('exec-1')).toBe(true);
+    expect(controller.signal.aborted).toBe(true);
+    expect(reg.size()).toBe(0);
+  });
+
+  it('cancel returns false for unknown id', () => {
+    const reg = new CancelRegistry();
+    expect(reg.cancel('missing')).toBe(false);
+    expect(reg.cancel('')).toBe(false);
+  });
+
+  it('release deregisters without aborting', () => {
+    const reg = new CancelRegistry();
+    const { controller, release } = reg.register('exec-1');
+    release();
+    expect(reg.size()).toBe(0);
+    expect(controller.signal.aborted).toBe(false);
+    // Subsequent cancel is a no-op.
+    expect(reg.cancel('exec-1')).toBe(false);
+  });
+
+  it('release is idempotent', () => {
+    const reg = new CancelRegistry();
+    const { release } = reg.register('exec-1');
+    release();
+    release();
+    expect(reg.size()).toBe(0);
+  });
+
+  it('register with empty id produces a usable but unregistered controller', () => {
+    const reg = new CancelRegistry();
+    const { controller } = reg.register('');
+    expect(reg.size()).toBe(0);
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  it('replacing the same id evicts the prior registration on release', () => {
+    const reg = new CancelRegistry();
+    const first = reg.register('exec-1');
+    const second = reg.register('exec-1');
+    // Releasing the FIRST entry must not delete the SECOND registration.
+    first.release();
+    expect(reg.size()).toBe(1);
+    expect(reg.cancel('exec-1')).toBe(true);
+    expect(second.controller.signal.aborted).toBe(true);
+  });
+
+  it('double cancel is idempotent', () => {
+    const reg = new CancelRegistry();
+    reg.register('exec-1');
+    expect(reg.cancel('exec-1')).toBe(true);
+    // Second cancel on already-cancelled (and now removed) id returns false.
+    expect(reg.cancel('exec-1')).toBe(false);
+  });
+});
+
+describe('installCancelRoute', () => {
+  function makeApp() {
+    const app = express();
+    app.use(express.json());
+    const reg = new CancelRegistry();
+    installCancelRoute(app, reg, { info: () => {} });
+    return { app, reg };
+  }
+
+  it('returns 200 with cancelled:true for an active execution', async () => {
+    const { app, reg } = makeApp();
+    const { controller } = reg.register('exec-active');
+    const resp = await postJson(app, '/_internal/executions/exec-active/cancel');
+    expect(resp.status).toBe(200);
+    expect(resp.body).toEqual({ cancelled: true, execution_id: 'exec-active' });
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it('returns 200 with cancelled:false + reason for unknown execution', async () => {
+    const { app } = makeApp();
+    const resp = await postJson(app, '/_internal/executions/exec-missing/cancel');
+    expect(resp.status).toBe(200);
+    expect(resp.body).toEqual({
+      cancelled: false,
+      execution_id: 'exec-missing',
+      reason: 'execution_not_active'
+    });
+  });
+
+  it('forwards the cancel reason to AbortController.abort', async () => {
+    const { app, reg } = makeApp();
+    const { controller } = reg.register('exec-reason');
+    await postJson(
+      app,
+      '/_internal/executions/exec-reason/cancel',
+      { reason: 'user clicked cancel' }
+    );
+    expect(controller.signal.aborted).toBe(true);
+    expect(controller.signal.reason).toBe('user clicked cancel');
+  });
+
+  it('logs an info line with the X-AgentField-Source header on success', async () => {
+    const app = express();
+    app.use(express.json());
+    const reg = new CancelRegistry();
+    const logs: Array<{ message: string; meta?: any }> = [];
+    installCancelRoute(app, reg, {
+      info: (message, meta) => logs.push({ message, meta })
+    });
+    reg.register('exec-logged');
+    await postJson(
+      app,
+      '/_internal/executions/exec-logged/cancel',
+      {},
+      { 'x-agentfield-source': 'cancel-dispatcher' }
+    );
+    expect(logs).toHaveLength(1);
+    expect(logs[0].message).toBe('cancel-callback fired');
+    expect(logs[0].meta).toMatchObject({
+      executionId: 'exec-logged',
+      source: 'cancel-dispatcher'
+    });
+  });
+});
+
+describe('Agent integration', () => {
+  it('passes a non-aborted signal to reasoner handlers by default', async () => {
+    const agent = new Agent({ nodeId: 'test-cancel-agent', devMode: true });
+    let capturedSignal: AbortSignal | undefined;
+    agent.reasoner('inspect-signal', async (ctx) => {
+      capturedSignal = ctx.signal;
+      return { ok: true };
+    });
+
+    // Drive the reasoner through Agent.execute() which goes through
+    // runReasoner — same path the HTTP route uses.
+    const result = await (agent as any).executeInvocation({
+      targetName: 'inspect-signal',
+      targetType: 'reasoner',
+      input: {},
+      metadata: { executionId: 'exec-it-1' },
+      respond: false
+    });
+    expect(result).toEqual({ ok: true });
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal!.aborted).toBe(false);
+  });
+
+  it('aborts ctx.signal mid-flight when the cancel route fires', async () => {
+    const agent = new Agent({ nodeId: 'test-cancel-agent', devMode: true });
+    let capturedSignal: AbortSignal | undefined;
+    let started = false;
+    let aborted = false;
+
+    agent.reasoner('long-running', async (ctx) => {
+      capturedSignal = ctx.signal;
+      started = true;
+      // Wait for the abort to propagate via the signal listener.
+      await new Promise<void>((resolve) => {
+        ctx.signal.addEventListener('abort', () => {
+          aborted = true;
+          resolve();
+        });
+      });
+      return { aborted: true };
+    });
+
+    // Start the reasoner in the background — runReasoner registers the
+    // controller against execution_id "exec-it-2" before invoking the
+    // handler. The inflight promise resolves when the abort fires.
+    const inflight = (agent as any).executeInvocation({
+      targetName: 'long-running',
+      targetType: 'reasoner',
+      input: {},
+      metadata: { executionId: 'exec-it-2' },
+      respond: false
+    });
+
+    // Wait for the handler to actually start (and register).
+    while (!started) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    const resp = await postJson(agent.app, '/_internal/executions/exec-it-2/cancel');
+    expect(resp.status).toBe(200);
+    expect(resp.body.cancelled).toBe(true);
+
+    const result = await inflight;
+    expect(result).toEqual({ aborted: true });
+    expect(aborted).toBe(true);
+    expect(capturedSignal!.aborted).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Add cooperative cancellation to the TypeScript SDK. Workers now register an \`AbortController\` per in-flight reasoner / skill invocation and expose \`POST /_internal/executions/:id/cancel\`. The control plane's cancel dispatcher (#538) calls into the route, which calls \`.abort()\` — surfacing as \`signal.aborted === true\` and rejecting any pending \`fetch\` / Anthropic-SDK / OpenAI-SDK request bound to \`ctx.signal\`.

Depends on #538 (cancel-signal transport). Functions correctly without it — the route is just dormant.

## Changes
- \`src/agent/cancel.ts\` — new module:
  - \`CancelRegistry\` with \`register / cancel / size\`. \`register\` returns \`{ controller, release }\` so the call site cleans up in \`finally\` regardless of outcome.
  - \`installCancelRoute(app, registry, logger?)\` registers \`POST /_internal/executions/:executionId/cancel\` on the Express app.
- \`src/agent/Agent.ts\`:
  - private \`cancelRegistry = new CancelRegistry()\`
  - \`installCancelRoute(this.app, this.cancelRegistry, ...)\` in the constructor (always-on)
  - \`runReasoner\` / \`runSkill\`: register a controller around the handler invocation, pass \`signal: controller.signal\` into the context, release in \`finally\`
- \`src/context/ReasonerContext.ts\` / \`src/context/SkillContext.ts\`: new \`readonly signal: AbortSignal\` field. Optional in the constructor (\`signal?: AbortSignal\`), defaults to a never-aborted signal so \`getCurrent*Context\` helpers and existing tests continue to work unchanged.

## Reasoner-author contract
\`\`\`ts
agent.reasoner('do-thing', async (ctx) => {
  const resp = await fetch(url, { signal: ctx.signal });        // aborts mid-flight
  const reply = await anthropic.messages.create(req, { signal: ctx.signal });
  for (const item of items) {
    if (ctx.signal.aborted) throw new Error('cancelled');        // CPU loop polling
  }
});
\`\`\`

## Backwards compatibility
Purely additive. Handlers that ignore \`ctx.signal\` continue to run; their output is discarded by the control plane (existing per-execution cancel behaviour). The \`/_internal/\` route is harmless when the dispatcher isn't running in front of the worker.

## Test plan
- [x] \`tsc --noEmit\` (clean)
- [x] \`vitest run tests/cancel.test.ts\` (14/14 pass)
- [x] \`vitest run\` (64 files / 595 tests pass)
- [ ] Manual: register a TS-SDK agent on the deployed control-plane, trigger a long-running reasoner using \`ctx.signal\` with \`fetch\`, hit Cancel, observe the request aborts and the handler reports a clean error

🤖 Generated with [Claude Code](https://claude.com/claude-code)