### PR TITLE
fix(sdk+cp): multi-hop pause propagation (3+-deep chains no longer time out)

### DIFF
--- a/control-plane/internal/handlers/execute_awaiter_status.go
+++ b/control-plane/internal/handlers/execute_awaiter_status.go
@@ -1,0 +1,222 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/Agent-Field/agentfield/control-plane/internal/events"
+	"github.com/Agent-Field/agentfield/control-plane/internal/logger"
+	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
+
+	"github.com/gin-gonic/gin"
+)
+
+// awaiterStatusReason marks WAITING transitions driven by the awaiter-status
+// endpoint, so the matching RUNNING transition can be distinguished from one
+// that would resume an approval (which has its own status_reason).
+const awaiterStatusReason = "awaiting_child"
+
+// AwaiterStatusRequest is the body for POST /executions/:execution_id/awaiter-status.
+//
+// An agent calls this on its OWN execution_id when its `app.call()` wait loop
+// observes the awaited child enter or leave WAITING. The point is to make the
+// awaiter visible as WAITING to anyone watching it — without this, pause-state
+// only propagates one hop up the call tree, and a great-grandparent times out
+// at wallclock even though a leaf descendant is paused on human approval.
+type AwaiterStatusRequest struct {
+	// Status is "waiting" (RUNNING -> WAITING) or "running" (WAITING -> RUNNING).
+	Status string `json:"status" binding:"required"`
+	// Reason is a free-text marker for observability, e.g. "awaiting child exec_abc".
+	Reason string `json:"reason,omitempty"`
+}
+
+// AwaiterStatusResponse is returned to the agent. ``Applied`` indicates whether
+// the transition actually changed state; the SDK treats no-ops as success.
+type AwaiterStatusResponse struct {
+	Status  string `json:"status"`
+	Applied bool   `json:"applied"`
+}
+
+// awaiterStatusController handles POST /executions/:execution_id/awaiter-status.
+type awaiterStatusController struct {
+	store ExecutionStore
+}
+
+// UpdateAwaiterStatusHandler returns a gin handler for the agent-scoped
+// awaiter-status route. Mirrors the agent-scoped approval handler.
+func UpdateAwaiterStatusHandler(store ExecutionStore) gin.HandlerFunc {
+	ctrl := &awaiterStatusController{store: store}
+	approvalCtrl := &approvalController{store: store}
+	return func(ctx *gin.Context) {
+		nodeID := ctx.Param("node_id")
+		executionID := ctx.Param("execution_id")
+		if nodeID == "" || executionID == "" {
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": "node_id and execution_id are required"})
+			return
+		}
+		if !approvalCtrl.verifyExecutionOwnership(ctx, executionID, nodeID) {
+			return
+		}
+		ctrl.handle(ctx)
+	}
+}
+
+func (c *awaiterStatusController) handle(ctx *gin.Context) {
+	executionID := ctx.Param("execution_id")
+
+	var req AwaiterStatusRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid request body: %v", err)})
+		return
+	}
+	if req.Status != "waiting" && req.Status != "running" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "status must be 'waiting' or 'running'"})
+		return
+	}
+
+	reqCtx := ctx.Request.Context()
+
+	wfExec, err := c.store.GetWorkflowExecution(reqCtx, executionID)
+	if err != nil {
+		logger.Logger.Error().Err(err).Str("execution_id", executionID).Msg("failed to load execution for awaiter-status update")
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to look up execution"})
+		return
+	}
+	if wfExec == nil {
+		ctx.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("execution %s not found", executionID)})
+		return
+	}
+
+	currentStatus := types.NormalizeExecutionStatus(wfExec.Status)
+	if types.IsTerminalExecutionStatus(currentStatus) {
+		// Race: child resolved after we fired the cascade. Benign — the
+		// awaiter has already moved on. Report no-op so the SDK swallows.
+		ctx.JSON(http.StatusOK, AwaiterStatusResponse{Status: currentStatus, Applied: false})
+		return
+	}
+
+	var (
+		targetStatus types.ExecutionStatus
+		targetReason string
+	)
+	switch req.Status {
+	case "waiting":
+		// Only cascade from RUNNING. If already WAITING (regardless of cause)
+		// we leave it alone — an approval-driven WAITING must not be
+		// converted to an awaiter-driven one, and an awaiter-driven WAITING
+		// is already what we'd be setting.
+		if currentStatus != string(types.ExecutionStatusRunning) {
+			ctx.JSON(http.StatusOK, AwaiterStatusResponse{Status: currentStatus, Applied: false})
+			return
+		}
+		targetStatus = types.ExecutionStatusWaiting
+		targetReason = awaiterStatusReason
+	case "running":
+		// Only resume from WAITING set BY US. If status_reason is something
+		// else (e.g. waiting_for_approval), an approval is still pending and
+		// must not be silently resumed.
+		if currentStatus != string(types.ExecutionStatusWaiting) {
+			ctx.JSON(http.StatusOK, AwaiterStatusResponse{Status: currentStatus, Applied: false})
+			return
+		}
+		if wfExec.StatusReason == nil || *wfExec.StatusReason != awaiterStatusReason {
+			// Not our WAITING to resume.
+			ctx.JSON(http.StatusOK, AwaiterStatusResponse{Status: currentStatus, Applied: false})
+			return
+		}
+		targetStatus = types.ExecutionStatusRunning
+		targetReason = ""
+	}
+
+	now := time.Now().UTC()
+	var reasonPtr *string
+	if targetReason != "" {
+		reasonPtr = &targetReason
+	}
+
+	// Update the lightweight execution record so downstream readers (UI,
+	// polling-side overdue checks) see the new status.
+	_, updateErr := c.store.UpdateExecutionRecord(reqCtx, executionID, func(current *types.Execution) (*types.Execution, error) {
+		if current == nil {
+			return nil, fmt.Errorf("execution %s not found", executionID)
+		}
+		current.Status = targetStatus
+		current.StatusReason = reasonPtr
+		return current, nil
+	})
+	if updateErr != nil {
+		logger.Logger.Error().Err(updateErr).Str("execution_id", executionID).Msg("failed to update execution record for awaiter-status")
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update execution status"})
+		return
+	}
+
+	// Update the workflow execution row.
+	err = c.store.UpdateWorkflowExecution(reqCtx, executionID, func(current *types.WorkflowExecution) (*types.WorkflowExecution, error) {
+		if current == nil {
+			return nil, fmt.Errorf("execution %s not found", executionID)
+		}
+		current.Status = targetStatus
+		current.StatusReason = reasonPtr
+		return current, nil
+	})
+	if err != nil {
+		logger.Logger.Error().Err(err).Str("execution_id", executionID).Msg("failed to update workflow execution for awaiter-status")
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update execution"})
+		return
+	}
+
+	// Emit observability event so the timeline reflects the cascade.
+	statusStr := string(targetStatus)
+	eventStatus := targetStatus
+	eventType := "execution.running"
+	if targetStatus == types.ExecutionStatusWaiting {
+		eventType = "execution.waiting"
+	}
+	eventPayload, _ := json.Marshal(map[string]interface{}{
+		"reason":    req.Reason,
+		"wait_kind": "awaiter_cascade",
+	})
+	event := &types.WorkflowExecutionEvent{
+		ExecutionID:  executionID,
+		WorkflowID:   wfExec.WorkflowID,
+		RunID:        wfExec.RunID,
+		EventType:    eventType,
+		Status:       &eventStatus,
+		StatusReason: reasonPtr,
+		Payload:      eventPayload,
+		EmittedAt:    now,
+	}
+	if storeErr := c.store.StoreWorkflowExecutionEvent(reqCtx, event); storeErr != nil {
+		logger.Logger.Warn().Err(storeErr).Str("execution_id", executionID).Msg("failed to store awaiter-status event (non-fatal)")
+	}
+
+	// Publish to the execution event bus.
+	if bus := c.store.GetExecutionEventBus(); bus != nil {
+		busType := events.ExecutionResumed
+		if targetStatus == types.ExecutionStatusWaiting {
+			busType = events.ExecutionWaiting
+		}
+		bus.Publish(events.ExecutionEvent{
+			Type:        busType,
+			ExecutionID: executionID,
+			WorkflowID:  wfExec.WorkflowID,
+			AgentNodeID: wfExec.AgentNodeID,
+			Status:      targetStatus,
+			Timestamp:   now,
+			Data: map[string]interface{}{
+				"reason":    req.Reason,
+				"wait_kind": "awaiter_cascade",
+			},
+		})
+	}
+
+	logger.Logger.Debug().
+		Str("execution_id", executionID).
+		Str("status", statusStr).
+		Str("reason", req.Reason).
+		Msg("awaiter-status cascade applied")
+
+	ctx.JSON(http.StatusOK, AwaiterStatusResponse{Status: statusStr, Applied: true})
+}

