### PR TITLE
feat(tools): web_search MCP tool + mcp_servers harness passthrough

### DIFF
--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -3253,6 +3253,7 @@ class Agent(FastAPI):
         max_turns: Optional[int] = None,
         max_budget_usd: Optional[float] = None,
         tools: Optional[List[str]] = None,
+        mcp_servers: Optional[Dict[str, Any]] = None,
         permission_mode: Optional[str] = None,
         system_prompt: Optional[str] = None,
         env: Optional[Dict[str, str]] = None,
@@ -3273,6 +3274,10 @@ class Agent(FastAPI):
             max_turns: Maximum agent iterations.
             max_budget_usd: Cost cap in USD.
             tools: Allowed tools list.
+            mcp_servers: Mapping of MCP server name to server config (e.g. from
+                ``claude_agent_sdk.create_sdk_mcp_server``). Only honored by the
+                ``claude-code`` provider; other providers ignore it. Tool names
+                from MCP servers must also appear in ``tools`` to be invokable.
             permission_mode: Permission mode ("plan", "auto", None).
             system_prompt: System prompt for the agent.
             env: Environment variables for the agent.
@@ -3290,6 +3295,7 @@ class Agent(FastAPI):
             max_turns=max_turns,
             max_budget_usd=max_budget_usd,
             tools=tools,
+            mcp_servers=mcp_servers,
             permission_mode=permission_mode,
             system_prompt=system_prompt,
             env=env,

--- a/sdk/python/agentfield/harness/_runner.py
+++ b/sdk/python/agentfield/harness/_runner.py
@@ -132,7 +132,10 @@ async def _ai_schema_repair(
         )
         content = response.choices[0].message.content  # type: ignore[union-attr]
     except Exception as exc:
-        logger.info("AI schema repair: LLM call failed (%s); falling through to harness retry", exc)
+        logger.info(
+            "AI schema repair: LLM call failed (%s); falling through to harness retry",
+            exc,
+        )
         return None
 
     if not content:
