### PR TITLE
fix(handlers): stop flaky coverage CI from global-logger race in parallel tests

### DIFF
--- a/control-plane/internal/handlers/coverage_handlers_92_target_test.go
+++ b/control-plane/internal/handlers/coverage_handlers_92_target_test.go
@@ -207,7 +207,11 @@ func TestAgentConcurrencyLimiter_MaxPerAgentNilAndConfigured(t *testing.T) {
 }
 
 func TestExecutionCleanupService_StartStopBranches(t *testing.T) {
-	t.Parallel()
+	// NOT t.Parallel(): this test swaps the process-global logger.Logger via
+	// setupExecutionCleanupTestLogger. Running it in parallel let a sibling test
+	// reassign the global logger mid-run, contaminating log buffers and flaking
+	// the coverage CI job. Keep it in the serial phase, like the other
+	// logger-swapping tests in execution_cleanup_test.go.
 
 	t.Run("disabled start is no-op", func(t *testing.T) {
 		service := NewExecutionCleanupService(&cleanupStoreMock{}, config.ExecutionCleanupConfig{Enabled: false})
@@ -341,7 +345,10 @@ func TestIsLightweightRequestQueryVariants(t *testing.T) {
 }
 
 func TestDiscoveryLoggingIncludesOptionalRequestID(t *testing.T) {
-	t.Parallel()
+	// NOT t.Parallel(): this test swaps the process-global logger.Logger via
+	// setupExecutionCleanupTestLogger and then asserts on the captured buffer.
+	// In parallel, a sibling test reassigning the global logger emptied this
+	// buffer and flaked the coverage CI job. Keep it in the serial phase.
 	gin.SetMode(gin.TestMode)
 
 	logBuffer := setupExecutionCleanupTestLogger(t)


### PR DESCRIPTION
## Summary

The `coverage (control-plane)` CI job (and the cascading `coverage-summary` job) flake because two tests mutate the **process-global** `logger.Logger` while running with `t.Parallel()`:

- `TestDiscoveryLoggingIncludesOptionalRequestID`
- `TestExecutionCleanupService_StartStopBranches`

Both call `setupExecutionCleanupTestLogger`, which swaps `logger.Logger` and restores it via `t.Cleanup`. Run in parallel, a sibling test reassigns the global logger mid-run, so the discovery test's captured buffer comes back empty and its assertions fail:

```
coverage_handlers_92_target_test.go:380: "" does not contain "\"request_id\":\"req-123\""
```

`coverage-summary` then fails with `missing input: control-plane.total.txt` because the control-plane coverage step exited non-zero. The non-test build is unaffected, which is why this slipped past the required gates and only surfaced in the coverage job's full parallel run.

## Fix

Drop `t.Parallel()` from both tests so they run in the serial phase, where nothing else mutates the global logger concurrently. This matches the existing convention — the logger-swapping tests in `execution_cleanup_test.go` are already non-parallel for the same reason.

## Verification

- `go test ./internal/handlers/ -count=20 -run 'TestDiscoveryLoggingIncludesOptionalRequestID|StartStopBranches|TestExecution'` — passes (this exact command reproduced the failure before the fix)
- full `go test ./internal/handlers/` — passes
- `go vet` clean; no new `gofmt` drift introduced (the file has pre-existing struct-alignment drift on `main`, left untouched to keep this PR scoped)

## Out of scope (flagged, not fixed here)

Running the package under `-race` surfaces several *separate*, pre-existing data races in the heartbeat coverage tests (`processHeartbeatAsync` async goroutines writing to test stubs in `TestHeartbeatHandler_AdditionalCoverage` / `TestDiscoveryAndNodeHandlers_AdditionalCoverage`). The coverage CI job does not run with `-race`, so those are not what breaks it — worth a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)