### PR TITLE
fix(examples): respect AI_MODEL env var on the two agents that ignored it

### DIFF
--- a/examples/python_agent_nodes/simulation_engine/main.py
+++ b/examples/python_agent_nodes/simulation_engine/main.py
@@ -33,7 +33,7 @@ app = Agent(
     agentfield_server=f"{os.getenv('AGENTFIELD_SERVER', 'http://localhost:8080')}",
     dev_mode=True,
     ai_config=AIConfig(
-        model="openrouter/deepseek/deepseek-v3.1-terminus",  # LiteLLM auto-detects provider from model name
+        model=os.getenv("AI_MODEL", "openrouter/deepseek/deepseek-v3.1-terminus"),  # LiteLLM auto-detects provider from model name
         api_key=os.getenv("OPENROUTER_API_KEY"),  # or set OPENAI_API_KEY env var
     ),
 )

--- a/examples/triggers-demo/agent.py
+++ b/examples/triggers-demo/agent.py
@@ -186,7 +186,7 @@ async def summarize_issue(event: dict, trigger: TriggerContext | None = None):
             f"Title: {title}\n\n"
             f"Body:\n{body}"
         ),
-        model="openrouter/anthropic/claude-haiku-4-5",
+        model=os.getenv("AI_MODEL", "openrouter/anthropic/claude-haiku-4-5"),
         max_tokens=300,
     )
 


### PR DESCRIPTION
## Summary

Two of the example agents in this repo hardcoded their model strings with no env-var fallback at all. Any deployer setting \`AI_MODEL\` globally for the rest of their stack would silently get bypassed for these — they'd bill DeepSeek (simulation_engine) and Claude Haiku (triggers-demo) regardless of config.

## Changes

| File | Before | After |
|---|---|---|
| \`examples/python_agent_nodes/simulation_engine/main.py\` | hardcoded \`openrouter/deepseek/deepseek-v3.1-terminus\` | \`os.getenv("AI_MODEL", "openrouter/deepseek/deepseek-v3.1-terminus")\` |
| \`examples/triggers-demo/agent.py\` | hardcoded \`openrouter/anthropic/claude-haiku-4-5\` | \`os.getenv("AI_MODEL", "openrouter/anthropic/claude-haiku-4-5")\` |

Defaults preserved exactly — this only adds the env-var override path, it does not change what an unset deployment runs on. Two other example agents (\`deep_research\`, \`rag_evaluation\`) were also briefly touched in an earlier revision of this branch but have been reverted; they already respect \`AI_MODEL\` and changing their fallback default was out of scope for an env-var-respecting fix.

## Test plan

- [x] \`python -m py_compile\` on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)