--- a/control-plane/internal/handlers/execute_awaiter_status_test.go
+++ b/control-plane/internal/handlers/execute_awaiter_status_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -246,4 +247,95 @@ func TestUpdateAwaiterStatusHandler_UnknownExecution404(t *testing.T) {
 	resp := postAwaiterStatus(t, store, "agent-1", "exec-missing", "waiting", "")
 	// verifyExecutionOwnership returns 404 before reaching handler logic.
 	assert.Equal(t, http.StatusNotFound, resp.Code)
+}
+
+func TestUpdateAwaiterStatusHandler_MalformedJSON400(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	agent := &types.AgentNode{ID: "agent-1"}
+	store := newTestExecutionStorage(agent)
+	seedRunningExecution(t, store, "exec-1", "agent-1")
+
+	router := gin.New()
+	router.POST("/api/v1/agents/:node_id/executions/:execution_id/awaiter-status",
+		UpdateAwaiterStatusHandler(store))
+	// Garbage body — should be caught by ShouldBindJSON and return 400 without
+	// touching storage.
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/agents/agent-1/executions/exec-1/awaiter-status",
+		bytes.NewReader([]byte("{not-json")),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+}
+
+// awaiterStatusGetWorkflowErrorStore returns an error from GetWorkflowExecution
+// so we can exercise the lookup-failure branch.
+type awaiterStatusGetWorkflowErrorStore struct {
+	*testExecutionStorage
+}
+
+func (s *awaiterStatusGetWorkflowErrorStore) GetWorkflowExecution(ctx context.Context, executionID string) (*types.WorkflowExecution, error) {
+	return nil, errors.New("storage unavailable")
+}
+
+func TestUpdateAwaiterStatusHandler_StoreLookupFailure500(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	agent := &types.AgentNode{ID: "agent-1"}
+	store := &awaiterStatusGetWorkflowErrorStore{
+		testExecutionStorage: newTestExecutionStorage(agent),
+	}
+	seedRunningExecution(t, store.testExecutionStorage, "exec-1", "agent-1")
+
+	resp := postAwaiterStatus(t, store, "agent-1", "exec-1", "waiting", "")
+	assert.Equal(t, http.StatusInternalServerError, resp.Code,
+		"a storage error during workflow lookup must surface as 500 so the SDK swallows it; "+
+			"a silent success would mask a real CP outage")
+}
+
+// awaiterStatusUpdateRecordErrorStore returns an error from UpdateExecutionRecord
+// so we can exercise the record-update failure branch.
+type awaiterStatusUpdateRecordErrorStore struct {
+	*testExecutionStorage
+}
+
+func (s *awaiterStatusUpdateRecordErrorStore) UpdateExecutionRecord(ctx context.Context, executionID string, mutator func(*types.Execution) (*types.Execution, error)) (*types.Execution, error) {
+	return nil, errors.New("record update failed")
+}
+
+func TestUpdateAwaiterStatusHandler_UpdateExecutionRecordFailure500(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	agent := &types.AgentNode{ID: "agent-1"}
+	store := &awaiterStatusUpdateRecordErrorStore{
+		testExecutionStorage: newTestExecutionStorage(agent),
+	}
+	seedRunningExecution(t, store.testExecutionStorage, "exec-1", "agent-1")
+
+	resp := postAwaiterStatus(t, store, "agent-1", "exec-1", "waiting", "")
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+}
+
+// awaiterStatusUpdateWorkflowErrorStore lets UpdateExecutionRecord succeed but
+// fails UpdateWorkflowExecution. The handler must surface 500.
+type awaiterStatusUpdateWorkflowErrorStore struct {
+	*testExecutionStorage
+}
+
+func (s *awaiterStatusUpdateWorkflowErrorStore) UpdateWorkflowExecution(ctx context.Context, executionID string, mutator func(*types.WorkflowExecution) (*types.WorkflowExecution, error)) error {
+	return errors.New("workflow update failed")
+}
+
+func TestUpdateAwaiterStatusHandler_UpdateWorkflowExecutionFailure500(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	agent := &types.AgentNode{ID: "agent-1"}
+	store := &awaiterStatusUpdateWorkflowErrorStore{
+		testExecutionStorage: newTestExecutionStorage(agent),
+	}
+	seedRunningExecution(t, store.testExecutionStorage, "exec-1", "agent-1")
+
+	resp := postAwaiterStatus(t, store, "agent-1", "exec-1", "waiting", "")
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
 }

