### PR TITLE
fix(sdk): exclude Agent.pause() time from reasoner wall-clock timeout

### DIFF
--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -662,6 +662,16 @@ class Agent(FastAPI):
         self._cancel_tasks: Dict[str, asyncio.Task] = {}
         self._cancel_lock = asyncio.Lock()
 
+        # Per-execution pause clock. Populated by _execute_async_with_callback
+        # before the reasoner task starts, consumed by Agent.pause() /
+        # Agent.wait_for_resume() to record paused intervals, and read by the
+        # watchdog to subtract paused time from elapsed wall-clock. Lifecycle
+        # is bounded by a single execution (single asyncio.Task), so no lock
+        # is required for the dict access.
+        from .agent_pause import PauseClock
+
+        self._pause_clocks: Dict[str, PauseClock] = {}
+
         # Install the /_internal/executions/{execution_id}/cancel route
         # before any user-defined reasoners are registered so the path is
         # always available for the control-plane callback.
@@ -2315,16 +2325,45 @@ class Agent(FastAPI):
             log_warn("Unable to construct callback URL for execution updates")
             return
 
-        # Wall-clock timeout to guarantee the callback always fires.
+        # Wall-clock budget to guarantee the callback always fires.
         # Without this, a hung reasoner blocks the execution forever and the
-        # control plane never sees a terminal status.
+        # control plane never sees a terminal status. The budget applies to
+        # *active* time only — intervals spent inside ``Agent.pause()`` or
+        # ``Agent.wait_for_resume()`` are subtracted by the watchdog so the
+        # ``expires_in_hours`` argument to ``pause()`` actually means what it
+        # says rather than being silently capped at this timeout.
         reasoner_timeout = getattr(
             self.async_config, "default_execution_timeout", 7200.0
         )
 
+        from .agent_pause import PauseClock
+
+        pause_clock = PauseClock()
+        self._pause_clocks[execution_id] = pause_clock
+
         start_time = time.time()
+        reasoner_task = asyncio.create_task(reasoner_coro())
+
+        async def _watchdog() -> None:
+            # Poll active-elapsed time and cancel the reasoner if the active
+            # budget is exceeded. ``check_interval`` is a small fraction of
+            # the timeout so we don't oversleep our own deadline by much.
+            check_interval = min(5.0, max(0.1, reasoner_timeout / 4.0))
+            while not reasoner_task.done():
+                try:
+                    await asyncio.sleep(check_interval)
+                except asyncio.CancelledError:
+                    return
+                active_elapsed = (time.time() - start_time) - pause_clock.total_paused()
+                if active_elapsed > reasoner_timeout:
+                    pause_clock.timed_out = True
+                    reasoner_task.cancel()
+                    return
+
+        watchdog_task = asyncio.create_task(_watchdog())
+
         try:
-            result = await asyncio.wait_for(reasoner_coro(), timeout=reasoner_timeout)
+            result = await reasoner_task
             payload = {
                 "status": "succeeded",
                 "result": jsonable_encoder(result),
@@ -2334,33 +2373,38 @@ class Agent(FastAPI):
                 "reasoner": reasoner_name,
             }
             log_info(f"Execution {execution_id} completed asynchronously")
-        except asyncio.TimeoutError:
-            payload = {
-                "status": "failed",
-                "error": (
-                    f"Reasoner '{reasoner_name}' timed out after {reasoner_timeout}s"
-                ),
-                "error_details": {"reason": "reasoner_timeout"},
-                "duration_ms": int((time.time() - start_time) * 1000),
-                "completed_at": datetime.now(timezone.utc).isoformat(),
-                "execution_id": execution_id,
-                "reasoner": reasoner_name,
-            }
-            log_error(f"Execution {execution_id} timed out after {reasoner_timeout}s")
         except asyncio.CancelledError:
