### PR TITLE
fix(sdk): poll-driven cross-reasoner pause propagation

### DIFF
--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -65,7 +65,6 @@ from dataclasses import dataclass, field
 import weakref
 
 if TYPE_CHECKING:
-    from agentfield.execution_state import ExecutionStatus
     from agentfield.harness._result import HarnessResult
     from agentfield.harness._runner import HarnessRunner
 
@@ -672,19 +671,6 @@ class Agent(FastAPI):
         from .agent_pause import PauseClock
 
         self._pause_clocks: Dict[str, PauseClock] = {}
-
-        # Cross-reasoner pause propagation registry. Populated by ``call()``
-        # before awaiting a child execution, consumed by the SSE status
-        # listener so that when the child enters ``waiting``/``paused`` the
-        # parent's pause-clock is paused too — otherwise the parent's
-        # active-time budget burns through the child's human-approval delay.
-        # ``_waiting_children`` maps child_execution_id -> parent_execution_id;
-        # ``_parent_paused_children`` maps parent_execution_id -> set of
-        # child_execution_ids currently paused, used to refcount so multiple
-        # children pausing in parallel don't double-toggle the parent clock.
-        self._waiting_children: Dict[str, str] = {}
-        self._parent_paused_children: Dict[str, set] = {}
-        self._waiting_children_lock = asyncio.Lock()
 
         # Install the /_internal/executions/{execution_id}/cancel route
         # before any user-defined reasoners are registered so the path is
@@ -2452,63 +2438,6 @@ class Agent(FastAPI):
             await deregister_execution(self, execution_id)
         await self._post_execution_status(callback_url, payload, execution_id)
 
-    def _on_child_status_change(
-        self, child_execution_id: str, status: "ExecutionStatus"
-    ) -> None:
-        """Cross-reasoner pause propagation hook.
-
-        Invoked from the AsyncExecutionManager's SSE listener for every
-        observed child status transition. If the child belongs to a parent
-        we're currently awaiting via ``call()``, toggles the parent's
-        pause-clock so its watchdog doesn't burn the budget while the child
-        is paused on a human approval.
-
-        Refcounts via ``_parent_paused_children`` so multiple children
-        pausing in parallel don't double-pause the parent clock; the parent
-        is paused while any awaited child is paused, and resumed only when
-        all of them are running again. Terminal child states clean up the
-        binding without leaving the parent stuck in a paused state.
-        """
-        from .execution_state import ExecutionStatus
-
-        parent_execution_id = self._waiting_children.get(child_execution_id)
-        if not parent_execution_id:
-            return
-        pause_clock = self._pause_clocks.get(parent_execution_id)
-        if pause_clock is None:
-            return
-
-        is_paused_state = status == ExecutionStatus.WAITING
-        is_terminal = status in {
-            ExecutionStatus.SUCCEEDED,
-            ExecutionStatus.FAILED,
-            ExecutionStatus.CANCELLED,
-            ExecutionStatus.TIMEOUT,
-        }
-
-        paused_set = self._parent_paused_children.get(parent_execution_id)
-        was_paused = paused_set is not None and child_execution_id in paused_set
-
-        if is_paused_state and not was_paused:
-            if paused_set is None:
-                paused_set = set()
-                self._parent_paused_children[parent_execution_id] = paused_set
-            paused_set.add(child_execution_id)
-            if len(paused_set) == 1:
-                pause_clock.start_pause()
-        elif (not is_paused_state) and was_paused:
-            assert paused_set is not None
-            paused_set.discard(child_execution_id)
-            if not paused_set:
-                pause_clock.end_pause()
-                self._parent_paused_children.pop(parent_execution_id, None)
-
-        if is_terminal:
-            # ``call()``'s finally block also cleans up, but doing it here
-            # too keeps the registry tidy if the listener observes the
-            # terminal transition before the awaiting task wakes up.
-            self._waiting_children.pop(child_execution_id, None)
-
     async def _post_execution_status(
         self,
         callback_url: str,
@@ -3969,81 +3898,38 @@ class Agent(FastAPI):
                             timeout=execution_timeout,
                         )
 
-                        # Wire cross-reasoner pause propagation: register the
-                        # child -> parent binding and ensure the SSE listener
-                        # is hooked up so child waiting/paused transitions
-                        # toggle the parent's pause-clock. Lookup of the
-                        # parent uses the current execution context and is
-                        # only meaningful when this call is made from inside
-                        # a reasoner that has a tracked pause-clock.
+                        # Cross-reasoner pause propagation: when this call is
+                        # made from inside a reasoner that has a tracked
+                        # pause-clock, hand it to ``wait_for_execution_result``
+                        # so the wait loop can pause the clock while the awaited
+                        # child sits in ``WAITING`` (e.g. on a hax-sdk human
+                        # approval). Without this, the parent's active-time
+                        # budget would burn through the child's wait and
+                        # spuriously trip the watchdog at the wallclock budget.
                         parent_execution_id = (
                             current_context.execution_id if current_context else None
                         )
                         # ``_pause_clocks`` is set in __init__; getattr keeps