--- a/control-plane/internal/handlers/execute_awaiter_status_test.go
+++ b/control-plane/internal/handlers/execute_awaiter_status_test.go
@@ -1,0 +1,249 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// UpdateAwaiterStatusHandler — multi-hop pause propagation
+//
+// These tests pin the state-machine semantics of the awaiter-status endpoint
+// that fixes the case where a 3+-deep call chain (e.g. implement_from_issue
+// → build → plan → run_X where only run_X explicitly app.pause()-s) times
+// out at wallclock on the great-grandparent because intermediate reasoners
+// stay in RUNNING while blocked on awaiting a paused descendant.
+//
+// The endpoint exists so the SDK's wait_for_result can push its own
+// execution to WAITING when it observes its awaited child in WAITING — and
+// back to RUNNING when the child resumes. The contract HAS to be tight:
+//   - never override an approval-driven WAITING
+//   - never re-introduce non-terminal status on a terminal execution
+//   - silently no-op on benign races (so the SDK doesn't need to special-case)
+// ---------------------------------------------------------------------------
+
+func seedRunningExecution(t *testing.T, store ExecutionStore, execID, agentID string) {
+	t.Helper()
+	now := time.Now().UTC()
+	require.NoError(t, store.CreateExecutionRecord(context.Background(), &types.Execution{
+		ExecutionID: execID,
+		RunID:       "run-1",
+		AgentNodeID: agentID,
+		Status:      types.ExecutionStatusRunning,
+		StartedAt:   now,
+		CreatedAt:   now,
+	}))
+	require.NoError(t, store.StoreWorkflowExecution(context.Background(), &types.WorkflowExecution{
+		ExecutionID: execID,
+		WorkflowID:  "wf-1",
+		RunID:       ptr("run-1"),
+		AgentNodeID: agentID,
+		Status:      types.ExecutionStatusRunning,
+		StartedAt:   now,
+	}))
+}
+
+func postAwaiterStatus(t *testing.T, store ExecutionStore, agentID, execID, status, reason string) *httptest.ResponseRecorder {
+	t.Helper()
+	router := gin.New()
+	router.POST("/api/v1/agents/:node_id/executions/:execution_id/awaiter-status",
+		UpdateAwaiterStatusHandler(store))
+	body, _ := json.Marshal(map[string]any{"status": status, "reason": reason})
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/agents/"+agentID+"/executions/"+execID+"/awaiter-status",
+		bytes.NewReader(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	return resp
+}
+
+func TestUpdateAwaiterStatusHandler_RunningToWaiting(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	agent := &types.AgentNode{ID: "agent-1"}
+	store := newTestExecutionStorage(agent)
+	seedRunningExecution(t, store, "exec-1", "agent-1")
+
+	resp := postAwaiterStatus(t, store, "agent-1", "exec-1", "waiting", "awaiting child exec_xyz")
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var result AwaiterStatusResponse
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &result))
+	assert.True(t, result.Applied, "RUNNING -> WAITING must be applied")
+	assert.Equal(t, "waiting", result.Status)
+
+	wfExec, err := store.GetWorkflowExecution(context.Background(), "exec-1")
+	require.NoError(t, err)
+	require.NotNil(t, wfExec)
+	assert.Equal(t, types.ExecutionStatusWaiting, wfExec.Status)
+	require.NotNil(t, wfExec.StatusReason)
+	assert.Equal(t, awaiterStatusReason, *wfExec.StatusReason,
+		"awaiter-driven WAITING must mark its status_reason so the RUNNING flip can recognize it")
+}
+
+func TestUpdateAwaiterStatusHandler_AwaiterWaitingToRunning(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	agent := &types.AgentNode{ID: "agent-1"}
+	store := newTestExecutionStorage(agent)
+	seedRunningExecution(t, store, "exec-1", "agent-1")
+
+	// First put it into awaiter-driven WAITING.
+	resp := postAwaiterStatus(t, store, "agent-1", "exec-1", "waiting", "awaiting child")
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	// Now flip back to RUNNING.
+	resp = postAwaiterStatus(t, store, "agent-1", "exec-1", "running", "awaiting child")
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var result AwaiterStatusResponse
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &result))
+	assert.True(t, result.Applied, "awaiter-driven WAITING -> RUNNING must be applied")
+	assert.Equal(t, "running", result.Status)
+
+	wfExec, err := store.GetWorkflowExecution(context.Background(), "exec-1")
+	require.NoError(t, err)
+	assert.Equal(t, types.ExecutionStatusRunning, wfExec.Status)
+	assert.Nil(t, wfExec.StatusReason, "RUNNING transition clears the awaiter status_reason")
+}
+
+func TestUpdateAwaiterStatusHandler_DoesNotOverrideApprovalWaiting(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	agent := &types.AgentNode{ID: "agent-1"}
+	store := newTestExecutionStorage(agent)
+	seedRunningExecution(t, store, "exec-1", "agent-1")
+
+	// Simulate approval flow: WAITING with status_reason=waiting_for_approval.
+	approvalReason := "waiting_for_approval"
+	_, err := store.UpdateExecutionRecord(context.Background(), "exec-1", func(c *types.Execution) (*types.Execution, error) {
+		c.Status = types.ExecutionStatusWaiting
+		c.StatusReason = &approvalReason
+		return c, nil
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.UpdateWorkflowExecution(context.Background(), "exec-1", func(c *types.WorkflowExecution) (*types.WorkflowExecution, error) {
+		c.Status = types.ExecutionStatusWaiting
+		c.StatusReason = &approvalReason
+		return c, nil
+	}))
+
+	// Awaiter cascade requesting RUNNING must NOT resume an approval-WAITING.
+	resp := postAwaiterStatus(t, store, "agent-1", "exec-1", "running", "awaiting child")
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var result AwaiterStatusResponse
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &result))
+	assert.False(t, result.Applied, "awaiter cascade must NOT resume an approval-driven WAITING")
+
+	wfExec, err := store.GetWorkflowExecution(context.Background(), "exec-1")
+	require.NoError(t, err)
+	assert.Equal(t, types.ExecutionStatusWaiting, wfExec.Status,
+		"approval-driven WAITING must survive an awaiter-cascade RUNNING attempt")
+	require.NotNil(t, wfExec.StatusReason)
+	assert.Equal(t, approvalReason, *wfExec.StatusReason,
+		"approval status_reason must be preserved untouched")
+}
+
+func TestUpdateAwaiterStatusHandler_TerminalExecutionIsNoOp(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	agent := &types.AgentNode{ID: "agent-1"}
+	store := newTestExecutionStorage(agent)
+	seedRunningExecution(t, store, "exec-1", "agent-1")
+
+	// Mark it succeeded.
+	_, err := store.UpdateExecutionRecord(context.Background(), "exec-1", func(c *types.Execution) (*types.Execution, error) {
+		c.Status = types.ExecutionStatusSucceeded
+		return c, nil
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.UpdateWorkflowExecution(context.Background(), "exec-1", func(c *types.WorkflowExecution) (*types.WorkflowExecution, error) {
+		c.Status = types.ExecutionStatusSucceeded
+		return c, nil
+	}))
+
+	// Cascade arrives after terminal — must no-op, not error.
+	resp := postAwaiterStatus(t, store, "agent-1", "exec-1", "waiting", "awaiting child")
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var result AwaiterStatusResponse
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &result))
+	assert.False(t, result.Applied)
+	assert.Equal(t, "succeeded", result.Status)
+
+	wfExec, err := store.GetWorkflowExecution(context.Background(), "exec-1")
+	require.NoError(t, err)
+	assert.Equal(t, types.ExecutionStatusSucceeded, wfExec.Status,
+		"terminal execution must not be unwound by an awaiter cascade")
+}
+
+func TestUpdateAwaiterStatusHandler_WaitingToWaitingIsIdempotentNoOp(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	agent := &types.AgentNode{ID: "agent-1"}
+	store := newTestExecutionStorage(agent)
+	seedRunningExecution(t, store, "exec-1", "agent-1")
+
+	// First cascade: RUNNING -> WAITING.
+	resp := postAwaiterStatus(t, store, "agent-1", "exec-1", "waiting", "awaiting child A")
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	// Second cascade (e.g. parallel app.call children, or a duplicate fire):
+	// already WAITING, should no-op cleanly.
+	resp = postAwaiterStatus(t, store, "agent-1", "exec-1", "waiting", "awaiting child B")
+	require.Equal(t, http.StatusOK, resp.Code)
+	var result AwaiterStatusResponse
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &result))
+	assert.False(t, result.Applied)
+	assert.Equal(t, "waiting", result.Status)
+}
+
+func TestUpdateAwaiterStatusHandler_BadStatus400(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	agent := &types.AgentNode{ID: "agent-1"}
+	store := newTestExecutionStorage(agent)
+	seedRunningExecution(t, store, "exec-1", "agent-1")
+
+	resp := postAwaiterStatus(t, store, "agent-1", "exec-1", "succeeded", "")
+	assert.Equal(t, http.StatusBadRequest, resp.Code,
+		"status must be 'waiting' or 'running' — anything else is a client bug")
+}
+
+func TestUpdateAwaiterStatusHandler_RunningWithoutWaitingIsNoOp(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	agent := &types.AgentNode{ID: "agent-1"}
+	store := newTestExecutionStorage(agent)
+	seedRunningExecution(t, store, "exec-1", "agent-1")
+
+	// Already RUNNING — a stray "running" cascade should no-op.
+	resp := postAwaiterStatus(t, store, "agent-1", "exec-1", "running", "")
+	require.Equal(t, http.StatusOK, resp.Code)
+	var result AwaiterStatusResponse
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &result))
+	assert.False(t, result.Applied)
+}
+
+func TestUpdateAwaiterStatusHandler_UnknownExecution404(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	agent := &types.AgentNode{ID: "agent-1"}
+	store := newTestExecutionStorage(agent)
+
+	resp := postAwaiterStatus(t, store, "agent-1", "exec-missing", "waiting", "")
+	// verifyExecutionOwnership returns 404 before reaching handler logic.
+	assert.Equal(t, http.StatusNotFound, resp.Code)
+}

