### PR TITLE
obs(sdk): info-level diagnostics on the pause-cascade hot path

### DIFF
--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -2340,6 +2340,10 @@ class Agent(FastAPI):
 
         pause_clock = PauseClock()
         self._pause_clocks[execution_id] = pause_clock
+        log_info(
+            f"pause_cascade: registered pause_clock id={id(pause_clock)} "
+            f"for execution_id={execution_id} reasoner={reasoner_name}"
+        )
 
         start_time = time.time()
         reasoner_task = asyncio.create_task(reasoner_coro())
@@ -2356,6 +2360,21 @@ class Agent(FastAPI):
                     return
                 active_elapsed = (time.time() - start_time) - pause_clock.total_paused()
                 if active_elapsed > reasoner_timeout:
+                    # Capture pause_clock state at the moment of timeout so
+                    # we can tell "watchdog fired with non-zero pause time
+                    # (legitimate long-running work)" apart from "watchdog
+                    # fired with zero pause time (cascade never ran even
+                    # though a descendant was clearly paused)" — the latter
+                    # is the production bug we're hunting.
+                    log_error(
+                        f"pause_cascade: WATCHDOG_FIRING execution_id={execution_id} "
+                        f"reasoner={reasoner_name} "
+                        f"wall_elapsed={time.time() - start_time:.1f}s "
+                        f"total_paused={pause_clock.total_paused():.1f}s "
+                        f"active_elapsed={active_elapsed:.1f}s "
+                        f"budget={reasoner_timeout:.1f}s "
+                        f"pause_clock_id={id(pause_clock)}"
+                    )
                     pause_clock.timed_out = True
                     reasoner_task.cancel()
                     return
@@ -3916,6 +3935,22 @@ class Agent(FastAPI):
                             _all_pause_clocks.get(parent_execution_id)
                             if parent_execution_id
                             else None
+                        )
+                        # INFO-level so this fires in production (dev_mode-gated
+                        # logs were silent during the run that motivated this
+                        # diagnostic). The three values together pinpoint the
+                        # cascade-disabled case: a missing parent_execution_id
+                        # (no current_context) vs. a missing _pause_clocks entry
+                        # (reasoner not invoked via _execute_async_with_callback)
+                        # are different failure modes that need different fixes.
+                        log_info(
+                            f"pause_cascade: target={target} "
+                            f"parent_execution_id={parent_execution_id} "
+                            f"parent_pause_clock_id="
+                            f"{id(parent_pause_clock) if parent_pause_clock else 'None'} "
+                            f"pause_clocks_keys="
+                            f"{list(_all_pause_clocks.keys())[:5]}"
+                            f"{'...' if len(_all_pause_clocks) > 5 else ''}"
                         )
 
                         # Only pass the pause_clock kwarg when we actually have

--- a/sdk/python/agentfield/async_execution_manager.py
+++ b/sdk/python/agentfield/async_execution_manager.py
@@ -685,6 +685,16 @@ class AsyncExecutionManager:
                     if is_waiting and not child_pause_active:
                         pause_clock.start_pause()
                         child_pause_active = True
