### PR TITLE
fix(sdk): treat cancellation as non-retryable in Agent.call sync-fallback path

### DIFF
--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -3954,29 +3954,34 @@ class Agent(FastAPI):
                             raise async_error
 
                         # Never fall back when the failure happened AFTER the
-                        # reasoner already ran. ExecutionFailedError means
-                        # the call reached the reasoner, the work executed,
-                        # and the reasoner returned an error — retrying
-                        # via sync would burn the same budget for the same
-                        # outcome. ExecutionTimeoutError means the work has
-                        # already used (or exceeded) its timeout budget on
-                        # the agent side; firing the same call again wastes
-                        # another full budget. Both classes surface as
-                        # subclasses of AgentFieldError so a local import
-                        # is safe even with the legacy AgentFieldClientError
-                        # catch path some callers depend on.
+                        # reasoner already ran, OR when the user explicitly
+                        # cancelled. ExecutionFailedError means the call
+                        # reached the reasoner, the work executed, and the
+                        # reasoner returned an error — retrying via sync
+                        # would burn the same budget for the same outcome.
+                        # ExecutionTimeoutError means the work has already
+                        # used (or exceeded) its timeout budget on the agent
+                        # side; firing the same call again wastes another
+                        # full budget. ExecutionCancelledError means the user
+                        # told us to stop — silently re-issuing the call via
+                        # sync fallback would defeat the cancellation.
                         from agentfield.exceptions import (
+                            ExecutionCancelledError,
                             ExecutionFailedError,
                             ExecutionTimeoutError,
                         )
                         if isinstance(
                             async_error,
-                            (ExecutionFailedError, ExecutionTimeoutError),
+                            (
+                                ExecutionFailedError,
+                                ExecutionTimeoutError,
+                                ExecutionCancelledError,
+                            ),
                         ):
                             if self.dev_mode:
                                 log_debug(
                                     f"Skipping sync fallback for {type(async_error).__name__}: "
-                                    f"reasoner already ran; retry would re-burn the budget"
+                                    f"reasoner already ran or was cancelled by user"
                                 )
                             raise async_error
 

--- a/sdk/python/agentfield/async_execution_manager.py
+++ b/sdk/python/agentfield/async_execution_manager.py
@@ -20,6 +20,7 @@ from .async_config import AsyncConfig
 from .execution_state import ExecuteError, ExecutionPriority, ExecutionState, ExecutionStatus
 from .exceptions import (
     AgentFieldClientError,
+    ExecutionCancelledError,
     ExecutionFailedError,
     ExecutionTimeoutError,
 )
@@ -528,7 +529,9 @@ class AsyncExecutionManager:
         Raises:
             KeyError: If execution_id is not found
             ExecutionTimeoutError: If execution times out