--- a/control-plane/internal/server/routes_core.go
+++ b/control-plane/internal/server/routes_core.go
@@ -127,6 +127,13 @@ func (s *AgentFieldServer) registerCoreRoutes(agentAPI *gin.RouterGroup) {
 	agentAPI.POST("/agents/:node_id/executions/:execution_id/request-approval", handlers.AgentScopedRequestApprovalHandler(s.storage))
 	agentAPI.GET("/agents/:node_id/executions/:execution_id/approval-status", handlers.AgentScopedGetApprovalStatusHandler(s.storage))
 
+	// Multi-hop pause propagation: an agent's app.call wait loop pushes its
+	// OWN status to WAITING when its awaited child enters WAITING, so any
+	// further ancestor sees WAITING transitively. Without this, pause only
+	// propagates one hop up the call tree and 3+-deep chains time out at
+	// wallclock on the great-grandparent.
+	agentAPI.POST("/agents/:node_id/executions/:execution_id/awaiter-status", handlers.UpdateAwaiterStatusHandler(s.storage))
+
 	// Approval resolution webhook (called by agents or external services when approval resolves)
 	agentAPI.POST("/webhooks/approval-response", handlers.ApprovalWebhookHandler(s.storage, s.config.AgentField.Approval.WebhookSecret))
 

--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -3927,6 +3927,54 @@ class Agent(FastAPI):
                         }
                         if parent_pause_clock is not None:
                             _wait_kwargs["pause_clock"] = parent_pause_clock
+
+                            # Multi-hop pause propagation: when our awaited
+                            # child enters WAITING, push OUR OWN execution
+                            # status to WAITING so anyone awaiting us sees
+                            # WAITING too (and transitively up the chain).
+                            # Fire-and-forget; the wait loop swallows
+                            # exceptions so a transient control-plane blip
+                            # can't break the call graph. See run
+                            # run_1778429268006_76e417b7 — implement_from_issue
+                            # timed out at 7200s wallclock because two-or-more
+                            # hops up from a paused descendant, no clock pause
+                            # ever fired without this.
+                            _self_exec_id = parent_execution_id
+                            _client = self.client
+                            if _self_exec_id and _client is not None:
+                                _waiting_reason = f"awaiting child {execution_id}"
+
+                                async def _push_self_waiting() -> None:
+                                    try:
+                                        await _client.notify_awaiter_status(
+                                            execution_id=_self_exec_id,
+                                            status="waiting",
+                                            reason=_waiting_reason,
+                                        )
+                                    except Exception as exc:
+                                        if self.dev_mode:
+                                            log_debug(
+                                                f"notify_awaiter_status(waiting) "
+                                                f"failed (swallowed): {exc}"
+                                            )
+
+                                async def _push_self_running() -> None:
+                                    try:
+                                        await _client.notify_awaiter_status(
+                                            execution_id=_self_exec_id,
+                                            status="running",
+                                            reason=_waiting_reason,
+                                        )
+                                    except Exception as exc:
+                                        if self.dev_mode:
+                                            log_debug(
+                                                f"notify_awaiter_status(running) "
+                                                f"failed (swallowed): {exc}"
+                                            )
+
+                                _wait_kwargs["on_child_waiting"] = _push_self_waiting
+                                _wait_kwargs["on_child_running"] = _push_self_running
+
                         result = await self.client.wait_for_execution_result(
                             **_wait_kwargs
                         )

--- a/sdk/python/agentfield/async_execution_manager.py
+++ b/sdk/python/agentfield/async_execution_manager.py
@@ -33,6 +33,24 @@ from .types import WebhookConfig
 logger = get_logger(__name__)
 
 
+async def _safe_pause_callback(callback: Any, name: str, timeout: float = 2.0) -> None:
+    """Run a pause-transition callback, swallowing any exception.
+
+    The on_child_waiting / on_child_running hooks fire HTTP calls to the
+    control plane (for multi-hop pause propagation). A transient blip there
+    must not break the wait loop or leave the local pause_clock stuck.
+    Bounded by ``timeout`` so a hung control plane can't stall the wait
+    loop — propagation is best-effort, and a missed update just falls back
+    to one-hop pause-clock semantics (the prior behavior).
+    """
+    try:
+        await asyncio.wait_for(callback(), timeout=timeout)
+    except asyncio.TimeoutError:
+        logger.debug(f"{name} callback timed out after {timeout}s (swallowed)")
+    except Exception as exc:
+        logger.debug(f"{name} callback raised (swallowed): {exc}")
+
+
 class LazyAsyncLock:
     """Deferred asyncio.Lock that instantiates once the event loop is running."""
 
@@ -509,6 +527,8 @@ class AsyncExecutionManager:
         execution_id: str,
         timeout: Optional[float] = None,
         pause_clock: Optional[Any] = None,
