### PR TITLE
fix(sdk): propagate child pause state across app.call to parent pause-clock

### DIFF
--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -672,6 +672,19 @@ class Agent(FastAPI):
 
         self._pause_clocks: Dict[str, PauseClock] = {}
 
+        # Cross-reasoner pause propagation registry. Populated by ``call()``
+        # before awaiting a child execution, consumed by the SSE status
+        # listener so that when the child enters ``waiting``/``paused`` the
+        # parent's pause-clock is paused too — otherwise the parent's
+        # active-time budget burns through the child's human-approval delay.
+        # ``_waiting_children`` maps child_execution_id -> parent_execution_id;
+        # ``_parent_paused_children`` maps parent_execution_id -> set of
+        # child_execution_ids currently paused, used to refcount so multiple
+        # children pausing in parallel don't double-toggle the parent clock.
+        self._waiting_children: Dict[str, str] = {}
+        self._parent_paused_children: Dict[str, set] = {}
+        self._waiting_children_lock = asyncio.Lock()
+
         # Install the /_internal/executions/{execution_id}/cancel route
         # before any user-defined reasoners are registered so the path is
         # always available for the control-plane callback.
@@ -2438,6 +2451,63 @@ class Agent(FastAPI):
             await deregister_execution(self, execution_id)
         await self._post_execution_status(callback_url, payload, execution_id)
 
+    def _on_child_status_change(
+        self, child_execution_id: str, status: "ExecutionStatus"
+    ) -> None:
+        """Cross-reasoner pause propagation hook.
+
+        Invoked from the AsyncExecutionManager's SSE listener for every
+        observed child status transition. If the child belongs to a parent
+        we're currently awaiting via ``call()``, toggles the parent's
+        pause-clock so its watchdog doesn't burn the budget while the child
+        is paused on a human approval.
+
+        Refcounts via ``_parent_paused_children`` so multiple children
+        pausing in parallel don't double-pause the parent clock; the parent
+        is paused while any awaited child is paused, and resumed only when
+        all of them are running again. Terminal child states clean up the
+        binding without leaving the parent stuck in a paused state.
+        """
+        from .execution_state import ExecutionStatus
+
+        parent_execution_id = self._waiting_children.get(child_execution_id)
+        if not parent_execution_id:
+            return
+        pause_clock = self._pause_clocks.get(parent_execution_id)
+        if pause_clock is None:
+            return
+
+        is_paused_state = status == ExecutionStatus.WAITING
+        is_terminal = status in {
+            ExecutionStatus.SUCCEEDED,
+            ExecutionStatus.FAILED,
+            ExecutionStatus.CANCELLED,
+            ExecutionStatus.TIMEOUT,
+        }
+
+        paused_set = self._parent_paused_children.get(parent_execution_id)
+        was_paused = paused_set is not None and child_execution_id in paused_set
+
+        if is_paused_state and not was_paused:
+            if paused_set is None:
+                paused_set = set()
+                self._parent_paused_children[parent_execution_id] = paused_set
+            paused_set.add(child_execution_id)
+            if len(paused_set) == 1:
+                pause_clock.start_pause()
+        elif (not is_paused_state) and was_paused:
+            assert paused_set is not None
+            paused_set.discard(child_execution_id)
+            if not paused_set:
+                pause_clock.end_pause()
+                self._parent_paused_children.pop(parent_execution_id, None)
+
+        if is_terminal:
+            # ``call()``'s finally block also cleans up, but doing it here
+            # too keeps the registry tidy if the listener observes the
+            # terminal transition before the awaiting task wakes up.
+            self._waiting_children.pop(child_execution_id, None)
+
     async def _post_execution_status(
         self,
         callback_url: str,
@@ -3898,10 +3968,81 @@ class Agent(FastAPI):
                             timeout=execution_timeout,
                         )
 