@@ -156,6 +159,7 @@ def _resolve_options(
             "max_delay",
             "backoff_factor",
             "tools",
+            "mcp_servers",
             "permission_mode",
             "system_prompt",
             "env",
@@ -209,6 +213,7 @@ class HarnessRunner:
         max_turns: Optional[int] = None,
         max_budget_usd: Optional[float] = None,
         tools: Optional[list[str]] = None,
+        mcp_servers: Optional[Dict[str, Any]] = None,
         permission_mode: Optional[str] = None,
         system_prompt: Optional[str] = None,
         env: Optional[Dict[str, str]] = None,
@@ -221,6 +226,7 @@ class HarnessRunner:
             "max_turns": max_turns,
             "max_budget_usd": max_budget_usd,
             "tools": tools,
+            "mcp_servers": mcp_servers,
             "permission_mode": permission_mode,
             "system_prompt": system_prompt,
             "env": env,

--- a/sdk/python/agentfield/harness/providers/claude.py
+++ b/sdk/python/agentfield/harness/providers/claude.py
@@ -47,6 +47,11 @@ class ClaudeCodeProvider:
             agent_options["max_turns"] = options["max_turns"]
         if options.get("tools") is not None:
             agent_options["allowed_tools"] = options["tools"]
+        if options.get("mcp_servers") is not None:
+            # In-process or external MCP servers exposed to the agent. Maps directly
+            # to ClaudeAgentOptions.mcp_servers — values are McpSdkServerConfig
+            # (from claude_agent_sdk.create_sdk_mcp_server) or other server configs.
+            agent_options["mcp_servers"] = options["mcp_servers"]
         if options.get("system_prompt") is not None:
             agent_options["system_prompt"] = options["system_prompt"]
         if options.get("max_budget_usd") is not None:

--- a/sdk/python/agentfield/tools/__init__.py
+++ b/sdk/python/agentfield/tools/__init__.py
@@ -1,0 +1,7 @@
+"""Built-in tools that can be exposed to harnessed agents.
+
+Currently provides:
+- ``search`` — multi-provider web search (Jina, Tavily, Firecrawl, Serper)
+- ``web_search`` — an in-process MCP server wrapping ``search`` so a harnessed
+  Claude Code agent can invoke it via tool call.
+"""

--- a/sdk/python/agentfield/tools/search/__init__.py
+++ b/sdk/python/agentfield/tools/search/__init__.py
@@ -1,0 +1,131 @@
+"""Multi-provider web search package.
+
+Provides a unified interface for web search across Jina, Tavily, Firecrawl,
+and Serper. Auto-detects available providers from env vars and uses the first
+available in priority order, or honors SEARCH_PROVIDER if set.
+
+Usage:
+    from agentfield.tools.search import search
+
+    results = await search("agentfield python sdk")
+    for r in results.results:
+        print(r.title, r.url)
+
+To force a specific provider:
+    from agentfield.tools.search import search_with_provider
+    results = await search_with_provider("query", provider="tavily")
+
+To check what's configured:
+    from agentfield.tools.search import list_provider_status
+    print(list_provider_status())
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import List, Optional
+
+from .base import SearchProvider, SearchResponse, SearchResult
+from .firecrawl import FirecrawlSearchProvider
+from .jina import JinaSearchProvider
+from .registry import (
+    DEFAULT_PROVIDER_PRIORITY,
+    PROVIDER_CLASSES,
+    get_all_providers,
+    get_available_providers,
+    get_default_provider,
+    get_provider,
+    list_provider_status,
+    register_provider,
+)
+from .serper import SerperSearchProvider
+from .tavily import TavilySearchProvider
+
+__all__ = [
+    "SearchProvider",
+    "SearchResponse",
+    "SearchResult",
+    "JinaSearchProvider",
+    "TavilySearchProvider",
+    "FirecrawlSearchProvider",
+    "SerperSearchProvider",
+    "DEFAULT_PROVIDER_PRIORITY",
+    "PROVIDER_CLASSES",
+    "get_all_providers",
+    "get_available_providers",
+    "get_default_provider",
+    "get_provider",
+    "list_provider_status",
+    "register_provider",
+    "search",
+    "search_with_provider",
+    "parallel_search",
+]
+
+
+async def search(query: str) -> SearchResponse:
+    """Search using the default available provider.
+
+    Raises RuntimeError if no providers are configured.
+    """
+    provider = get_default_provider()
+    if provider is None:
+        raise RuntimeError(
+            "No search providers available. Set at least one of: "
+            "JINA_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY, SERPER_API_KEY."
+        )
+    return await provider.search(query)
+
+
+async def search_with_provider(query: str, provider: str) -> SearchResponse:
+    """Search using a specific provider name.
+
+    Raises ValueError if the provider is unknown or not configured.
+    """
+    instance = get_provider(provider)
+    if instance is None:
+        raise ValueError(f"Unknown search provider: {provider}")
+    if not instance.is_available():
+        raise ValueError(
+            f"Provider '{provider}' is not available (API key not configured)"
+        )
+    return await instance.search(query)
+
+
+async def parallel_search(
+    queries: List[str], provider: Optional[str] = None
+) -> List[SearchResponse]:
+    """Execute multiple searches concurrently.
+
+    Failures for individual queries return an empty SearchResponse rather than
+    raising — callers can inspect total_results to detect them.
+    """
+    if not queries:
+        return []
+
+    if provider:
+        instance = get_provider(provider)
+        if instance is None or not instance.is_available():
+            raise ValueError(f"Provider '{provider}' is not available")
+    else:
+        instance = get_default_provider()
+        if instance is None:
+            raise RuntimeError("No search providers available")
+
+    tasks = [instance.search(q) for q in queries]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    out: List[SearchResponse] = []
+    for i, r in enumerate(results):
+        if isinstance(r, Exception):
+            out.append(
+                SearchResponse(
+                    results=[],
+                    total_results=0,
+                    query_used=queries[i],
+                    provider=instance.name,
+                )
+            )
+        else:
+            out.append(r)
+    return out

--- a/sdk/python/agentfield/tools/search/base.py
+++ b/sdk/python/agentfield/tools/search/base.py
@@ -1,0 +1,68 @@
+"""Base classes and models for web search providers.
+
+Vendored from github.com/Agent-Field/af-deep-research at skills/search/base.py.
+Adapted for agentfield: no behavioral changes, kept the SearchProvider ABC and
+unified pydantic models.
+"""
+
+from __future__ import annotations
+
+import os
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SearchResult(BaseModel):
+    """Unified search result model for all providers."""
+
+    title: str = Field(description="Result title")
+    url: str = Field(description="Result URL")
+    content: str = Field(description="Result content/snippet")
+    description: Optional[str] = Field(None, description="Result description")
+    published_time: Optional[datetime] = Field(None, description="Publication time")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class SearchResponse(BaseModel):
+    """Unified response model for all search providers."""
+
+    results: List[SearchResult] = Field(
+        default_factory=list, description="Search results"
+    )
+    total_results: int = Field(0, description="Total number of results")
+    query_used: str = Field("", description="Query that was executed")
+    provider: str = Field("", description="Provider that executed the search")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class SearchProvider(ABC):
+    """Abstract base class for search providers."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Provider name identifier."""
+
+    @property
+    @abstractmethod
+    def api_key_env_var(self) -> str:
+        """Environment variable name for the API key."""
+
+    def get_api_key(self) -> Optional[str]:
+        return os.getenv(self.api_key_env_var)
+
+    def is_available(self) -> bool:
+        api_key = self.get_api_key()
+        return api_key is not None and len(api_key) > 0
+
+    @abstractmethod
+    async def search(self, query: str) -> SearchResponse:
+        """Execute a search query."""
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(available={self.is_available()})"

--- a/sdk/python/agentfield/tools/search/firecrawl.py
+++ b/sdk/python/agentfield/tools/search/firecrawl.py
@@ -1,0 +1,88 @@
+"""Firecrawl search provider (search + optional content scraping)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Optional
+
+import httpx
+
+from .base import SearchProvider, SearchResponse, SearchResult
+
+
+class FirecrawlSearchProvider(SearchProvider):
+    """Firecrawl search provider implementation."""
+
+    def __init__(
+        self,
+        limit: int = 10,
+        scrape_results: bool = False,
+        source_filter: Optional[
+            Literal["web", "news", "github", "research", "pdf"]
+        ] = None,
+    ):
+        self.limit = limit
+        self.scrape_results = scrape_results
+        self.source_filter = source_filter
+
+    @property
+    def name(self) -> str:
+        return "firecrawl"
+
+    @property
+    def api_key_env_var(self) -> str:
+        return "FIRECRAWL_API_KEY"
+
+    async def search(self, query: str) -> SearchResponse:
+        api_key = self.get_api_key()
+        if not api_key:
+            raise ValueError(f"{self.api_key_env_var} environment variable is required")
+
+        url = "https://api.firecrawl.dev/v1/search"
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        }
+        payload: dict = {"query": query, "limit": self.limit}
+        if self.source_filter:
+            payload["filter"] = {"sourceType": self.source_filter}
+        if self.scrape_results:
+            payload["scrapeOptions"] = {"formats": ["markdown"]}
+
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.post(url, headers=headers, json=payload)
+            response.raise_for_status()
+            data = response.json()
+
+        results = []
+        for item in data.get("data", []):
+            content = (
+                item.get("markdown")
+                or item.get("description")
+                or item.get("snippet", "")
+            )
+            published_time: Optional[datetime] = None
+            if item.get("publishedDate"):
+                try:
+                    published_time = datetime.fromisoformat(
+                        item["publishedDate"].replace("Z", "+00:00")
+                    )
+                except (ValueError, TypeError):
+                    pass
+
+            results.append(
+                SearchResult(
+                    title=item.get("title", ""),
+                    url=item.get("url", ""),
+                    content=content,
+                    description=item.get("description"),
+                    published_time=published_time,
+                )
+            )
+
+        return SearchResponse(
+            results=results,
+            total_results=len(results),
+            query_used=query,
+            provider=self.name,
+        )

--- a/sdk/python/agentfield/tools/search/jina.py
+++ b/sdk/python/agentfield/tools/search/jina.py
@@ -1,0 +1,72 @@
+"""Jina AI search provider.
+
+Ported from af-deep-research's aiohttp implementation to httpx for consistency
+with agentfield's existing pytest-httpx test infrastructure.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+import httpx
+
+from .base import SearchProvider, SearchResponse, SearchResult
+
+
+class JinaSearchProvider(SearchProvider):
+    """Jina AI search provider implementation."""
+
+    @property
+    def name(self) -> str:
+        return "jina"
+
+    @property
+    def api_key_env_var(self) -> str:
+        return "JINA_API_KEY"
+
+    async def search(self, query: str) -> SearchResponse:
+        api_key = self.get_api_key()
+        if not api_key:
+            raise ValueError(f"{self.api_key_env_var} environment variable is required")
+
+        url = "https://s.jina.ai/"
+        headers = {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {api_key}",
+            "X-Engine": "browser",
+        }
+        params = {"q": query}
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(url, headers=headers, params=params)
+            response.raise_for_status()
+            data = response.json()
+
+        results = []
+        for item in data.get("data", []):
+            published_time: Optional[datetime] = None
+            if item.get("publishedTime"):
+                try:
+                    published_time = datetime.fromisoformat(
+                        item["publishedTime"].replace("Z", "+00:00")
+                    )
+                except (ValueError, TypeError):
+                    pass
+
+            results.append(
+                SearchResult(
+                    title=item.get("title", ""),
+                    url=item.get("url", ""),
+                    content=item.get("content", ""),
+                    description=item.get("description"),
+                    published_time=published_time,
+                )
+            )
+
+        return SearchResponse(
+            results=results,
+            total_results=len(results),
+            query_used=query,
+            provider=self.name,
+        )

--- a/sdk/python/agentfield/tools/search/registry.py
+++ b/sdk/python/agentfield/tools/search/registry.py
@@ -1,0 +1,84 @@
+"""Search provider registry: auto-detection and selection."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Dict, List, Optional, Type
+
+from .base import SearchProvider
+from .firecrawl import FirecrawlSearchProvider
+from .jina import JinaSearchProvider
+from .serper import SerperSearchProvider
+from .tavily import TavilySearchProvider
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_PROVIDER_PRIORITY = ["jina", "tavily", "firecrawl", "serper"]
+
+PROVIDER_CLASSES: Dict[str, Type[SearchProvider]] = {
+    "jina": JinaSearchProvider,
+    "tavily": TavilySearchProvider,
+    "firecrawl": FirecrawlSearchProvider,
+    "serper": SerperSearchProvider,
+}
+
+
+def get_all_providers() -> Dict[str, SearchProvider]:
+    return {name: cls() for name, cls in PROVIDER_CLASSES.items()}
+
+
+def get_available_providers() -> List[SearchProvider]:
+    available = []
+    for name in DEFAULT_PROVIDER_PRIORITY:
+        if name in PROVIDER_CLASSES:
+            provider = PROVIDER_CLASSES[name]()
+            if provider.is_available():
+                available.append(provider)
+    return available
+
+
+def get_provider(name: str) -> Optional[SearchProvider]:
+    if name in PROVIDER_CLASSES:
+        return PROVIDER_CLASSES[name]()
+    return None
+
+
+def get_default_provider() -> Optional[SearchProvider]:
+    """Return the default provider based on env config and availability.
+
+    Order:
+    1. SEARCH_PROVIDER env var if set and available
+    2. First available provider in DEFAULT_PROVIDER_PRIORITY
+    3. None if no provider has its API key configured
+    """
+    preferred = os.getenv("SEARCH_PROVIDER", "").lower().strip()
+    if preferred:
+        provider = get_provider(preferred)
+        if provider and provider.is_available():
+            return provider
+        logger.warning(
+            "Preferred SEARCH_PROVIDER=%s not available; falling through to priority order",
+            preferred,
+        )
+
+    available = get_available_providers()
+    if available:
+        return available[0]
+    return None
+
+
+def list_provider_status() -> Dict[str, bool]:
+    return {
+        name: PROVIDER_CLASSES[name]().is_available()
+        for name in DEFAULT_PROVIDER_PRIORITY
+    }
+
+
+def register_provider(name: str, provider_class: Type[SearchProvider]) -> None:
+    if not issubclass(provider_class, SearchProvider):
+        raise TypeError("Provider must inherit from SearchProvider")
+    PROVIDER_CLASSES[name] = provider_class
+    if name not in DEFAULT_PROVIDER_PRIORITY:
+        DEFAULT_PROVIDER_PRIORITY.append(name)

--- a/sdk/python/agentfield/tools/search/serper.py
+++ b/sdk/python/agentfield/tools/search/serper.py
@@ -1,0 +1,85 @@
+"""Serper search provider (Google SERP API)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import httpx
+
+from .base import SearchProvider, SearchResponse, SearchResult
+
+
+class SerperSearchProvider(SearchProvider):
+    """Serper (Google SERP) search provider implementation."""
+
+    def __init__(
+        self,
+        search_type: Literal["search", "news", "images"] = "search",
+        num_results: int = 10,
+        country: str = "us",
+        locale: str = "en",
+    ):
+        self.search_type = search_type
+        self.num_results = num_results
+        self.country = country
+        self.locale = locale
+
+    @property
+    def name(self) -> str:
+        return "serper"
+
+    @property
+    def api_key_env_var(self) -> str:
+        return "SERPER_API_KEY"
+
+    async def search(self, query: str) -> SearchResponse:
+        api_key = self.get_api_key()
+        if not api_key:
+            raise ValueError(f"{self.api_key_env_var} environment variable is required")
+
+        url = f"https://google.serper.dev/{self.search_type}"
+        headers = {"Content-Type": "application/json", "X-API-KEY": api_key}
+        payload = {
+            "q": query,
+            "num": self.num_results,
+            "gl": self.country,
+            "hl": self.locale,
+        }
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(url, headers=headers, json=payload)
+            response.raise_for_status()
+            data = response.json()
+
+        if self.search_type == "news":
+            items = data.get("news", [])
+        elif self.search_type == "images":
+            items = data.get("images", [])
+        else:
+            items = data.get("organic", [])
+
+        results = []
+        for item in items:
+            url_field = item.get("link") or item.get("imageUrl", "")
+            content = item.get("snippet", "")
+            if self.search_type == "news":
+                content = item.get("snippet") or item.get("description", "")
+            elif self.search_type == "images":
+                content = item.get("title", "")
+
+            results.append(
+                SearchResult(
+                    title=item.get("title", ""),
+                    url=url_field,
+                    content=content,
+                    description=item.get("snippet"),
+                    published_time=None,
+                )
+            )
+
+        return SearchResponse(
+            results=results,
+            total_results=len(results),
+            query_used=query,
+            provider=self.name,
+        )

--- a/sdk/python/agentfield/tools/search/tavily.py
+++ b/sdk/python/agentfield/tools/search/tavily.py
@@ -1,0 +1,74 @@
+"""Tavily search provider (AI-native search)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Optional
+
+import httpx
+
+from .base import SearchProvider, SearchResponse, SearchResult
+
+
+class TavilySearchProvider(SearchProvider):
+    """Tavily search provider implementation."""
+
+    def __init__(self, search_depth: Literal["basic", "advanced"] = "basic"):
+        self.search_depth = search_depth
+
+    @property
+    def name(self) -> str:
+        return "tavily"
+
+    @property
+    def api_key_env_var(self) -> str:
+        return "TAVILY_API_KEY"
+
+    async def search(self, query: str) -> SearchResponse:
+        api_key = self.get_api_key()
+        if not api_key:
+            raise ValueError(f"{self.api_key_env_var} environment variable is required")
+
+        url = "https://api.tavily.com/search"
+        headers = {"Content-Type": "application/json"}
+        payload = {
+            "api_key": api_key,
+            "query": query,
+            "search_depth": self.search_depth,
+            "include_answer": False,
+            "include_raw_content": False,
+            "max_results": 10,
+        }
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(url, headers=headers, json=payload)
+            response.raise_for_status()
+            data = response.json()
+
+        results = []
+        for item in data.get("results", []):
+            published_time: Optional[datetime] = None
+            if item.get("published_date"):
+                try:
+                    published_time = datetime.fromisoformat(
+                        item["published_date"].replace("Z", "+00:00")
+                    )
+                except (ValueError, TypeError):
+                    pass
+
+            results.append(
+                SearchResult(
+                    title=item.get("title", ""),
+                    url=item.get("url", ""),
+                    content=item.get("content", ""),
+                    description=item.get("snippet"),
+                    published_time=published_time,
+                )
+            )
+
+        return SearchResponse(
+            results=results,
+            total_results=len(results),
+            query_used=query,
+            provider=self.name,
+        )

--- a/sdk/python/agentfield/tools/web_search.py
+++ b/sdk/python/agentfield/tools/web_search.py
@@ -1,0 +1,167 @@
+"""Web search exposed to harnessed Claude Code agents as an in-process MCP tool.
+
+Wraps the multi-provider :mod:`agentfield.tools.search` package as a single
+``web_search`` tool that a Claude Code agent can call during a harness run.
+
+Usage from a reasoner::
+
+    from agentfield.tools.web_search import get_web_search_server
+
+    server, tool_names = get_web_search_server()
+    result = await router.harness(
+        prompt=...,
+        tools=["Read", "Bash", *tool_names],
+        mcp_servers={"af_search": server},
+        ...,
+    )
+
+The MCP tool name exposed to the agent is namespaced by Claude Code as
+``mcp__<server_name>__web_search``. ``tool_names`` returns these fully-namespaced
+names so they can be dropped straight into the ``tools`` allow-list.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Tuple
+
+from .search import SearchResponse, get_default_provider, search
+
+logger = logging.getLogger(__name__)
+
+
+SERVER_NAME = "af_search"
+SERVER_VERSION = "1.0.0"
+TOOL_NAME = "web_search"
+
+
+def _format_results_as_markdown(response: SearchResponse) -> str:
+    """Format a SearchResponse as a readable markdown block for the LLM.
+
+    Compact-but-informative: provider line, then numbered results with title
+    (linked), URL, and a trimmed snippet. Missing fields are skipped silently.
+    """
+    if not response.results:
+        return (
+            f"No results from provider `{response.provider}` for query "
+            f"`{response.query_used}`."
+        )
+
+    lines: List[str] = [
+        f"Search results from `{response.provider}` for `{response.query_used}` "
+        f"({response.total_results} results):",
+        "",
+    ]
+    for i, r in enumerate(response.results, start=1):
+        title = r.title.strip() or r.url
+        snippet = (r.content or r.description or "").strip()
+        if len(snippet) > 600:
+            snippet = snippet[:600].rstrip() + "…"
+        lines.append(f"{i}. **[{title}]({r.url})**")
+        if snippet:
+            lines.append(f"   {snippet}")
+        if r.published_time:
+            lines.append(f"   _published: {r.published_time.isoformat()}_")
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def _build_web_search_tool() -> Any:
+    """Construct the SdkMcpTool. Lazy-imports claude_agent_sdk."""
+    try:
+        from claude_agent_sdk import tool
+    except ImportError as exc:
+        raise ImportError(
+            "claude_agent_sdk is required to expose web_search as an MCP tool. "
+            "Install it with: pip install claude-agent-sdk"
+        ) from exc
+
+    @tool(
+        TOOL_NAME,
+        (
+            "Search the web for documentation, library APIs, error messages, "
+            "and other external context. Returns ranked results with titles, "
+            "URLs, and snippets. Backed by Jina/Tavily/Firecrawl/Serper "
+            "depending on which API key is configured. Use sparingly — only "
+            "for information that cannot be answered from the codebase."
+        ),
+        {"query": str},
+    )
+    async def _web_search(args: Dict[str, Any]) -> Dict[str, Any]:
+        query = (args.get("query") or "").strip()
+        if not query:
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Error: 'query' must be a non-empty string.",
+                    }
+                ],
+                "is_error": True,
+            }
+
+        if get_default_provider() is None:
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "Error: no search provider configured. Set one of "
+                            "JINA_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY, "
+                            "or SERPER_API_KEY."
+                        ),
+                    }
+                ],
+                "is_error": True,
+            }
+
+        try:
+            response = await search(query)
+        except Exception as exc:
+            logger.warning("web_search failed for query %r: %s", query, exc)
+            return {
+                "content": [
+                    {"type": "text", "text": f"Error executing web search: {exc}"}
+                ],
+                "is_error": True,
+            }
+
+        return {
+            "content": [{"type": "text", "text": _format_results_as_markdown(response)}]
+        }
+
+    return _web_search
+
+
+def get_web_search_server() -> Tuple[Any, List[str]]:
+    """Return ``(server_config, allowed_tool_names)`` for the web_search MCP server.
+
+    ``server_config`` is the ``McpSdkServerConfig`` to put under
+    ``mcp_servers[SERVER_NAME]`` in the harness call. ``allowed_tool_names``
+    is the list of fully-namespaced tool names to merge into the ``tools=``
+    allow-list so the agent is permitted to call them.
+
+    Raises ImportError if claude_agent_sdk isn't installed (i.e. the
+    claude-code provider isn't being used).
+    """
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server
+    except ImportError as exc:
+        raise ImportError(
+            "claude_agent_sdk is required for the web_search MCP server. "
+            "Install it with: pip install claude-agent-sdk"
+        ) from exc
+
+    web_search_tool = _build_web_search_tool()
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME, version=SERVER_VERSION, tools=[web_search_tool]
+    )
+    tool_names = [f"mcp__{SERVER_NAME}__{TOOL_NAME}"]
+    return server, tool_names
+
+
+__all__ = [
+    "SERVER_NAME",
+    "TOOL_NAME",
+    "get_web_search_server",
+]