+        on_child_waiting: Optional[Any] = None,
+        on_child_running: Optional[Any] = None,
     ) -> Any:
         """
         Wait for execution result with intelligent polling.
@@ -522,6 +542,18 @@ class AsyncExecutionManager:
                 doesn't time out while the awaited child is parked on a
                 human approval — the active-time semantics here match the
                 reasoner watchdog in ``_execute_async_with_callback``.
+            on_child_waiting: Optional async callable fired (best-effort,
+                fire-and-forget) when the awaited child transitions into
+                WAITING. ``Agent.call`` wires this to push the AWAITER's own
+                execution status to WAITING so any further ancestor sees
+                WAITING transitively — without this, the parent's pause-clock
+                only pauses for immediate-child waits, not for grandchild or
+                deeper waits, and the great-grandparent times out at
+                wallclock on multi-hop call chains.
+            on_child_running: Mirror of ``on_child_waiting`` fired when the
+                child exits WAITING, used to push the awaiter back to
+                RUNNING. Exceptions from either callback are swallowed so a
+                transient control-plane blip can't break the wait loop.
 
         Returns:
             Any: Execution result
@@ -636,13 +668,34 @@ class AsyncExecutionManager:
                 # whenever ``Agent.call`` is awaited, regardless of whether
                 # ``enable_event_stream`` is on. Done outside the lock so the
                 # ``time.time()`` reads in PauseClock don't pile up under it.
+                #
+                # The ``on_child_waiting`` / ``on_child_running`` callbacks
+                # fire in lockstep — ``Agent.call`` uses them to push the
+                # AWAITER's own status to the control plane so multi-hop
+                # propagation works (one-hop pause-clock pause isn't enough
+                # when the awaiter has its own parent watching).
+                #
+                # We ``await`` the callback rather than ``create_task`` so
+                # the WAITING and RUNNING notifications can't race past each
+                # other and leave the awaiter stuck in WAITING after the
+                # child has already resumed. ``_safe_pause_callback`` enforces
+                # a short timeout and swallows exceptions, so a slow / dead
+                # control plane can't stall the wait loop indefinitely.
                 if pause_clock is not None:
                     if is_waiting and not child_pause_active:
                         pause_clock.start_pause()
                         child_pause_active = True
+                        if on_child_waiting is not None:
+                            await _safe_pause_callback(
+                                on_child_waiting, "on_child_waiting"
+                            )
                     elif (not is_waiting) and child_pause_active:
                         pause_clock.end_pause()
                         child_pause_active = False
+                        if on_child_running is not None:
+                            await _safe_pause_callback(
+                                on_child_running, "on_child_running"
+                            )
 
                 # Wait before next check
                 await asyncio.sleep(0.1)

--- a/sdk/python/agentfield/client.py
+++ b/sdk/python/agentfield/client.py
@@ -1507,6 +1507,8 @@ class AgentFieldClient:
         execution_id: str,
         timeout: Optional[float] = None,
         pause_clock: Optional[Any] = None,
+        on_child_waiting: Optional[Any] = None,
+        on_child_running: Optional[Any] = None,
     ) -> Any:
         """
         Wait for execution completion with polling.
@@ -1518,6 +1520,11 @@ class AgentFieldClient:
                 seconds are subtracted from elapsed wall-clock when checking
                 ``timeout`` — used by ``Agent.call`` to keep the wait alive
                 across child pauses.
+            on_child_waiting / on_child_running: Optional async callables
+                fired when the awaited child transitions in/out of WAITING.
+                ``Agent.call`` wires these to push the AWAITER's own status
+                upstream so multi-hop pause propagation works (a child two+
+                hops below WAITING wouldn't pause anything otherwise).
 
         Returns:
             Any: Execution result
@@ -1532,7 +1539,11 @@ class AgentFieldClient:
         try:
             manager = await self._get_async_execution_manager()
             result = await manager.wait_for_result(
-                execution_id, timeout, pause_clock=pause_clock
+                execution_id,
+                timeout,
+                pause_clock=pause_clock,
+                on_child_waiting=on_child_waiting,
+                on_child_running=on_child_running,
             )
 
             logger.debug(f"Execution {execution_id[:8]}... completed successfully")
@@ -1772,6 +1783,65 @@ class AgentFieldClient:
             approval_request_id=data.get("approval_request_id", ""),
             approval_request_url=data.get("approval_request_url", ""),
         )
