### PR TITLE
fix(control-plane): default-deny mode for tag policy middleware

### DIFF
--- a/control-plane/.env.example
+++ b/control-plane/.env.example
@@ -54,6 +54,9 @@ AGENTFIELD_STORAGE_MODE=local
 # Internal token sent to agents during request forwarding.
 # Agents with RequireOriginAuth=true validate this to ensure only the control plane can invoke them.
 # AGENTFIELD_AUTHORIZATION_INTERNAL_TOKEN=internal-secret-token
+# When true, the tag policy middleware returns 403 for any request where no access policy matches.
+# Default false preserves existing behavior. See docs/ENVIRONMENT_VARIABLES.md for details.
+# AGENTFIELD_AUTHORIZATION_DEFAULT_DENY=false
 
 # UI → agent log proxy (GET /api/ui/v1/nodes/:nodeId/logs). Optional env overrides; otherwise YAML / DB overlay.
 # AGENTFIELD_NODE_LOG_PROXY_CONNECT_TIMEOUT=10s

--- a/control-plane/internal/config/config.go
+++ b/control-plane/internal/config/config.go
@@ -234,6 +234,10 @@ type AuthorizationConfig struct {
 	TagApprovalRules TagApprovalRulesConfig `yaml:"tag_approval_rules" mapstructure:"tag_approval_rules"`
 	// AccessPolicies defines tag-based authorization policies for cross-agent calls.
 	AccessPolicies []AccessPolicyConfig `yaml:"access_policies" mapstructure:"access_policies"`
+	// DefaultDeny, when true, causes the permission middleware to return 403 if
+	// no access policy matches a request. Default false preserves the existing
+	// behavior of allowing unmatched requests (backward compat for untagged agents).
+	DefaultDeny bool `yaml:"default_deny" mapstructure:"default_deny" default:"false"`
 }
 
 // TagApprovalRulesConfig configures tag approval behavior at registration.
@@ -491,6 +495,9 @@ func ApplyEnvOverrides(cfg *Config) {
 	}
 	if val := os.Getenv("AGENTFIELD_AUTHORIZATION_INTERNAL_TOKEN"); val != "" {
 		cfg.Features.DID.Authorization.InternalToken = val
+	}
+	if val := os.Getenv("AGENTFIELD_AUTHORIZATION_DEFAULT_DENY"); val != "" {
+		cfg.Features.DID.Authorization.DefaultDeny = val == "true" || val == "1"
 	}
 
 	// Node log proxy (UI → agent NDJSON)

