### PR TITLE
fix(sdk): per-call ai() timeout + OpenRouter image retry/strip fallback

### DIFF
--- a/sdk/python/agentfield/agent_ai.py
+++ b/sdk/python/agentfield/agent_ai.py
@@ -277,6 +277,7 @@ class AgentAI:
         ] = None,
         max_turns: Optional[int] = None,
         max_tool_calls: Optional[int] = None,
+        timeout: Optional[float] = None,
         **kwargs,
     ) -> Any:
         """
@@ -311,6 +312,7 @@ class AgentAI:
                 - ToolCallConfig or dict: discover with filtering/progressive options
             max_turns (int, optional): Maximum LLM turns in the tool-call loop (default: 10).
             max_tool_calls (int, optional): Maximum total tool calls allowed (default: 25).
+            timeout (float, optional): Per-call timeout in seconds. Overrides agent's async_config.llm_call_timeout for this call only.
             **kwargs: Additional provider-specific parameters to pass to the LLM.
 
         Returns:
@@ -531,10 +533,13 @@ class AgentAI:
         # then grab the stale pooled connection and hang forever — a silent
         # deadlock that py-spy reveals as 'all worker threads idle'.
         # litellm forwards `timeout` to httpx as a request-level timeout.
-        _litellm_call_timeout = getattr(
-            self.agent.async_config, "llm_call_timeout", 120.0
+        # Per-call `timeout` kwarg overrides the agent-wide async_config default.
+        effective_timeout = (
+            timeout
+            if timeout is not None
+            else getattr(self.agent.async_config, "llm_call_timeout", 120.0)
         )
-        litellm_params.setdefault("timeout", _litellm_call_timeout)
+        litellm_params.setdefault("timeout", effective_timeout)
 
         if schema:
             # Convert Pydantic model to JSON schema format for LiteLLM
@@ -582,19 +587,16 @@ class AgentAI:
                     )
 
                 async def _make_call():
-                    timeout = getattr(
-                        self.agent.async_config, "llm_call_timeout", 120.0
-                    )
                     # Ensure litellm/httpx itself enforces the timeout at the
                     # socket level, so cancelled requests don't poison the
                     # connection pool for subsequent calls.
-                    params.setdefault("timeout", timeout)
+                    params.setdefault("timeout", effective_timeout)
                     # asyncio.wait_for is a safety net at 2x the litellm timeout
                     # in case litellm fails to honor its own timeout.
                     try:
                         return await asyncio.wait_for(
                             litellm_module.acompletion(**params),
-                            timeout=timeout * 2,
+                            timeout=effective_timeout * 2,
                         )
                     except asyncio.TimeoutError:
                         model_name = params.get("model", "unknown")
@@ -602,7 +604,7 @@ class AgentAI:
                         # gets a fresh connection pool.
                         _reset_litellm_http_clients(litellm_module)
                         raise TimeoutError(
-                            f"LLM call to {model_name} timed out after {timeout * 2}s (asyncio safety net)"
+                            f"LLM call to {model_name} timed out after {effective_timeout * 2}s (asyncio safety net)"
                         )
 
                 async def _call_with_fallbacks():
@@ -662,14 +664,13 @@ class AgentAI:
                 raise ImportError(
                     "litellm is not installed. Please install it with `pip install litellm`."
                 )
-            timeout = getattr(self.agent.async_config, "llm_call_timeout", 120.0)
             # litellm/httpx already gets `timeout` via litellm_params (set
             # earlier). asyncio.wait_for is a safety net at 2x in case litellm
             # fails to honor its own timeout.
             try:
                 return await asyncio.wait_for(
                     litellm_module.acompletion(**litellm_params),
-                    timeout=timeout * 2,
+                    timeout=effective_timeout * 2,
                 )
             except asyncio.TimeoutError:
                 model_name = litellm_params.get("model", "unknown")
@@ -678,7 +679,7 @@ class AgentAI:
                 # holding a stuck connection that will hang forever.
                 _reset_litellm_http_clients(litellm_module)
                 raise TimeoutError(
-                    f"LLM call to {model_name} timed out after {timeout * 2}s (asyncio safety net)"
+                    f"LLM call to {model_name} timed out after {effective_timeout * 2}s (asyncio safety net)"
                 )
 
         async def _execute_with_fallbacks():

--- a/sdk/python/agentfield/agent_ai.py
+++ b/sdk/python/agentfield/agent_ai.py
@@ -534,6 +534,8 @@ class AgentAI:
         # deadlock that py-spy reveals as 'all worker threads idle'.
         # litellm forwards `timeout` to httpx as a request-level timeout.
         # Per-call `timeout` kwarg overrides the agent-wide async_config default.
+        if timeout is not None and timeout <= 0:
+            raise ValueError(f"timeout must be positive, got {timeout}")
         effective_timeout = (
             timeout
             if timeout is not None

--- a/sdk/python/agentfield/vision.py
+++ b/sdk/python/agentfield/vision.py
@@ -12,7 +12,18 @@ Supported Providers:
 import asyncio
 import os
 from typing import Any, Dict, Optional
-from agentfield.logger import log_error
+from agentfield.logger import log_error, log_warn
+
+
+# Substring identifying OpenRouter's transient "no upstream provider" 404
+# (issues #3 and #5 in reel-af AGENTFIELD_SDK_ISSUES.md).
+_NO_ENDPOINTS_MARKER = "No endpoints found that support the requested output modalities"
+# Sleeps between the 3 in-loop attempts; index 0 is before the strip attempt.
+# Sequence: attempt 1 → sleep 1s → attempt 2 → sleep 2s → attempt 3 → (sleep 4s
+# → strip-and-retry) if image_config was set, else give up.
+_NO_ENDPOINTS_TOTAL_ATTEMPTS = 3
+_NO_ENDPOINTS_INTER_SLEEPS = (1.0, 2.0)
+_NO_ENDPOINTS_STRIP_SLEEP = 4.0
 
 
 async def generate_image_litellm(
@@ -165,13 +176,45 @@ async def generate_image_openrouter(
         completion_params["image_config"] = image_config
 
     try:
-        # Use LiteLLM's completion function (OpenRouter uses chat API)
-        # Wrap with timeout to prevent silent hangs
+        # Use LiteLLM's completion function (OpenRouter uses chat API).
+        # Wrap each attempt with timeout to prevent silent hangs.
+        # Retry OpenRouter's "No endpoints found" 404 (issues #3, #5): transient
+        # under load; if image_config caused it, drop image_config on a final
+        # attempt and warn.
         timeout = float(os.getenv("AGENTFIELD_LLM_CALL_TIMEOUT", "120.0"))
-        response = await asyncio.wait_for(
-            litellm.acompletion(**completion_params),
-            timeout=timeout,
-        )
+        response = None
+        last_exc: Optional[BaseException] = None
+        for attempt in range(_NO_ENDPOINTS_TOTAL_ATTEMPTS):
+            try:
+                response = await asyncio.wait_for(
+                    litellm.acompletion(**completion_params),
+                    timeout=timeout,
+                )
+                break
+            except Exception as e:
+                if _NO_ENDPOINTS_MARKER not in str(e):
+                    raise
+                last_exc = e
+                if attempt < len(_NO_ENDPOINTS_INTER_SLEEPS):
+                    await asyncio.sleep(_NO_ENDPOINTS_INTER_SLEEPS[attempt])
+        if response is None:
+            # All in-loop attempts exhausted. If image_config was set, try once
+            # without it before giving up.
+            if completion_params.get("image_config"):
+                log_warn(
+                    "OpenRouter returned 'No endpoints found' after retries; "
+                    "retrying once with image_config stripped (no upstream provider "
+                    "accepted the requested image_config)."
+                )
+                completion_params.pop("image_config", None)
+                await asyncio.sleep(_NO_ENDPOINTS_STRIP_SLEEP)
+                response = await asyncio.wait_for(
+                    litellm.acompletion(**completion_params),
+                    timeout=timeout,
+                )
+            else:
+                assert last_exc is not None
+                raise last_exc
 
         # Extract images from OpenRouter response
         # OpenRouter returns images in choices[0].message.images

--- a/sdk/python/agentfield/vision.py
+++ b/sdk/python/agentfield/vision.py
@@ -199,7 +199,9 @@ async def generate_image_openrouter(
                     await asyncio.sleep(_NO_ENDPOINTS_INTER_SLEEPS[attempt])
         if response is None:
             # All in-loop attempts exhausted. If image_config was set, try once
-            # without it before giving up.
+            # without it before giving up. Falsy check (not `is not None`) is
+            # intentional: image_config={} produces an identical wire call
+            # whether stripped or not, so we skip the useless extra attempt.
             if completion_params.get("image_config"):
                 log_warn(
                     "OpenRouter returned 'No endpoints found' after retries; "

--- a/sdk/python/tests/test_agent_ai.py
+++ b/sdk/python/tests/test_agent_ai.py
@@ -293,3 +293,71 @@ async def test_ai_with_vision_invokes_litellm(monkeypatch, agent_with_ai):
 
     stub_module.aimage_generation.assert_awaited_once()
     assert result.images[0].url == "http://image"
+
+
+def _setup_timeout_test(monkeypatch, agent_with_ai):
+    """Common setup for per-call timeout tests. Returns (ai, stub_module, captured)."""
+    agent_with_ai.async_config.llm_call_timeout = 120.0
+    stub_module = setup_litellm_stub(monkeypatch)
+    captured = {}
+
+    async def acompletion_side_effect(**params):
+        captured["params"] = params
+        return make_chat_response("ok")
+
+    stub_module.acompletion.side_effect = acompletion_side_effect
+
+    class StubLimiter:
+        async def execute_with_retry(self, func):
+            return await func()
+
+    ai = AgentAI(agent_with_ai)
+    monkeypatch.setattr(ai, "_ensure_model_limits_cached", lambda: asyncio.sleep(0))
+    monkeypatch.setattr(ai, "_get_rate_limiter", lambda: StubLimiter())
+    monkeypatch.setattr(
+        "agentfield.agent_ai.AgentUtils.detect_input_type", lambda value: "text"
+    )
+    monkeypatch.setattr(
+        "agentfield.agent_ai.AgentUtils.serialize_result", lambda value: value
+    )
+    return ai, stub_module, captured
+
+
+@pytest.mark.asyncio
+async def test_ai_per_call_timeout_overrides_agent_default(monkeypatch, agent_with_ai):
+    ai, _stub, captured = _setup_timeout_test(monkeypatch, agent_with_ai)
+
+    await ai.ai("hello", timeout=30.0)
+
+    assert captured["params"]["timeout"] == 30.0
+
+
+@pytest.mark.asyncio
+async def test_ai_falls_back_to_agent_default_when_no_per_call_timeout(
+    monkeypatch, agent_with_ai
+):
+    ai, _stub, captured = _setup_timeout_test(monkeypatch, agent_with_ai)
+
+    await ai.ai("hello")
+
+    assert captured["params"]["timeout"] == 120.0
+
+
+@pytest.mark.asyncio
+async def test_ai_per_call_timeout_applies_to_wait_for_safety_net(
+    monkeypatch, agent_with_ai
+):
+    ai, _stub, _captured = _setup_timeout_test(monkeypatch, agent_with_ai)
+
+    wait_for_timeouts = []
+    real_wait_for = asyncio.wait_for
+
+    async def capturing_wait_for(awaitable, timeout=None):
+        wait_for_timeouts.append(timeout)
+        return await real_wait_for(awaitable, timeout=timeout)
+
+    monkeypatch.setattr("agentfield.agent_ai.asyncio.wait_for", capturing_wait_for)
+
+    await ai.ai("hi", timeout=10.0)
+
+    assert 20.0 in wait_for_timeouts

--- a/sdk/python/tests/test_agent_ai.py
+++ b/sdk/python/tests/test_agent_ai.py
@@ -361,3 +361,14 @@ async def test_ai_per_call_timeout_applies_to_wait_for_safety_net(
     await ai.ai("hi", timeout=10.0)
 
     assert 20.0 in wait_for_timeouts
+
+
+@pytest.mark.asyncio
+async def test_ai_rejects_non_positive_timeout(monkeypatch, agent_with_ai):
+    ai, _stub, _captured = _setup_timeout_test(monkeypatch, agent_with_ai)
+
+    with pytest.raises(ValueError, match="timeout must be positive"):
+        await ai.ai("hi", timeout=0)
+
+    with pytest.raises(ValueError, match="timeout must be positive"):
+        await ai.ai("hi", timeout=-1.0)

--- a/sdk/python/tests/test_vision.py
+++ b/sdk/python/tests/test_vision.py
@@ -282,3 +282,146 @@ async def test_generate_image_openrouter_with_kwargs():
         call_kwargs = mock_litellm.acompletion.call_args[1]
         assert call_kwargs["image_config"] == {"aspect_ratio": "16:9"}
         assert call_kwargs["temperature"] == 0.7
+
+
+# ---------------------------------------------------------------------------
+# Retry / image_config fallback (issues #3 and #5 from reel-af)
+# ---------------------------------------------------------------------------
+
+
+def _build_openrouter_success_response():
+    """Build a minimal mock OpenRouter success response."""
+    mock_image_url = MagicMock()
+    mock_image_url.url = "data:image/png;base64,abc"
+    mock_image = MagicMock()
+    mock_image.image_url = mock_image_url
+    mock_choice = MagicMock()
+    mock_choice.message.content = "ok"
+    mock_choice.message.images = [mock_image]
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    return mock_response
+
+
+_NO_ENDPOINTS_MSG = (
+    "litellm.NotFoundError: NotFoundError: OpenrouterException - "
+    '{"error":{"message":"No endpoints found that support the requested '
+    'output modalities: image, text","code":404}}'
+)
+
+
+@pytest.mark.asyncio
+async def test_generate_image_openrouter_retries_on_no_endpoints_then_succeeds(
+    monkeypatch,
+):
+    """First call hits 'No endpoints found' 404; second call succeeds (issue #5)."""
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+    success_response = _build_openrouter_success_response()
+    failure = Exception(_NO_ENDPOINTS_MSG)
+
+    mock_litellm = MagicMock()
+    mock_litellm.acompletion = AsyncMock(side_effect=[failure, success_response])
+
+    with patch.dict(sys.modules, {"litellm": mock_litellm}):
+        result = await generate_image_openrouter(
+            prompt="test",
+            model="openrouter/google/gemini-2.5-flash-image",
+            size="1024x1024",
+            quality="standard",
+            style=None,
+            response_format="url",
+        )
+
+    assert isinstance(result, MultimodalResponse)
+    assert mock_litellm.acompletion.call_count == 2
+    assert result.raw_response is success_response
+
+
+@pytest.mark.asyncio
+async def test_generate_image_openrouter_strips_image_config_after_retries(
+    monkeypatch,
+):
+    """All 3 in-loop attempts fail; strip-and-retry succeeds without image_config (issue #3)."""
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+    success_response = _build_openrouter_success_response()
+    failure = Exception(_NO_ENDPOINTS_MSG)
+
+    mock_litellm = MagicMock()
+    mock_litellm.acompletion = AsyncMock(
+        side_effect=[failure, failure, failure, success_response]
+    )
+
+    with patch.dict(sys.modules, {"litellm": mock_litellm}):
+        result = await generate_image_openrouter(
+            prompt="test",
+            model="openrouter/google/gemini-2.5-flash-image",
+            size="1024x1024",
+            quality="standard",
+            style=None,
+            response_format="url",
+            image_config={"aspect_ratio": "9:16"},
+        )
+
+    assert isinstance(result, MultimodalResponse)
+    assert mock_litellm.acompletion.call_count == 4
+    # The final (strip) call must not carry image_config.
+    final_kwargs = mock_litellm.acompletion.call_args_list[-1][1]
+    assert "image_config" not in final_kwargs
+    # And the earlier failing calls must have carried image_config.
+    first_kwargs = mock_litellm.acompletion.call_args_list[0][1]
+    assert first_kwargs.get("image_config") == {"aspect_ratio": "9:16"}
+    assert result.raw_response is success_response
+
+
+@pytest.mark.asyncio
+async def test_generate_image_openrouter_does_not_retry_on_other_errors(monkeypatch):
+    """Generic exceptions propagate immediately; no retry, no strip."""
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+    mock_litellm = MagicMock()
+    mock_litellm.acompletion = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with patch.dict(sys.modules, {"litellm": mock_litellm}):
+        with pytest.raises(RuntimeError, match="boom"):
+            await generate_image_openrouter(
+                prompt="test",
+                model="openrouter/test",
+                size="1024x1024",
+                quality="standard",
+                style=None,
+                response_format="url",
+                image_config={"aspect_ratio": "9:16"},
+            )
+
+    assert mock_litellm.acompletion.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_image_openrouter_gives_up_after_all_retries_no_image_config(
+    monkeypatch,
+):
+    """When image_config is None, exhaust 3 in-loop attempts then re-raise.
+
+    No strip attempt is performed (nothing to strip), so total call count is 3.
+    """
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+    failure = Exception(_NO_ENDPOINTS_MSG)
+    mock_litellm = MagicMock()
+    mock_litellm.acompletion = AsyncMock(side_effect=[failure, failure, failure])
+
+    with patch.dict(sys.modules, {"litellm": mock_litellm}):
+        with pytest.raises(Exception) as exc_info:
+            await generate_image_openrouter(
+                prompt="test",
+                model="openrouter/test",
+                size="1024x1024",
+                quality="standard",
+                style=None,
+                response_format="url",
+            )
+
+    assert "No endpoints found" in str(exc_info.value)
+    assert mock_litellm.acompletion.call_count == 3


### PR DESCRIPTION
## Summary

Two SDK gaps surfaced by the [reel-af](https://github.com/Agent-Field/agentfield/tree/main/examples) example project under a real URL → vertical-reel workload. Both forced consumer-side workarounds that this PR removes.

Filed alongside seven other reel-af pain points in `AGENTFIELD_SDK_ISSUES.md`. Of the seven, **four were already fixed upstream** (PR #579 + the video-download auth fix). This PR covers the remaining three.

| # | Issue | Status |
|---|---|---|
| 1 | `generate_audio` hardcoded `stream=true` rejects `format='wav'` | Already fixed (auto pcm16 → wav wrap) |
| 2 | `generate_audio` cannot accept a system message | Already fixed (`system` kwarg) |
| 3 | `generate_image_openrouter` 404s deterministically with `image_config={"aspect_ratio":"9:16"}` | **Fixed here** |
| 4 | `ImageOutput.save()` chokes on `data:` URLs from Gemini | Already fixed (`get_bytes()` handles `data:`) |
| 5 | Intermittent ~1-3% routing 404 on `generate_image_openrouter` under concurrency | **Fixed here** |
| 6 | `generate_video` downloads `unsigned_urls` without auth → 401 | Already fixed (per-host header logic) |
| 7 | `app.ai()` has no per-call timeout override | **Fixed here** |

## Changes

### `vision.generate_image_openrouter` — retry on routing 404 (#3, #5)

OpenRouter's `litellm.NotFoundError: \"No endpoints found that support the requested output modalities\"` surfaces in two flavours:

1. **Deterministic** when `image_config` (e.g. `aspect_ratio=9:16`) hits a model whose upstream replicas don't expose that param.
2. **Intermittent** ~1-3% under load when routing momentarily lands on a replica without image modality.

Single retry policy that handles both:

- Wraps the `litellm.acompletion(...)` call in a **3-attempt backoff** loop (sleeps 1s, 2s between attempts).
- If `image_config` was non-empty and all 3 retries failed, makes **one final attempt with `image_config` stripped**, logs a warning via `log_warn`, and uses the result.
- Other exceptions still propagate immediately (no retry on generic errors).
- The existing `asyncio.wait_for(..., timeout=...)` envelope still wraps every individual attempt — env var `AGENTFIELD_LLM_CALL_TIMEOUT` semantics unchanged.
- Worst-case wait: **3s** without `image_config`, **7s** with.

### `agent_ai.ai()` — per-call timeout override (#7)

`ai()` now accepts `timeout: Optional[float] = None`. When set, it overrides `async_config.llm_call_timeout` **for that single call only**, propagating to:

- `litellm_params[\"timeout\"]` — so httpx aborts at the socket level (preserves the comment block at line 527-533 explaining the connection-pool deadlock this prevents).
- The `asyncio.wait_for(..., timeout=effective_timeout * 2)` safety net.

Wired through all three call paths inside `ai()`:
- Direct (line 534-537 region)
- Tool-loop `_make_call()` closure (line 585-606 region)
- Non-tool `_make_litellm_call()` closure (line 665-682 region)

A single `effective_timeout` is computed once at function scope and captured by both nested closures. No env-var defaults touched. No sibling methods (`ai_with_audio`, `ai_with_vision`, etc.) modified.

**Why this matters:** the previous model forced every call in a mixed fast/slow pipeline to use the slowest expected timeout. reel-af's distiller and scene_breaker want ~60s; `compose_script` on a long arXiv preprint needs 10+ minutes. Today the agent-wide knob makes the fast calls wait too long on the rare timeout path.

## Test plan

- [x] `tests/test_vision.py` — 4 new cases:
  - `test_generate_image_openrouter_retries_on_no_endpoints_then_succeeds` — first call raises, second succeeds → `acompletion` called twice
  - `test_generate_image_openrouter_strips_image_config_after_retries` — all 3 retries fail with `image_config={\"aspect_ratio\":\"9:16\"}`; 4th attempt has `image_config` stripped and succeeds
  - `test_generate_image_openrouter_does_not_retry_on_other_errors` — generic `RuntimeError` propagates after a single call
  - `test_generate_image_openrouter_gives_up_after_all_retries_no_image_config` — 3 attempts then re-raise (no useless 4th call when there's nothing to strip)
  - `asyncio.sleep` patched out via monkeypatch — suite remains instant
- [x] `tests/test_agent_ai.py` — 3 new cases sharing a `_setup_timeout_test` helper:
  - `test_ai_per_call_timeout_overrides_agent_default` — `ai(\"hello\", timeout=30.0)` → captured `acompletion(timeout=30.0)`
  - `test_ai_falls_back_to_agent_default_when_no_per_call_timeout` → captured `timeout=120.0`
  - `test_ai_per_call_timeout_applies_to_wait_for_safety_net` — `timeout=10.0` → captured `wait_for(timeout=20.0)`
- [x] **112 related tests pass:** full `test_agent_ai*`, `test_vision`, `test_media_providers`, `test_openrouter_audio`, `test_image_config`, `test_agent_ai_deadlock_recovery` suites
- [x] `ruff check` clean on all touched files
- [x] `ruff format --check` clean on all touched files
- [ ] CI (Python 3.10 / 3.11 / 3.12 matrix) — kicks off on PR open

## Notes for reviewers

- No public API breaks. `timeout=` is opt-in; `image_config` retry/strip is transparent and only triggers on the specific "No endpoints found" error shape.
- Both fixes are scoped to single functions. No new module-level abstractions or refactoring.
- After this lands, the reel-af `sdk_patches.py` monkey-patch can shrink (it carries the video-download auth fix which is also now upstream) and the `AGENTFIELD_ASYNC_LLM_CALL_TIMEOUT=600` env bump can be replaced with per-call `timeout=` on the slow calls only.