### PR TITLE
fix(ui/runs): truncate long error-category badges so they don't overflow the status cell

### DIFF
--- a/control-plane/web/client/src/components/StepDetail.tsx
+++ b/control-plane/web/client/src/components/StepDetail.tsx
@@ -390,8 +390,9 @@ export function StepDetail({ executionId }: { executionId: string }) {
               <div className="mt-2 flex flex-wrap items-center gap-2">
                 <Badge
                   variant="outline"
+                  title={errorCategoryMeta.tooltip}
                   className={cn(
-                    "h-5 px-1.5 text-micro-plus capitalize",
+                    "h-5 max-w-[18rem] truncate whitespace-nowrap px-1.5 text-micro-plus capitalize",
                     errorCategoryMeta.badgeClassName,
                   )}
                 >

--- a/control-plane/web/client/src/pages/RunsPage.tsx
+++ b/control-plane/web/client/src/pages/RunsPage.tsx
@@ -1618,14 +1618,15 @@ function RunRow({
       {/* Status dot — prefer the root execution status so pause/cancel are
           reflected immediately, even when stragglers are still in-flight */}
       <TableCell className="w-44 min-w-[11rem]">
-        <div className="flex flex-col items-start gap-1">
+        <div className="flex min-w-0 max-w-full flex-col items-start gap-1">
           <StatusDot status={run.root_execution_status ?? run.status} />
           {errorMeta ? (
-            <div className="flex max-w-full flex-wrap items-center gap-1">
+            <div className="flex min-w-0 max-w-full items-center gap-1">
               <span
+                title={errorMeta.tooltip}
                 className={cn(
                   badgeVariants({ variant: "outline", size: "sm" }),
-                  "h-5 max-w-full px-1.5 text-micro-plus capitalize",
+                  "h-5 min-w-0 max-w-full truncate whitespace-nowrap px-1.5 text-micro-plus capitalize",
                   errorMeta.badgeClassName,
                 )}
               >
@@ -1634,7 +1635,7 @@ function RunRow({
               {errorMeta.diagnosticsLabel && errorMeta.diagnosticsPath ? (
                 <Link
                   to={errorMeta.diagnosticsPath}
-                  className="text-micro-plus text-sky-600 underline-offset-2 hover:underline dark:text-sky-400"
+                  className="shrink-0 text-micro-plus text-sky-600 underline-offset-2 hover:underline dark:text-sky-400"
                   onClick={(e) => e.stopPropagation()}
                 >
                   {errorMeta.diagnosticsLabel}

--- a/control-plane/web/client/src/utils/executionErrorCategory.test.ts
+++ b/control-plane/web/client/src/utils/executionErrorCategory.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+
+import { getExecutionErrorCategoryMeta } from "./executionErrorCategory";
+
+describe("getExecutionErrorCategoryMeta", () => {
+  it("returns null for nullish input", () => {
+    expect(getExecutionErrorCategoryMeta(null)).toBeNull();
+    expect(getExecutionErrorCategoryMeta(undefined)).toBeNull();
+    expect(getExecutionErrorCategoryMeta("")).toBeNull();
+  });
+
+  it("returns the canonical meta for a known category", () => {
+    const meta = getExecutionErrorCategoryMeta("agent_timeout");
+    expect(meta).not.toBeNull();
+    expect(meta?.label).toBe("Agent timeout");
+    expect(meta?.tooltip).toBe(meta?.description);
+  });
+
+  it("uses a short label for an unknown category whose raw form is short", () => {
+    const meta = getExecutionErrorCategoryMeta("custom_thing");
+    expect(meta?.label).toBe("custom thing");
+    expect(meta?.tooltip).toBe("custom_thing");
+  });
+
+  it("collapses a long, free-form category to a fixed-length fallback label", () => {
+    const longRaw =
+      "Agent Restart Orphaned: Tier2-Test Re-Registered With New Instance (was 38ffec8279554ffa97aea6f0ab69a53c)";
+    const meta = getExecutionErrorCategoryMeta(longRaw);
+    expect(meta).not.toBeNull();
+    // Label is bounded so the badge stays single-line in the Runs table.
+    expect(meta!.label.length).toBeLessThanOrEqual(32);
+    // Original string survives on the tooltip so context isn't lost on hover.
+    expect(meta!.tooltip).toBe(longRaw);
+  });
+});

--- a/control-plane/web/client/src/utils/executionErrorCategory.ts
+++ b/control-plane/web/client/src/utils/executionErrorCategory.ts
@@ -14,9 +14,15 @@ export interface ExecutionErrorCategoryMeta {
   badgeClassName: string;
   diagnosticsLabel?: string;
   diagnosticsPath?: string;
+  /**
+   * Full text safe to surface on hover (`title=`). For canonical categories
+   * this mirrors `description`; for unknown categories it preserves the raw
+   * incoming string so a one-line truncated badge label doesn't drop context.
+   */
+  tooltip: string;
 }
 
-const ERROR_CATEGORY_META: Record<ExecutionErrorCategory, Omit<ExecutionErrorCategoryMeta, "category">> = {
+const ERROR_CATEGORY_META: Record<ExecutionErrorCategory, Omit<ExecutionErrorCategoryMeta, "category" | "tooltip">> = {
   llm_unavailable: {
     label: "LLM unavailable",
     description: "LLM backend circuit breaker is open.",
@@ -60,21 +66,38 @@ const ERROR_CATEGORY_META: Record<ExecutionErrorCategory, Omit<ExecutionErrorCat
   },
 };
 
+/**
+ * Max characters we let through as a badge label. The Runs table status cell
+ * is only ~11rem wide, so anything longer becomes an ellipsised pill (full
+ * text remains available via the badge's `title=tooltip`).
+ */
+const FALLBACK_LABEL_MAX_CHARS = 24;
+
 export function getExecutionErrorCategoryMeta(
   category?: string | null,
 ): ExecutionErrorCategoryMeta | null {
   if (!category) {
     return null;
   }
-  const normalized = category.trim().toLowerCase() as ExecutionErrorCategory;
+  const raw = category.trim();
+  const normalized = raw.toLowerCase() as ExecutionErrorCategory;
   const known = ERROR_CATEGORY_META[normalized];
-  if (!known) {
-    return {
-      category: normalized,
-      label: normalized.replace(/_/g, " "),
-      description: "Execution failed with an uncategorized error.",
-      badgeClassName: "bg-red-500/10 text-red-700 border-red-500/30 dark:text-red-300",
-    };
+  if (known) {
+    return { category: normalized, ...known, tooltip: known.description };
   }
-  return { category: normalized, ...known };
+  // Unknown category — likely a diagnostic message leaking through instead of
+  // a slug. Render a short fallback label so the badge stays single-line and
+  // preserve the original string on hover.
+  const slugged = raw.replace(/_/g, " ");
+  const label =
+    slugged.length > FALLBACK_LABEL_MAX_CHARS
+      ? "Unknown error"
+      : slugged;
+  return {
+    category: normalized,
+    label,
+    description: "Execution failed with an uncategorized error.",
+    badgeClassName: "bg-red-500/10 text-red-700 border-red-500/30 dark:text-red-300",
+    tooltip: raw,
+  };
 }


### PR DESCRIPTION
## Summary

In the Runs list (`/ui/runs`), the error-category badge under each run's
status was wrapping multiple lines and overflowing into the row below.

![bug — overlapping badges](https://github.com/Agent-Field/agentfield/issues)

The status column is `w-44 min-w-[11rem]` (≈11rem) and the badge is `h-5`
fixed height. When `root_error_category` was a long descriptive string
(e.g. `"Agent Restart Orphaned: Tier2-Test Re-Registered With New
Instance (was 38ffec8279...)"`) instead of one of the canonical seven
slugs, the badge wrapped, the row height didn't grow to match, and the
overflow bled into the next row.

## Root cause

Two layers conspired:

1. **Util** — `getExecutionErrorCategoryMeta()` ([executionErrorCategory.ts:71-78](../blob/main/control-plane/web/client/src/utils/executionErrorCategory.ts#L71-L78)) echoed the raw category string as `label` for any unknown category. That's fine for short slugs but pathological for diagnostic-message-style values.
2. **Consumer** — `RunsPage` ([line 1620-1646](../blob/main/control-plane/web/client/src/pages/RunsPage.tsx#L1620-L1646)) wrapped the badge in `flex flex-wrap` with no truncation, so a long label could wrap inside a fixed-height pill.

## Fix (two commits)

- **`fix(ui/runs): cap error-category fallback label …`** — bounds the fallback label to 24 chars (else "Unknown error") and adds a new `tooltip` field on `ExecutionErrorCategoryMeta` that preserves the original string. Known categories get `tooltip = description` so the API is uniform. Adds 4 vitest cases for the new behavior.
- **`fix(ui/runs): truncate error badge …`** — both consumers (RunsPage status cell, StepDetail error box) now render the badge as a single-line ellipsised pill with `title={errorMeta.tooltip}`. The diagnostics link (when present) gets `shrink-0` so the badge takes the slack first.

## Why both layers

Capping the label at the util prevents the most likely culprit (a long string in `error_category`) from reaching the badge at all. Adding truncate at the consumer is defense-in-depth — even a 24-char label inside a future narrower cell would otherwise still overflow.

## Test plan

- [x] `npm run build` — clean (Vite + tsc)
- [x] `npm run test` — 128 files / 659 tests pass (4 new tests in `executionErrorCategory.test.ts`)
- [x] `npx eslint <touched files>` — clean
- [ ] CI green on this PR
- [ ] Visual: load `/ui/runs` against a run whose `root_error_category` is a long free-form string; confirm the badge is a single-line ellipsised pill that fits in the column and hovering reveals the full text

## Out of scope

The fact that `root_error_category` is sometimes carrying a multi-line diagnostic message instead of a canonical slug is a backend concern — likely a place where an error reason got written into the category field. This PR is purely UI hardening so the front end is robust to that data shape; the upstream source is a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)