-                        # bypass-init test fixtures from AttributeErroring
-                        # here. When the parent has no clock registered, we
-                        # have nothing meaningful to propagate to anyway.
+                        # bypass-init test fixtures from AttributeErroring here.
                         _all_pause_clocks = getattr(self, "_pause_clocks", None) or {}
-                        propagate_pause = bool(
-                            parent_execution_id
-                            and parent_execution_id in _all_pause_clocks
+                        parent_pause_clock = (
+                            _all_pause_clocks.get(parent_execution_id)
+                            if parent_execution_id
+                            else None
                         )
-                        if propagate_pause:
-                            try:
-                                _mgr = await self.client._get_async_execution_manager()
-                                _mgr.register_status_listener(
-                                    self._on_child_status_change
-                                )
-                                async with self._waiting_children_lock:
-                                    self._waiting_children[execution_id] = (
-                                        parent_execution_id
-                                    )
-                            except Exception as _exc:
-                                # Pause propagation is best-effort; never
-                                # block the actual call on registry wiring.
-                                propagate_pause = False
-                                if self.dev_mode:
-                                    log_debug(
-                                        f"Pause propagation registration failed: {_exc}"
-                                    )
 
-                        try:
-                            # Only pass the pause_clock kwarg when we actually
-                            # have one to propagate — keeps the call shape
-                            # backward-compatible with mocks / older clients
-                            # that don't yet accept the kwarg.
-                            _wait_kwargs: Dict[str, Any] = {
-                                "execution_id": execution_id,
-                                "timeout": execution_timeout,
-                            }
-                            if propagate_pause:
-                                _wait_kwargs["pause_clock"] = (
-                                    self._pause_clocks.get(parent_execution_id)
-                                )
-                            result = await self.client.wait_for_execution_result(
-                                **_wait_kwargs
-                            )
-                        finally:
-                            if propagate_pause:
-                                async with self._waiting_children_lock:
-                                    self._waiting_children.pop(execution_id, None)
-                                    paused_set = self._parent_paused_children.get(
-                                        parent_execution_id
-                                    )
-                                    if (
-                                        paused_set is not None
-                                        and execution_id in paused_set
-                                    ):
-                                        paused_set.discard(execution_id)
-                                        if not paused_set:
-                                            _pc = self._pause_clocks.get(
-                                                parent_execution_id
-                                            )
-                                            if _pc is not None:
-                                                _pc.end_pause()
-                                            self._parent_paused_children.pop(
-                                                parent_execution_id, None
-                                            )
+                        # Only pass the pause_clock kwarg when we actually have
+                        # one — keeps the call shape backward-compatible with
+                        # mocks / older clients that don't yet accept the kwarg.
+                        _wait_kwargs: Dict[str, Any] = {
+                            "execution_id": execution_id,
+                            "timeout": execution_timeout,
+                        }
+                        if parent_pause_clock is not None:
+                            _wait_kwargs["pause_clock"] = parent_pause_clock
+                        result = await self.client.wait_for_execution_result(
+                            **_wait_kwargs
+                        )
 
                         elapsed_time = time.time() - start_time
                         if self.dev_mode:

--- a/sdk/python/agentfield/async_execution_manager.py
+++ b/sdk/python/agentfield/async_execution_manager.py
@@ -11,7 +11,7 @@ import json
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urljoin
 
 import aiohttp
@@ -240,37 +240,7 @@ class AsyncExecutionManager:
         self._circuit_breaker_last_failure = 0.0
         self._circuit_breaker_open = False
 
-        # Listeners notified on every observed execution status transition.
-        # The Agent registers a listener here so a parent reasoner waiting on
-        # a child via ``app.call`` can pause its own pause-clock while the
-        # child is in ``waiting``/``paused``, and resume it when the child
-        # transitions back to ``running`` (or terminates).
-        self._status_listeners: List[Callable[[str, ExecutionStatus], None]] = []
-
         logger.debug(f"AsyncExecutionManager initialized with base_url={base_url}")
-
-    def register_status_listener(
-        self, callback: Callable[[str, ExecutionStatus], None]
-    ) -> None:
-        """Register a callback invoked on every observed status transition.
-
-        The callback receives ``(execution_id, status)`` and must be
-        non-blocking — it is invoked from the SSE event loop. Idempotent:
-        the same callable is only registered once.
-        """
-        if callback not in self._status_listeners:
-            self._status_listeners.append(callback)
-
-    def _fire_status_listeners(
-        self, execution_id: str, status: ExecutionStatus
-    ) -> None:
-        for cb in self._status_listeners:
-            try:
-                cb(execution_id, status)
-            except Exception as exc:
-                logger.debug(
-                    f"Status listener raised for {execution_id[:8]}...: {exc}"
-                )
 
     def set_event_stream_headers(self, headers: Optional[Dict[str, str]]) -> None:
         """Configure headers forwarded to the SSE event stream."""
@@ -587,54 +557,88 @@ class AsyncExecutionManager:
                     pass
             return elapsed
 
-        # Wait for completion
-        while _active_elapsed() < wait_timeout:
+        # Tracks whether we currently have ``pause_clock`` paused on behalf of
+        # the awaited child. Toggled below as we observe the child entering
+        # and leaving ``WAITING`` via the polling task's status updates.
+        # Polling is unconditional, so this works whether or not the SSE
+        # event stream is enabled.
+        child_pause_active = False
+        try:
+            # Wait for completion
+            while _active_elapsed() < wait_timeout:
+                async with self._execution_lock:
+                    execution = self._executions.get(execution_id)
+                    if execution is None:
+                        raise KeyError(f"Execution {execution_id} was removed")
+
+                    is_waiting = execution.status == ExecutionStatus.WAITING
+
+                    if execution.is_terminal:
+                        if execution.is_successful:
+                            # Cache successful result
+                            if execution.result is not None:
+                                self.result_cache.set_execution_result(
+                                    execution_id, execution.result
+                                )
+                            return execution.result
+                        elif execution.status == ExecutionStatus.FAILED:
+                            # The reasoner ran and explicitly returned a failed
+                            # result. Surface as ExecutionFailedError (a subclass
+                            # of AgentFieldClientError, kept for backward compat)
+                            # so Agent.call can skip the sync fallback path: the
+                            # reasoner's already done its work, retrying with the
+                            # same input would burn the same budget for the same
+                            # outcome. Transient transport / submission errors
+                            # still surface as plain AgentFieldClientError and
+                            # remain retry-eligible.
+                            raise ExecutionFailedError(
+                                f"Execution failed: {execution.error_message}"
+                            )
+                        elif execution.status == ExecutionStatus.CANCELLED:
+                            raise AgentFieldClientError(
+                                f"Execution was cancelled: {execution._cancellation_reason}"
+                            )
+                        elif execution.status == ExecutionStatus.TIMEOUT:
+                            raise ExecutionTimeoutError(
+                                f"Execution timed out after {execution.timeout} seconds"
+                            )
+
+                # Toggle the parent's pause-clock based on the child's status.
+                # Doing this in the wait loop (rather than via the SSE event
+                # listener) means cross-reasoner pause propagation works
+                # whenever ``Agent.call`` is awaited, regardless of whether
+                # ``enable_event_stream`` is on. Done outside the lock so the
+                # ``time.time()`` reads in PauseClock don't pile up under it.
+                if pause_clock is not None:
+                    if is_waiting and not child_pause_active:
+                        pause_clock.start_pause()
+                        child_pause_active = True
+                    elif (not is_waiting) and child_pause_active:
+                        pause_clock.end_pause()
+                        child_pause_active = False
+
+                # Wait before next check
+                await asyncio.sleep(0.1)
+
+            # Timeout reached
             async with self._execution_lock:
                 execution = self._executions.get(execution_id)
-                if execution is None:
-                    raise KeyError(f"Execution {execution_id} was removed")
+                if execution and execution.is_active:
+                    execution.timeout_execution()
+                    self.metrics.timeout_executions += 1
 
-                if execution.is_terminal:
-                    if execution.is_successful:
-                        # Cache successful result
-                        if execution.result is not None:
-                            self.result_cache.set_execution_result(
-                                execution_id, execution.result
-                            )
-                        return execution.result
-                    elif execution.status == ExecutionStatus.FAILED:
-                        # The reasoner ran and explicitly returned a failed
-                        # result. Surface as ExecutionFailedError (a subclass
-                        # of AgentFieldClientError, kept for backward compat)
-                        # so Agent.call can skip the sync fallback path: the
-                        # reasoner's already done its work, retrying with the
-                        # same input would burn the same budget for the same
-                        # outcome. Transient transport / submission errors
-                        # still surface as plain AgentFieldClientError and
-                        # remain retry-eligible.
-                        raise ExecutionFailedError(
-                            f"Execution failed: {execution.error_message}"
-                        )
-                    elif execution.status == ExecutionStatus.CANCELLED:
-                        raise AgentFieldClientError(
-                            f"Execution was cancelled: {execution._cancellation_reason}"
-                        )
-                    elif execution.status == ExecutionStatus.TIMEOUT:
-                        raise ExecutionTimeoutError(
-                            f"Execution timed out after {execution.timeout} seconds"
-                        )
-
-            # Wait before next check
-            await asyncio.sleep(0.1)
-
-        # Timeout reached
-        async with self._execution_lock:
-            execution = self._executions.get(execution_id)
-            if execution and execution.is_active:
-                execution.timeout_execution()
-                self.metrics.timeout_executions += 1
-
-        raise ExecutionTimeoutError(f"Wait timeout reached after {wait_timeout} seconds")
+            raise ExecutionTimeoutError(
+                f"Wait timeout reached after {wait_timeout} seconds"
+            )
+        finally:
+            # Ensure we don't leave the parent's clock stuck in a paused state
+            # if we exit via terminal / timeout / exception while the child
+            # was last seen waiting.
+            if child_pause_active and pause_clock is not None:
+                try:
+                    pause_clock.end_pause()
+                except Exception:
+                    pass
 
     async def cancel_execution(
         self, execution_id: str, reason: Optional[str] = None
@@ -870,20 +874,13 @@ class AsyncExecutionManager:
         schedule_poll = False
         status_hint = normalize_status(payload.get("status"))
         event_type = str(payload.get("type", "")).lower()
-        # ``execution.waiting`` is what RequestApprovalHandler publishes when
-        # a child reasoner enters ``app.pause``; the payload often omits an
-        # explicit status field, in which case ``normalize_status`` would
-        # report ``"unknown"`` and we'd lose the signal. Override based on
-        # event_type so the hint reflects what actually happened.
-        if event_type == "execution.waiting":
-            status_hint = "waiting"
 
-        new_status: Optional[ExecutionStatus] = None
         async with self._execution_lock:
             execution = self._executions.get(execution_id)
             if execution is None:
                 return
 
+            new_status: Optional[ExecutionStatus] = None
             if event_type == "execution_started" or status_hint == "running":
                 new_status = ExecutionStatus.RUNNING
             elif status_hint == "queued":
@@ -891,9 +888,6 @@ class AsyncExecutionManager:
             elif status_hint == "pending":
                 new_status = ExecutionStatus.PENDING
             elif status_hint in {"waiting", "paused"}:
-                # Child entered an external-wait state (e.g. waiting on a
-                # human approval via app.pause). The status listener uses
-                # this transition to pause the parent's pause-clock.
                 new_status = ExecutionStatus.WAITING
             elif status_hint in {
                 "succeeded",
@@ -913,11 +907,6 @@ class AsyncExecutionManager:
 
             if new_status is not None and new_status != execution.status:
                 execution.update_status(new_status)
-            else:
-                new_status = None  # no-op transition; don't fire listeners
-
-        if new_status is not None:
-            self._fire_status_listeners(execution_id, new_status)
 
         if schedule_poll:
             asyncio.create_task(self._poll_execution_immediate(execution_id))

--- a/sdk/python/tests/test_agent_coverage_additions.py
+++ b/sdk/python/tests/test_agent_coverage_additions.py
@@ -33,9 +33,6 @@ def make_agent():
         resolve=AsyncMock(),
     )
     agent._pause_clocks = {}
-    agent._waiting_children = {}
-    agent._parent_paused_children = {}
-    agent._waiting_children_lock = asyncio.Lock()
     agent.note = Mock()
     agent.agentfield_server = "http://agentfield.test"
     agent.api_key = "key"

--- a/sdk/python/tests/test_async_execution.py
+++ b/sdk/python/tests/test_async_execution.py
@@ -409,134 +409,200 @@ async def test_external_cancel_during_pause_reports_cancelled_not_timeout(monkey
 # ---------------------------------------------------------------------------
 
 
-def _make_propagation_agent() -> Agent:
-    """Build a real Agent so the pause-clock dict, registry and listener
-    method are wired up via ``__init__``. Tests poke at those structures
-    directly instead of going through the full HTTP / SSE pipeline."""
-    return Agent(
-        node_id="parent-agent",
-        agentfield_server="http://control",
-        auto_register=False,
+@pytest.mark.asyncio
+async def test_wait_for_result_pauses_parent_clock_while_child_waits():
+    """End-to-end check on the production path: the polling task updates
+    ``_executions[child].status`` from RUNNING -> WAITING -> RUNNING -> SUCCEEDED,
+    and ``wait_for_result`` (with a pause_clock) toggles the parent's clock
+    accordingly. No SSE listener, no internal hooks — just the data path the
+    deployed services actually use.
+
+    Regression for run_1778268481826_8c9dd544 where the parent watchdog tripped
+    at exactly the wallclock budget despite a long approval wait, because the
+    listener-based mechanism was gated off behind ``enable_event_stream`` and
+    never fired in production. Polling is unconditional, so this version of
+    the propagation works regardless of the SSE flag.
+    """
+    from agentfield.async_execution_manager import AsyncExecutionManager
+    from agentfield.async_config import AsyncConfig
+    from agentfield.execution_state import ExecutionState, ExecutionStatus
+
+    manager = AsyncExecutionManager(base_url="http://control", config=AsyncConfig())
+    exec_id = "exec-child"
+    state = ExecutionState(
+        execution_id=exec_id,
+        target="agent.reasoner",
+        input_data={},
+        timeout=5.0,
     )
-
-
-def test_child_status_change_pauses_parent_clock_on_waiting():
-    """Child entering WAITING should pause the parent's clock immediately;
-    transitioning back to RUNNING should end the pause."""
-    from agentfield.execution_state import ExecutionStatus
-
-    agent = _make_propagation_agent()
-    parent_id = "exec-parent"
-    child_id = "exec-child"
+    state.update_status(ExecutionStatus.RUNNING)
+    manager._executions[exec_id] = state
 
     parent_clock = PauseClock()
-    agent._pause_clocks[parent_id] = parent_clock
-    agent._waiting_children[child_id] = parent_id
 
-    assert parent_clock.total_paused() == 0.0
+    async def _drive_polling():
+        # t=0.05: child enters WAITING (e.g. hax-sdk approval gate fires).
+        await asyncio.sleep(0.05)
+        async with manager._execution_lock:
+            state.update_status(ExecutionStatus.WAITING)
+        # t=0.25: child resumes after ~0.2s of waiting.
+        await asyncio.sleep(0.20)
+        async with manager._execution_lock:
+            state.update_status(ExecutionStatus.RUNNING)
+        # t=0.30: child finishes shortly after resuming.
+        await asyncio.sleep(0.05)
+        async with manager._execution_lock:
+            state.set_result({"ok": True})
 
-    agent._on_child_status_change(child_id, ExecutionStatus.WAITING)
-    time.sleep(0.05)
-    paused_after_waiting = parent_clock.total_paused()
-    assert paused_after_waiting > 0.0, (
-        "parent clock must accumulate paused time while child is in WAITING"
+    poller = asyncio.create_task(_drive_polling())
+    result = await manager.wait_for_result(
+        exec_id, timeout=5.0, pause_clock=parent_clock
     )
+    await poller
 
-    agent._on_child_status_change(child_id, ExecutionStatus.RUNNING)
-    final_paused = parent_clock.total_paused()
-    # After end_pause, total_paused freezes — sleeping should not grow it.
-    time.sleep(0.05)
-    assert abs(parent_clock.total_paused() - final_paused) < 1e-3, (
-        "parent clock must stop accumulating once child resumes"
+    assert result == {"ok": True}
+    paused = parent_clock.total_paused()
+    # The WAITING window was ~0.2s. Allow generous slack for scheduler jitter.
+    assert paused >= 0.15, (
+        f"parent clock should reflect the child's WAITING window, got {paused:.3f}s"
     )
-    assert child_id not in agent._parent_paused_children.get(parent_id, set())
-
-
-def test_child_status_change_refcounts_parallel_children():
-    """Two children pausing in parallel must not double-pause the parent
-    clock. The parent stays paused while ANY awaited child is paused, and
-    only resumes when ALL of them are running again."""
-    from agentfield.execution_state import ExecutionStatus
-
-    agent = _make_propagation_agent()
-    parent_id = "exec-parent"
-    child_a = "exec-a"
-    child_b = "exec-b"
-
-    parent_clock = PauseClock()
-    agent._pause_clocks[parent_id] = parent_clock
-    agent._waiting_children[child_a] = parent_id
-    agent._waiting_children[child_b] = parent_id
-
-    agent._on_child_status_change(child_a, ExecutionStatus.WAITING)
-    assert parent_clock._pause_started_at is not None
-    first_pause_started = parent_clock._pause_started_at
-
-    # Second child also pausing should NOT reset the pause start (which
-    # would erase the time accumulated since child A first paused).
-    time.sleep(0.05)
-    agent._on_child_status_change(child_b, ExecutionStatus.WAITING)
-    assert parent_clock._pause_started_at == first_pause_started, (
-        "second child entering WAITING must not restart the parent pause"
+    assert paused < 0.5, (
+        f"parent clock should not include time outside WAITING, got {paused:.3f}s"
     )
-
-    # Only one child resuming: parent stays paused (refcount > 0).
-    agent._on_child_status_change(child_a, ExecutionStatus.RUNNING)
-    assert parent_clock._pause_started_at is not None, (
-        "parent must remain paused while any awaited child is still paused"
-    )
-
-    # Last child resumes: parent's pause finally ends.
-    agent._on_child_status_change(child_b, ExecutionStatus.RUNNING)
-    assert parent_clock._pause_started_at is None
-    assert parent_id not in agent._parent_paused_children
-
-
-def test_child_status_change_ignores_unrelated_executions():
-    """An execution we're not awaiting must be a no-op — the listener fires
-    for every execution on the SSE bus, including unrelated ones."""
-    from agentfield.execution_state import ExecutionStatus
-
-    agent = _make_propagation_agent()
-    parent_clock = PauseClock()
-    agent._pause_clocks["exec-parent"] = parent_clock
-    # Note: no _waiting_children entry for the unrelated child.
-
-    agent._on_child_status_change("exec-stranger", ExecutionStatus.WAITING)
-    assert parent_clock.total_paused() == 0.0
-    assert "exec-parent" not in agent._parent_paused_children
-
-
-def test_child_status_change_terminal_cleans_up_registry():
-    """A terminal child status must purge the binding so a long-lived
-    parent doesn't accumulate stale child refs."""
-    from agentfield.execution_state import ExecutionStatus
-
-    agent = _make_propagation_agent()
-    parent_id = "exec-parent"
-    child_id = "exec-child"
-    agent._pause_clocks[parent_id] = PauseClock()
-    agent._waiting_children[child_id] = parent_id
-
-    agent._on_child_status_change(child_id, ExecutionStatus.SUCCEEDED)
-    assert child_id not in agent._waiting_children
 
 
 @pytest.mark.asyncio
-async def test_wait_for_result_subtracts_pause_clock_from_elapsed(monkeypatch):
-    """``wait_for_result`` is the cross-agent wait; if its own timeout is
-    wall-clock it'll fire while the child is correctly paused on a human
-    approval. Passing the parent's pause_clock makes the wait active-time
-    aware so it survives long human-approval gaps."""
+async def test_wait_for_result_preserves_budget_across_long_wait():
+    """The headline scenario: the WAITING window is longer than the entire
+    wait_timeout, but ``wait_for_result`` must still complete because
+    waiting time is excluded from active-elapsed. Without the pause toggle
+    in the wait loop this would (and previously did) trip the timeout."""
+    from agentfield.async_execution_manager import AsyncExecutionManager
+    from agentfield.async_config import AsyncConfig
+    from agentfield.execution_state import ExecutionState, ExecutionStatus
+
+    manager = AsyncExecutionManager(base_url="http://control", config=AsyncConfig())
+    exec_id = "exec-long-wait"
+    state = ExecutionState(
+        execution_id=exec_id,
+        target="agent.reasoner",
+        input_data={},
+        timeout=0.5,
+    )
+    state.update_status(ExecutionStatus.RUNNING)
+    manager._executions[exec_id] = state
+
+    parent_clock = PauseClock()
+
+    async def _drive_polling():
+        await asyncio.sleep(0.05)
+        async with manager._execution_lock:
+            state.update_status(ExecutionStatus.WAITING)
+        # WAITING for 0.7s — longer than the 0.5s wait_timeout. With the
+        # pause_clock active this whole window is excluded from active time,
+        # so the wait must NOT raise ExecutionTimeoutError here.
+        await asyncio.sleep(0.7)
+        async with manager._execution_lock:
+            state.update_status(ExecutionStatus.RUNNING)
+        await asyncio.sleep(0.05)
+        async with manager._execution_lock:
+            state.set_result({"value": 42})
+
+    poller = asyncio.create_task(_drive_polling())
+    result = await manager.wait_for_result(
+        exec_id, timeout=0.5, pause_clock=parent_clock
+    )
+    await poller
+
+    assert result == {"value": 42}
+
+
+@pytest.mark.asyncio
+async def test_wait_for_result_without_pause_clock_unaffected():
+    """No pause_clock kwarg = no toggling, behaves as a plain wallclock wait.
+    Regression check that the new toggle code doesn't change pre-existing
+    semantics for callers that don't pass a clock."""
+    from agentfield.async_execution_manager import AsyncExecutionManager
+    from agentfield.async_config import AsyncConfig
+    from agentfield.execution_state import ExecutionState, ExecutionStatus
+    from agentfield.exceptions import ExecutionTimeoutError
+
+    manager = AsyncExecutionManager(base_url="http://control", config=AsyncConfig())
+    exec_id = "exec-plain"
+    state = ExecutionState(
+        execution_id=exec_id,
+        target="agent.reasoner",
+        input_data={},
+        timeout=0.2,
+    )
+    state.update_status(ExecutionStatus.WAITING)
+    manager._executions[exec_id] = state
+
+    # No pause_clock provided. Even though the child sits in WAITING, the
+    # wait must time out at wallclock since there's no clock to subtract from.
+    with pytest.raises(ExecutionTimeoutError):
+        await manager.wait_for_result(exec_id, timeout=0.2)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_result_ends_pause_on_terminal_while_waiting():
+    """If the child transitions straight from WAITING to a terminal state
+    (e.g. cancelled mid-approval), the wait's finally block must still close
+    the in-flight pause so the parent's clock isn't stuck paused forever."""
+    from agentfield.async_execution_manager import AsyncExecutionManager
+    from agentfield.async_config import AsyncConfig
+    from agentfield.execution_state import ExecutionState, ExecutionStatus
+    from agentfield.exceptions import AgentFieldClientError
+
+    manager = AsyncExecutionManager(base_url="http://control", config=AsyncConfig())
+    exec_id = "exec-cancelled-while-waiting"
+    state = ExecutionState(
+        execution_id=exec_id,
+        target="agent.reasoner",
+        input_data={},
+        timeout=5.0,
+    )
+    state.update_status(ExecutionStatus.RUNNING)
+    manager._executions[exec_id] = state
+
+    parent_clock = PauseClock()
+
+    async def _drive_polling():
+        await asyncio.sleep(0.05)
+        async with manager._execution_lock:
+            state.update_status(ExecutionStatus.WAITING)
+        await asyncio.sleep(0.10)
+        async with manager._execution_lock:
+            state.cancel("user_cancelled_during_approval")
+
+    poller = asyncio.create_task(_drive_polling())
+    with pytest.raises(AgentFieldClientError):
+        await manager.wait_for_result(
+            exec_id, timeout=5.0, pause_clock=parent_clock
+        )
+    await poller
+
+    # Pause must be closed: total_paused stops accumulating once the wait
+    # returns. Sleep and verify the value is stable.
+    paused_at_exit = parent_clock.total_paused()
+    await asyncio.sleep(0.1)
+    assert abs(parent_clock.total_paused() - paused_at_exit) < 1e-3, (
+        "pause must be closed when wait_for_result exits via terminal child status"
+    )
+
+
+@pytest.mark.asyncio
+async def test_wait_for_result_subtracts_pause_clock_from_elapsed():
+    """Direct check on the active-elapsed math: a pause_clock that reports
+    10s of paused time keeps a 0.5s wait alive long enough to settle."""
     from agentfield.async_execution_manager import AsyncExecutionManager
     from agentfield.async_config import AsyncConfig
     from agentfield.execution_state import ExecutionState
     from agentfield.exceptions import ExecutionTimeoutError
 
-    cfg = AsyncConfig()
-    manager = AsyncExecutionManager(base_url="http://control", config=cfg)
+    manager = AsyncExecutionManager(base_url="http://control", config=AsyncConfig())
 
-    exec_id = "exec-child"
+    exec_id = "exec-fake-clock"
     state = ExecutionState(
         execution_id=exec_id,
         target="agent.reasoner",
@@ -545,13 +611,15 @@ async def test_wait_for_result_subtracts_pause_clock_from_elapsed(monkeypatch):
     )
     manager._executions[exec_id] = state
 
-    # Pause clock that always reports 10s of paused time — way more than
-    # the 0.5s wait timeout. Without subtraction, wait_for_result would
-    # fire instantly; with subtraction, elapsed - paused stays negative
-    # so the loop keeps running until the execution becomes terminal.
     class _FakeClock:
         def total_paused(self) -> float:
             return 10.0
+
+        def start_pause(self) -> None:
+            pass
+
+        def end_pause(self) -> None:
+            pass
 
     async def _settle_after_short_delay():
         await asyncio.sleep(0.2)
@@ -564,8 +632,8 @@ async def test_wait_for_result_subtracts_pause_clock_from_elapsed(monkeypatch):
     )
     assert result == {"ok": True}
 
-    # Sanity: without the pause_clock the same setup with a stricter
-    # timeout would actually time out.
+    # Sanity: without any pause_clock, the same kind of setup with a tighter
+    # timeout actually trips ExecutionTimeoutError.
     state2 = ExecutionState(
         execution_id="exec-strict",
         target="agent.reasoner",
@@ -575,56 +643,3 @@ async def test_wait_for_result_subtracts_pause_clock_from_elapsed(monkeypatch):
     manager._executions["exec-strict"] = state2
     with pytest.raises(ExecutionTimeoutError):
         await manager.wait_for_result("exec-strict", timeout=0.1)
-
-
-@pytest.mark.asyncio
-async def test_sse_handler_fires_status_listener_on_waiting():
-    """The SSE event handler must translate ``execution.waiting`` events
-    into a listener invocation so the parent process learns its child is
-    paused."""
-    from agentfield.async_execution_manager import AsyncExecutionManager
-    from agentfield.async_config import AsyncConfig
-    from agentfield.execution_state import ExecutionState, ExecutionStatus
-
-    manager = AsyncExecutionManager(base_url="http://control", config=AsyncConfig())
-    exec_id = "exec-waiter"
-    manager._executions[exec_id] = ExecutionState(
-        execution_id=exec_id, target="agent.reasoner", input_data={},
-    )
-
-    seen: list[tuple[str, ExecutionStatus]] = []
-    manager.register_status_listener(lambda eid, st: seen.append((eid, st)))
-
-    await manager._handle_event_stream_payload(
-        {"execution_id": exec_id, "type": "execution.waiting"}
-    )
-    assert (exec_id, ExecutionStatus.WAITING) in seen
-
-    await manager._handle_event_stream_payload(
-        {"execution_id": exec_id, "status": "running"}
-    )
-    assert (exec_id, ExecutionStatus.RUNNING) in seen
-
-    # Duplicate event with no transition: listener must NOT re-fire.
-    seen.clear()
-    await manager._handle_event_stream_payload(
-        {"execution_id": exec_id, "status": "running"}
-    )
-    assert seen == []
-
-
-@pytest.mark.asyncio
-async def test_sse_handler_ignores_unknown_executions():
-    """SSE events for executions this manager didn't submit must be a
-    no-op — they belong to a different waiter or an unrelated agent."""
-    from agentfield.async_execution_manager import AsyncExecutionManager
-    from agentfield.async_config import AsyncConfig
-
-    manager = AsyncExecutionManager(base_url="http://control", config=AsyncConfig())
-    seen: list[str] = []
-    manager.register_status_listener(lambda eid, st: seen.append(eid))
-
-    await manager._handle_event_stream_payload(
-        {"execution_id": "exec-unknown", "status": "waiting"}
-    )
-    assert seen == []


### PR DESCRIPTION
## Summary

The v0.1.80 listener-based pause propagation **never fired in production** because it depended on the SDK's SSE event-stream subscription, which is gated behind `enable_event_stream` (default `False`) and not enabled on any deployed service.

Reproduced on Railway run `run_1778268481826_8c9dd544`: `implement_from_issue` timed out at exactly 7200s wallclock despite a ~21min hax-sdk approval gap clearly visible in the SWE-AF logs (20:10:42 → 20:31:35) and a second silent gap before the timeout.

## Why the listener didn't fire

- Control plane DOES publish `execution_waiting` to the bus (verified in `execute_approval.go`).
- Parents subscribe to that bus only when `enable_event_stream=True`. Default is `False` and no service overrides it. Verified via `railway ssh ... env`: no service has the var set, and the only subscriber on the live SSE bus is the user's browser.
- So `register_status_listener` callbacks were never invoked, `pause_clock.start_pause()` was never called, `total_paused()` stayed at 0, `active_elapsed == wallclock`, watchdog tripped at the budget.

The previous tests poked `_on_child_status_change` and `_handle_event_stream_payload` directly, which bypassed the `enable_event_stream` gate entirely. They passed; production was broken.

## Fix

Replace the SSE-listener mechanism with a poll-driven toggle inside `wait_for_result`:

- The polling task already runs unconditionally and already updates `_executions[id].status` from control-plane responses (`_update_execution_from_status`).
- `wait_for_result` now reads that status each loop iteration. When it reads as `WAITING`, the parent's `pause_clock.start_pause()` is called; when it reads back as anything else, `end_pause()` is called. A `finally` block closes any in-flight pause if we exit via terminal / timeout / exception.
- No SSE subscription needed. No listener registry. No refcount machinery. Works whether or not `enable_event_stream` is on.

### Removed
- `async_execution_manager.py`: `register_status_listener`, `_status_listeners`, `_fire_status_listeners`, the `execution.waiting` event-type override (the WAITING-status branch in `_handle_event_stream_payload` stays for when SSE *is* on).
- `agent.py`: `_on_child_status_change`, `_waiting_children`, `_parent_paused_children`, the listener registration in `call()`. The `pause_clock` kwarg pass-through (the actual fix) is preserved.

Net: −387 / +274 lines across 4 files.

### Tests
Replaced the listener tests with integration tests that drive the **production data path**: they update `_executions[id].status` the same way the polling task does, then assert `wait_for_result` toggles the parent clock and survives a long `WAITING` window. Includes a regression for the headline scenario (WAITING window > wait_timeout, must complete) and a finally-block check for cancelled-while-waiting.

## Test plan
- [x] `cd sdk/python && ruff check .` — clean
- [x] `cd sdk/python && python -m pytest --no-cov` — 1482 passed, 4 skipped (integration tests requiring server sources, pre-existing)
- [ ] CI green
- [ ] Verify on Railway after release: re-run an `implement_from_issue` flow that hits the hax-sdk gate; parent should not time out at wallclock 2hr if active work < 2hr

🤖 Generated with [Claude Code](https://claude.com/claude-code)