-            AgentFieldClientError: If execution fails or is cancelled
+            ExecutionFailedError: If the reasoner ran and returned a failed status
+            ExecutionCancelledError: If the execution was cancelled (user intent)
+            AgentFieldClientError: For other transport / submission failures
         """
         # Check cache first
         cached_result = self.result_cache.get_execution_result(execution_id)
@@ -615,7 +618,11 @@ class AsyncExecutionManager:
                                 f"Execution failed: {execution.error_message}"
                             )
                         elif execution.status == ExecutionStatus.CANCELLED:
-                            raise AgentFieldClientError(
+                            # Surface as ExecutionCancelledError (NOT a subclass
+                            # of AgentFieldClientError) so Agent.call's
+                            # sync-fallback path skips it: cancellation is
+                            # explicit user intent, never retry-eligible.
+                            raise ExecutionCancelledError(
                                 f"Execution was cancelled: {execution._cancellation_reason}"
                             )
                         elif execution.status == ExecutionStatus.TIMEOUT:

--- a/sdk/python/agentfield/exceptions.py
+++ b/sdk/python/agentfield/exceptions.py
@@ -39,6 +39,25 @@ class ExecutionTimeoutError(AgentFieldError):
     pass
 
 
+class ExecutionCancelledError(AgentFieldError):
+    """The awaited execution was cancelled (typically by user action via the
+    control plane's cancel-tree endpoint).
+
+    Distinct from ``ExecutionFailedError`` (the reasoner ran and failed) and
+    from a transport / submission failure (plain ``AgentFieldClientError``):
+    cancellation expresses *explicit user intent* to stop the work. The SDK's
+    ``Agent.call`` must not silently re-issue a cancelled call via the sync
+    fallback path — that would re-run work the user explicitly told the
+    system to abandon.
+
+    Intentionally NOT a subclass of ``AgentFieldClientError`` (the
+    retry-eligible bucket): cancellation is never retry-eligible, regardless
+    of ``async_config.fallback_to_sync``.
+    """
+
+    pass
+
+
 class MemoryAccessError(AgentFieldError):
     """Error accessing agent memory storage."""
 
@@ -62,6 +81,7 @@ __all__ = [
     "AgentFieldClientError",
     "ExecutionFailedError",
     "ExecutionTimeoutError",
+    "ExecutionCancelledError",
     "MemoryAccessError",
     "RegistrationError",
     "ValidationError",

--- a/sdk/python/tests/test_agent_call.py
+++ b/sdk/python/tests/test_agent_call.py
@@ -215,6 +215,54 @@ async def test_call_skips_sync_fallback_on_execution_timeout_error():
 
 
 @pytest.mark.asyncio
+async def test_call_skips_sync_fallback_on_execution_cancelled_error():
+    """ExecutionCancelledError = the user explicitly cancelled the awaited
+    child (typically via the control plane's cancel-tree endpoint). The SDK
+    must NOT retry via sync — silently re-issuing a cancelled call defeats
+    the cancellation and re-runs work the user told the system to abandon.
+    Repro: github-buddy → pr-af.review run cancelled mid-flight; pr-af got
+    invoked again seconds later because the cancellation surfaced as a
+    plain AgentFieldClientError and slipped past the skip-list."""
+    from agentfield.exceptions import ExecutionCancelledError
+
+    agent = _make_agent_with_async_path()
+
+    sync_calls = 0
+
+    async def fake_execute_async(target, input_data, headers, timeout=None):
+        return "exec_xyz"
+
+    async def fake_wait_for_execution_result(execution_id, timeout=None):
+        raise ExecutionCancelledError(
+            "Execution was cancelled: user clicked cancel"
+        )
+
+    async def fake_execute(target, input_data, headers):
+        nonlocal sync_calls
+        sync_calls += 1
+        return {"result": {"never_reached": True}}
+
+    agent.client = SimpleNamespace(
+        execute=fake_execute,
+        execute_async=fake_execute_async,
+        wait_for_execution_result=fake_wait_for_execution_result,
+    )
+
+    set_current_agent(agent)
+    try:
+        with pytest.raises(ExecutionCancelledError):
+            await agent.call("other.reasoner", 1)
+    finally:
+        clear_current_agent()
+
+    assert sync_calls == 0, (
+        "ExecutionCancelledError must NOT trigger sync fallback — "
+        "the user explicitly told the system to stop; silently re-issuing "
+        "the call defeats the cancellation."
+    )
+
+
+@pytest.mark.asyncio
 async def test_call_still_falls_back_on_transport_errors():
     """Plain AgentFieldClientError (transport / submission / network) MUST
     still trigger the sync fallback. Only post-execution errors are skipped.

--- a/sdk/python/tests/test_async_execution.py
+++ b/sdk/python/tests/test_async_execution.py
@@ -552,7 +552,7 @@ async def test_wait_for_result_ends_pause_on_terminal_while_waiting():
     from agentfield.async_execution_manager import AsyncExecutionManager
     from agentfield.async_config import AsyncConfig
     from agentfield.execution_state import ExecutionState, ExecutionStatus
-    from agentfield.exceptions import AgentFieldClientError
+    from agentfield.exceptions import ExecutionCancelledError
 
     manager = AsyncExecutionManager(base_url="http://control", config=AsyncConfig())
     exec_id = "exec-cancelled-while-waiting"
@@ -576,7 +576,7 @@ async def test_wait_for_result_ends_pause_on_terminal_while_waiting():
             state.cancel("user_cancelled_during_approval")
 
     poller = asyncio.create_task(_drive_polling())
-    with pytest.raises(AgentFieldClientError):
+    with pytest.raises(ExecutionCancelledError):
         await manager.wait_for_result(
             exec_id, timeout=5.0, pause_clock=parent_clock
         )

--- a/sdk/python/tests/test_async_execution_manager_final90.py
+++ b/sdk/python/tests/test_async_execution_manager_final90.py
@@ -10,7 +10,11 @@ import pytest
 from agentfield.async_config import AsyncConfig
 from agentfield.async_execution_manager import AsyncExecutionManager
 from agentfield.execution_state import ExecutionState, ExecutionStatus
-from agentfield.exceptions import AgentFieldClientError, ExecutionTimeoutError
+from agentfield.exceptions import (
+    AgentFieldClientError,
+    ExecutionCancelledError,
+    ExecutionTimeoutError,
+)
 
 
 class _DummyTask:
@@ -125,7 +129,7 @@ async def test_wait_for_result_handles_success_failure_cancel_timeout(manager, m
     with pytest.raises(AgentFieldClientError, match="boom"):
         await manager.wait_for_result("failed")
 
-    with pytest.raises(AgentFieldClientError, match="cancelled"):
+    with pytest.raises(ExecutionCancelledError, match="cancelled"):
         await manager.wait_for_result("cancelled")
 
     async def fast_sleep(_seconds):


### PR DESCRIPTION
## Summary

Fixes a bug where cancelling a run via the control plane's `cancel-tree` endpoint did not actually stop work — the parent reasoner's `app.call(...)` silently re-issued the cancelled call via the sync-fallback path, creating a fresh execution against the same target. From the user's perspective: they cancelled, but the work ran anyway.

## The bug

When a parent reasoner is awaiting a child execution via `Agent.call(...)`, the SDK goes through `wait_for_execution_result` → `AsyncExecutionManager.wait_for_result`. When the child terminates as `CANCELLED`, that wait loop raised a **plain `AgentFieldClientError`**:

```python
elif execution.status == ExecutionStatus.CANCELLED:
    raise AgentFieldClientError(
        f"Execution was cancelled: {execution._cancellation_reason}"
    )
```

`AgentFieldClientError` is the SDK's "transient transport / submission failure" bucket — it's deliberately retry-eligible. So `Agent.call`'s exception handler ([`agent.py:3944-3984`](https://github.com/Agent-Field/agentfield/blob/main/sdk/python/agentfield/agent.py#L3944-L3984)), whose post-execution skip-list only excluded `ExecutionFailedError` and `ExecutionTimeoutError`, treated cancellation as a transport blip and fell through to:

```python
if not self.async_config.fallback_to_sync:
    raise async_error
# ... falls through to client.execute(target=target, input_data=...) ...
```

That sync fallback is a brand-new call to the same target. Reproduced on a `github-buddy` → `pr-af.review` run cancelled mid-flight via cancel-tree: `pr-af` got invoked again seconds later.

The control plane's auto-retry sweeper (`RetryStaleWorkflowExecutions`) is **not** the culprit — its `WHERE status IN ('running', 'pending', 'queued')` filter correctly excludes cancelled rows. The bug lives entirely in the Python SDK.

## The fix

Three commits, kept separate so the rationale at each step is reviewable on its own:

1. **`feat(sdk): introduce ExecutionCancelledError for cancelled awaits`** — adds `ExecutionCancelledError(AgentFieldError)`, parallel to `ExecutionTimeoutError`. Intentionally **not** a subclass of `AgentFieldClientError`: cancellation is explicit user intent, never retry-eligible. The wait loop in `async_execution_manager.py` now raises this on `CANCELLED`.
2. **`fix(sdk): skip sync fallback on ExecutionCancelledError`** — extends `Agent.call`'s post-execution skip-list to include the new exception alongside `ExecutionFailedError` and `ExecutionTimeoutError`. This is the actual user-visible fix.
3. **`test(sdk): pin cancellation behavior in Agent.call and wait loop`** — adds `test_call_skips_sync_fallback_on_execution_cancelled_error` mirroring the existing failed/timeout tests, asserting `client.execute` is never invoked when the awaited child is cancelled. Also updates two pre-existing tests whose expected exception class is now `ExecutionCancelledError` instead of plain `AgentFieldClientError`.

### Why a new exception class instead of reusing `ExecutionFailedError`

`ExecutionFailedError` means "the reasoner ran and returned an error" — that's a different signal than "the user told us to stop". Callers may legitimately want to react differently (e.g. don't surface a failure alert for a user-initiated cancel). Keeping them distinct preserves that signal at the API surface.

### Backward-compatibility note

Code that previously caught `AgentFieldClientError` to handle a cancelled await will need to switch to catching `ExecutionCancelledError` (or `AgentFieldError` if it wants both). I grepped the SDK + tests and updated the two test sites that depended on the old class. No production code paths in this repo relied on the old behavior.

## Test plan

- [x] `ruff check .` clean
- [x] `python -m pytest --no-cov` — **1489 passed**, 4 skipped, 0 failed
- [x] New test `test_call_skips_sync_fallback_on_execution_cancelled_error` pins that `Agent.call` does not invoke `client.execute` when the awaited child surfaces `ExecutionCancelledError` (mirrors the failed/timeout tests in the same file)
- [x] Pre-existing `test_wait_for_result_handles_success_failure_cancel_timeout` and `test_wait_for_result_ends_pause_on_terminal_while_waiting` updated to expect `ExecutionCancelledError` and still pass
- [ ] Manual repro in test deployment: cancel a `github-buddy` → `pr-af.review` run mid-flight, confirm `pr-af` is not invoked a second time after upgrade

## Validation contract

- When the user cancels a non-terminal child execution that a parent reasoner is awaiting via `app.call(...)`, the parent's call must raise (not return) and must not trigger a sync-fallback re-execution.
- The raised error must be distinguishable from `ExecutionFailedError` / `ExecutionTimeoutError` so callers can branch on "user-cancelled" vs other terminal failures.
- `fallback_to_sync = True` (default) and `fallback_to_sync = False` must both honor the no-retry rule for cancellation.
- Existing behavior for `FAILED` and `TIMEOUT` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)