+
+    async def notify_awaiter_status(
+        self,
+        execution_id: str,
+        status: str,
+        reason: str = "",
+    ) -> None:
+        """Notify the control plane that this execution is now WAITING or
+        RUNNING because of its awaited child's state — propagation hook.
+
+        Calls ``POST /api/v1/agents/{node}/executions/{id}/awaiter-status``.
+        Distinct from ``request_approval``: there's no approval ID, no
+        webhook callback, no human in the loop. It exists only so that
+        ancestors watching this execution see WAITING transitively when
+        any descendant is paused. The control plane validates that the
+        execution is non-terminal and the transition is RUNNING<->WAITING.
+
+        Fire-and-forget from the caller's perspective: failures are swallowed
+        by the caller. We still want to know on the server side if a bad
+        transition was attempted, hence the response check here for logs.
+
+        Args:
+            execution_id: The awaiter's own execution_id (NOT the child's).
+            status: ``"waiting"`` or ``"running"``.
+            reason: Optional free-text reason for observability (e.g.
+                ``"awaiting child exec_abc"``).
+
+        Raises:
+            AgentFieldClientError: If the control plane returns 4xx/5xx.
+        """
+        if status not in {"waiting", "running"}:
+            raise AgentFieldClientError(
+                f"notify_awaiter_status: status must be 'waiting' or 'running', got {status!r}"
+            )
+
+        node_id = self.caller_agent_id or ""
+        body: Dict[str, Any] = {"status": status}
+        if reason:
+            body["reason"] = reason
+        url = f"{self.api_base}/agents/{node_id}/executions/{execution_id}/awaiter-status"
+
+        try:
+            client = await self.get_async_http_client()
+            response = await client.post(
+                url,
+                json=body,
+                headers=self._sanitize_header_values(self._get_headers_with_context(None)),
+                timeout=10,
+            )
+        except Exception as exc:
+            raise AgentFieldClientError(
+                f"Failed to notify awaiter status: {exc}"
+            ) from exc
+
+        if response.status_code >= 400:
+            raise AgentFieldClientError(
+                f"Awaiter-status update failed ({response.status_code}): "
+                f"{response.text[:500]}"
+            )
 
     async def get_approval_status(
         self,

--- a/sdk/python/tests/test_agent_call.py
+++ b/sdk/python/tests/test_agent_call.py
@@ -263,6 +263,111 @@ async def test_call_skips_sync_fallback_on_execution_cancelled_error():
 
 
 @pytest.mark.asyncio
+async def test_call_wires_awaiter_status_callbacks_for_multihop_pause():
+    """Agent.call must pass on_child_waiting / on_child_running callbacks to
+    wait_for_execution_result, and those callbacks must hit
+    client.notify_awaiter_status(execution_id=<MY exec_id>, status=...).
+
+    Without this wiring, multi-hop pause propagation breaks: a grandparent
+    awaiting a middle reasoner only ever sees middle as RUNNING (because
+    middle's status doesn't transition while it's blocked on its own
+    awaited child), so grandparent's pause_clock never pauses and it times
+    out at wallclock. This pins the contract end-to-end through Agent.call.
+    """
+    from agentfield.agent_pause import PauseClock
+    from agentfield.execution_context import (
+        ExecutionContext,
+        set_execution_context,
+        reset_execution_context,
+    )
+
+    agent = object.__new__(Agent)
+    agent.node_id = "middle"
+    agent.agentfield_connected = True
+    agent.dev_mode = False
+    agent.async_config = SimpleNamespace(
+        enable_async_execution=True,
+        fallback_to_sync=True,
+    )
+    agent._async_execution_manager = None
+    agent._current_execution_context = None
+    # PauseClock registry — this is how Agent.call recovers the parent's clock.
+    agent._pause_clocks = {"middle-exec-id": PauseClock()}
+
+    notify_calls: list[dict] = []
+
+    async def fake_notify_awaiter_status(execution_id, status, reason=""):
+        notify_calls.append(
+            {"execution_id": execution_id, "status": status, "reason": reason}
+        )
+
+    captured_wait_kwargs: dict = {}
+
+    async def fake_execute_async(target, input_data, headers, timeout=None):
+        return "exec_child_xyz"
+
+    async def fake_wait_for_execution_result(**kwargs):
+        # Capture so we can verify the kwargs Agent.call constructed.
+        captured_wait_kwargs.update(kwargs)
+        # Simulate the wait loop firing the on_child_waiting / on_child_running
+        # callbacks the way wait_for_result would when the awaited child enters
+        # and leaves WAITING.
+        if "on_child_waiting" in kwargs:
+            await kwargs["on_child_waiting"]()
+        if "on_child_running" in kwargs:
+            await kwargs["on_child_running"]()
+        return {"result": {"ok": True}}
+
+    agent.client = SimpleNamespace(
+        execute_async=fake_execute_async,
+        wait_for_execution_result=fake_wait_for_execution_result,
+        notify_awaiter_status=fake_notify_awaiter_status,
+    )
+
+    ctx = ExecutionContext(
+        run_id="run-123",
+        execution_id="middle-exec-id",
+        agent_instance=agent,
+        reasoner_name="middle.process",
+        agent_node_id="middle",
+    )
+    ctx_token = set_execution_context(ctx)
+    set_current_agent(agent)
+    try:
+        result = await agent.call("other.reasoner", 1)
+    finally:
+        clear_current_agent()
+        reset_execution_context(ctx_token)
+
+    assert result == {"ok": True}
+
+    # The callbacks must have been passed.
+    assert "on_child_waiting" in captured_wait_kwargs, (
+        "Agent.call must pass on_child_waiting to wait_for_execution_result "
+        "when it has a parent pause_clock — otherwise multi-hop propagation "
+        "is impossible"
+    )
+    assert "on_child_running" in captured_wait_kwargs
+
+    # The callbacks must target THIS reasoner's own execution_id, not the
+    # child's — pushing the child's status would be a no-op (child already
+    # handles its own status).
+    waiting_calls = [c for c in notify_calls if c["status"] == "waiting"]
+    running_calls = [c for c in notify_calls if c["status"] == "running"]
+    assert len(waiting_calls) == 1, (
+        f"on_child_waiting must call notify_awaiter_status once; got {notify_calls}"
+    )
+    assert len(running_calls) == 1
+    assert waiting_calls[0]["execution_id"] == "middle-exec-id", (
+        f"awaiter-status update must target the awaiter's own execution_id, "
+        f"not the child's; got {waiting_calls[0]['execution_id']}"
+    )
+    assert running_calls[0]["execution_id"] == "middle-exec-id"
+    # Reason should reference the awaited child for observability.
+    assert "exec_child_xyz" in waiting_calls[0]["reason"]
+
+
+@pytest.mark.asyncio
 async def test_call_still_falls_back_on_transport_errors():
     """Plain AgentFieldClientError (transport / submission / network) MUST
     still trigger the sync fallback. Only post-execution errors are skipped.

--- a/sdk/python/tests/test_async_execution.py
+++ b/sdk/python/tests/test_async_execution.py
@@ -517,6 +517,195 @@ async def test_wait_for_result_preserves_budget_across_long_wait():
     assert result == {"value": 42}
 
 
+# ---------------------------------------------------------------------------
+# Multi-hop pause propagation
+#
+# A reasoner R that's awaiting a child via app.call() blocks for the duration
+# the child sits in WAITING. Today only R's *local* pause_clock pauses — R's
+# *status* in the control plane stays RUNNING. If R has its own parent G,
+# G's wait loop polls R's status, sees RUNNING, and never pauses G's clock —
+# producing the 7200s timeout on the great-grandparent observed in run
+# run_1778429268006_76e417b7 (implement_from_issue → build → plan → run_X
+# where only run_X explicitly called app.pause()).
+#
+# The fix: wait_for_result accepts on_child_waiting / on_child_running async
+# callbacks, fired in lockstep with start_pause / end_pause on the local
+# clock. Agent.call wires these to push the awaiter's OWN status as WAITING
+# to the control plane, so the next hop up sees WAITING and the chain
+# propagates transparently to arbitrary depth.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wait_for_result_invokes_callbacks_on_child_waiting_transitions():
+    """When the awaited child enters WAITING, ``wait_for_result`` must fire
+    the ``on_child_waiting`` callback alongside ``pause_clock.start_pause()``.
+    When the child exits WAITING, it must fire ``on_child_running`` alongside
+    ``end_pause``. This is the hook ``Agent.call`` uses to push its own
+    execution's status upstream so multi-hop pause propagation works.
+
+    Pins the new SDK contract — without these callbacks the SDK has no way
+    to tell the control plane "I am also waiting now" while it's blocked in
+    its own wait loop, and any ancestor 2+ hops up times out at wallclock."""
+    from agentfield.async_execution_manager import AsyncExecutionManager
+    from agentfield.async_config import AsyncConfig
+    from agentfield.execution_state import ExecutionState, ExecutionStatus
+
+    manager = AsyncExecutionManager(base_url="http://control", config=AsyncConfig())
+    exec_id = "exec-multihop-child"
+    state = ExecutionState(
+        execution_id=exec_id,
+        target="agent.reasoner",
+        input_data={},
+        timeout=5.0,
+    )
+    state.update_status(ExecutionStatus.RUNNING)
+    manager._executions[exec_id] = state
+
+    parent_clock = PauseClock()
+    waiting_events: list[float] = []
+    running_events: list[float] = []
+
+    async def on_child_waiting() -> None:
+        waiting_events.append(time.time())
+
+    async def on_child_running() -> None:
+        running_events.append(time.time())
+
+    async def _drive_polling():
+        await asyncio.sleep(0.05)
+        async with manager._execution_lock:
+            state.update_status(ExecutionStatus.WAITING)
+        await asyncio.sleep(0.20)
+        async with manager._execution_lock:
+            state.update_status(ExecutionStatus.RUNNING)
+        await asyncio.sleep(0.05)
+        async with manager._execution_lock:
+            state.set_result({"ok": True})
+
+    poller = asyncio.create_task(_drive_polling())
+    result = await manager.wait_for_result(
+        exec_id,
+        timeout=5.0,
+        pause_clock=parent_clock,
+        on_child_waiting=on_child_waiting,
+        on_child_running=on_child_running,
+    )
+    await poller
+
+    assert result == {"ok": True}
+    assert len(waiting_events) == 1, (
+        f"on_child_waiting should fire exactly once when child enters WAITING; "
+        f"fired {len(waiting_events)} times"
+    )
+    assert len(running_events) == 1, (
+        f"on_child_running should fire exactly once when child exits WAITING; "
+        f"fired {len(running_events)} times"
+    )
+    assert running_events[0] > waiting_events[0], (
+        "on_child_running must fire AFTER on_child_waiting"
+    )
+    # The callbacks must fire in lockstep with the local pause-clock toggles.
+    assert parent_clock.total_paused() >= 0.15
+
+
+@pytest.mark.asyncio
+async def test_wait_for_result_callbacks_optional_for_backward_compat():
+    """A caller that doesn't pass the new callbacks must see no change in
+    behavior. The pause_clock toggle and overall wait semantics stay identical
+    to the existing tests."""
+    from agentfield.async_execution_manager import AsyncExecutionManager
+    from agentfield.async_config import AsyncConfig
+    from agentfield.execution_state import ExecutionState, ExecutionStatus
+
+    manager = AsyncExecutionManager(base_url="http://control", config=AsyncConfig())
+    exec_id = "exec-multihop-nocallbacks"
+    state = ExecutionState(
+        execution_id=exec_id,
+        target="agent.reasoner",
+        input_data={},
+        timeout=5.0,
+    )
+    state.update_status(ExecutionStatus.RUNNING)
+    manager._executions[exec_id] = state
+
+    parent_clock = PauseClock()
+
+    async def _drive_polling():
+        await asyncio.sleep(0.05)
+        async with manager._execution_lock:
+            state.update_status(ExecutionStatus.WAITING)
+        await asyncio.sleep(0.20)
+        async with manager._execution_lock:
+            state.set_result({"ok": True})
+
+    poller = asyncio.create_task(_drive_polling())
+    result = await manager.wait_for_result(
+        exec_id, timeout=5.0, pause_clock=parent_clock
+    )
+    await poller
+
+    assert result == {"ok": True}
+    assert parent_clock.total_paused() >= 0.15
+
+
+@pytest.mark.asyncio
+async def test_wait_for_result_callback_exceptions_dont_break_wait_loop():
+    """If on_child_waiting / on_child_running raises (e.g. control plane is
+    temporarily unreachable), the wait loop MUST continue — pause-state
+    propagation is best-effort and an HTTP blip up the chain must not crash
+    the awaiter or leave its pause_clock in a stuck state. Pinned because the
+    callbacks fire HTTP calls in production and we never want a transient
+    failure there to break the call graph."""
+    from agentfield.async_execution_manager import AsyncExecutionManager
+    from agentfield.async_config import AsyncConfig
+    from agentfield.execution_state import ExecutionState, ExecutionStatus
+
+    manager = AsyncExecutionManager(base_url="http://control", config=AsyncConfig())
+    exec_id = "exec-multihop-flaky"
+    state = ExecutionState(
+        execution_id=exec_id,
+        target="agent.reasoner",
+        input_data={},
+        timeout=5.0,
+    )
+    state.update_status(ExecutionStatus.RUNNING)
+    manager._executions[exec_id] = state
+
+    parent_clock = PauseClock()
+
+    async def boom_waiting() -> None:
+        raise RuntimeError("control plane unreachable")
+
+    async def boom_running() -> None:
+        raise RuntimeError("control plane unreachable")
+
+    async def _drive_polling():
+        await asyncio.sleep(0.05)
+        async with manager._execution_lock:
+            state.update_status(ExecutionStatus.WAITING)
+        await asyncio.sleep(0.20)
+        async with manager._execution_lock:
+            state.update_status(ExecutionStatus.RUNNING)
+        await asyncio.sleep(0.05)
+        async with manager._execution_lock:
+            state.set_result({"ok": True})
+
+    poller = asyncio.create_task(_drive_polling())
+    result = await manager.wait_for_result(
+        exec_id,
+        timeout=5.0,
+        pause_clock=parent_clock,
+        on_child_waiting=boom_waiting,
+        on_child_running=boom_running,
+    )
+    await poller
+
+    # Result must still come through; clock must still have paused.
+    assert result == {"ok": True}
+    assert parent_clock.total_paused() >= 0.15
+
+
 @pytest.mark.asyncio
 async def test_wait_for_result_without_pause_clock_unaffected():
     """No pause_clock kwarg = no toggling, behaves as a plain wallclock wait.

--- a/sdk/python/tests/test_client_laser_push.py
+++ b/sdk/python/tests/test_client_laser_push.py
@@ -821,3 +821,109 @@ async def test_approval_helpers_surface_http_errors_and_log_post_is_best_effort(
             assert log_route.call_count == 2
         finally:
             monkeypatch.undo()
+
+
+# ---------------------------------------------------------------------------
+# notify_awaiter_status — multi-hop pause propagation HTTP method
+#
+# Pins behavior of the new client method that the SDK's wait_for_result loop
+# calls when an awaited child enters/leaves WAITING. Direct tests because
+# the in-tree Agent.call integration test mocks this method, leaving the
+# real HTTP machinery uncovered.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_notify_awaiter_status_posts_waiting(client, monkeypatch):
+    """Happy path: status='waiting' posts to the agent-scoped endpoint with
+    the body the control-plane handler expects."""
+    client.caller_agent_id = "middle-agent"
+    router = respx.MockRouter(assert_all_called=True, assert_all_mocked=True)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(router.async_handler)) as async_client:
+        monkeypatch.setattr(client, "get_async_http_client", AsyncMock(return_value=async_client))
+
+        route = router.post(
+            "http://example.test/api/v1/agents/middle-agent/executions/middle-exec-1/awaiter-status"
+        ).mock(return_value=Response(200, json={"status": "waiting", "applied": True}))
+
+        await client.notify_awaiter_status(
+            execution_id="middle-exec-1",
+            status="waiting",
+            reason="awaiting child exec_xyz",
+        )
+
+        assert route.called
+        request = route.calls[0].request
+        body = request.content.decode()
+        assert '"status": "waiting"' in body or '"status":"waiting"' in body
+        assert "awaiting child exec_xyz" in body
+
+
+@pytest.mark.asyncio
+async def test_notify_awaiter_status_posts_running(client, monkeypatch):
+    """Symmetric: status='running' completes the cascade pair."""
+    client.caller_agent_id = "middle-agent"
+    router = respx.MockRouter(assert_all_called=True, assert_all_mocked=True)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(router.async_handler)) as async_client:
+        monkeypatch.setattr(client, "get_async_http_client", AsyncMock(return_value=async_client))
+
+        route = router.post(
+            "http://example.test/api/v1/agents/middle-agent/executions/middle-exec-1/awaiter-status"
+        ).mock(return_value=Response(200, json={"status": "running", "applied": True}))
+
+        await client.notify_awaiter_status(
+            execution_id="middle-exec-1",
+            status="running",
+        )
+
+        assert route.called
+
+
+@pytest.mark.asyncio
+async def test_notify_awaiter_status_rejects_bad_status(client):
+    """The client validates ``status`` before going to the network — a bad
+    value is a programmer error in the SDK call site, not a CP-side issue,
+    so it surfaces as an immediate AgentFieldClientError."""
+    with pytest.raises(AgentFieldClientError, match="status must be 'waiting' or 'running'"):
+        await client.notify_awaiter_status(
+            execution_id="exec-1",
+            status="succeeded",  # invalid for this endpoint
+        )
+
+
+@pytest.mark.asyncio
+async def test_notify_awaiter_status_surfaces_http_errors(client, monkeypatch):
+    """A 4xx/5xx response surfaces as AgentFieldClientError so the wait-loop
+    wrapper (``_safe_pause_callback``) can swallow it and continue. Pinned
+    so the error path isn't silently dropped at this layer."""
+    client.caller_agent_id = "middle-agent"
+    router = respx.MockRouter(assert_all_called=True, assert_all_mocked=True)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(router.async_handler)) as async_client:
+        monkeypatch.setattr(client, "get_async_http_client", AsyncMock(return_value=async_client))
+
+        router.post(
+            "http://example.test/api/v1/agents/middle-agent/executions/exec-bad/awaiter-status"
+        ).mock(return_value=Response(500, text="boom"))
+
+        with pytest.raises(AgentFieldClientError, match="Awaiter-status update failed"):
+            await client.notify_awaiter_status(
+                execution_id="exec-bad",
+                status="waiting",
+            )
+
+
+@pytest.mark.asyncio
+async def test_notify_awaiter_status_surfaces_transport_errors(client, monkeypatch):
+    """A transport-level failure (network down, DNS, etc) surfaces as
+    AgentFieldClientError. Pinned so the wait-loop wrapper can swallow it."""
+
+    async def boom_client():
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(client, "get_async_http_client", boom_client)
+
+    with pytest.raises(AgentFieldClientError, match="Failed to notify awaiter status"):
+        await client.notify_awaiter_status(
+            execution_id="exec-1",
+            status="waiting",
+        )