-                        result = await self.client.wait_for_execution_result(
-                            execution_id=execution_id,
-                            timeout=execution_timeout,
+                        # Wire cross-reasoner pause propagation: register the
+                        # child -> parent binding and ensure the SSE listener
+                        # is hooked up so child waiting/paused transitions
+                        # toggle the parent's pause-clock. Lookup of the
+                        # parent uses the current execution context and is
+                        # only meaningful when this call is made from inside
+                        # a reasoner that has a tracked pause-clock.
+                        parent_execution_id = (
+                            current_context.execution_id if current_context else None
                         )
+                        # ``_pause_clocks`` is set in __init__; getattr keeps
+                        # bypass-init test fixtures from AttributeErroring
+                        # here. When the parent has no clock registered, we
+                        # have nothing meaningful to propagate to anyway.
+                        _all_pause_clocks = getattr(self, "_pause_clocks", None) or {}
+                        propagate_pause = bool(
+                            parent_execution_id
+                            and parent_execution_id in _all_pause_clocks
+                        )
+                        if propagate_pause:
+                            try:
+                                _mgr = await self.client._get_async_execution_manager()
+                                _mgr.register_status_listener(
+                                    self._on_child_status_change
+                                )
+                                async with self._waiting_children_lock:
+                                    self._waiting_children[execution_id] = (
+                                        parent_execution_id
+                                    )
+                            except Exception as _exc:
+                                # Pause propagation is best-effort; never
+                                # block the actual call on registry wiring.
+                                propagate_pause = False
+                                if self.dev_mode:
+                                    log_debug(
+                                        f"Pause propagation registration failed: {_exc}"
+                                    )
+
+                        try:
+                            # Only pass the pause_clock kwarg when we actually
+                            # have one to propagate — keeps the call shape
+                            # backward-compatible with mocks / older clients
+                            # that don't yet accept the kwarg.
+                            _wait_kwargs: Dict[str, Any] = {
+                                "execution_id": execution_id,
+                                "timeout": execution_timeout,
+                            }
+                            if propagate_pause:
+                                _wait_kwargs["pause_clock"] = (
+                                    self._pause_clocks.get(parent_execution_id)
+                                )
+                            result = await self.client.wait_for_execution_result(
+                                **_wait_kwargs
+                            )
+                        finally:
+                            if propagate_pause:
+                                async with self._waiting_children_lock:
+                                    self._waiting_children.pop(execution_id, None)
+                                    paused_set = self._parent_paused_children.get(
+                                        parent_execution_id
+                                    )
+                                    if (
+                                        paused_set is not None
+                                        and execution_id in paused_set
+                                    ):
+                                        paused_set.discard(execution_id)
+                                        if not paused_set:
+                                            _pc = self._pause_clocks.get(
+                                                parent_execution_id
+                                            )
+                                            if _pc is not None:
+                                                _pc.end_pause()
+                                            self._parent_paused_children.pop(
+                                                parent_execution_id, None
+                                            )
 
                         elapsed_time = time.time() - start_time
                         if self.dev_mode:

--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -65,6 +65,7 @@ from dataclasses import dataclass, field
 import weakref
 
 if TYPE_CHECKING:
+    from agentfield.execution_state import ExecutionStatus
     from agentfield.harness._result import HarnessResult
     from agentfield.harness._runner import HarnessRunner
 

--- a/sdk/python/agentfield/async_execution_manager.py
+++ b/sdk/python/agentfield/async_execution_manager.py
@@ -11,7 +11,7 @@ import json
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 from urllib.parse import urljoin
 
 import aiohttp
@@ -240,7 +240,37 @@ class AsyncExecutionManager:
         self._circuit_breaker_last_failure = 0.0
         self._circuit_breaker_open = False
 
+        # Listeners notified on every observed execution status transition.
+        # The Agent registers a listener here so a parent reasoner waiting on
+        # a child via ``app.call`` can pause its own pause-clock while the
+        # child is in ``waiting``/``paused``, and resume it when the child
+        # transitions back to ``running`` (or terminates).
+        self._status_listeners: List[Callable[[str, ExecutionStatus], None]] = []
+
         logger.debug(f"AsyncExecutionManager initialized with base_url={base_url}")
+
+    def register_status_listener(
+        self, callback: Callable[[str, ExecutionStatus], None]
+    ) -> None:
+        """Register a callback invoked on every observed status transition.
+
+        The callback receives ``(execution_id, status)`` and must be
+        non-blocking — it is invoked from the SSE event loop. Idempotent:
+        the same callable is only registered once.
+        """
+        if callback not in self._status_listeners:
+            self._status_listeners.append(callback)
+
+    def _fire_status_listeners(
+        self, execution_id: str, status: ExecutionStatus
+    ) -> None:
+        for cb in self._status_listeners:
+            try:
+                cb(execution_id, status)
+            except Exception as exc:
+                logger.debug(
+                    f"Status listener raised for {execution_id[:8]}...: {exc}"
+                )
 
     def set_event_stream_headers(self, headers: Optional[Dict[str, str]]) -> None:
         """Configure headers forwarded to the SSE event stream."""
@@ -504,7 +534,10 @@ class AsyncExecutionManager:
             return None
 
     async def wait_for_result(
-        self, execution_id: str, timeout: Optional[float] = None
+        self,
+        execution_id: str,
+        timeout: Optional[float] = None,
+        pause_clock: Optional[Any] = None,
     ) -> Any:
         """
         Wait for execution result with intelligent polling.
@@ -512,6 +545,12 @@ class AsyncExecutionManager:
         Args:
             execution_id: Execution ID to wait for
             timeout: Optional timeout override
+            pause_clock: Optional ``PauseClock`` whose accumulated paused
+                seconds are subtracted from elapsed wall-clock when checking
+                ``timeout``. Supplied by ``Agent.call()`` so the wait
+                doesn't time out while the awaited child is parked on a
+                human approval — the active-time semantics here match the
+                reasoner watchdog in ``_execute_async_with_callback``.
 
         Returns:
             Any: Execution result
@@ -539,8 +578,17 @@ class AsyncExecutionManager:
         )
         start_time = time.time()
 
+        def _active_elapsed() -> float:
+            elapsed = time.time() - start_time
+            if pause_clock is not None:
+                try:
+                    elapsed -= pause_clock.total_paused()
+                except Exception:
+                    pass
+            return elapsed
+
         # Wait for completion
-        while time.time() - start_time < wait_timeout:
+        while _active_elapsed() < wait_timeout:
             async with self._execution_lock:
                 execution = self._executions.get(execution_id)
                 if execution is None:
@@ -822,18 +870,31 @@ class AsyncExecutionManager:
         schedule_poll = False
         status_hint = normalize_status(payload.get("status"))
         event_type = str(payload.get("type", "")).lower()
+        # ``execution.waiting`` is what RequestApprovalHandler publishes when
+        # a child reasoner enters ``app.pause``; the payload often omits an
+        # explicit status field, in which case ``normalize_status`` would
+        # report ``"unknown"`` and we'd lose the signal. Override based on
+        # event_type so the hint reflects what actually happened.
+        if event_type == "execution.waiting":
+            status_hint = "waiting"
 
+        new_status: Optional[ExecutionStatus] = None
         async with self._execution_lock:
             execution = self._executions.get(execution_id)
             if execution is None:
                 return
 
             if event_type == "execution_started" or status_hint == "running":
-                execution.update_status(ExecutionStatus.RUNNING)
+                new_status = ExecutionStatus.RUNNING
             elif status_hint == "queued":
-                execution.update_status(ExecutionStatus.QUEUED)
+                new_status = ExecutionStatus.QUEUED
             elif status_hint == "pending":
-                execution.update_status(ExecutionStatus.PENDING)
+                new_status = ExecutionStatus.PENDING
+            elif status_hint in {"waiting", "paused"}:
+                # Child entered an external-wait state (e.g. waiting on a
+                # human approval via app.pause). The status listener uses
+                # this transition to pause the parent's pause-clock.
+                new_status = ExecutionStatus.WAITING
             elif status_hint in {
                 "succeeded",
                 "failed",
@@ -841,14 +902,22 @@ class AsyncExecutionManager:
                 "timeout",
             } or event_type in {"execution_completed", "execution_failed"}:
                 if status_hint == "failed":
-                    execution.update_status(ExecutionStatus.FAILED)
+                    new_status = ExecutionStatus.FAILED
                 elif status_hint == "cancelled":
-                    execution.update_status(ExecutionStatus.CANCELLED)
+                    new_status = ExecutionStatus.CANCELLED
                 elif status_hint == "timeout":
-                    execution.update_status(ExecutionStatus.TIMEOUT)
+                    new_status = ExecutionStatus.TIMEOUT
                 else:
-                    execution.update_status(ExecutionStatus.SUCCEEDED)
+                    new_status = ExecutionStatus.SUCCEEDED
                 schedule_poll = True
+
+            if new_status is not None and new_status != execution.status:
+                execution.update_status(new_status)
+            else:
+                new_status = None  # no-op transition; don't fire listeners
+
+        if new_status is not None:
+            self._fire_status_listeners(execution_id, new_status)
 
         if schedule_poll:
             asyncio.create_task(self._poll_execution_immediate(execution_id))

--- a/sdk/python/agentfield/client.py
+++ b/sdk/python/agentfield/client.py
@@ -1503,7 +1503,10 @@ class AgentFieldClient:
             ) from e
 
     async def wait_for_execution_result(
-        self, execution_id: str, timeout: Optional[float] = None
+        self,
+        execution_id: str,
+        timeout: Optional[float] = None,
+        pause_clock: Optional[Any] = None,
     ) -> Any:
         """
         Wait for execution completion with polling.
@@ -1511,6 +1514,10 @@ class AgentFieldClient:
         Args:
             execution_id: Execution ID to wait for
             timeout: Optional timeout override (uses config default if None)
+            pause_clock: Optional ``PauseClock`` whose accumulated paused
+                seconds are subtracted from elapsed wall-clock when checking
+                ``timeout`` — used by ``Agent.call`` to keep the wait alive
+                across child pauses.
 
         Returns:
             Any: Execution result
@@ -1524,7 +1531,9 @@ class AgentFieldClient:
 
         try:
             manager = await self._get_async_execution_manager()
-            result = await manager.wait_for_result(execution_id, timeout)
+            result = await manager.wait_for_result(
+                execution_id, timeout, pause_clock=pause_clock
+            )
 
             logger.debug(f"Execution {execution_id[:8]}... completed successfully")
             return result

--- a/sdk/python/tests/test_agent_coverage_additions.py
+++ b/sdk/python/tests/test_agent_coverage_additions.py
@@ -33,6 +33,9 @@ def make_agent():
         resolve=AsyncMock(),
     )
     agent._pause_clocks = {}
