### PR TITLE
fix(sdk-python): count opencode turns from JSON step events

### DIFF
--- a/sdk/python/agentfield/harness/_cli.py
+++ b/sdk/python/agentfield/harness/_cli.py
@@ -71,14 +71,18 @@ def extract_final_text(events: List[Dict[str, Any]]) -> Optional[str]:
     Looks for common patterns across different CLI tools:
     - type: "result" with text/result field
     - type: "item.completed" with item.text field (Codex)
+    - type: "text" with part.text field (OpenCode JSON stream)
     - Last assistant message text
     """
     result_text = None
+    current_text_parts: List[str] = []
 
     for event in events:
         event_type = event.get("type", "")
 
-        if event_type == "item.completed":
+        if event_type == "step_start":
+            current_text_parts = []
+        elif event_type == "item.completed":
             item = event.get("item", {})
             if item.get("type") == "agent_message":
                 text = item.get("text", "")
@@ -94,6 +98,14 @@ def extract_final_text(events: List[Dict[str, Any]]) -> Optional[str]:
             content = event.get("content", event.get("text", ""))
             if isinstance(content, str) and content:
                 result_text = content
+        elif event_type == "text":
+            content = event.get("text", event.get("content", ""))
+            part = event.get("part")
+            if not content and isinstance(part, dict):
+                content = part.get("text", "")
+            if isinstance(content, str) and content:
+                current_text_parts.append(content)
+                result_text = "".join(current_text_parts)
 
     return result_text
 

--- a/sdk/python/agentfield/harness/providers/opencode.py
+++ b/sdk/python/agentfield/harness/providers/opencode.py
@@ -11,7 +11,13 @@ import tempfile
 import time
 from typing import ClassVar, Dict, Optional
 
-from agentfield.harness._cli import estimate_cli_cost, run_cli, strip_ansi
+from agentfield.harness._cli import (
+    estimate_cli_cost,
+    extract_final_text,
+    parse_jsonl,
+    run_cli,
+    strip_ansi,
+)
 from agentfield.harness._result import FailureType, Metrics, RawResult
 
 logger = logging.getLogger("agentfield.harness.opencode")
@@ -27,6 +33,20 @@ _OPENCODE_STDERR_ERROR_PATTERNS = (
     re.compile(r"\bUnauthorized\b"),
     re.compile(r"\bAPIError\b"),
 )
+
+
+def _count_turns_from_events(events: list[dict[str, object]]) -> int:
+    """Count opencode turns from JSON events.
+
+    Preferred definition is one turn per ``step_start`` event. If a stream
+    has no step markers, fall back to counting ``tool_use`` events.
+    """
+    step_starts = sum(1 for event in events if event.get("type") == "step_start")
+    if step_starts > 0:
+        return step_starts
+
+    tool_uses = sum(1 for event in events if event.get("type") == "tool_use")
+    return tool_uses
 
 
 def _extract_opencode_error(stderr: str) -> str:
@@ -88,6 +108,7 @@ class OpenCodeProvider:
     async def _execute_impl(self, prompt: str, options: dict[str, object]) -> RawResult:
         # opencode v1.4+ uses the `run` subcommand (replaces deprecated -p/-c flags)
         cmd = [self._bin, "run"]
+        cmd.extend(["--format", "json"])
 
         # Use --dir for project directory (replaces deprecated -c which now means --continue)
         cwd_value = options.get("cwd")
@@ -194,7 +215,11 @@ class OpenCodeProvider:
                 shutil.rmtree(temp_data_dir, ignore_errors=True)
 
         api_ms = int((time.monotonic() - start_api) * 1000)
-        result_text = stdout.strip() if stdout.strip() else None
+        events = parse_jsonl(stdout)
+        if events:
+            result_text = extract_final_text(events)
+        else:
+            result_text = stdout.strip() if stdout.strip() else None
         clean_stderr = strip_ansi(stderr.strip()) if stderr else ""
 
         logger.info(
@@ -245,12 +270,16 @@ class OpenCodeProvider:
             result_text=result_text,
         )
 
+        num_turns = _count_turns_from_events(events)
+        if num_turns == 0 and result_text:
+            num_turns = 1
+
         return RawResult(
             result=result_text,
-            messages=[],
+            messages=events,
             metrics=Metrics(
                 duration_api_ms=api_ms,
-                num_turns=1 if result_text else 0,
+                num_turns=num_turns,
                 total_cost_usd=estimated_cost,
                 session_id="",
             ),

--- a/sdk/python/agentfield/harness/providers/opencode.py
+++ b/sdk/python/agentfield/harness/providers/opencode.py
@@ -49,6 +49,48 @@ def _count_turns_from_events(events: list[dict[str, object]]) -> int:
     return tool_uses
 
 
+def _cost_from_events(events: list[dict[str, object]]) -> float | None:
+    """Sum opencode per-step costs when present in the JSON stream."""
+    total_cost = 0.0
+    found_cost = False
+
+    for event in events:
+        if event.get("type") != "step_finish":
+            continue
+        part = event.get("part")
+        if not isinstance(part, dict):
+            continue
+        cost = part.get("cost")
+        if isinstance(cost, (int, float)) and not isinstance(cost, bool):
+            total_cost += float(cost)
+            found_cost = True
+
+    return total_cost if found_cost else None
+
+
+def _extract_opencode_event_error(events: list[dict[str, object]]) -> str | None:
+    """Pull a meaningful failure message from an in-band JSON error event."""
+    for event in events:
+        if event.get("type") != "error":
+            continue
+
+        for key in ("message", "error", "text"):
+            value = event.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()[:1000]
+
+        part = event.get("part")
+        if isinstance(part, dict):
+            for key in ("message", "error", "text"):
+                value = part.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()[:1000]
+
+        return str(event)[:1000]
+
+    return None
+
+
 def _extract_opencode_error(stderr: str) -> str:
     """Pull the meaningful failure line(s) out of opencode stderr.
 