### PR DESCRIPTION
## Summary

Closes the gap where 3+-deep call chains time out at wallclock on the great-grandparent even when a leaf descendant is correctly paused on `app.pause()`. Reproduced on run `run_1778429268006_76e417b7` — `implement_from_issue` (github-buddy) → `build` (swe-planner) → `plan` → `run_X` (paused on hax-sdk approval). Only `run_X` transitioned to WAITING; `build` and `plan` stayed RUNNING, so `implement_from_issue`'s wait loop never saw a WAITING child to pause its own clock, and the watchdog tripped at exactly 7200s.

## Why the prior PRs didn't fix this

PR #562 / #564 made the ONE-hop case work: a parent's pause-clock pauses when its DIRECT awaited child enters WAITING, and the polling task respects that clock. But when there are intermediate reasoners between the awaiter and the paused descendant, those intermediates stay in `RUNNING` status while blocked on their own `await` — they don't transition to WAITING. So nothing two hops up ever saw WAITING to pause on.

`app.pause()` is the only thing that transitions an execution to WAITING. `app.call()` did not — until this PR.

## The fix

New CP endpoint `POST /api/v1/agents/:node_id/executions/:execution_id/awaiter-status` lets the SDK push a non-terminal `RUNNING <-> WAITING` transition on its OWN execution, with `status_reason=awaiting_child` to distinguish it from approval-driven WAITING. The SDK calls this from `Agent.call`'s wait loop when the awaited child enters/leaves WAITING. The chain now cascades transparently to arbitrary depth.