--- a/sdk/python/tests/test_harness_mcp.py
+++ b/sdk/python/tests/test_harness_mcp.py
@@ -1,0 +1,193 @@
+"""Test that mcp_servers passes through ``router.harness`` → claude-code provider.
+
+This is the structural verification of the new framework feature: when a
+reasoner calls ``router.harness(mcp_servers={...}, tools=[...])`` against the
+claude-code provider, those values land in ``ClaudeAgentOptions`` so the
+in-process MCP server is registered with the SDK and the namespaced tool
+names are permitted.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any, Dict, List
+
+import pytest
+
+from agentfield import Agent
+
+pytestmark = pytest.mark.unit
+
+
+class _CapturingClaudeSdk:
+    """A drop-in stand-in for the claude_agent_sdk module.
+
+    We capture the ClaudeAgentOptions kwargs and the prompt for each call so
+    tests can assert on them. The ``query`` async generator emits one
+    minimal result message so the harness ``run`` path completes successfully.
+    """
+
+    def __init__(self) -> None:
+        self.last_options_kwargs: Dict[str, Any] = {}
+        self.last_prompt: str | None = None
+        self.calls: List[Dict[str, Any]] = []
+
+    # Expose a ClaudeAgentOptions class that just records construction kwargs.
+    class ClaudeAgentOptions:
+        def __init__(self, **kwargs: Any) -> None:
+            self._kwargs = kwargs
+
+        def __getattr__(self, item: str) -> Any:
+            if item == "_kwargs":
+                raise AttributeError(item)
+            try:
+                return self._kwargs[item]
+            except KeyError as exc:
+                raise AttributeError(item) from exc
+
+    async def query(self, *, prompt: str, options: Any):
+        # Capture the call shape
+        kwargs = (
+            getattr(options, "_kwargs", {})
+            if not isinstance(options, dict)
+            else options
+        )
+        self.calls.append({"prompt": prompt, "options": kwargs})
+        self.last_options_kwargs = kwargs
+        self.last_prompt = prompt
+
+        # Minimal "result" message that the provider's parsing loop accepts
+        yield {
+            "type": "result",
+            "subtype": "success",
+            "result": "ok",
+            "session_id": "fake-session",
+            "num_turns": 1,
+            "total_cost_usd": 0.0,
+        }
+
+
+@pytest.fixture
+def fake_sdk(monkeypatch):
+    """Patch the lazy-imported claude_agent_sdk in the provider with a fake."""
+    sdk = _CapturingClaudeSdk()
+
+    # Build a module-shaped namespace with the attributes the provider reads
+    fake_module = types.SimpleNamespace(
+        ClaudeAgentOptions=sdk.ClaudeAgentOptions,
+        query=sdk.query,
+    )
+
+    def _fake_get_sdk() -> Any:
+        return fake_module
+
+    monkeypatch.setattr(
+        "agentfield.harness.providers.claude._get_claude_sdk", _fake_get_sdk
+    )
+    return sdk
+
+
+async def _build_agent() -> Agent:
+    # Construct an Agent without going through the full af init / control plane.
+    # We only need the harness() method, which is a thin wrapper over HarnessRunner.
+    return Agent(node_id="test-agent")
+
+
+async def test_harness_passes_mcp_servers_to_claude_options(fake_sdk):
+    agent = await _build_agent()
+    fake_server = {"type": "sdk", "name": "af_search", "instance": object()}
+
+    result = await agent.harness(
+        prompt="say hi",
+        provider="claude-code",
+        tools=["Read", "mcp__af_search__web_search"],
+        mcp_servers={"af_search": fake_server},
+        cwd=".",
+    )
+
+    assert result.is_error is False
+    opts = fake_sdk.last_options_kwargs
+    # mcp_servers passed through verbatim
+    assert opts["mcp_servers"] == {"af_search": fake_server}
+    # Tools list is untouched (claude-code respects MCP-namespaced names directly)
+    assert opts["allowed_tools"] == ["Read", "mcp__af_search__web_search"]
+
+
+async def test_harness_omits_mcp_servers_when_not_provided(fake_sdk):
+    agent = await _build_agent()
+    await agent.harness(
+        prompt="hi",
+        provider="claude-code",
+        tools=["Read"],
+        cwd=".",
+    )
+    # When the caller didn't pass mcp_servers, the provider must not set it
+    # on ClaudeAgentOptions — leaving the SDK to use its default.
+    assert "mcp_servers" not in fake_sdk.last_options_kwargs
+
+
+async def test_harness_with_real_web_search_server_config(fake_sdk, monkeypatch):
+    """End-to-end shape check: build the real web_search MCP server config and
+    verify it makes it through the harness layer untouched."""
+    monkeypatch.setenv("JINA_API_KEY", "fake-key")  # avoid no-provider gate
+    from agentfield.tools.web_search import get_web_search_server
+
+    server, tool_names = get_web_search_server()
+    agent = await _build_agent()
+
+    await agent.harness(
+        prompt="hi",
+        provider="claude-code",
+        tools=["Read", *tool_names],
+        mcp_servers={"af_search": server},
+        cwd=".",
+    )
+
+    opts = fake_sdk.last_options_kwargs
+    assert "af_search" in opts["mcp_servers"]
+    assert opts["mcp_servers"]["af_search"] is server
+    assert "mcp__af_search__web_search" in opts["allowed_tools"]
+
+
+async def test_non_claude_provider_ignores_mcp_servers(monkeypatch, fake_sdk):
+    """For codex/gemini/opencode providers, mcp_servers should be silently
+    ignored (the same way tools=[] already is). Failing closed here would
+    silently break harness calls that pass mcp_servers across providers."""
+    # Switch to opencode provider; we don't want to actually invoke its CLI
+    # so swap in a stub via the import-side reference in _runner (which binds
+    # build_provider at import time, so patching the source module is too late).
+
+    class _StubProvider:
+        def __init__(self) -> None:
+            self.last_options: Dict[str, Any] = {}
+
+        async def execute(self, prompt: str, options: Dict[str, Any]):
+            from agentfield.harness._result import Metrics, RawResult
+
+            self.last_options = dict(options)
+            return RawResult(
+                result="ok",
+                messages=[],
+                metrics=Metrics(duration_api_ms=1, session_id="x"),
+                is_error=False,
+            )
+
+    stub = _StubProvider()
+    monkeypatch.setattr(
+        "agentfield.harness._runner.build_provider", lambda config: stub
+    )
+
+    agent = await _build_agent()
+    await agent.harness(
+        prompt="hi",
+        provider="opencode",
+        tools=["Read"],
+        mcp_servers={"af_search": object()},
+        cwd=".",
+    )
+
+    # The runner forwards mcp_servers in options regardless; non-claude
+    # providers just don't pluck it out of options. That's the contract:
+    # silent ignore, not error. Verify the option arrived in the bag and
+    # the call succeeded.
+    assert "mcp_servers" in stub.last_options

--- a/sdk/python/tests/test_harness_mcp.py
+++ b/sdk/python/tests/test_harness_mcp.py
@@ -129,6 +129,10 @@ async def test_harness_omits_mcp_servers_when_not_provided(fake_sdk):
 async def test_harness_with_real_web_search_server_config(fake_sdk, monkeypatch):
     """End-to-end shape check: build the real web_search MCP server config and
     verify it makes it through the harness layer untouched."""
+    pytest.importorskip(
+        "claude_agent_sdk",
+        reason="claude_agent_sdk not installed (optional dep)",
+    )
     monkeypatch.setenv("JINA_API_KEY", "fake-key")  # avoid no-provider gate
     from agentfield.tools.web_search import get_web_search_server
 

--- a/sdk/python/tests/test_harness_web_search_e2e.py
+++ b/sdk/python/tests/test_harness_web_search_e2e.py
@@ -1,0 +1,85 @@
+"""End-to-end harness test with real Claude + real web_search tool.
+
+This is the headline functional test the user asked for: it spins up a
+genuine ``router.harness`` call against ``provider="claude-code"`` with the
+``web_search`` MCP server attached, asks Claude a question that requires
+external lookup, and asserts that (a) the harness completed without error
+and (b) Claude actually invoked the web_search tool.
+
+Marked ``harness_live`` because it costs real money: requires both
+``ANTHROPIC_API_KEY`` (for Claude) and ``JINA_API_KEY`` (for the underlying
+search). Excluded from default test runs by the pytest ``addopts``
+configuration; run explicitly with ``pytest -m harness_live``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from agentfield import Agent
+from agentfield.tools.web_search import get_web_search_server
+
+pytestmark = [
+    pytest.mark.harness_live,
+    pytest.mark.skipif(
+        not (os.environ.get("ANTHROPIC_API_KEY") and os.environ.get("JINA_API_KEY")),
+        reason="ANTHROPIC_API_KEY and JINA_API_KEY both required for live e2e",
+    ),
+]
+
+
+@pytest.mark.asyncio
+async def test_claude_invokes_web_search_tool():
+    """Real Claude harness call must successfully invoke the web_search tool.
+
+    We instruct Claude to use web_search to look up a fact, then verify both
+    that the harness returned a successful result AND that at least one
+    tool_use message in the captured transcript names the web_search tool.
+    """
+    agent = Agent(node_id="test-web-search-e2e")
+    server, tool_names = get_web_search_server()
+
+    result = await agent.harness(
+        prompt=(
+            "Use the web_search tool to find the official documentation URL for "
+            "the Python pytest framework. After searching, reply in one sentence "
+            "with the documentation URL."
+        ),
+        provider="claude-code",
+        tools=["Read", *tool_names],
+        mcp_servers={"af_search": server},
+        cwd=".",
+        max_turns=4,
+        permission_mode="auto",
+    )
+
+    assert result.is_error is False, f"harness errored: {result.error_message}"
+    assert result.result is not None and result.result.strip()
+
+    # Walk the captured messages looking for a tool_use of web_search.
+    used_web_search = False
+    for msg in result.messages or []:
+        # Messages are dicts; tool calls may be nested under content blocks.
+        content = msg.get("content")
+        if content is None:
+            inner = msg.get("message")
+            if isinstance(inner, dict):
+                content = inner.get("content")
+        if isinstance(content, list):
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                if block.get("type") == "tool_use":
+                    name = block.get("name", "")
+                    if "web_search" in name:
+                        used_web_search = True
+                        break
+        if used_web_search:
+            break
+
+    assert used_web_search, (
+        "Expected Claude to invoke the web_search tool, but no tool_use for "
+        "web_search appeared in the message transcript."
+    )