@@ -220,6 +262,7 @@ class OpenCodeProvider:
             result_text = extract_final_text(events)
         else:
             result_text = stdout.strip() if stdout.strip() else None
+        event_error = _extract_opencode_event_error(events)
         clean_stderr = strip_ansi(stderr.strip()) if stderr else ""
 
         logger.info(
@@ -248,6 +291,13 @@ class OpenCodeProvider:
                 else (f"Process exited with code {returncode} and produced no output.")
             )
         elif (
+            event_error is not None
+            and result_text is None
+        ):
+            failure_type = FailureType.CRASH
+            is_error = True
+            error_message = event_error
+        elif (
             result_text is None
             and clean_stderr
             and any(pat.search(clean_stderr) for pat in _OPENCODE_STDERR_ERROR_PATTERNS)
@@ -264,11 +314,15 @@ class OpenCodeProvider:
             is_error = False
             error_message = None
 
-        estimated_cost = estimate_cli_cost(
-            model=str(options.get("model", "")),
-            prompt=effective_prompt,
-            result_text=result_text,
-        )
+        stream_cost = _cost_from_events(events)
+        if stream_cost is not None:
+            estimated_cost = stream_cost
+        else:
+            estimated_cost = estimate_cli_cost(
+                model=str(options.get("model", "")),
+                prompt=effective_prompt,
+                result_text=result_text,
+            )
 
         num_turns = _count_turns_from_events(events)
         if num_turns == 0 and result_text:

--- a/sdk/python/tests/test_harness_provider_opencode.py
+++ b/sdk/python/tests/test_harness_provider_opencode.py
@@ -41,6 +41,8 @@ async def test_opencode_provider_constructs_command_and_maps_result(
     assert captured["cmd"] == [
         "/usr/local/bin/opencode",
         "run",
+        "--format",
+        "json",
         "--dir",
         "/tmp/work",
         "--dangerously-skip-permissions",
@@ -123,6 +125,8 @@ async def test_opencode_passes_model_flag(monkeypatch: pytest.MonkeyPatch):
     assert captured["cmd"] == [
         "opencode",
         "run",
+        "--format",
+        "json",
         "-m",
         "openai/gpt-5",
         "--dangerously-skip-permissions",
@@ -326,6 +330,8 @@ async def test_opencode_v14_cli_shape_no_deprecated_flags(
     cmd_str = " ".join(captured_cmd)
     # Must use `run` subcommand
     assert captured_cmd[1] == "run", "Must use 'opencode run' subcommand (v1.4+)"
+    assert "--format" in captured_cmd, "Must request JSON stream for metrics parsing"
+    assert "json" in captured_cmd, "Must request JSON output format"
     # Must NOT use deprecated -p flag
     assert "-p" not in captured_cmd, "Must not use deprecated -p flag (v1.4+)"
     # Must NOT use deprecated -c flag (now means --continue)
@@ -338,3 +344,33 @@ async def test_opencode_v14_cli_shape_no_deprecated_flags(
     assert "--dangerously-skip-permissions" in cmd_str
     # Prompt must be positional (last arg)
     assert captured_cmd[-1] == "build the feature"
+
+
+@pytest.mark.asyncio
+async def test_opencode_num_turns_counts_step_start_events(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Regression test for issue #518: count actual opencode steps as turns."""
+    stdout = "\n".join(
+        [
+            '{"type":"step_start","step":1}',
+            '{"type":"tool_use","name":"read"}',
+            '{"type":"step_start","step":2}',
+            '{"type":"tool_use","name":"edit"}',
+            '{"type":"step_start","step":3}',
+            '{"type":"result","result":"final text"}',
+        ]
+    )
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        _ = (cmd, env, cwd, timeout)
+        return stdout, "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
+
+    provider = OpenCodeProvider()
+    raw = await provider.execute("hello", {})
+
+    assert raw.is_error is False
+    assert raw.result == "final text"
+    assert raw.metrics.num_turns == 3

--- a/sdk/python/tests/test_harness_provider_opencode.py
+++ b/sdk/python/tests/test_harness_provider_opencode.py
@@ -157,6 +157,39 @@ async def test_opencode_cost_flows_through_metrics(monkeypatch: pytest.MonkeyPat
 
 
 @pytest.mark.asyncio
+async def test_opencode_cost_prefers_stream_cost_when_present(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """OpenCode JSON streams report per-step cost on step_finish.part.cost."""
+    stdout = "\n".join(
+        [
+            '{"type":"step_start","step":1}',
+            '{"type":"step_finish","part":{"type":"step-finish","cost":0.0012}}',
+            '{"type":"step_start","step":2}',
+            '{"type":"text","part":{"type":"text","text":"done"}}',
+            '{"type":"step_finish","part":{"type":"step-finish","cost":0.0023}}',
+        ]
+    )
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        _ = (cmd, env, cwd, timeout)
+        return stdout, "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
+
+    with patch(
+        "agentfield.harness.providers.opencode.estimate_cli_cost", return_value=99.0
+    ):
+        provider = OpenCodeProvider()
+        raw = await provider.execute("hello", {"model": "openai/gpt-4o"})
+
+    assert raw.is_error is False
+    assert raw.result == "done"
+    assert raw.metrics.num_turns == 2
+    assert raw.metrics.total_cost_usd == pytest.approx(0.0035)
+
+
+@pytest.mark.asyncio
 async def test_opencode_cost_none_without_model(monkeypatch: pytest.MonkeyPatch):
     """Without a model, cost estimation returns None (not 0)."""
 
@@ -280,6 +313,33 @@ async def test_opencode_exit0_with_only_migration_stderr_is_success(
 
 
 @pytest.mark.asyncio
+async def test_opencode_exit0_with_json_error_event_is_treated_as_failure(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """OpenCode may report failures via JSON events with clean stderr/exit code."""
+    stdout = "\n".join(
+        [
+            '{"type":"step_start","step":1}',
+            '{"type":"error","message":"AuthenticationError: bad key"}',
+        ]
+    )
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        _ = (cmd, env, cwd, timeout)
+        return stdout, "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
+
+    provider = OpenCodeProvider()
+    raw = await provider.execute("hello", {})
+
+    assert raw.is_error is True
+    assert raw.result is None
+    assert raw.error_message is not None
+    assert "AuthenticationError" in raw.error_message
+
+
+@pytest.mark.asyncio
 async def test_opencode_exit_nonzero_uses_extracted_error_not_truncated_prelude(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -374,3 +434,58 @@ async def test_opencode_num_turns_counts_step_start_events(
     assert raw.is_error is False
     assert raw.result == "final text"
     assert raw.metrics.num_turns == 3
+
+
+@pytest.mark.asyncio
+async def test_opencode_extracts_result_from_text_events(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """OpenCode JSON streams emit assistant output as type='text' with part.text."""
+    stdout = "\n".join(
+        [
+            '{"type":"step_start","step":1}',
+            '{"type":"text","part":{"type":"text","text":"draft"}}',
+            '{"type":"step_start","step":2}',
+            '{"type":"text","part":{"type":"text","text":"final answer"}}',
+        ]
+    )
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        _ = (cmd, env, cwd, timeout)
+        return stdout, "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
+
+    provider = OpenCodeProvider()
+    raw = await provider.execute("hello", {})
+
+    assert raw.is_error is False
+    assert raw.result == "final answer"
+    assert raw.metrics.num_turns == 2
+
+
+@pytest.mark.asyncio
+async def test_opencode_accumulates_multiple_text_parts(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """OpenCode may emit multiple text parts for one final assistant answer."""
+    stdout = "\n".join(
+        [
+            '{"type":"step_start","step":1}',
+            '{"type":"text","part":{"type":"text","text":"first "}}',
+            '{"type":"text","part":{"type":"text","text":"second"}}',
+        ]
+    )
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        _ = (cmd, env, cwd, timeout)
+        return stdout, "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
+
+    provider = OpenCodeProvider()
+    raw = await provider.execute("hello", {})
+
+    assert raw.is_error is False
+    assert raw.result == "first second"
+    assert raw.metrics.num_turns == 1


### PR DESCRIPTION
## Summary
Fixes `HarnessResult.num_turns` for `provider="opencode"` in the Python SDK.  
Instead of reporting `1` whenever text output exists, the provider now parses OpenCode JSON events and counts actual turns from `step_start` events (with fallback behavior). Added regression coverage to ensure multi-step runs report `num_turns > 1`. This PR also hardens the newer JSON-stream path so OpenCode-specific output is handled correctly: assistant text is extracted from `type:"text"` `part.text` events, multi-part text within a step is accumulated, per-step stream cost is preferred over prompt/completion estimation when available, and in-band `type:"error"` events are surfaced as real failures instead of falling through as empty success.

## Testing

- [x] `./scripts/test-all.sh`

- [x] Additional verification (please describe):
  - `python3 -m venv .venv && .venv/bin/python -m pip install -r sdk/python/requirements-dev.txt`
  - `.venv/bin/python -m pytest sdk/python/tests/test_harness_provider_opencode.py -v`

## Checklist

- [ ] I updated documentation where applicable.
- [x] I added or updated tests (or none were needed).
- [x] I updated `CHANGELOG.md` (or this change does not warrant a changelog entry).

## Screenshots (if UI-related)
Not applicable (no UI changes).

## Related issues
Fixes #518