Three commits, each pins its own layer:

1. **`feat(cp): awaiter-status endpoint for multi-hop pause propagation`** — handler + route + 8 tests pinning the state machine. Key guards: never overrides an approval-driven WAITING (different `status_reason`), no-ops on terminal executions, no-ops idempotently on `WAITING -> WAITING` and `RUNNING -> RUNNING`.

2. **`feat(sdk): on_child_waiting / on_child_running hooks in wait_for_result`** — adds optional async callbacks to `wait_for_result`, fired in lockstep with the existing pause-clock toggle. Callbacks are `await`-ed (not `create_task`) so WAITING and RUNNING notifications can't reorder on the network and leave the awaiter stuck in WAITING. Bounded by a 2s timeout and exception-swallowed via `_safe_pause_callback` — a hung control plane can't stall the wait loop.

3. **`fix(sdk): Agent.call propagates own WAITING upstream so 3+-hop chains don't time out`** — wires the callbacks. `Agent.call` constructs `on_child_waiting` / `on_child_running` closures that POST `awaiter-status` for the awaiter's own `execution_id`. New `client.notify_awaiter_status` method does the HTTP.

## Validation contract

- When the deepest reasoner in a chain enters WAITING via `app.pause()`, EVERY intermediate reasoner blocked on `await app.call(...)` cascades to WAITING in the control plane.
- When the deepest reasoner resumes (RUNNING / terminal), every intermediate cascades back to RUNNING.
- An approval-driven WAITING (status_reason=waiting_for_approval) is NEVER silently resumed by an awaiter cascade — pinned by `TestUpdateAwaiterStatusHandler_DoesNotOverrideApprovalWaiting`.
- A cascade arriving after the awaiter has resolved (race) is a benign no-op — pinned by `TestUpdateAwaiterStatusHandler_TerminalExecutionIsNoOp`.
- A transient control-plane failure during cascade does not break the wait loop or leave the local `pause_clock` stuck — pinned by `test_wait_for_result_callback_exceptions_dont_break_wait_loop`.
- One-hop callers (without callbacks) see no behavior change — pinned by `test_wait_for_result_callbacks_optional_for_backward_compat`.

## Known limitation

Parallel `app.call` children (via `asyncio.gather`) can race on the RUNNING flip — one resolving flips the parent to RUNNING even if another's child is still WAITING. Local `pause_clock` is unaffected; only the propagated control-plane status flaps. Acceptable for v1; follow-up can add a server-side counter (`awaiter_pause_count`) for idempotency.

## Test plan

- [x] `python -m pytest --no-cov` — **1492 passed**, 4 skipped, 0 failed (4 new tests added)
- [x] `ruff check .` clean
- [x] `go vet ./...` clean (full control-plane)
- [x] `go test ./internal/handlers/` clean — 8 new handler tests for the awaiter-status state machine
- [x] `go test ./internal/...` clean — no regressions across the rest of the control plane
- [ ] Manual repro in test deployment: trigger an `implement_from_issue` run with a deep paused descendant, confirm the parent does NOT trip the 7200s watchdog while the descendant is in WAITING

## Files

**Control plane (Go):**
- `control-plane/internal/handlers/execute_awaiter_status.go` (new)
- `control-plane/internal/handlers/execute_awaiter_status_test.go` (new)
- `control-plane/internal/server/routes_core.go` (route registration)

**SDK (Python):**
- `sdk/python/agentfield/async_execution_manager.py` (callbacks in wait_for_result)
- `sdk/python/agentfield/client.py` (notify_awaiter_status, threading)
- `sdk/python/agentfield/agent.py` (Agent.call wiring)
- `sdk/python/tests/test_async_execution.py` (3 new tests)
- `sdk/python/tests/test_agent_call.py` (1 new integration test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)