--- a/control-plane/internal/config/config_additional_test.go
+++ b/control-plane/internal/config/config_additional_test.go
@@ -249,6 +249,7 @@ func TestApplyEnvOverrides(t *testing.T) {
 		"AGENTFIELD_AUTHORIZATION_DOMAIN":                            "auth.local",
 		"AGENTFIELD_AUTHORIZATION_ADMIN_TOKEN":                       "admin-token",
 		"AGENTFIELD_AUTHORIZATION_INTERNAL_TOKEN":                    "internal-token",
+		"AGENTFIELD_AUTHORIZATION_DEFAULT_DENY":                      "true",
 		"AGENTFIELD_NODE_LOG_PROXY_CONNECT_TIMEOUT":                  "21s",
 		"AGENTFIELD_NODE_LOG_PROXY_STREAM_IDLE_TIMEOUT":              "22s",
 		"AGENTFIELD_NODE_LOG_PROXY_MAX_DURATION":                     "23s",
@@ -309,7 +310,8 @@ func TestApplyEnvOverrides(t *testing.T) {
 		!cfg.Features.DID.Authorization.DIDAuthEnabled ||
 		cfg.Features.DID.Authorization.Domain != "auth.local" ||
 		cfg.Features.DID.Authorization.AdminToken != "admin-token" ||
-		cfg.Features.DID.Authorization.InternalToken != "internal-token" {
+		cfg.Features.DID.Authorization.InternalToken != "internal-token" ||
+		!cfg.Features.DID.Authorization.DefaultDeny {
 		t.Fatalf("unexpected authorization overrides: %+v", cfg.Features.DID.Authorization)
 	}
 	if cfg.AgentField.NodeLogProxy.ConnectTimeout != 21*time.Second ||

--- a/control-plane/internal/server/middleware/permission.go
+++ b/control-plane/internal/server/middleware/permission.go
@@ -40,6 +40,9 @@ type TagVCVerifierInterface interface {
 type PermissionConfig struct {
 	// Enabled determines if permission checking is active
 	Enabled bool
+	// DefaultDeny returns 403 instead of allowing fall-through when no
+	// access policy matches. Default false preserves backward compat.
+	DefaultDeny bool
 }
 
 // PermissionCheckResult contains the result of a permission check.
@@ -69,7 +72,12 @@ const (
 //  2. Resolves the target agent from the request path
 //  3. Evaluates access policies based on caller/target tags
 //  4. If a policy denies access, returns 403 Forbidden
-//  5. If no policy matches, allows the request (backward compat for untagged agents)
+//  5. If no policy matches and DefaultDeny is false, allows the request
+//     (backward compat for untagged agents). When DefaultDeny is true,
+//     returns HTTP 403 with an opaque error. The unmatched
+//     (caller_tags, target_tags, function) tuple is logged at DEBUG in
+//     both modes; it is not included in the response body to avoid
+//     leaking tag taxonomy to denied callers.
 func PermissionCheckMiddleware(
 	policyService AccessPolicyServiceInterface,
 	tagVCVerifier TagVCVerifierInterface,
@@ -232,9 +240,26 @@ func PermissionCheckMiddleware(
 				c.Next()
 				return
 			}
+
+			// No policy matched. Log the tuple at DEBUG so operators can
+			// diagnose coverage gaps even when DefaultDeny is off.
+			logger.Logger.Debug().
+				Str("target", target).
+				Str("function", functionName).
+				Strs("caller_tags", callerTags).
+				Strs("target_tags", tags).
+				Msg("Permission middleware: no policy matched")
+
+			if config.DefaultDeny {
+				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+					"error":   "no_policy_matched",
+					"message": "no access policy matches this request; see server logs for the unmatched tuple",
+				})
+				return
+			}
 		}
 
-		// No policy matched — allow (backward compat for untagged agents)
+		// No policy service configured, or no policy matched with DefaultDeny off.
 		c.Set(string(PermissionCheckResultKey), &PermissionCheckResult{Allowed: true})
 		c.Next()
 	}

--- a/control-plane/internal/server/middleware/permission_test.go
+++ b/control-plane/internal/server/middleware/permission_test.go
@@ -6,6 +6,7 @@ package middleware
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -81,6 +82,26 @@ func setupPermissionRouter(
 	didResolver DIDResolverInterface,
 	handler gin.HandlerFunc,
 ) *gin.Engine {
+	return setupPermissionRouterWithConfig(
+		verifiedCallerDID,
+		policy,
+		tagVCVerifier,
+		agentResolver,
+		didResolver,
+		PermissionConfig{Enabled: true},
+		handler,
+	)
+}
+
+func setupPermissionRouterWithConfig(
+	verifiedCallerDID string,
+	policy AccessPolicyServiceInterface,
+	tagVCVerifier TagVCVerifierInterface,
+	agentResolver AgentResolverInterface,
+	didResolver DIDResolverInterface,
+	config PermissionConfig,
+	handler gin.HandlerFunc,
+) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 
 	router := gin.New()
@@ -96,7 +117,7 @@ func setupPermissionRouter(
 		tagVCVerifier,
 		agentResolver,
 		didResolver,
-		PermissionConfig{Enabled: true},
+		config,
 	))
 
 	router.POST("/execute/:target", handler)
@@ -310,4 +331,175 @@ func TestParseTargetParam(t *testing.T) {
 	t.Run("missing function name should error", func(t *testing.T) {
 		t.Skip("source bug: parseTargetParam returns nil error when no function segment is present")
 	})
+}
+
+func defaultDenyTestResolver() *permissionAgentResolverStub {
+	return &permissionAgentResolverStub{
+		agents: map[string]*types.AgentNode{
+			"target-agent": {ID: "target-agent", ApprovedTags: []string{"target"}},
+			"caller-agent": {ID: "caller-agent", ApprovedTags: []string{"caller"}},
+		},
+	}
+}
+
+func defaultDenyTestDIDResolver() *permissionDIDResolverStub {
+	return &permissionDIDResolverStub{
+		dids: map[string]string{"did:caller": "caller-agent"},
+	}
+}
+
+func newDefaultDenyTestRequest() *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/execute/target-agent.run", bytes.NewBufferString(`{"input":{"limit":5}}`))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func TestPermissionDefaultDenyOffAllowsUnmatched(t *testing.T) {
+	handlerCalled := false
+	router := setupPermissionRouterWithConfig(
+		"did:caller",
+		&permissionPolicyCapture{},
+		&permissionTagVCVerifierStub{},
+		defaultDenyTestResolver(),
+		defaultDenyTestDIDResolver(),
+		PermissionConfig{Enabled: true, DefaultDeny: false},
+		func(c *gin.Context) {
+			handlerCalled = true
+			c.Status(http.StatusOK)
+		},
+	)
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, newDefaultDenyTestRequest())
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.True(t, handlerCalled, "handler should be reached when default_deny is off and no policy matches")
+}
+
+func TestPermissionDefaultDenyOnBlocksUnmatched(t *testing.T) {
+	router := setupPermissionRouterWithConfig(
+		"did:caller",
+		&permissionPolicyCapture{},
+		&permissionTagVCVerifierStub{},
+		defaultDenyTestResolver(),
+		defaultDenyTestDIDResolver(),
+		PermissionConfig{Enabled: true, DefaultDeny: true},
+		func(c *gin.Context) {
+			t.Fatal("handler should not be reached when default_deny blocks an unmatched request")
+		},
+	)
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, newDefaultDenyTestRequest())
+
+	require.Equal(t, http.StatusForbidden, recorder.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &body))
+	require.Equal(t, "no_policy_matched", body["error"])
+	require.NotContains(t, body, "caller_tags", "tag list must not be exposed in the response body")
+	require.NotContains(t, body, "target_tags", "tag list must not be exposed in the response body")
+	require.NotContains(t, body, "function", "function name must not be exposed in the response body")
+}
+
+func TestPermissionDefaultDenyOnEmptyFunctionNameBlocks(t *testing.T) {
+	router := setupPermissionRouterWithConfig(
+		"did:caller",
+		&permissionPolicyCapture{},
+		&permissionTagVCVerifierStub{},
+		defaultDenyTestResolver(),
+		defaultDenyTestDIDResolver(),
+		PermissionConfig{Enabled: true, DefaultDeny: true},
+		func(c *gin.Context) {
+			t.Fatal("handler should not be reached when default_deny blocks a request with no function segment")
+		},
+	)
+
+	// Target without a "." segment — function name parses as empty string.
+	req := httptest.NewRequest(http.MethodPost, "/execute/target-agent", bytes.NewBufferString(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusForbidden, recorder.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &body))
+	require.Equal(t, "no_policy_matched", body["error"])
+}
+
+func TestPermissionDefaultDenyOnPolicyMatchedAllowsRequest(t *testing.T) {
+	policy := &permissionPolicyCapture{
+		evaluate: func(_, _ []string, _ string, _ map[string]any) *types.PolicyEvaluationResult {
+			return &types.PolicyEvaluationResult{Matched: true, Allowed: true}
+		},
+	}
+	handlerCalled := false
+	router := setupPermissionRouterWithConfig(
+		"did:caller",
+		policy,
+		&permissionTagVCVerifierStub{},
+		defaultDenyTestResolver(),
+		defaultDenyTestDIDResolver(),
+		PermissionConfig{Enabled: true, DefaultDeny: true},
+		func(c *gin.Context) {
+			handlerCalled = true
+			c.Status(http.StatusOK)
+		},
+	)
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, newDefaultDenyTestRequest())
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.True(t, handlerCalled, "an explicit policy-allow result must not be overridden by default_deny")
+}
+
+func TestPermissionDefaultDenyOnPolicyMatchedDenyKeepsExistingDenyResponse(t *testing.T) {
+	policy := &permissionPolicyCapture{
+		evaluate: func(_, _ []string, _ string, _ map[string]any) *types.PolicyEvaluationResult {
+			return &types.PolicyEvaluationResult{Matched: true, Allowed: false}
+		},
+	}
+	router := setupPermissionRouterWithConfig(
+		"did:caller",
+		policy,
+		&permissionTagVCVerifierStub{},
+		defaultDenyTestResolver(),
+		defaultDenyTestDIDResolver(),
+		PermissionConfig{Enabled: true, DefaultDeny: true},
+		func(c *gin.Context) {
+			t.Fatal("handler should not be reached when an explicit policy denies access")
+		},
+	)
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, newDefaultDenyTestRequest())
+
+	require.Equal(t, http.StatusForbidden, recorder.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &body))
+	require.Equal(t, "access_denied", body["error"], "explicit deny must take precedence over the no_policy_matched response")
+}
+
+func TestPermissionDefaultDenyOnNoPolicyServiceIsNoop(t *testing.T) {
+	handlerCalled := false
+	router := setupPermissionRouterWithConfig(
+		"did:caller",
+		nil,
+		&permissionTagVCVerifierStub{},
+		defaultDenyTestResolver(),
+		defaultDenyTestDIDResolver(),
+		PermissionConfig{Enabled: true, DefaultDeny: true},
+		func(c *gin.Context) {
+			handlerCalled = true
+			c.Status(http.StatusOK)
+		},
+	)
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, newDefaultDenyTestRequest())
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.True(t, handlerCalled, "default_deny must not engage when no policy service is configured")
 }

