### PR TITLE
chore(ci): track Docker Hub pulls in download stats gist

### DIFF
--- a/.github/workflows/update-download-stats.yml
+++ b/.github/workflows/update-download-stats.yml
@@ -71,8 +71,26 @@ jobs:
             const npmDownloads = npmData.downloads || 0;
             console.log('NPM downloads:', npmDownloads);
 
+            // Fetch Docker Hub pull count (cumulative — Docker Hub does not expose history)
+            // Snapshotting here every 6h lets us reconstruct daily pulls from the gist.
+            let dockerDownloads = 0;
+            try {
+              const dockerRes = await fetch(
+                'https://hub.docker.com/v2/repositories/agentfield/control-plane/'
+              );
+              if (dockerRes.ok) {
+                const dockerData = await dockerRes.json();
+                dockerDownloads = dockerData.pull_count || 0;
+              } else {
+                console.error('Docker Hub API error:', dockerRes.status);
+              }
+            } catch (e) {
+              console.error('Docker Hub fetch failed:', e.message);
+            }
+            console.log('Docker pulls:', dockerDownloads);
+
             // Calculate total
-            const total = githubDownloads + pypiDownloads + npmDownloads;
+            const total = githubDownloads + pypiDownloads + npmDownloads + dockerDownloads;
             console.log('Total downloads:', total);
 
             // Format number (e.g., 12500 -> "12.5k")
@@ -96,7 +114,8 @@ jobs:
               sources: {
                 github: githubDownloads,
                 pypi: pypiDownloads,
-                npm: npmDownloads
+                npm: npmDownloads,
+                docker: dockerDownloads
               },
               lastUpdated: new Date().toISOString()
             };


### PR DESCRIPTION
## Summary
- `update-download-stats.yml` (the 6-hourly job that writes the badge gist) was capturing GitHub releases / PyPI / npm but **not** Docker Hub.
- As a result `stats.json.sources.docker` was always `0`, and every analytics script that reads the gist history (e.g. `marketing/analytics/gist_download_analysis.py`) had no Docker series to plot.
- Docker Hub's public API only exposes a cumulative `pull_count` — there is no daily/historical endpoint on the free tier. The only way to reconstruct a daily Docker series is to snapshot it ourselves every few hours, which is exactly what this workflow already does for every other channel.

## Change
Adds a Docker Hub fetch to the inline script:
- Hits `https://hub.docker.com/v2/repositories/agentfield/control-plane/` and reads `pull_count`.
- Rolls the value into the total and into `stats.json.sources.docker`.
- Wrapped in try/catch — a Docker Hub outage falls back to `docker: 0` without failing the job.

After this lands, every 6-hour gist snapshot will carry a real Docker number, and the marketing analytics will be able to chart Docker pulls over time (going forward — there is no way to recover the ~5 months of pre-existing history).

## Verification
- Validated the workflow YAML parses cleanly.
- Ran the inline script body in Node 25 against a mocked `github` SDK and a live Docker Hub call:
  - Live `pull_count` returned: **11,298**
  - Generated `stats.json` payload shape:
    ```json
    {
      "total": 229874,
      "sources": { "github": 180, "pypi": 184754, "npm": 33642, "docker": 11298 },
      "lastUpdated": "..."
    }
    ```
  - Asserted: `docker` key present, numeric, total = sum of sources.

## Test plan
- [ ] Merge and either wait for the next scheduled 6h run or trigger the workflow manually via the Actions tab.
- [ ] Confirm the new gist commit's `stats.json` contains `sources.docker` with a non-zero value.
- [ ] Confirm `marketing/analytics/gist_download_analysis.py --from-gist` picks up the populated `docker` column on the next refresh.