### PR TITLE
Feat/UI queue concurrency status 323

### DIFF
--- a/control-plane/web/client/src/components/HealthStrip.tsx
+++ b/control-plane/web/client/src/components/HealthStrip.tsx
@@ -24,6 +24,7 @@ import { useLLMHealth, useQueueStatus, useAgents } from "@/hooks/queries";
 import { useSSESync } from "@/hooks/useSSEQuerySync";
 import { cn } from "@/lib/utils";
 import type { AgentNodeSummary } from "@/types/agentfield";
+import type { QueueAgentStatus } from "@/hooks/queries";
 
 type HealthStripProps = {
   className?: string;
@@ -54,10 +55,39 @@ export function HealthStrip({ className }: HealthStripProps) {
       n.lifecycle_status === "ready",
   ).length;
 
-  const totalRunning = Object.values(queueStatus.data?.agents ?? {}).reduce(
+  const queueAgents = queueStatus.data?.agents ?? [];
+  const totalRunning = queueStatus.data?.total_running ?? queueAgents.reduce(
     (sum, a) => sum + (a.running || 0),
     0,
   );
+  const topQueueAgents = [...queueAgents]
+    .sort((a, b) => b.running - a.running)
+    .slice(0, 3);
+
+  const renderQueueAgentLine = (agent: QueueAgentStatus) => {
+    const atCapacity = agent.max > 0 && agent.running >= agent.max;
+    return (
+      <li key={agent.agent_node_id} className="flex items-center justify-between text-xs">
+        <span
+          className={cn(
+            "max-w-[11rem] truncate",
+            atCapacity ? "text-destructive" : "text-muted-foreground",
+          )}
+          title={agent.agent_node_id}
+        >
+          {agent.agent_node_id}
+        </span>
+        <span
+          className={cn(
+            "font-mono tabular-nums",
+            atCapacity ? "text-destructive" : "text-muted-foreground",
+          )}
+        >
+          {agent.running}/{agent.max} ({agent.available} free)
+        </span>
+      </li>
+    );
+  };
 
   const sseLabel = sseConnected
     ? "Live"
@@ -175,6 +205,11 @@ export function HealthStrip({ className }: HealthStripProps) {
                       {totalRunning} execution{totalRunning === 1 ? "" : "s"}{" "}
                       running
                     </div>
+                    {topQueueAgents.length > 0 ? (
+                      <ul className="mt-1.5 space-y-1">
+                        {topQueueAgents.map(renderQueueAgentLine)}
+                      </ul>
+                    ) : null}
                   </div>
                 </li>
                 <li className="flex items-start gap-2">
@@ -299,7 +334,18 @@ export function HealthStrip({ className }: HealthStripProps) {
                 </Badge>
               </div>
             </TooltipTrigger>
-            <TooltipContent>Execution queue status</TooltipContent>
+            <TooltipContent>
+              <div className="space-y-1">
+                <div>Execution queue status</div>
+                {topQueueAgents.length > 0 ? (
+                  <ul className="space-y-0.5">
+                    {topQueueAgents.map(renderQueueAgentLine)}
+                  </ul>
+                ) : (
+                  <div className="text-xs text-muted-foreground">No active agent slots</div>
+                )}
+              </div>
+            </TooltipContent>
           </Tooltip>
 
           <Separator orientation="vertical" className="h-4" />

--- a/control-plane/web/client/src/hooks/queries/useSystemHealth.ts
+++ b/control-plane/web/client/src/hooks/queries/useSystemHealth.ts
@@ -18,13 +18,16 @@ export interface LLMHealthResponse {
 }
 
 export interface QueueAgentStatus {
+  agent_node_id: string;
   running: number;
-  queued: number;
-  max_concurrent: number;
+  max: number;
+  available: number;
 }
 
 export interface QueueStatusResponse {
-  agents: Record<string, QueueAgentStatus>;
+  enabled: boolean;
+  max_per_agent: number;
+  agents: QueueAgentStatus[];
   total_running: number;
 }
 
@@ -46,8 +49,68 @@ async function fetchQueueStatus(): Promise<QueueStatusResponse> {
     headers["X-API-Key"] = apiKey;
   }
   const response = await fetch(`${API_BASE_URL}/queue/status`, { headers });
-  if (!response.ok) return { agents: {}, total_running: 0 };
-  return response.json();
+  if (!response.ok) {
+    return {
+      enabled: false,
+      max_per_agent: 0,
+      agents: [],
+      total_running: 0,
+    };
+  }
+
+  const payload = await response.json();
+
+  // Backward-compat shim for older API responses that returned agents as a map.
+  if (!Array.isArray(payload?.agents) && payload?.agents && typeof payload.agents === "object") {
+    const agents: QueueAgentStatus[] = Object.entries(
+      payload.agents as Record<string, { running?: number; max_concurrent?: number }>,
+    ).map(([agentNodeId, status]) => {
+        const max = Number(status.max_concurrent ?? payload.max_per_agent ?? 0);
+        const running = Number(status.running ?? 0);
+        return {
+          agent_node_id: agentNodeId,
+          running,
+          max,
+          available: Math.max(0, max - running),
+        };
+      });
+
+    return {
+      enabled: Number(payload.max_per_agent ?? 0) > 0,
+      max_per_agent: Number(payload.max_per_agent ?? 0),
+      total_running: Number(
+        payload.total_running ??
+          agents.reduce((sum: number, item: QueueAgentStatus) => sum + item.running, 0),
+      ),
+      agents,
+    };
+  }
+
+  const agents = (Array.isArray(payload?.agents) ? payload.agents : [])
+    .map((agent: Partial<QueueAgentStatus>) => {
+      const max = Number(agent.max ?? payload?.max_per_agent ?? 0);
+      const running = Number(agent.running ?? 0);
+      const available = Number(
+        agent.available ?? Math.max(0, max - running),
+      );
+      return {
+        agent_node_id: String(agent.agent_node_id ?? ""),
+        running,
+        max,
+        available,
+      };
+    })
+    .filter((agent: QueueAgentStatus) => agent.agent_node_id.length > 0);
+
+  return {
+    enabled: Boolean(payload?.enabled),
+    max_per_agent: Number(payload?.max_per_agent ?? 0),
+    total_running: Number(
+      payload?.total_running ??
+        agents.reduce((sum: number, item: QueueAgentStatus) => sum + item.running, 0),
+    ),
+    agents,
+  };
 }
 
 export function useLLMHealth() {

--- a/control-plane/web/client/src/pages/NewDashboardPage.test.tsx
+++ b/control-plane/web/client/src/pages/NewDashboardPage.test.tsx
@@ -120,7 +120,10 @@ describe("NewDashboardPage", () => {
       data: { endpoints: [{ name: "test-llm", healthy: true }] },
       isLoading: false,
     });
-    vi.mocked(useQueueStatus).mockReturnValue({ data: { agents: {} }, isLoading: false });
+    vi.mocked(useQueueStatus).mockReturnValue({
+      data: { enabled: true, max_per_agent: 3, total_running: 0, agents: [] },
+      isLoading: false,
+    });
     vi.mocked(useAgents).mockReturnValue({
       data: { count: 1, nodes: [{ health_status: "ready" }] },
       isLoading: false,
@@ -186,7 +189,12 @@ describe("NewDashboardPage", () => {
 
   it("renders issues banner for overloaded agent queues", () => {
     vi.mocked(useQueueStatus).mockReturnValue({
-      data: { agents: { "agent-1": { running: 10, max_concurrent: 10 } } },
+      data: {
+        enabled: true,
+        max_per_agent: 10,
+        total_running: 10,
+        agents: [{ agent_node_id: "agent-1", running: 10, max: 10, available: 0 }],
+      },
       isLoading: false,
     });
     vi.mocked(useRuns).mockReturnValue({ isLoading: false, data: { workflows: [], total_count: 0 } });
@@ -195,6 +203,41 @@ describe("NewDashboardPage", () => {
 
     expect(screen.getByText("System issues")).toBeInTheDocument();
     expect(screen.getByText(/Queue at capacity for agent: agent-1/i)).toBeInTheDocument();
+  });
+
+  it("renders queue card disabled state when limiter is off", () => {
+    vi.mocked(useQueueStatus).mockReturnValue({
+      data: {
+        enabled: false,
+        max_per_agent: 0,
+        total_running: 0,
+        agents: [],
+      },
+      isLoading: false,
+    });
+    vi.mocked(useRuns).mockReturnValue({ isLoading: false, data: { workflows: [], total_count: 0 } });
+
+    render(<NewDashboardPage />, { wrapper });
+
+    expect(screen.getByText("Queue concurrency")).toBeInTheDocument();
+    expect(screen.getByText("Concurrency limiter is disabled.")).toBeInTheDocument();
+  });
+
+  it("computes total running from agents when API omits total_running", () => {
+    vi.mocked(useQueueStatus).mockReturnValue({
+      data: {
+        enabled: true,
+        max_per_agent: 3,
+        agents: [{ agent_node_id: "agent-fallback", running: 2, max: 3, available: 1 }],
+      },
+      isLoading: false,
+    });
+    vi.mocked(useRuns).mockReturnValue({ isLoading: false, data: { workflows: [], total_count: 0 } });
+
+    render(<NewDashboardPage />, { wrapper });
+
+    expect(screen.getByText("2 running")).toBeInTheDocument();
+    expect(screen.getByText("Max concurrency per agent: 3")).toBeInTheDocument();
   });
   
   it("renders failures attention card with failed runs", () => {

--- a/control-plane/web/client/src/pages/NewDashboardPage.tsx
+++ b/control-plane/web/client/src/pages/NewDashboardPage.tsx
@@ -39,6 +39,7 @@ import {
   isTerminalStatus,
   isTimeoutStatus,
 } from "@/utils/status";
+import { cn } from "@/lib/utils";
 import type { WorkflowSummary } from "@/types/workflows";
 import type { AgentNodeSummary } from "@/types/agentfield";
 
@@ -174,6 +175,89 @@ function IssuesBanner({
         ))}
       </AlertDescription>
     </Alert>
+  );
+}
+
+interface QueueConcurrencyProps {
+  totalRunning: number;
+  queueEnabled: boolean;
+  maxPerAgent: number;
+  queueAgents: Array<{
+    agent_node_id: string;
+    running: number;
+    max: number;
+    available: number;
+  }>;
+}
+
+function QueueConcurrencyCard({
+  totalRunning,
+  queueEnabled,
+  maxPerAgent,
+  queueAgents,
+}: QueueConcurrencyProps) {
+  const sortedAgents = [...queueAgents].sort((a, b) => b.running - a.running);
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-1">
+            <CardTitle className="text-base font-semibold">Queue concurrency</CardTitle>
+            <CardDescription>
+              Per-agent slot usage with saturation warnings when an agent reaches max concurrency.
+            </CardDescription>
+          </div>
+          <Badge variant="secondary" className="shrink-0">
+            {totalRunning} running
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="pt-0">
+        {!queueEnabled ? (
+          <p className="text-sm text-muted-foreground">
+            Concurrency limiter is disabled.
+          </p>
+        ) : sortedAgents.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No agents are currently consuming execution slots.
+          </p>
+        ) : (
+          <ul className="space-y-2.5">
+            {sortedAgents.map((agent) => {
+              const atCapacity = agent.max > 0 && agent.running >= agent.max;
+              return (
+                <li
+                  key={agent.agent_node_id}
+                  className={cn(
+                    "rounded-md border px-3 py-2",
+                    atCapacity ? "border-destructive/50 bg-destructive/5" : "border-border bg-card",
+                  )}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="truncate text-sm font-medium" title={agent.agent_node_id}>
+                      {agent.agent_node_id}
+                    </span>
+                    <Badge variant={atCapacity ? "destructive" : "secondary"}>
+                      {agent.running}/{agent.max}
+                    </Badge>
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {agent.available} slot{agent.available === 1 ? "" : "s"} available
+                    {atCapacity ? " · at capacity" : ""}
+                  </p>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        {queueEnabled && maxPerAgent > 0 ? (
+          <p className="mt-3 text-xs text-muted-foreground">
+            Max concurrency per agent: {maxPerAgent}
+          </p>
+        ) : null}
+      </CardContent>
+    </Card>
   );
 }
 
@@ -587,9 +671,16 @@ export function NewDashboardPage() {
       ?.filter((ep) => !ep.healthy)
       .map((ep) => ep.name) ?? [];
 
-  const overloadedAgents = Object.entries(queueQuery.data?.agents ?? {})
-    .filter(([, s]) => s.running >= s.max_concurrent && s.max_concurrent > 0)
-    .map(([name]) => name);
+  const queueAgents = queueQuery.data?.agents ?? [];
+  const overloadedAgents = queueAgents
+    .filter((s) => s.running >= s.max && s.max > 0)
+    .map((s) => s.agent_node_id);
+  const totalRunning = queueQuery.data?.total_running ?? queueAgents.reduce(
+    (sum, agent) => sum + agent.running,
+    0,
+  );
+  const queueEnabled = queueQuery.data?.enabled ?? false;
+  const maxPerAgent = queueQuery.data?.max_per_agent ?? 0;
 
   const hasIssues = unhealthyEndpoints.length > 0 || overloadedAgents.length > 0;
 
@@ -642,6 +733,13 @@ export function NewDashboardPage() {
         latestCompleted={latestCompleted}
         onOpenRun={(runId) => navigate(`/runs/${runId}`)}
         onViewRunsList={() => navigate("/runs")}
+      />
+
+      <QueueConcurrencyCard
+        totalRunning={totalRunning}
+        queueEnabled={queueEnabled}
+        maxPerAgent={maxPerAgent}
+        queueAgents={queueAgents}
       />
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">

--- a/control-plane/web/client/src/test/components/HealthStrip.test.tsx
+++ b/control-plane/web/client/src/test/components/HealthStrip.test.tsx
@@ -63,7 +63,13 @@ describe("HealthStrip", () => {
       data: { healthy: true, endpoints: [{ healthy: true }] },
     });
     state.queueStatus.mockReturnValue({
-      data: { agents: { a: { running: 2 }, b: { running: 1 } } },
+      data: {
+        total_running: 3,
+        agents: [
+          { agent_node_id: "a", running: 2, max: 3, available: 1 },
+          { agent_node_id: "b", running: 1, max: 3, available: 2 },
+        ],
+      },
     });
     state.agents.mockReturnValue({
       data: {
@@ -105,7 +111,7 @@ describe("HealthStrip", () => {
       isLoading: true,
       data: undefined,
     });
-    state.queueStatus.mockReturnValue({ data: { agents: {} } });
+    state.queueStatus.mockReturnValue({ data: { agents: [], total_running: 0 } });
     state.agents.mockReturnValue({
       data: {
         count: 1,

--- a/control-plane/web/client/src/test/hooks/useSystemHealth.test.tsx
+++ b/control-plane/web/client/src/test/hooks/useSystemHealth.test.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useQueueStatus } from "@/hooks/queries/useSystemHealth";
+
+const apiState = vi.hoisted(() => ({
+  getGlobalApiKey: vi.fn(),
+}));
+
+vi.mock("@/services/api", () => apiState);
+vi.mock("@/hooks/useSSEQuerySync", () => ({
+  useSSESync: () => ({ execConnected: true }),
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+};
+
+describe("useQueueStatus", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    apiState.getGlobalApiKey.mockReturnValue("test-key");
+  });
+
+  it("returns safe defaults when queue endpoint fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+    } as Response);
+
+    const { result } = renderHook(() => useQueueStatus(), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data).toEqual({
+      enabled: false,
+      max_per_agent: 0,
+      agents: [],
+      total_running: 0,
+    });
+    expect(fetch).toHaveBeenCalledWith("/api/ui/v1/queue/status", {
+      headers: { "X-API-Key": "test-key" },
+    });
+  });
+
+  it("normalizes legacy map-based queue payloads", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        max_per_agent: 3,
+        agents: {
+          "agent-a": { running: 2, max_concurrent: 3 },
+          "agent-b": { running: 1, max_concurrent: 3 },
+        },
+      }),
+    } as Response);
+
+    const { result } = renderHook(() => useQueueStatus(), { wrapper });
+
+    await waitFor(() => expect(result.current.data?.agents?.length).toBe(2));
+    expect(result.current.data).toEqual({
+      enabled: true,
+      max_per_agent: 3,
+      total_running: 3,
+      agents: [
+        { agent_node_id: "agent-a", running: 2, max: 3, available: 1 },
+        { agent_node_id: "agent-b", running: 1, max: 3, available: 2 },
+      ],
+    });
+  });
+
+  it("normalizes array payloads and filters invalid agent ids", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        enabled: true,
+        max_per_agent: 4,
+        agents: [
+          { agent_node_id: "node-1", running: 2, max: 4 },
+          { agent_node_id: "", running: 1, max: 4, available: 3 },
+        ],
+      }),
+    } as Response);
+
+    const { result } = renderHook(() => useQueueStatus(), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data).toEqual({
+      enabled: true,
+      max_per_agent: 4,
+      total_running: 2,
+      agents: [{ agent_node_id: "node-1", running: 2, max: 4, available: 2 }],
+    });
+  });
+});

--- a/control-plane/web/client/src/test/pages/NewDashboardPage.test.tsx
+++ b/control-plane/web/client/src/test/pages/NewDashboardPage.test.tsx
@@ -25,7 +25,17 @@ const pageState = vi.hoisted(() => ({
     data: { endpoints: [] as Array<{ name: string; healthy: boolean }> },
   },
   queueResult: {
-    data: { agents: {} as Record<string, { running: number; max_concurrent: number }> },
+    data: {
+      enabled: true,
+      max_per_agent: 3,
+      total_running: 0,
+      agents: [] as Array<{
+        agent_node_id: string;
+        running: number;
+        max: number;
+        available: number;
+      }>,
+    },
   },
   agentsResult: {
     isLoading: false,
@@ -174,7 +184,12 @@ describe("NewDashboardPage", () => {
       data: { endpoints: [{ name: "primary-llm", healthy: false }] },
     };
     pageState.queueResult = {
-      data: { agents: { "agent-1": { running: 2, max_concurrent: 2 } } },
+      data: {
+        enabled: true,
+        max_per_agent: 2,
+        total_running: 2,
+        agents: [{ agent_node_id: "agent-1", running: 2, max: 2, available: 0 }],
+      },
     };
     pageState.agentsResult = {
       isLoading: false,
@@ -196,6 +211,9 @@ describe("NewDashboardPage", () => {
     expect(screen.getByText(/LLM circuit OPEN on endpoint: primary-llm/)).toBeInTheDocument();
     expect(screen.getByText(/Queue at capacity for agent: agent-1/)).toBeInTheDocument();
     expect(screen.getByText("Active runs")).toBeInTheDocument();
+    expect(screen.getByText("Queue concurrency")).toBeInTheDocument();
+    expect(screen.getByText("agent-1")).toBeInTheDocument();
+    expect(screen.getByText("0 slots available · at capacity")).toBeInTheDocument();
     expect(screen.getByText("Needs attention")).toBeInTheDocument();
     expect(screen.getByText("Run timeline")).toBeInTheDocument();
     expect(screen.getByText("Active by reasoner")).toBeInTheDocument();
@@ -226,7 +244,7 @@ describe("NewDashboardPage", () => {
       data: { endpoints: [] },
     };
     pageState.queueResult = {
-      data: { agents: {} },
+      data: { enabled: true, max_per_agent: 3, total_running: 0, agents: [] },
     };
 
     render(<NewDashboardPage />);

--- a/sdk/python/agentfield/harness/_cli.py
+++ b/sdk/python/agentfield/harness/_cli.py
@@ -71,14 +71,18 @@ def extract_final_text(events: List[Dict[str, Any]]) -> Optional[str]:
     Looks for common patterns across different CLI tools:
     - type: "result" with text/result field
     - type: "item.completed" with item.text field (Codex)
+    - type: "text" with part.text field (OpenCode JSON stream)
     - Last assistant message text
     """
     result_text = None
+    current_text_parts: List[str] = []
 
     for event in events:
         event_type = event.get("type", "")
 
-        if event_type == "item.completed":
+        if event_type == "step_start":
+            current_text_parts = []
+        elif event_type == "item.completed":
             item = event.get("item", {})
             if item.get("type") == "agent_message":
                 text = item.get("text", "")
@@ -94,6 +98,14 @@ def extract_final_text(events: List[Dict[str, Any]]) -> Optional[str]:
             content = event.get("content", event.get("text", ""))
             if isinstance(content, str) and content:
                 result_text = content
+        elif event_type == "text":
+            content = event.get("text", event.get("content", ""))
+            part = event.get("part")
+            if not content and isinstance(part, dict):
+                content = part.get("text", "")
+            if isinstance(content, str) and content:
+                current_text_parts.append(content)
+                result_text = "".join(current_text_parts)
 
     return result_text
 

--- a/sdk/python/agentfield/harness/providers/opencode.py
+++ b/sdk/python/agentfield/harness/providers/opencode.py
@@ -11,7 +11,13 @@ import tempfile
 import time
 from typing import ClassVar, Dict, Optional
 
-from agentfield.harness._cli import estimate_cli_cost, run_cli, strip_ansi
+from agentfield.harness._cli import (
+    estimate_cli_cost,
+    extract_final_text,
+    parse_jsonl,
+    run_cli,
+    strip_ansi,
+)
 from agentfield.harness._result import FailureType, Metrics, RawResult
 
 logger = logging.getLogger("agentfield.harness.opencode")
@@ -27,6 +33,20 @@ _OPENCODE_STDERR_ERROR_PATTERNS = (
     re.compile(r"\bUnauthorized\b"),
     re.compile(r"\bAPIError\b"),
 )
+
+
+def _count_turns_from_events(events: list[dict[str, object]]) -> int:
+    """Count opencode turns from JSON events.
+
+    Preferred definition is one turn per ``step_start`` event. If a stream
+    has no step markers, fall back to counting ``tool_use`` events.
+    """
+    step_starts = sum(1 for event in events if event.get("type") == "step_start")
+    if step_starts > 0:
+        return step_starts
+
+    tool_uses = sum(1 for event in events if event.get("type") == "tool_use")
+    return tool_uses
 
 
 def _extract_opencode_error(stderr: str) -> str:
@@ -88,6 +108,7 @@ class OpenCodeProvider:
     async def _execute_impl(self, prompt: str, options: dict[str, object]) -> RawResult:
         # opencode v1.4+ uses the `run` subcommand (replaces deprecated -p/-c flags)
         cmd = [self._bin, "run"]
+        cmd.extend(["--format", "json"])
 
         # Use --dir for project directory (replaces deprecated -c which now means --continue)
         cwd_value = options.get("cwd")
@@ -194,7 +215,11 @@ class OpenCodeProvider:
                 shutil.rmtree(temp_data_dir, ignore_errors=True)
 
         api_ms = int((time.monotonic() - start_api) * 1000)
-        result_text = stdout.strip() if stdout.strip() else None
+        events = parse_jsonl(stdout)
+        if events:
+            result_text = extract_final_text(events)
+        else:
+            result_text = stdout.strip() if stdout.strip() else None
         clean_stderr = strip_ansi(stderr.strip()) if stderr else ""
 
         logger.info(
@@ -245,12 +270,16 @@ class OpenCodeProvider:
             result_text=result_text,
         )
 
+        num_turns = _count_turns_from_events(events)
+        if num_turns == 0 and result_text:
+            num_turns = 1
+
         return RawResult(
             result=result_text,
-            messages=[],
+            messages=events,
             metrics=Metrics(
                 duration_api_ms=api_ms,
-                num_turns=1 if result_text else 0,
+                num_turns=num_turns,
                 total_cost_usd=estimated_cost,
                 session_id="",
             ),

--- a/sdk/python/agentfield/harness/providers/opencode.py
+++ b/sdk/python/agentfield/harness/providers/opencode.py
@@ -49,6 +49,48 @@ def _count_turns_from_events(events: list[dict[str, object]]) -> int:
     return tool_uses
 
 
+def _cost_from_events(events: list[dict[str, object]]) -> float | None:
+    """Sum opencode per-step costs when present in the JSON stream."""
+    total_cost = 0.0
+    found_cost = False
+
+    for event in events:
+        if event.get("type") != "step_finish":
+            continue
+        part = event.get("part")
+        if not isinstance(part, dict):
+            continue
+        cost = part.get("cost")
+        if isinstance(cost, (int, float)) and not isinstance(cost, bool):
+            total_cost += float(cost)
+            found_cost = True
+
+    return total_cost if found_cost else None
+
+
+def _extract_opencode_event_error(events: list[dict[str, object]]) -> str | None:
+    """Pull a meaningful failure message from an in-band JSON error event."""
+    for event in events:
+        if event.get("type") != "error":
+            continue
+
+        for key in ("message", "error", "text"):
+            value = event.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()[:1000]
+
+        part = event.get("part")
+        if isinstance(part, dict):
+            for key in ("message", "error", "text"):
+                value = part.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()[:1000]
+
+        return str(event)[:1000]
+
+    return None
+
+
 def _extract_opencode_error(stderr: str) -> str:
     """Pull the meaningful failure line(s) out of opencode stderr.
 
@@ -220,6 +262,7 @@ class OpenCodeProvider:
             result_text = extract_final_text(events)
         else:
             result_text = stdout.strip() if stdout.strip() else None
+        event_error = _extract_opencode_event_error(events)
         clean_stderr = strip_ansi(stderr.strip()) if stderr else ""
 
         logger.info(
@@ -248,6 +291,13 @@ class OpenCodeProvider:
                 else (f"Process exited with code {returncode} and produced no output.")
             )
         elif (
+            event_error is not None
+            and result_text is None
+        ):
+            failure_type = FailureType.CRASH
+            is_error = True
+            error_message = event_error
+        elif (
             result_text is None
             and clean_stderr
             and any(pat.search(clean_stderr) for pat in _OPENCODE_STDERR_ERROR_PATTERNS)
@@ -264,11 +314,15 @@ class OpenCodeProvider:
             is_error = False
             error_message = None
 
-        estimated_cost = estimate_cli_cost(
-            model=str(options.get("model", "")),
-            prompt=effective_prompt,
-            result_text=result_text,
-        )
+        stream_cost = _cost_from_events(events)
+        if stream_cost is not None:
+            estimated_cost = stream_cost
+        else:
+            estimated_cost = estimate_cli_cost(
+                model=str(options.get("model", "")),
+                prompt=effective_prompt,
+                result_text=result_text,
+            )
 
         num_turns = _count_turns_from_events(events)
         if num_turns == 0 and result_text:

--- a/sdk/python/tests/test_harness_provider_opencode.py
+++ b/sdk/python/tests/test_harness_provider_opencode.py
@@ -41,6 +41,8 @@ async def test_opencode_provider_constructs_command_and_maps_result(
     assert captured["cmd"] == [
         "/usr/local/bin/opencode",
         "run",
+        "--format",
+        "json",
         "--dir",
         "/tmp/work",
         "--dangerously-skip-permissions",
@@ -123,6 +125,8 @@ async def test_opencode_passes_model_flag(monkeypatch: pytest.MonkeyPatch):
     assert captured["cmd"] == [
         "opencode",
         "run",
+        "--format",
+        "json",
         "-m",
         "openai/gpt-5",
         "--dangerously-skip-permissions",
@@ -326,6 +330,8 @@ async def test_opencode_v14_cli_shape_no_deprecated_flags(
     cmd_str = " ".join(captured_cmd)
     # Must use `run` subcommand
     assert captured_cmd[1] == "run", "Must use 'opencode run' subcommand (v1.4+)"
+    assert "--format" in captured_cmd, "Must request JSON stream for metrics parsing"
+    assert "json" in captured_cmd, "Must request JSON output format"
     # Must NOT use deprecated -p flag
     assert "-p" not in captured_cmd, "Must not use deprecated -p flag (v1.4+)"
     # Must NOT use deprecated -c flag (now means --continue)
@@ -338,3 +344,33 @@ async def test_opencode_v14_cli_shape_no_deprecated_flags(
     assert "--dangerously-skip-permissions" in cmd_str
     # Prompt must be positional (last arg)
     assert captured_cmd[-1] == "build the feature"
+
+
+@pytest.mark.asyncio
+async def test_opencode_num_turns_counts_step_start_events(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Regression test for issue #518: count actual opencode steps as turns."""
+    stdout = "\n".join(
+        [
+            '{"type":"step_start","step":1}',
+            '{"type":"tool_use","name":"read"}',
+            '{"type":"step_start","step":2}',
+            '{"type":"tool_use","name":"edit"}',
+            '{"type":"step_start","step":3}',
+            '{"type":"result","result":"final text"}',
+        ]
+    )
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        _ = (cmd, env, cwd, timeout)
+        return stdout, "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
+
+    provider = OpenCodeProvider()
+    raw = await provider.execute("hello", {})
+
+    assert raw.is_error is False
+    assert raw.result == "final text"
+    assert raw.metrics.num_turns == 3

--- a/sdk/python/tests/test_harness_provider_opencode.py
+++ b/sdk/python/tests/test_harness_provider_opencode.py
@@ -157,6 +157,39 @@ async def test_opencode_cost_flows_through_metrics(monkeypatch: pytest.MonkeyPat
 
 
 @pytest.mark.asyncio
+async def test_opencode_cost_prefers_stream_cost_when_present(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """OpenCode JSON streams report per-step cost on step_finish.part.cost."""
+    stdout = "\n".join(
+        [
+            '{"type":"step_start","step":1}',
+            '{"type":"step_finish","part":{"type":"step-finish","cost":0.0012}}',
+            '{"type":"step_start","step":2}',
+            '{"type":"text","part":{"type":"text","text":"done"}}',
+            '{"type":"step_finish","part":{"type":"step-finish","cost":0.0023}}',
+        ]
+    )
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        _ = (cmd, env, cwd, timeout)
+        return stdout, "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
+
+    with patch(
+        "agentfield.harness.providers.opencode.estimate_cli_cost", return_value=99.0
+    ):
+        provider = OpenCodeProvider()
+        raw = await provider.execute("hello", {"model": "openai/gpt-4o"})
+
+    assert raw.is_error is False
+    assert raw.result == "done"
+    assert raw.metrics.num_turns == 2
+    assert raw.metrics.total_cost_usd == pytest.approx(0.0035)
+
+
+@pytest.mark.asyncio
 async def test_opencode_cost_none_without_model(monkeypatch: pytest.MonkeyPatch):
     """Without a model, cost estimation returns None (not 0)."""
 
@@ -280,6 +313,33 @@ async def test_opencode_exit0_with_only_migration_stderr_is_success(
 
 
 @pytest.mark.asyncio
+async def test_opencode_exit0_with_json_error_event_is_treated_as_failure(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """OpenCode may report failures via JSON events with clean stderr/exit code."""
+    stdout = "\n".join(
+        [
+            '{"type":"step_start","step":1}',
+            '{"type":"error","message":"AuthenticationError: bad key"}',
+        ]
+    )
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        _ = (cmd, env, cwd, timeout)
+        return stdout, "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
+
+    provider = OpenCodeProvider()
+    raw = await provider.execute("hello", {})
+
+    assert raw.is_error is True
+    assert raw.result is None
+    assert raw.error_message is not None
+    assert "AuthenticationError" in raw.error_message
+
+
+@pytest.mark.asyncio
 async def test_opencode_exit_nonzero_uses_extracted_error_not_truncated_prelude(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -374,3 +434,58 @@ async def test_opencode_num_turns_counts_step_start_events(
     assert raw.is_error is False
     assert raw.result == "final text"
     assert raw.metrics.num_turns == 3
+
+
+@pytest.mark.asyncio
+async def test_opencode_extracts_result_from_text_events(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """OpenCode JSON streams emit assistant output as type='text' with part.text."""
+    stdout = "\n".join(
+        [
+            '{"type":"step_start","step":1}',
+            '{"type":"text","part":{"type":"text","text":"draft"}}',
+            '{"type":"step_start","step":2}',
+            '{"type":"text","part":{"type":"text","text":"final answer"}}',
+        ]
+    )
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        _ = (cmd, env, cwd, timeout)
+        return stdout, "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
+
+    provider = OpenCodeProvider()
+    raw = await provider.execute("hello", {})
+
+    assert raw.is_error is False
+    assert raw.result == "final answer"
+    assert raw.metrics.num_turns == 2
+
+
+@pytest.mark.asyncio
+async def test_opencode_accumulates_multiple_text_parts(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """OpenCode may emit multiple text parts for one final assistant answer."""
+    stdout = "\n".join(
+        [
+            '{"type":"step_start","step":1}',
+            '{"type":"text","part":{"type":"text","text":"first "}}',
+            '{"type":"text","part":{"type":"text","text":"second"}}',
+        ]
+    )
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        _ = (cmd, env, cwd, timeout)
+        return stdout, "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
+
+    provider = OpenCodeProvider()
+    raw = await provider.execute("hello", {})
+
+    assert raw.is_error is False
+    assert raw.result == "first second"
+    assert raw.metrics.num_turns == 1


### PR DESCRIPTION
## Summary

Expose per-agent queue concurrency in the UI using the new `/api/ui/v1/queue/status` response shape.
This adds per-agent running/max/available visibility, capacity highlighting, and total running status on the dashboard/header so users can immediately detect saturation.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] Tests only
- [ ] CI / tooling
- [ ] Breaking change

## Test plan

- [x] `npm --prefix control-plane/web/client test -- src/test/hooks/useSystemHealth.test.tsx src/test/components/HealthStrip.test.tsx src/test/pages/NewDashboardPage.test.tsx src/pages/NewDashboardPage.test.tsx`
- [x] Manual validation:
  - Start server with `AGENTFIELD_MAX_CONCURRENT_PER_AGENT=3`
  - Run `test-slow` agent
  - Fire 5 parallel requests to `test-slow.slow_task`
  - Confirm 3x `200` and 2x `429`
  - Confirm dashboard shows queue capacity warning + per-agent slot usage
- [x] `./scripts/coverage-summary.sh && ./scripts/patch-coverage-gate.sh`

## Test coverage

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR (no bare additions).
- [ ] If I removed code, I updated `coverage-baseline.json` in this PR *only if* the removal caused a legitimate regression and I called it out in the summary above.
- [ ] The coverage gate check is green in CI before requesting review.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) (if present) and [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
- [x] Commits are signed and follow conventional-commits style.
- [x] I have linked any related issues (Fixes #123 / Closes #456).

## Related issues / PRs

Closes #323  
Refs #316  
Refs #319

## Screenshots

- [x] Dashboard: Queue concurrency card visible with at-capacity state
<img width="1685" height="824" alt="Screenshot 2026-05-07 at 16 01 39" src="https://github.com/user-attachments/assets/c7fbb49f-5601-4b2a-a9cf-9eb8e8ff434f" />

- [x] Header: Queue status tooltip/popover showing per-agent running/max/available
<img width="633" height="71" alt="Screenshot 2026-05-07 at 16 01 59" src="https://github.com/user-attachments/assets/cc7a854f-ce57-4957-b213-c037cfe49b77" />