-            # Cooperative cancel hit while the reasoner was awaiting.
-            # Report cancelled status so the control-plane sees a clean
-            # terminal transition rather than a generic failure.
-            payload = {
-                "status": "cancelled",
-                "error": "cancelled_by_control_plane",
-                "error_details": {"reason": "cancelled"},
-                "duration_ms": int((time.time() - start_time) * 1000),
-                "completed_at": datetime.now(timezone.utc).isoformat(),
-                "execution_id": execution_id,
-                "reasoner": reasoner_name,
-            }
-            log_info(f"Execution {execution_id} cancelled cooperatively")
+            if pause_clock.timed_out:
+                payload = {
+                    "status": "failed",
+                    "error": (
+                        f"Reasoner '{reasoner_name}' timed out after "
+                        f"{reasoner_timeout}s of active time"
+                    ),
+                    "error_details": {"reason": "reasoner_timeout"},
+                    "duration_ms": int((time.time() - start_time) * 1000),
+                    "completed_at": datetime.now(timezone.utc).isoformat(),
+                    "execution_id": execution_id,
+                    "reasoner": reasoner_name,
+                }
+                log_error(
+                    f"Execution {execution_id} timed out after "
+                    f"{reasoner_timeout}s of active time"
+                )
+            else:
+                # External cooperative cancel arrived (cancel dispatcher or
+                # outer task cancellation). Report cancelled status so the
+                # control plane sees a clean terminal transition.
+                payload = {
+                    "status": "cancelled",
+                    "error": "cancelled_by_control_plane",
+                    "error_details": {"reason": "cancelled"},
+                    "duration_ms": int((time.time() - start_time) * 1000),
+                    "completed_at": datetime.now(timezone.utc).isoformat(),
+                    "execution_id": execution_id,
+                    "reasoner": reasoner_name,
+                }
+                log_info(f"Execution {execution_id} cancelled cooperatively")
         except Exception as exc:
             error_details = getattr(exc, "error_details", None)
             payload = {
@@ -2374,6 +2418,21 @@ class Agent(FastAPI):
             }
             log_error(f"Execution {execution_id} failed asynchronously: {exc}")
         finally:
+            # If we landed here without the reasoner finishing (e.g. our own
+            # task was cancelled mid-await), make sure the user code stops
+            # too so it doesn't keep running detached.
+            if not reasoner_task.done():
+                reasoner_task.cancel()
+                try:
+                    await reasoner_task
+                except BaseException:
+                    pass
+            watchdog_task.cancel()
+            try:
+                await watchdog_task
+            except BaseException:
+                pass
+            self._pause_clocks.pop(execution_id, None)
             # Deregister the cancel hook regardless of outcome.
             from .cancel import deregister_execution
             await deregister_execution(self, execution_id)
@@ -4276,6 +4335,12 @@ class Agent(FastAPI):
         effective_timeout = (
             timeout if timeout is not None else expires_in_hours * 3600.0
         )
+        # Tell the reasoner-level watchdog to discount this wait from the
+        # active-time budget. ``end_pause`` runs on every exit path (including
+        # the timeout branch) so the clock never gets stuck open.
+        pause_clock = self._pause_clocks.get(execution_id)
+        if pause_clock is not None:
+            pause_clock.start_pause()
         try:
             result = await asyncio.wait_for(future, timeout=effective_timeout)
         except asyncio.TimeoutError:
@@ -4288,6 +4353,9 @@ class Agent(FastAPI):
             )
             await self._pause_manager.resolve(approval_request_id, expired_result)
             return expired_result
+        finally:
+            if pause_clock is not None:
+                pause_clock.end_pause()
 
         return result
 
@@ -4325,11 +4393,17 @@ class Agent(FastAPI):
         )
 
         effective_timeout = timeout if timeout is not None else 72 * 3600.0
+        pause_clock = self._pause_clocks.get(execution_id or "")
+        if pause_clock is not None:
+            pause_clock.start_pause()
         try:
             result = await asyncio.wait_for(future, timeout=effective_timeout)
             return result
         except asyncio.TimeoutError:
             pass
+        finally:
+            if pause_clock is not None:
+                pause_clock.end_pause()
 
         # Fallback: poll CP once
         try:

--- a/sdk/python/agentfield/agent_pause.py
+++ b/sdk/python/agentfield/agent_pause.py
@@ -1,9 +1,50 @@
 import asyncio