+    agent._waiting_children = {}
+    agent._parent_paused_children = {}
+    agent._waiting_children_lock = asyncio.Lock()
     agent.note = Mock()
     agent.agentfield_server = "http://agentfield.test"
     agent.api_key = "key"

--- a/sdk/python/tests/test_async_execution.py
+++ b/sdk/python/tests/test_async_execution.py
@@ -396,3 +396,235 @@ async def test_external_cancel_during_pause_reports_cancelled_not_timeout(monkey
         f"external cancel during pause should not be reported as timeout; "
         f"payload={payload}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Cross-reasoner pause propagation
+#
+# When a parent reasoner calls a child via ``app.call`` and the child enters
+# an ``app.pause`` waiting state, the parent's pause-clock must be paused too
+# — otherwise the parent's wall-clock budget keeps ticking through the
+# child's human-approval delay and the parent times out at 7200s while the
+# child is correctly waiting. These tests pin the propagation logic.
+# ---------------------------------------------------------------------------
+
+
+def _make_propagation_agent() -> Agent:
+    """Build a real Agent so the pause-clock dict, registry and listener
+    method are wired up via ``__init__``. Tests poke at those structures
+    directly instead of going through the full HTTP / SSE pipeline."""
+    return Agent(
+        node_id="parent-agent",
+        agentfield_server="http://control",
+        auto_register=False,
+    )
+
+
+def test_child_status_change_pauses_parent_clock_on_waiting():
+    """Child entering WAITING should pause the parent's clock immediately;
+    transitioning back to RUNNING should end the pause."""
+    from agentfield.execution_state import ExecutionStatus
+
+    agent = _make_propagation_agent()
+    parent_id = "exec-parent"
+    child_id = "exec-child"
+
+    parent_clock = PauseClock()
+    agent._pause_clocks[parent_id] = parent_clock
+    agent._waiting_children[child_id] = parent_id
+
+    assert parent_clock.total_paused() == 0.0
+
+    agent._on_child_status_change(child_id, ExecutionStatus.WAITING)
+    time.sleep(0.05)
+    paused_after_waiting = parent_clock.total_paused()
+    assert paused_after_waiting > 0.0, (
+        "parent clock must accumulate paused time while child is in WAITING"
+    )
+
+    agent._on_child_status_change(child_id, ExecutionStatus.RUNNING)
+    final_paused = parent_clock.total_paused()
+    # After end_pause, total_paused freezes — sleeping should not grow it.
+    time.sleep(0.05)
+    assert abs(parent_clock.total_paused() - final_paused) < 1e-3, (
+        "parent clock must stop accumulating once child resumes"
+    )
+    assert child_id not in agent._parent_paused_children.get(parent_id, set())
+
+
+def test_child_status_change_refcounts_parallel_children():
+    """Two children pausing in parallel must not double-pause the parent
+    clock. The parent stays paused while ANY awaited child is paused, and
+    only resumes when ALL of them are running again."""
+    from agentfield.execution_state import ExecutionStatus
+
+    agent = _make_propagation_agent()
+    parent_id = "exec-parent"
+    child_a = "exec-a"
+    child_b = "exec-b"
+
+    parent_clock = PauseClock()
+    agent._pause_clocks[parent_id] = parent_clock
+    agent._waiting_children[child_a] = parent_id
+    agent._waiting_children[child_b] = parent_id
+
+    agent._on_child_status_change(child_a, ExecutionStatus.WAITING)
+    assert parent_clock._pause_started_at is not None
+    first_pause_started = parent_clock._pause_started_at
+
+    # Second child also pausing should NOT reset the pause start (which
+    # would erase the time accumulated since child A first paused).
+    time.sleep(0.05)
+    agent._on_child_status_change(child_b, ExecutionStatus.WAITING)
+    assert parent_clock._pause_started_at == first_pause_started, (
+        "second child entering WAITING must not restart the parent pause"
+    )
+
+    # Only one child resuming: parent stays paused (refcount > 0).
+    agent._on_child_status_change(child_a, ExecutionStatus.RUNNING)
+    assert parent_clock._pause_started_at is not None, (
+        "parent must remain paused while any awaited child is still paused"
+    )
+
+    # Last child resumes: parent's pause finally ends.
+    agent._on_child_status_change(child_b, ExecutionStatus.RUNNING)
+    assert parent_clock._pause_started_at is None
+    assert parent_id not in agent._parent_paused_children
+
+
+def test_child_status_change_ignores_unrelated_executions():
+    """An execution we're not awaiting must be a no-op — the listener fires
+    for every execution on the SSE bus, including unrelated ones."""
+    from agentfield.execution_state import ExecutionStatus
+
+    agent = _make_propagation_agent()
+    parent_clock = PauseClock()
+    agent._pause_clocks["exec-parent"] = parent_clock
+    # Note: no _waiting_children entry for the unrelated child.
+
+    agent._on_child_status_change("exec-stranger", ExecutionStatus.WAITING)
+    assert parent_clock.total_paused() == 0.0
+    assert "exec-parent" not in agent._parent_paused_children
+
+
+def test_child_status_change_terminal_cleans_up_registry():
+    """A terminal child status must purge the binding so a long-lived
+    parent doesn't accumulate stale child refs."""
+    from agentfield.execution_state import ExecutionStatus
+
+    agent = _make_propagation_agent()
+    parent_id = "exec-parent"
+    child_id = "exec-child"
+    agent._pause_clocks[parent_id] = PauseClock()
+    agent._waiting_children[child_id] = parent_id
+
+    agent._on_child_status_change(child_id, ExecutionStatus.SUCCEEDED)
+    assert child_id not in agent._waiting_children
+
+
+@pytest.mark.asyncio
+async def test_wait_for_result_subtracts_pause_clock_from_elapsed(monkeypatch):
+    """``wait_for_result`` is the cross-agent wait; if its own timeout is
+    wall-clock it'll fire while the child is correctly paused on a human
+    approval. Passing the parent's pause_clock makes the wait active-time
+    aware so it survives long human-approval gaps."""
+    from agentfield.async_execution_manager import AsyncExecutionManager
+    from agentfield.async_config import AsyncConfig
+    from agentfield.execution_state import ExecutionState, ExecutionStatus
+    from agentfield.exceptions import ExecutionTimeoutError
+
+    cfg = AsyncConfig()
+    manager = AsyncExecutionManager(base_url="http://control", config=cfg)
+
+    exec_id = "exec-child"
+    state = ExecutionState(
+        execution_id=exec_id,
+        target="agent.reasoner",
+        input_data={},
+        timeout=0.5,
+    )
+    manager._executions[exec_id] = state
+
+    # Pause clock that always reports 10s of paused time — way more than
+    # the 0.5s wait timeout. Without subtraction, wait_for_result would
+    # fire instantly; with subtraction, elapsed - paused stays negative
+    # so the loop keeps running until the execution becomes terminal.
+    class _FakeClock:
+        def total_paused(self) -> float:
+            return 10.0
+
+    async def _settle_after_short_delay():
+        await asyncio.sleep(0.2)
+        async with manager._execution_lock:
+            state.set_result({"ok": True})
+
+    asyncio.create_task(_settle_after_short_delay())
+    result = await manager.wait_for_result(
+        exec_id, timeout=0.5, pause_clock=_FakeClock()
+    )
+    assert result == {"ok": True}
+
+    # Sanity: without the pause_clock the same setup with a stricter
+    # timeout would actually time out.
+    state2 = ExecutionState(
+        execution_id="exec-strict",
+        target="agent.reasoner",
+        input_data={},
+        timeout=0.1,
+    )
+    manager._executions["exec-strict"] = state2
+    with pytest.raises(ExecutionTimeoutError):
+        await manager.wait_for_result("exec-strict", timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_sse_handler_fires_status_listener_on_waiting():
+    """The SSE event handler must translate ``execution.waiting`` events
+    into a listener invocation so the parent process learns its child is
+    paused."""
+    from agentfield.async_execution_manager import AsyncExecutionManager
+    from agentfield.async_config import AsyncConfig
+    from agentfield.execution_state import ExecutionState, ExecutionStatus
+
+    manager = AsyncExecutionManager(base_url="http://control", config=AsyncConfig())
+    exec_id = "exec-waiter"
+    manager._executions[exec_id] = ExecutionState(
+        execution_id=exec_id, target="agent.reasoner", input_data={},
+    )
+
+    seen: list[tuple[str, ExecutionStatus]] = []
+    manager.register_status_listener(lambda eid, st: seen.append((eid, st)))
+
+    await manager._handle_event_stream_payload(
+        {"execution_id": exec_id, "type": "execution.waiting"}
+    )
+    assert (exec_id, ExecutionStatus.WAITING) in seen
+
+    await manager._handle_event_stream_payload(
+        {"execution_id": exec_id, "status": "running"}
+    )
+    assert (exec_id, ExecutionStatus.RUNNING) in seen
+
+    # Duplicate event with no transition: listener must NOT re-fire.
+    seen.clear()
+    await manager._handle_event_stream_payload(
+        {"execution_id": exec_id, "status": "running"}
+    )
+    assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_sse_handler_ignores_unknown_executions():
+    """SSE events for executions this manager didn't submit must be a
+    no-op — they belong to a different waiter or an unrelated agent."""
+    from agentfield.async_execution_manager import AsyncExecutionManager
+    from agentfield.async_config import AsyncConfig
+
+    manager = AsyncExecutionManager(base_url="http://control", config=AsyncConfig())
+    seen: list[str] = []
+    manager.register_status_listener(lambda eid, st: seen.append(eid))
+
+    await manager._handle_event_stream_payload(
+        {"execution_id": "exec-unknown", "status": "waiting"}
+    )
+    assert seen == []

--- a/sdk/python/tests/test_async_execution.py
+++ b/sdk/python/tests/test_async_execution.py
@@ -530,7 +530,7 @@ async def test_wait_for_result_subtracts_pause_clock_from_elapsed(monkeypatch):
     aware so it survives long human-approval gaps."""
     from agentfield.async_execution_manager import AsyncExecutionManager
     from agentfield.async_config import AsyncConfig
-    from agentfield.execution_state import ExecutionState, ExecutionStatus
+    from agentfield.execution_state import ExecutionState
     from agentfield.exceptions import ExecutionTimeoutError
 
     cfg = AsyncConfig()


### PR DESCRIPTION
## Summary

When a parent reasoner calls a child via `app.call` and the child enters `app.pause` (e.g. waiting on a hax-sdk human approval), the parent's pause-clock must be paused too — otherwise the parent's `default_execution_timeout` watchdog burns through the child's human-response time and cancels the parent at 7200s while the child is correctly waiting.

This is the cross-reasoner companion to #552: that PR fixed the pause-clock for the reasoner that calls `pause()`, but its scope was the local execution only. Ancestors awaiting via `app.call` had no idea the child was paused, so a multi-iteration approval loop in SWE-AF would still surface as `Reasoner 'implement_from_issue' timed out after 7200.0s`.

## Mechanism

- `AsyncExecutionManager` gains a status-listener hook fired on every observed transition over the SSE event stream, plus translation of `execution.waiting` events / `waiting` / `paused` status hints into `ExecutionStatus.WAITING` (1st commit).
- `Agent.call()` registers a child→parent binding for cross-agent waits whose parent has a tracked pause-clock; the listener uses that binding to toggle the parent's pause-clock when the child transitions in/out of WAITING.
- Refcounting (`_parent_paused_children`) keeps the parent paused while *any* awaited child is in WAITING and only resumes when all of them are running again — so a parent calling multiple children in parallel doesn't get double-toggled.
- `client.wait_for_execution_result` and `manager.wait_for_result` accept an optional `pause_clock` kwarg whose accumulated paused seconds are subtracted from elapsed wall-clock; without this the wait itself would still time out at 7200s during a long human-approval gap even with the propagation wired up.

## Symptom this fixes

Run on the test deployment timed out the parent reasoner at 7200s after the child cycled through hax-sdk request_changes → re-iteration → re-approval. Build child correctly excluded its pause time (v0.1.79 fix); parent didn't, because nothing told it the child was paused.

## Test plan

- [x] Unit tests for `Agent._on_child_status_change` (WAITING pauses parent, RUNNING resumes, parallel children refcount correctly, unrelated execs ignored, terminal events clean registry).
- [x] Integration test for `manager.wait_for_result` with a synthetic pause_clock: wait survives a paused interval longer than the configured timeout; without the kwarg the same setup still times out.
- [x] SSE event-stream handler tests: `execution.waiting` events fire the listener; duplicate transitions don't re-fire; unknown executions are ignored.
- [x] Full Python SDK pytest suite: 1484 passed, 4 skipped, 12 deselected. No regressions.
- [ ] Once released, downstream `agentfield>=` floor bumps in github-buddy / pr-af / SWE-AF requirements files (Docker layer cache busting — not part of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)