+                        # INFO-level — this is the moment cascade either works
+                        # or doesn't. If we never see this log for a parent
+                        # awaiting a paused child, the polling task isn't
+                        # marking the local ExecutionState as WAITING and the
+                        # rest of the cascade can't fire.
+                        logger.info(
+                            f"pause_cascade: start_pause child={execution_id[:8]}... "
+                            f"pause_clock_id={id(pause_clock)} "
+                            f"total_paused_so_far={pause_clock.total_paused():.2f}s"
+                        )
                         if on_child_waiting is not None:
                             await _safe_pause_callback(
                                 on_child_waiting, "on_child_waiting"
@@ -692,6 +702,11 @@ class AsyncExecutionManager:
                     elif (not is_waiting) and child_pause_active:
                         pause_clock.end_pause()
                         child_pause_active = False
+                        logger.info(
+                            f"pause_cascade: end_pause child={execution_id[:8]}... "
+                            f"pause_clock_id={id(pause_clock)} "
+                            f"total_paused_so_far={pause_clock.total_paused():.2f}s"
+                        )
                         if on_child_running is not None:
                             await _safe_pause_callback(
                                 on_child_running, "on_child_running"
@@ -1328,6 +1343,19 @@ class AsyncExecutionManager:
             logger.debug(
                 f"Execution {execution.execution_id[:8]}... status: {old_repr} -> {new_repr}"
             )
+            # INFO-level for the specific WAITING / RUNNING transitions a
+            # cascading parent cares about — debug-only logs were silent in
+            # the failing production run so we couldn't tell whether the
+            # awaited child was ever observed entering WAITING. Other status
+            # transitions (queued/running/succeeded/failed) stay at debug to
+            # avoid log spam from healthy workflows.
+            if new_status in (ExecutionStatus.WAITING, ExecutionStatus.RUNNING) and (
+                old_status != new_status
+            ):
+                logger.info(
+                    f"pause_cascade: poll_observed execution_id={execution.execution_id} "
+                    f"status_transition={old_repr}->{new_repr}"
+                )
 
     def _release_capacity_for_execution(self, execution: ExecutionState) -> None:
         if getattr(execution, "_capacity_released", False):

--- a/sdk/python/tests/test_async_execution.py
+++ b/sdk/python/tests/test_async_execution.py
@@ -576,10 +576,18 @@ async def test_wait_for_result_invokes_callbacks_on_child_waiting_transitions():
         await asyncio.sleep(0.05)
         async with manager._execution_lock:
             state.update_status(ExecutionStatus.WAITING)
-        await asyncio.sleep(0.20)
+        # Keep the WAITING and RUNNING windows comfortably above the wait
+        # loop's 0.1s poll interval so the loop is guaranteed to observe
+        # each transition before the next one happens. The original 0.05s
+        # post-RUNNING gap raced with the loop's poll cycle and any added
+        # work inside the toggle block (logging, callback overhead) tipped
+        # the race the wrong way on 3.10/3.11 — the loop would see
+        # WAITING then jump straight to SUCCEEDED, never firing
+        # on_child_running.
+        await asyncio.sleep(0.30)
         async with manager._execution_lock:
             state.update_status(ExecutionStatus.RUNNING)
-        await asyncio.sleep(0.05)
+        await asyncio.sleep(0.30)
         async with manager._execution_lock:
             state.set_result({"ok": True})
 


### PR DESCRIPTION
## Summary
Promote five points on the cross-reasoner pause-propagation hot path from `debug` to `info` so the next failing run is diagnosable from logs alone — no behavior change.

## Why
Run `run_1778458437977_fb6f588b` (production): `implement_from_issue` failed with `"Reasoner 'implement_from_issue' timed out after 7200.0s of active time"` at **wall-clock duration_ms=7201393**. Its child `swe-planner.build` was visibly WAITING on a hax-sdk approval for ≥20 min (gap between `plan` completing at 00:42:34 and the revision iteration of `run_architect` starting at 01:02:57). Math: if the cascade had fired, `pause_clock.total_paused() ≥ 1200s` → `active_elapsed ≤ 6001s` → watchdog wouldn't have tripped. It tripped at 7201s wallclock, so `pause_clock.total_paused() ≈ 0` — the cascade never started.

A local 3-hop repro (outer→middle→inner-with-`app.pause`) at the same SDK version (0.1.83) **does** fire the cascade correctly (outer's CP exec went to `waiting / awaiting_child` within seconds, survived 30s past a 5s budget). Something differs in production. All cascade toggles were emitted at `logger.debug` level, so the production log was silent on which specific link broke — no signal on whether `parent_pause_clock` lookup missed, whether the polling task ever observed the awaited child as WAITING, or whether `pause_clock.start_pause()` fired.

## What this PR adds

All `info` level (so they appear in production without `dev_mode`), all on hot path but bounded — at most one line per state transition.

1. **`agent.py` — `_execute_async_with_callback`**: log `pause_clock` registration with `id()` + `execution_id` + `reasoner_name` at reasoner entry.
2. **`agent.py` — `app.call` (cross-reasoner pause prop block)**: log `target`, `parent_execution_id`, `parent_pause_clock id()`, and a peek at `_pause_clocks` keys. Distinguishes "no current_context" from "lookup missed" — they need different fixes.
3. **`agent.py` — watchdog firing**: log `wall_elapsed`, `total_paused`, `active_elapsed`, `budget`, `pause_clock_id` at the moment the timeout cancels the reasoner. Tells "legitimate long active work" apart from "cascade never ran" without re-deriving from the run timeline.
4. **`async_execution_manager.py` — `wait_for_result` pause toggles**: log `start_pause` and `end_pause` on the parent's pause_clock with the awaited child id + clock id + cumulative paused seconds.
5. **`async_execution_manager.py` — poll status mapper**: log `WAITING`/`RUNNING` transitions on the awaited child at `info` (other transitions stay at `debug` to avoid spam from healthy workflows).

## Diagnostic value
The next production run that hits this failure mode will show, in order:
- (1) `pause_cascade: registered pause_clock id=<X> for execution_id=<parent>`
- (2) `pause_cascade: target=<child> parent_execution_id=<parent> parent_pause_clock_id=<X>` (or `None` — which itself names the bug)
- (5) `pause_cascade: poll_observed execution_id=<child> status_transition=running->waiting` (or missing — which names a different bug)
- (4) `pause_cascade: start_pause child=<child> pause_clock_id=<X>` (or missing — names yet another bug)
- (3) `pause_cascade: WATCHDOG_FIRING ... total_paused=<N>s active_elapsed=<N>s budget=<N>s`

Diff between expected-vs-actual at each step pinpoints the broken link.

## Validation Contract
- No behavior change. Same imports, same control flow, same condition checks.
- One additional `log_info` at reasoner start (per execution).
- One additional `log_info` per `app.call` from a reasoner (per call).
- One additional `logger.info` per `WAITING`/`RUNNING` transition on awaited child (bounded by the number of child status flips — typically 2-3 per pause cycle).
- One additional `log_error` if and only if the watchdog actually fires (rare by design).

## Test plan
- [x] `ruff check .` — clean
- [x] `python -m pytest --no-cov` — passes (exit 0)
- [ ] Deploy to Railway test stack
- [ ] Trigger another `implement_from_issue` run that pauses on hax approval
- [ ] Read `pause_cascade:` log lines on github-buddy to identify which link broke