--- a/control-plane/internal/server/routes_core.go
+++ b/control-plane/internal/server/routes_core.go
@@ -67,7 +67,8 @@ func (s *AgentFieldServer) registerCoreRoutes(agentAPI *gin.RouterGroup) {
 		legacyReasonerGroup := agentAPI.Group("/reasoners")
 		legacySkillGroup := agentAPI.Group("/skills")
 		permConfigLegacy := middleware.PermissionConfig{
-			Enabled: true,
+			Enabled:     true,
+			DefaultDeny: s.config.Features.DID.Authorization.DefaultDeny,
 		}
 		legacyMiddleware := middleware.PermissionCheckMiddleware(
 			s.accessPolicyService,
@@ -92,7 +93,8 @@ func (s *AgentFieldServer) registerCoreRoutes(agentAPI *gin.RouterGroup) {
 	{
 		if s.config.Features.DID.Authorization.Enabled && s.accessPolicyService != nil && s.didWebService != nil {
 			permConfig := middleware.PermissionConfig{
-				Enabled: true,
+				Enabled:     true,
+				DefaultDeny: s.config.Features.DID.Authorization.DefaultDeny,
 			}
 			executeGroup.Use(middleware.PermissionCheckMiddleware(
 				s.accessPolicyService,

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -67,6 +67,7 @@ When enabled, the control plane issues DID identities to agents and enforces tag
 - `AGENTFIELD_AUTHORIZATION_ENABLED` (default: `false`): Enable VC-based authorization.
 - `AGENTFIELD_AUTHORIZATION_MASTER_SEED` (required when enabled): Master seed for deriving Ed25519 keypairs for agent DIDs. Keep this secret and consistent across restarts — changing it invalidates all existing DID signatures.
 - `AGENTFIELD_AUTHORIZATION_TAG_APPROVAL_MODE` (default: `auto`): `auto` (tags approved immediately) or `admin` (tags require admin approval before the agent becomes ready).
+- `AGENTFIELD_AUTHORIZATION_DEFAULT_DENY` (default: `false`): When `true`, the tag policy middleware returns HTTP 403 for any request where no access policy matches the `(caller_tags, target_tags, function)` tuple. Default is `false`, preserving the existing behavior of allowing unmatched requests. The unmatched tuple is logged at `DEBUG` in both modes for diagnosis. Equivalent YAML: `features.did.authorization.default_deny`.
 
 ### Connector (External Management API)
 


### PR DESCRIPTION
## Summary

Adds an opt-in `default_deny` mode to the tag policy middleware so requests with no matching access policy can be rejected rather than falling through. Default remains allow; existing deployments are unaffected.

When enabled and no policy matches, the request returns 403 with an opaque `no_policy_matched` error. The unmatched `(caller_tags, target_tags, function)` tuple is logged at `DEBUG` in both modes so operators can diagnose coverage gaps; it is intentionally not included in the response body to avoid leaking tag taxonomy to denied callers (matching the existing `access_denied` response shape).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] Tests only
- [ ] CI / tooling
- [ ] Breaking change

## Test plan

- `cd control-plane && go test ./internal/server/middleware/... -run Permission`
- `cd control-plane && go test ./internal/config/...`
- `cd control-plane && go build ./...`
- `cd control-plane && golangci-lint run --new-from-rev=main ./...`

Verified locally with Go 1.26.3 on darwin/arm64:

- [x] `default_deny` off + no match → request proceeds (`TestPermissionCallerDIDResolutionPrecedence`, `TestPermissionDefaultDenyOffAllowsUnmatched`)
- [x] `default_deny` on + no match → 403 with opaque body; tags and function name are *not* present in the response (`TestPermissionDefaultDenyOnBlocksUnmatched`)
- [x] `default_deny` on + target with no function segment → 403 (`TestPermissionDefaultDenyOnEmptyFunctionNameBlocks`)
- [x] `default_deny` on + explicit policy deny → existing `access_denied` 403 takes precedence (`TestPermissionDefaultDenyOnPolicyMatchedDenyKeepsExistingDenyResponse`)
- [x] `default_deny` on + explicit policy allow → request proceeds (`TestPermissionDefaultDenyOnPolicyMatchedAllowsRequest`)
- [x] `default_deny` on + `policyService` nil → no-op, request proceeds (`TestPermissionDefaultDenyOnNoPolicyServiceIsNoop`)
- [x] `AGENTFIELD_AUTHORIZATION_DEFAULT_DENY=true` is applied to \`AuthorizationConfig.DefaultDeny\` (`TestApplyEnvOverrides`)
- [x] \`golangci-lint run --new-from-rev=main\` → 0 issues
- [x] \`go vet\` clean on touched packages
- [x] \`go mod tidy\` produces no diff

Full \`go test ./...\` passes except a pre-existing port-allocation flake in \`internal/packages/TestRunnerErrorCases/RunAgentNode-getFreePort-fails\` that also fails on \`main\` (environment-dependent; unrelated to this change).

## Test coverage

This repo enforces a **coverage gate** on every PR (see [\`.github/workflows/coverage.yml\`](.github/workflows/coverage.yml) and [\`docs/COVERAGE.md\`](docs/COVERAGE.md)).

Before asking for review, please confirm:

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR (no bare additions).
- [x] If I removed code, I updated \`coverage-baseline.json\` in this PR *only if* the removal caused a legitimate regression and I called it out in the summary above. (No baseline change needed; the patch is strictly additive.)
- [x] The coverage gate check is green in CI before requesting review.

New tests are additive; no existing test bodies were modified beyond the additive \`setupPermissionRouterWithConfig\` helper that the original \`setupPermissionRouter\` now delegates through.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
- [x] Commits are signed and follow conventional-commits style (\`fix(control-plane):\`).
- [x] I have linked the related issue (\`Fixes #426\`).

## Notes on placement

I considered both \`AuthorizationConfig.DefaultDeny\` (chosen here) and a new \`TagPolicy{}\` substruct as suggested in the issue body. The flat field on \`AuthorizationConfig\` keeps it consistent with how \`AccessPolicies\` already lives on the same struct. Happy to move it to a substruct if you prefer the grouping.

## Related issues / PRs

Fixes #426