-from typing import Dict
+import time
+from typing import Dict, Optional
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from agentfield.client import ApprovalResult
+
+
+class PauseClock:
+    """Tracks how long a single execution has spent inside ``Agent.pause()``.
+
+    The reasoner-level wall-clock timeout in ``_execute_async_with_callback``
+    must not count time spent waiting for an external approval — otherwise
+    ``expires_in_hours`` is silently capped at the reasoner timeout.  The
+    watchdog in ``_execute_async_with_callback`` reads ``total_paused()`` and
+    subtracts it from elapsed wall-clock to decide whether to fire a timeout.
+
+    A reasoner is a single asyncio task, so ``pause()`` calls cannot overlap
+    on the same clock.  No locking is needed.
+    """
+
+    __slots__ = ("_total_paused", "_pause_started_at", "timed_out")
+
+    def __init__(self) -> None:
+        self._total_paused: float = 0.0
+        self._pause_started_at: Optional[float] = None
+        # Set by the watchdog when it cancels the reasoner for exceeding
+        # the active-time budget.  Distinguishes timeout-cancel from an
+        # external cooperative cancel arriving via the cancel dispatcher.
+        self.timed_out: bool = False
+
+    def start_pause(self) -> None:
+        if self._pause_started_at is None:
+            self._pause_started_at = time.time()
+
+    def end_pause(self) -> None:
+        if self._pause_started_at is not None:
+            self._total_paused += time.time() - self._pause_started_at
+            self._pause_started_at = None
+
+    def total_paused(self) -> float:
+        """Cumulative paused seconds, including any in-progress pause."""
+        if self._pause_started_at is None:
+            return self._total_paused
+        return self._total_paused + (time.time() - self._pause_started_at)
+
 
 class _PauseManager:
     """Manages pending execution pause futures resolved via webhook callback.

--- a/sdk/python/tests/test_agent_coverage_additions.py
+++ b/sdk/python/tests/test_agent_coverage_additions.py
@@ -32,6 +32,7 @@ def make_agent():
         register=AsyncMock(),
         resolve=AsyncMock(),
     )
+    agent._pause_clocks = {}
     agent.note = Mock()
     agent.agentfield_server = "http://agentfield.test"
     agent.api_key = "key"

--- a/sdk/python/tests/test_async_execution.py
+++ b/sdk/python/tests/test_async_execution.py
@@ -1,8 +1,11 @@
 import asyncio
+import time
+
 import httpx
 import pytest
 
 from agentfield.agent import Agent
+from agentfield.agent_pause import PauseClock
 from agentfield.client import AgentFieldClient, ApprovalResult
 
 
@@ -249,3 +252,147 @@ async def test_active_work_past_timeout_still_times_out(monkeypatch):
     payload = status_calls[-1]["json"]
     assert payload["status"] == "failed"
     assert payload["error_details"]["reason"] == "reasoner_timeout"
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests for the PauseClock primitive.  The Agent-level tests above
+# exercise the same machinery end-to-end, but pinning behaviour at this layer
+# protects the primitive from accidental refactors and gives a faster failure
+# signal when the contract changes.
+
+
+def test_pause_clock_starts_with_zero_paused():
+    clock = PauseClock()
+    assert clock.total_paused() == 0.0
+    assert clock.timed_out is False
+
+
+def test_pause_clock_accumulates_completed_intervals():
+    clock = PauseClock()
+
+    clock.start_pause()
+    time.sleep(0.05)
+    clock.end_pause()
+    first = clock.total_paused()
+    assert first >= 0.05
+
+    clock.start_pause()
+    time.sleep(0.05)
+    clock.end_pause()
+    second = clock.total_paused()
+    assert second >= first + 0.05
+
+
+def test_pause_clock_includes_in_progress_pause():
+    clock = PauseClock()
+    clock.start_pause()
+    time.sleep(0.05)
+    # Without ending the pause we should still see the elapsed time so the
+    # watchdog doesn't trip while a long pause is mid-flight.
+    mid = clock.total_paused()
+    assert mid >= 0.05
+    clock.end_pause()
+    assert clock.total_paused() >= mid
+
+
+def test_pause_clock_double_start_is_idempotent():
+    clock = PauseClock()
+    clock.start_pause()
+    time.sleep(0.05)
+    # A second start_pause must not reset the in-progress interval — otherwise
+    # nested awaits inside pause() could silently zero the paused duration.
+    clock.start_pause()
+    clock.end_pause()
+    assert clock.total_paused() >= 0.05
+
+
+def test_pause_clock_end_without_start_is_safe():
+    clock = PauseClock()
+    clock.end_pause()
+    assert clock.total_paused() == 0.0
+
+
+@pytest.mark.asyncio
+async def test_external_cancel_during_pause_reports_cancelled_not_timeout(monkeypatch):
+    """An external cooperative cancel that arrives while the reasoner is
+    inside ``app.pause()`` must surface as ``cancelled`` — not as a phantom
+    timeout. The watchdog distinguishes its own timeout-cancel from external
+    cancels by reading ``PauseClock.timed_out``.
+    """
+    agent = Agent(
+        node_id="test-agent",
+        agentfield_server="http://control",
+        auto_register=False,
+    )
+    agent.base_url = "http://agent"
+    # Generous active budget so the watchdog cannot fire while we cancel.
+    agent.async_config.default_execution_timeout = 60.0
+
+    @agent.reasoner()
+    async def needs_approval(prompt: str) -> dict:
+        result = await agent.pause(
+            approval_request_id="req-cancel",
+            approval_request_url="http://hax/approvals/req-cancel",
+            expires_in_hours=24,
+        )
+        return {"decision": result.decision}
+
+    recorded: list[dict] = []
+
+    class DummyResponse:
+        def __init__(self, status_code: int = 200):
+            self.status_code = status_code
+
+        def json(self):
+            return {}
+
+    async def fake_request(self, method, url, **kwargs):
+        recorded.append({"method": method, "url": url, "json": kwargs.get("json")})
+        return DummyResponse(200)
+
+    monkeypatch.setattr(AgentFieldClient, "_async_request", fake_request)
+
+    async def fake_request_approval(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(agent.client, "request_approval", fake_request_approval)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=agent), base_url="http://agent"
+    ) as client:
+        response = await client.post(
+            "/reasoners/needs_approval",
+            json={"prompt": "ship it?"},
+            headers={"X-Execution-ID": "exec-cancel-1"},
+        )
+
+    assert response.status_code == 202
+
+    # Give the reasoner task a tick to enter pause(), then cooperatively
+    # cancel via the same path the control plane uses.
+    await asyncio.sleep(0.1)
+    from agentfield.cancel import cancel_execution
+
+    cancelled = await cancel_execution(agent, "exec-cancel-1")
+    assert cancelled is True
+
+    def terminal_calls():
+        out = []
+        for e in recorded:
+            body = e.get("json") or {}
+            if body.get("status") in {"succeeded", "failed", "cancelled"}:
+                out.append(e)
+        return out
+
+    for _ in range(30):
+        await asyncio.sleep(0.1)
+        if terminal_calls():
+            break
+
+    status_calls = terminal_calls()
+    assert status_calls, "expected terminal callback after external cancel"
+    payload = status_calls[-1]["json"]
+    assert payload["status"] == "cancelled", (
+        f"external cancel during pause should not be reported as timeout; "
+        f"payload={payload}"
+    )

--- a/sdk/python/tests/test_async_execution.py
+++ b/sdk/python/tests/test_async_execution.py
@@ -3,7 +3,7 @@ import httpx
 import pytest
 
 from agentfield.agent import Agent
-from agentfield.client import AgentFieldClient
+from agentfield.client import AgentFieldClient, ApprovalResult
 
 
 @pytest.mark.asyncio
@@ -87,3 +87,165 @@ async def test_post_execution_status_retries(monkeypatch):
 
     assert attempts["count"] == 3
     assert sleeps == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_pause_does_not_consume_active_timeout_budget(monkeypatch):
+    """A reasoner paused in ``app.pause()`` for longer than the wall-clock
+    timeout should still succeed once the approval webhook resolves it.
+
+    The reasoner-level timeout is supposed to bound *active* time (so a hung
+    reasoner can't run forever) — not human-response time, which is governed
+    by ``expires_in_hours``. Without the pause-clock subtraction, the outer
+    timeout silently caps every approval at the reasoner timeout.
+    """
+    agent = Agent(
+        node_id="test-agent",
+        agentfield_server="http://control",
+        auto_register=False,
+    )
+    agent.base_url = "http://agent"
+    agent.async_config.default_execution_timeout = 1.0
+
+    pause_duration = 2.0  # > default_execution_timeout
+
+    @agent.reasoner()
+    async def needs_approval(prompt: str) -> dict:
+        result = await agent.pause(
+            approval_request_id="req-1",
+            approval_request_url="http://hax/approvals/req-1",
+            expires_in_hours=24,
+        )
+        return {"decision": result.decision}
+
+    recorded: list[dict] = []
+
+    class DummyResponse:
+        def __init__(self, status_code: int = 200):
+            self.status_code = status_code
+
+        def json(self):
+            return {}
+
+    async def fake_request(self, method, url, **kwargs):
+        recorded.append({"method": method, "url": url, "json": kwargs.get("json")})
+        return DummyResponse(200)
+
+    monkeypatch.setattr(AgentFieldClient, "_async_request", fake_request)
+
+    async def fake_request_approval(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(agent.client, "request_approval", fake_request_approval)
+
+    async def resolve_after_delay():
+        await asyncio.sleep(pause_duration)
+        await agent._pause_manager.resolve(
+            "req-1",
+            ApprovalResult(
+                decision="approved",
+                execution_id="exec-pause-1",
+                approval_request_id="req-1",
+            ),
+        )
+
+    resolver = asyncio.create_task(resolve_after_delay())
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=agent), base_url="http://agent"
+    ) as client:
+        response = await client.post(
+            "/reasoners/needs_approval",
+            json={"prompt": "ship it?"},
+            headers={"X-Execution-ID": "exec-pause-1"},
+        )
+
+    assert response.status_code == 202
+
+    # Wait for the resolver to fire and the reasoner to post its terminal
+    # status callback (the running-event broadcasts are not what we want).
+    await resolver
+
+    def terminal_calls():
+        out = []
+        for e in recorded:
+            body = e.get("json") or {}
+            if body.get("status") in {"succeeded", "failed", "cancelled"}:
+                out.append(e)
+        return out
+
+    for _ in range(30):
+        await asyncio.sleep(0.1)
+        if terminal_calls():
+            break
+
+    status_calls = terminal_calls()
+    assert status_calls, "expected terminal async status callback after pause resolved"
+    payload = status_calls[-1]["json"]
+    assert payload["status"] == "succeeded", (
+        f"reasoner timed out while paused; payload={payload}"
+    )
+    assert payload["result"]["decision"] == "approved"
+
+
+@pytest.mark.asyncio
+async def test_active_work_past_timeout_still_times_out(monkeypatch):
+    """A reasoner doing real CPU/IO work past the active budget must still
+    time out — the pause-clock subtraction must not disable the watchdog.
+    """
+    agent = Agent(
+        node_id="test-agent",
+        agentfield_server="http://control",
+        auto_register=False,
+    )
+    agent.async_config.default_execution_timeout = 0.5
+
+    @agent.reasoner()
+    async def slow_work(value: int) -> dict:
+        await asyncio.sleep(2.0)
+        return {"value": value}
+
+    recorded: list[dict] = []
+
+    class DummyResponse:
+        def __init__(self, status_code: int = 200):
+            self.status_code = status_code
+
+        def json(self):
+            return {}
+
+    async def fake_request(self, method, url, **kwargs):
+        recorded.append({"method": method, "url": url, "json": kwargs.get("json")})
+        return DummyResponse(200)
+
+    monkeypatch.setattr(AgentFieldClient, "_async_request", fake_request)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=agent), base_url="http://agent"
+    ) as client:
+        response = await client.post(
+            "/reasoners/slow_work",
+            json={"value": 1},
+            headers={"X-Execution-ID": "exec-timeout-1"},
+        )
+
+    assert response.status_code == 202
+
+    def terminal_calls():
+        out = []
+        for e in recorded:
+            body = e.get("json") or {}
+            if body.get("status") in {"succeeded", "failed", "cancelled"}:
+                out.append(e)
+        return out
+
+    for _ in range(40):
+        await asyncio.sleep(0.1)
+        if terminal_calls():
+            break
+
+    status_calls = terminal_calls()
+    assert status_calls, "expected terminal async status callback after timeout"
+    payload = status_calls[-1]["json"]
+    assert payload["status"] == "failed"
+    assert payload["error_details"]["reason"] == "reasoner_timeout"


### PR DESCRIPTION
## Summary

The async reasoner timeout in `Agent._execute_async_with_callback` was a straight `asyncio.wait_for` around the reasoner coroutine, so wall-clock time spent inside `Agent.pause()` (waiting for an external human approval — e.g. via hax-sdk) was billed against the same budget as active CPU/IO. That silently capped `expires_in_hours` at `default_execution_timeout` (default 7200s).

In SWE-AF this surfaced as a hard 2-hour ceiling on plan approvals: any reviewer who took longer would see the build fail with `Reasoner 'build' timed out after 7200.0s` regardless of how `expires_in_hours` was configured on the `pause()` call.

## Fix

Replace `asyncio.wait_for(reasoner_coro(), timeout=...)` with a watchdog task that subtracts paused intervals from elapsed wall-clock before checking the budget:

- New `PauseClock` primitive in `agent_pause.py` records `start_pause` / `end_pause` and exposes `total_paused()` (including any in-progress pause).
- `Agent` registers one `PauseClock` per execution in `self._pause_clocks[execution_id]` for the duration of the reasoner task.
- `Agent.pause()` and `Agent.wait_for_resume()` wrap their internal `asyncio.wait_for(future, ...)` with `start_pause` / `end_pause` (try/finally so the clock closes on every exit path, including `TimeoutError`).
- The watchdog polls `(time.time() - start) - pause_clock.total_paused()` against `default_execution_timeout`; if exceeded, it sets `pause_clock.timed_out = True` and cancels the reasoner task.
- Active CPU/IO time past the budget still trips the watchdog and produces the existing `failed/reasoner_timeout` payload — the safety net is preserved.
- The `CancelledError` handler branches on `pause_clock.timed_out` to distinguish a watchdog timeout from an external cooperative cancel (cancel dispatcher / outer task cancel); the latter still emits the existing `cancelled_by_control_plane` payload.

The control plane already transitions the execution to `ExecutionStatusWaiting` when `pause()` is called, so this aligns the SDK-side timeout accounting with the existing waiting/running distinction at the CP layer.

## Commits

- `feat(sdk): add PauseClock to track paused intervals per execution` — primitive only, no behaviour change
- `fix(sdk): exclude pause() time from reasoner wall-clock timeout` — wires the watchdog and pause-clock integration
- `test(sdk): cover pause-aware reasoner timeout` — adds two tests

## Test plan

- [x] New tests in `sdk/python/tests/test_async_execution.py`:
  - `test_pause_does_not_consume_active_timeout_budget` — reasoner pauses for longer than `default_execution_timeout`; webhook resolution still produces `succeeded`.
  - `test_active_work_past_timeout_still_times_out` — reasoner doing `asyncio.sleep` past the budget still emits `failed / reasoner_timeout`.
- [x] Adjacent suites pass: `test_cancel.py`, `test_async_execution.py`, `test_agent_server.py`, `test_agent_lifecycle_invariants.py`, `test_agent_call.py`, `test_async_execution_manager_comprehensive.py`, `test_async_config.py`, `test_agent_graceful_shutdown.py` — 107 passed.
- [x] `ruff check` clean on modified files; `ruff format --check` clean on new code (other format hunks in `agent.py` are pre-existing on `main` and intentionally left alone to keep the diff focused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)