--- a/sdk/python/tests/tools/test_search_live_jina.py
+++ b/sdk/python/tests/tools/test_search_live_jina.py
@@ -1,0 +1,52 @@
+"""Live functional smoke test for the Jina search provider.
+
+Skipped unless ``JINA_API_KEY`` is set in the environment. When the key is
+present, this test issues one real search request and asserts that the
+provider returns at least one result with a URL and a non-empty content
+field. This is the proper functional test that proves the integration
+actually works against the provider's API.
+
+Marked ``functional`` so it runs alongside other end-to-end-within-SDK
+tests but is gated on the API key at import time.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from agentfield.tools.search import JinaSearchProvider, search
+
+pytestmark = [
+    pytest.mark.functional,
+    pytest.mark.skipif(
+        not os.environ.get("JINA_API_KEY"),
+        reason="JINA_API_KEY not set — skipping live Jina smoke test",
+    ),
+]
+
+
+@pytest.mark.asyncio
+async def test_jina_live_search_returns_results():
+    """Real Jina search must return at least one result with a URL."""
+    response = await JinaSearchProvider().search("agentfield python sdk")
+
+    assert response.provider == "jina"
+    assert response.query_used == "agentfield python sdk"
+    assert response.total_results >= 1, "expected at least one result from Jina"
+
+    first = response.results[0]
+    assert first.url, "first result should have a URL"
+    assert first.url.startswith(("http://", "https://"))
+    # Most results have content; a few might just have title+url. We require
+    # at least one of the three text fields to be non-empty.
+    assert first.title or first.content or first.description
+
+
+@pytest.mark.asyncio
+async def test_module_search_helper_live():
+    """The top-level search() helper auto-resolves to Jina when only Jina is set."""
+    response = await search("pytest")
+    assert response.provider in {"jina", "tavily", "firecrawl", "serper"}
+    assert response.total_results >= 1

--- a/sdk/python/tests/tools/test_search_providers.py
+++ b/sdk/python/tests/tools/test_search_providers.py
@@ -1,0 +1,365 @@
+"""Unit tests for the four web search providers and the registry.
+
+HTTP traffic is mocked with pytest-httpx so these tests run without keys and
+without hitting the network. Live tests against real APIs live in
+``test_search_live_jina.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from agentfield.tools.search import (
+    DEFAULT_PROVIDER_PRIORITY,
+    FirecrawlSearchProvider,
+    JinaSearchProvider,
+    SearchProvider,
+    SerperSearchProvider,
+    TavilySearchProvider,
+    get_available_providers,
+    get_default_provider,
+    get_provider,
+    list_provider_status,
+    register_provider,
+    search,
+    search_with_provider,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------- Jina ----------
+
+
+async def test_jina_search_parses_response(monkeypatch, httpx_mock: HTTPXMock):
+    monkeypatch.setenv("JINA_API_KEY", "jina-test-key")
+    httpx_mock.add_response(
+        url="https://s.jina.ai/?q=pytest+docs",
+        method="GET",
+        json={
+            "data": [
+                {
+                    "title": "Pytest documentation",
+                    "url": "https://docs.pytest.org",
+                    "content": "pytest is a framework",
+                    "description": "Test framework",
+                    "publishedTime": "2024-01-01T00:00:00Z",
+                },
+                {
+                    "title": "Pytest on PyPI",
+                    "url": "https://pypi.org/project/pytest",
+                    "content": "Latest release",
+                },
+            ]
+        },
+    )
+
+    response = await JinaSearchProvider().search("pytest docs")
+
+    assert response.provider == "jina"
+    assert response.query_used == "pytest docs"
+    assert response.total_results == 2
+    assert response.results[0].title == "Pytest documentation"
+    assert response.results[0].url == "https://docs.pytest.org"
+    assert response.results[0].published_time is not None
+    # Second result has no publishedTime — should not blow up
+    assert response.results[1].published_time is None
+
+
+async def test_jina_missing_key_raises(monkeypatch):
+    monkeypatch.delenv("JINA_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="JINA_API_KEY"):
+        await JinaSearchProvider().search("anything")
+
+
+async def test_jina_http_error_propagates(monkeypatch, httpx_mock: HTTPXMock):
+    monkeypatch.setenv("JINA_API_KEY", "jina-test-key")
+    httpx_mock.add_response(
+        url="https://s.jina.ai/?q=fail", method="GET", status_code=500
+    )
+    import httpx
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await JinaSearchProvider().search("fail")
+
+
+# ---------- Tavily ----------
+
+
+async def test_tavily_search_parses_response(monkeypatch, httpx_mock: HTTPXMock):
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-test")
+    httpx_mock.add_response(
+        url="https://api.tavily.com/search",
+        method="POST",
+        json={
+            "results": [
+                {
+                    "title": "Article",
+                    "url": "https://example.com/a",
+                    "content": "snippet body",
+                    "snippet": "short",
+                    "published_date": "2024-06-15T12:00:00Z",
+                }
+            ]
+        },
+    )
+
+    response = await TavilySearchProvider().search("topic")
+    assert response.provider == "tavily"
+    assert response.total_results == 1
+    assert response.results[0].url == "https://example.com/a"
+    assert response.results[0].description == "short"
+    assert response.results[0].published_time is not None
+
+
+async def test_tavily_missing_key_raises(monkeypatch):
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="TAVILY_API_KEY"):
+        await TavilySearchProvider().search("anything")
+
+
+# ---------- Firecrawl ----------
+
+
+async def test_firecrawl_search_parses_response(monkeypatch, httpx_mock: HTTPXMock):
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
+    httpx_mock.add_response(
+        url="https://api.firecrawl.dev/v1/search",
+        method="POST",
+        json={
+            "data": [
+                {
+                    "title": "Doc",
+                    "url": "https://example.com/doc",
+                    "markdown": "# Heading\nbody",
+                    "description": "doc desc",
+                    "publishedDate": "2025-02-01T08:30:00Z",
+                },
+                {
+                    "title": "Snippet only",
+                    "url": "https://example.com/snip",
+                    "snippet": "fallback snippet",
+                },
+            ]
+        },
+    )
+
+    response = await FirecrawlSearchProvider().search("docs")
+    assert response.provider == "firecrawl"
+    assert response.total_results == 2
+    # First result prefers markdown over description/snippet
+    assert response.results[0].content.startswith("# Heading")
+    # Second result falls back to snippet (no markdown, no description)
+    assert response.results[1].content == "fallback snippet"
+
+
+async def test_firecrawl_missing_key_raises(monkeypatch):
+    monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="FIRECRAWL_API_KEY"):
+        await FirecrawlSearchProvider().search("anything")
+
+
+# ---------- Serper ----------
+
+
+async def test_serper_search_parses_organic(monkeypatch, httpx_mock: HTTPXMock):
+    monkeypatch.setenv("SERPER_API_KEY", "serper-test")
+    httpx_mock.add_response(
+        url="https://google.serper.dev/search",
+        method="POST",
+        json={
+            "organic": [
+                {
+                    "title": "Result A",
+                    "link": "https://a.example",
+                    "snippet": "A snippet",
+                },
+                {
+                    "title": "Result B",
+                    "link": "https://b.example",
+                    "snippet": "B snippet",
+                },
+            ]
+        },
+    )
+
+    response = await SerperSearchProvider().search("query")
+    assert response.provider == "serper"
+    assert response.total_results == 2
+    assert response.results[0].url == "https://a.example"
+
+
+async def test_serper_news_uses_news_section(monkeypatch, httpx_mock: HTTPXMock):
+    monkeypatch.setenv("SERPER_API_KEY", "serper-test")
+    httpx_mock.add_response(
+        url="https://google.serper.dev/news",
+        method="POST",
+        json={
+            "news": [
+                {
+                    "title": "Breaking",
+                    "link": "https://news.example",
+                    "snippet": "news snippet",
+                }
+            ]
+        },
+    )
+    response = await SerperSearchProvider(search_type="news").search("topic")
+    assert response.total_results == 1
+    assert response.results[0].url == "https://news.example"
+
+
+async def test_serper_missing_key_raises(monkeypatch):
+    monkeypatch.delenv("SERPER_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="SERPER_API_KEY"):
+        await SerperSearchProvider().search("anything")
+
+
+# ---------- Registry / auto-detect ----------
+
+
+def _clear_all_keys(monkeypatch):
+    for key in (
+        "JINA_API_KEY",
+        "TAVILY_API_KEY",
+        "FIRECRAWL_API_KEY",
+        "SERPER_API_KEY",
+        "SEARCH_PROVIDER",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_default_priority_picks_jina_when_only_jina_set(monkeypatch):
+    _clear_all_keys(monkeypatch)
+    monkeypatch.setenv("JINA_API_KEY", "k")
+    provider = get_default_provider()
+    assert provider is not None
+    assert provider.name == "jina"
+
+
+def test_default_priority_picks_first_available_in_priority_order(monkeypatch):
+    _clear_all_keys(monkeypatch)
+    # Skip jina, configure tavily and serper. Priority order is jina,tavily,firecrawl,serper
+    # so the default should be tavily (first available).
+    monkeypatch.setenv("TAVILY_API_KEY", "t")
+    monkeypatch.setenv("SERPER_API_KEY", "s")
+    provider = get_default_provider()
+    assert provider is not None
+    assert provider.name == "tavily"
+
+
+def test_explicit_search_provider_env_var_wins(monkeypatch):
+    _clear_all_keys(monkeypatch)
+    monkeypatch.setenv("JINA_API_KEY", "j")
+    monkeypatch.setenv("SERPER_API_KEY", "s")
+    monkeypatch.setenv("SEARCH_PROVIDER", "serper")
+    provider = get_default_provider()
+    assert provider is not None
+    assert provider.name == "serper"
+
+
+def test_explicit_search_provider_falls_through_when_unavailable(monkeypatch):
+    _clear_all_keys(monkeypatch)
+    monkeypatch.setenv("JINA_API_KEY", "j")
+    monkeypatch.setenv("SEARCH_PROVIDER", "tavily")  # not configured
+    provider = get_default_provider()
+    assert provider is not None
+    assert provider.name == "jina"  # falls back to first available in priority
+
+
+def test_no_providers_returns_none(monkeypatch):
+    _clear_all_keys(monkeypatch)
+    assert get_default_provider() is None
+    assert get_available_providers() == []
+
+
+def test_list_provider_status_reflects_env(monkeypatch):
+    _clear_all_keys(monkeypatch)
+    monkeypatch.setenv("JINA_API_KEY", "j")
+    status = list_provider_status()
+    assert status["jina"] is True
+    assert status["tavily"] is False
+    assert set(status.keys()) == set(DEFAULT_PROVIDER_PRIORITY)
+
+
+def test_get_provider_unknown_returns_none():
+    assert get_provider("nonexistent") is None
+
+
+def test_register_custom_provider(monkeypatch):
+    _clear_all_keys(monkeypatch)
+
+    class FakeProvider(SearchProvider):
+        @property
+        def name(self) -> str:
+            return "fake"
+
+        @property
+        def api_key_env_var(self) -> str:
+            return "FAKE_API_KEY"
+
+        async def search(self, query: str):  # pragma: no cover - not exercised
+            raise NotImplementedError
+
+    register_provider("fake", FakeProvider)
+    monkeypatch.setenv("FAKE_API_KEY", "k")
+    instance = get_provider("fake")
+    assert isinstance(instance, FakeProvider)
+
+
+def test_register_provider_rejects_non_subclass():
+    class NotAProvider:
+        pass
+
+    with pytest.raises(TypeError):
+        register_provider("bad", NotAProvider)  # type: ignore[arg-type]
+
+
+# ---------- module-level search() helper ----------
+
+
+async def test_module_search_helper_uses_default_provider(
+    monkeypatch, httpx_mock: HTTPXMock
+):
+    _clear_all_keys(monkeypatch)
+    monkeypatch.setenv("JINA_API_KEY", "k")
+    httpx_mock.add_response(
+        url="https://s.jina.ai/?q=hello",
+        method="GET",
+        json={"data": [{"title": "H", "url": "https://h", "content": "hi"}]},
+    )
+
+    response = await search("hello")
+    assert response.provider == "jina"
+    assert response.total_results == 1
+
+
+async def test_module_search_helper_raises_without_providers(monkeypatch):
+    _clear_all_keys(monkeypatch)
+    with pytest.raises(RuntimeError, match="No search providers"):
+        await search("anything")
+
+
+async def test_search_with_provider_specific(monkeypatch, httpx_mock: HTTPXMock):
+    _clear_all_keys(monkeypatch)
+    monkeypatch.setenv("TAVILY_API_KEY", "t")
+    httpx_mock.add_response(
+        url="https://api.tavily.com/search",
+        method="POST",
+        json={"results": [{"title": "T", "url": "https://t", "content": "c"}]},
+    )
+
+    response = await search_with_provider("q", provider="tavily")
+    assert response.provider == "tavily"
+
+
+async def test_search_with_provider_unknown_raises():
+    with pytest.raises(ValueError, match="Unknown"):
+        await search_with_provider("q", provider="bogus")
+
+
+async def test_search_with_provider_unconfigured_raises(monkeypatch):
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="not available"):
+        await search_with_provider("q", provider="tavily")

--- a/sdk/python/tests/tools/test_web_search.py
+++ b/sdk/python/tests/tools/test_web_search.py
@@ -1,0 +1,213 @@
+"""Unit tests for the web_search MCP tool wrapper.
+
+The wrapper turns the multi-provider search package into a single in-process
+MCP tool that a Claude Code harness can invoke. We assert input validation,
+output formatting, error paths, and the public ``get_web_search_server``
+helper's contract.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from agentfield.tools.search.base import SearchResponse, SearchResult
+from agentfield.tools.web_search import (
+    SERVER_NAME,
+    TOOL_NAME,
+    _build_web_search_tool,
+    _format_results_as_markdown,
+    get_web_search_server,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------- markdown formatting ----------
+
+
+def test_format_results_renders_title_url_and_snippet():
+    response = SearchResponse(
+        results=[
+            SearchResult(
+                title="Pytest docs",
+                url="https://docs.pytest.org",
+                content="Test framework for Python.",
+            )
+        ],
+        total_results=1,
+        query_used="pytest docs",
+        provider="jina",
+    )
+    out = _format_results_as_markdown(response)
+    assert "jina" in out
+    assert "pytest docs" in out
+    assert "[Pytest docs](https://docs.pytest.org)" in out
+    assert "Test framework for Python." in out
+
+
+def test_format_results_truncates_long_snippets():
+    response = SearchResponse(
+        results=[
+            SearchResult(
+                title="Long",
+                url="https://x",
+                content="x" * 1500,
+            )
+        ],
+        total_results=1,
+        query_used="q",
+        provider="jina",
+    )
+    out = _format_results_as_markdown(response)
+    # Long snippet was truncated to 600 chars + ellipsis
+    assert "…" in out
+    # Original 1500-char body must not appear in full
+    assert "x" * 1500 not in out
+
+
+def test_format_results_includes_published_time_when_present():
+    response = SearchResponse(
+        results=[
+            SearchResult(
+                title="Dated",
+                url="https://x",
+                content="body",
+                published_time=datetime(2025, 6, 1, tzinfo=timezone.utc),
+            )
+        ],
+        total_results=1,
+        query_used="q",
+        provider="jina",
+    )
+    out = _format_results_as_markdown(response)
+    assert "2025-06-01" in out
+
+
+def test_format_results_handles_empty():
+    response = SearchResponse(
+        results=[], total_results=0, query_used="q", provider="jina"
+    )
+    out = _format_results_as_markdown(response)
+    assert "No results" in out
+    assert "jina" in out
+
+
+def test_format_falls_back_to_url_when_title_missing():
+    response = SearchResponse(
+        results=[SearchResult(title="", url="https://x", content="snip")],
+        total_results=1,
+        query_used="q",
+        provider="jina",
+    )
+    out = _format_results_as_markdown(response)
+    assert "[https://x](https://x)" in out
+
+
+# ---------- @tool wrapper handler ----------
+
+
+def _clear_all_keys(monkeypatch):
+    for key in (
+        "JINA_API_KEY",
+        "TAVILY_API_KEY",
+        "FIRECRAWL_API_KEY",
+        "SERPER_API_KEY",
+        "SEARCH_PROVIDER",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _get_handler():
+    sdk_tool = _build_web_search_tool()
+    # SdkMcpTool exposes the original async fn via .handler
+    return sdk_tool.handler
+
+
+async def test_handler_rejects_empty_query(monkeypatch):
+    _clear_all_keys(monkeypatch)
+    monkeypatch.setenv("JINA_API_KEY", "k")
+    handler = _get_handler()
+
+    result = await handler({"query": ""})
+    assert result.get("is_error") is True
+    assert "non-empty" in result["content"][0]["text"].lower()
+
+
+async def test_handler_rejects_missing_query(monkeypatch):
+    _clear_all_keys(monkeypatch)
+    monkeypatch.setenv("JINA_API_KEY", "k")
+    handler = _get_handler()
+    result = await handler({})
+    assert result.get("is_error") is True
+
+
+async def test_handler_returns_provider_error_when_no_keys(monkeypatch):
+    _clear_all_keys(monkeypatch)
+    handler = _get_handler()
+    result = await handler({"query": "anything"})
+    assert result.get("is_error") is True
+    text = result["content"][0]["text"]
+    assert "no search provider" in text.lower()
+    assert "JINA_API_KEY" in text
+
+
+async def test_handler_returns_formatted_results(monkeypatch):
+    _clear_all_keys(monkeypatch)
+    monkeypatch.setenv("JINA_API_KEY", "k")
+
+    fake_response = SearchResponse(
+        results=[
+            SearchResult(title="A", url="https://a", content="alpha"),
+            SearchResult(title="B", url="https://b", content="beta"),
+        ],
+        total_results=2,
+        query_used="qq",
+        provider="jina",
+    )
+
+    async def fake_search(query: str):
+        return fake_response
+
+    monkeypatch.setattr("agentfield.tools.web_search.search", fake_search)
+
+    handler = _get_handler()
+    result = await handler({"query": "qq"})
+    assert "is_error" not in result or result.get("is_error") is False
+    text = result["content"][0]["text"]
+    assert "A" in text and "https://a" in text
+    assert "B" in text and "https://b" in text
+
+
+async def test_handler_catches_search_exception(monkeypatch):
+    _clear_all_keys(monkeypatch)
+    monkeypatch.setenv("JINA_API_KEY", "k")
+
+    async def boom(query: str):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr("agentfield.tools.web_search.search", boom)
+    handler = _get_handler()
+    result = await handler({"query": "q"})
+    assert result.get("is_error") is True
+    assert "network down" in result["content"][0]["text"]
+
+
+# ---------- get_web_search_server contract ----------
+
+
+def test_get_web_search_server_returns_config_and_namespaced_tool_names(monkeypatch):
+    _clear_all_keys(monkeypatch)
+    monkeypatch.setenv("JINA_API_KEY", "k")
+
+    server, tool_names = get_web_search_server()
+
+    # claude_agent_sdk's create_sdk_mcp_server returns a McpSdkServerConfig
+    # which is a TypedDict. We just verify we got a non-empty dict and the
+    # tool names are correctly namespaced.
+    assert server is not None
+    assert tool_names == [f"mcp__{SERVER_NAME}__{TOOL_NAME}"]
+    # Specifically: an LLM allow-list referencing the namespaced name should
+    # be sufficient for Claude Code to permit the call.
+    assert tool_names[0].startswith("mcp__")

--- a/sdk/python/tests/tools/test_web_search.py
+++ b/sdk/python/tests/tools/test_web_search.py
@@ -24,6 +24,19 @@ from agentfield.tools.web_search import (
 pytestmark = pytest.mark.unit
 
 
+# The @tool decorator and create_sdk_mcp_server must be exercised against
+# the *real* claude_agent_sdk to verify the resulting SdkMcpTool /
+# McpSdkServerConfig shapes. Tests that call those functions are gated on
+# the SDK being installed (it's an optional dependency under the
+# harness-claude / harness extras). Pure-Python tests above this fixture
+# (markdown formatting) need no gating.
+def _require_claude_sdk():
+    pytest.importorskip(
+        "claude_agent_sdk",
+        reason="claude_agent_sdk not installed (optional dep — install via .[harness])",
+    )
+
+
 # ---------- markdown formatting ----------
 
 
@@ -120,6 +133,7 @@ def _clear_all_keys(monkeypatch):
 
 
 def _get_handler():
+    _require_claude_sdk()
     sdk_tool = _build_web_search_tool()
     # SdkMcpTool exposes the original async fn via .handler
     return sdk_tool.handler
@@ -198,6 +212,7 @@ async def test_handler_catches_search_exception(monkeypatch):
 
 
 def test_get_web_search_server_returns_config_and_namespaced_tool_names(monkeypatch):
+    _require_claude_sdk()
     _clear_all_keys(monkeypatch)
     monkeypatch.setenv("JINA_API_KEY", "k")
 


### PR DESCRIPTION
## Summary

Adds a way for harnessed Claude Code agents to invoke web search during a run, so reasoners can look up library docs, error messages, deprecation status, and other context that doesn't live in the codebase.

Three layers, three commits:

1. **`agentfield.tools.search`** — vendored multi-provider search package (Jina, Tavily, Firecrawl, Serper) with a unified `SearchProvider` ABC, env-driven auto-detection, and a priority order overridable via `SEARCH_PROVIDER`. Ported from `Agent-Field/af-deep-research`'s `skills/search` from `aiohttp` to `httpx` so it lines up with this repo's existing `pytest-httpx` test infra.

2. **`mcp_servers` parameter on `Agent.harness`** — new keyword arg (also reachable via the `router.harness` delegation path) that forwards an MCP-server mapping straight to `ClaudeAgentOptions.mcp_servers`. Honored only by the `claude-code` provider; `opencode`/`codex`/`gemini` ignore it the same way they already ignore `tools=[...]`.

3. **`agentfield.tools.web_search.get_web_search_server()`** — returns `(McpSdkServerConfig, [tool_names])` for an in-process MCP server (built via `claude_agent_sdk.create_sdk_mcp_server` + `@tool`) that wraps the search package. Reasoners drop the server under a key in `mcp_servers={...}` and merge the namespaced `mcp__af_search__web_search` name into their `tools=[...]` allow-list. Tool description tells the model to reach for it only when the answer can't come from the codebase, mitigating loop risk in coding agents.

## Why this shape

Considered building it as a per-call Python pre-step (search before the prompt, inject results) and as a custom-tool registry across providers. Pre-step loses the agent's ability to decide *when* to search; cross-provider registries would have required modifying three external CLI binaries. The in-process MCP server is the canonical extension point in `claude-agent-sdk` and matches the way Claude Code itself ships built-in tools — minimal new surface area, no per-call wrapper code in reasoners.

## Test plan

- 39 unit/integration tests pass (`tests/tools/`, `tests/test_harness_mcp.py`)
  - Per-provider HTTP mocking for Jina, Tavily, Firecrawl, Serper
  - Registry/auto-detect: priority order, `SEARCH_PROVIDER` override, fallback when preferred is unavailable, custom provider registration
  - `web_search` wrapper: input validation, no-provider error path, exception-in-search handler, markdown formatting (snippet truncation, missing fields, empty results)
  - Harness plumbing: passthrough to `ClaudeAgentOptions`, omission when not set, real-server-config wiring, silent ignore on non-claude provider
- 2 live tests in `tests/tools/test_search_live_jina.py` — skipped without `JINA_API_KEY`, otherwise hit the real Jina API and assert structured results
- 1 end-to-end test in `tests/test_harness_web_search_e2e.py` — `harness_live` marker (deselected by default `addopts`), gated on both `ANTHROPIC_API_KEY` and `JINA_API_KEY`. Drives a real Claude harness call, asks the model to use `web_search` to look up pytest's docs URL, asserts the model actually invoked the tool

Existing harness suite (130 tests under `-k harness`): all green, no regressions.

## Follow-up

Sister PR coming on `Agent-Field/SWE-AF` that wires `get_web_search_server()` into 6 reasoners — `run_architect`, `run_ci_fixer`, `run_pr_resolver` as Tier 1 (web access is high-leverage), and `run_coder`, `run_retry_advisor`, `run_product_manager` as Tier 2 (with prompt guardrails on the coder to scope use). Per-reasoner cost analysis already done; the deterministic / pure-synthesis / short-budget reasoners are deliberately excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)