### PR TITLE
fix(cli): stop `af call` rejecting valid input for optional reasoner params

### DIFF
--- a/control-plane/internal/cli/call.go
+++ b/control-plane/internal/cli/call.go
@@ -450,14 +450,13 @@ func validateSchemaType(name string, value interface{}, schemaType string) error
 		if _, ok := value.(bool); !ok {
 			return fmt.Errorf("field %q must be a boolean", name)
 		}
-	case "object":
-		if _, ok := value.(map[string]interface{}); !ok {
-			return fmt.Errorf("field %q must be an object", name)
-		}
-	case "array":
-		if _, ok := value.([]interface{}); !ok {
-			return fmt.Errorf("field %q must be an array", name)
-		}
+	case "object", "array":
+		// The Python SDK serializes every Optional[...] parameter as
+		// {"type": "object"} (e.g. `pr_url: str | None` becomes an object), so
+		// enforcing the declared type here would wrongly reject a concrete scalar
+		// passed to an optional field. The control plane validates structured
+		// input itself and is the source of truth, so skip the client-side check
+		// for object/array rather than reject input the server would accept.
 	}
 	return nil
 }

--- a/control-plane/internal/cli/call_test.go
+++ b/control-plane/internal/cli/call_test.go
@@ -91,6 +91,38 @@ func TestValidateInputAgainstSchema(t *testing.T) {
 	require.ErrorContains(t, err, `field "count" must be an integer`)
 }
 
+// TestValidateInputAcceptsOptionalFieldValues guards the regression where the
+// CLI rejected valid input for optional parameters. The Python SDK serializes
+// every Optional[...] parameter (e.g. `pr_url: str | None`) as {"type": "object"},
+// so passing a concrete scalar to such a field must be accepted — the control
+// plane validates types itself and is the source of truth.
+func TestValidateInputAcceptsOptionalFieldValues(t *testing.T) {
+	schema := map[string]interface{}{
+		"properties": map[string]interface{}{
+			// Optional[str] / Optional[list] both collapse to "object" in the schema.
+			"pr_url":   map[string]interface{}{"type": "object"},
+			"ignore":   map[string]interface{}{"type": "object"},
+			"depth":    map[string]interface{}{"type": "string"},
+			"required": map[string]interface{}{"type": "object"},
+		},
+		"required": []interface{}{"pr_url"},
+	}
+
+	require.NoError(t, validateInputAgainstSchema(map[string]interface{}{
+		"pr_url": "https://github.com/owner/repo/pull/123",
+		"ignore": []interface{}{"vendor/"},
+		"depth":  "quick",
+	}, schema))
+
+	// Required-field presence is still enforced, and scalar types still caught.
+	require.ErrorContains(t,
+		validateInputAgainstSchema(map[string]interface{}{"depth": "quick"}, schema),
+		`missing required field "pr_url"`)
+	require.ErrorContains(t,
+		validateInputAgainstSchema(map[string]interface{}{"pr_url": "x", "depth": 1}, schema),
+		`field "depth" must be a string`)
+}
+
 func TestExitCodeMapping(t *testing.T) {
 	require.Equal(t, 3, httpExitCode(500))
 	require.Equal(t, 3, httpExitCode(401))

--- a/control-plane/internal/cli/trigger_commands_test.go
+++ b/control-plane/internal/cli/trigger_commands_test.go
@@ -320,8 +320,11 @@ func TestCallResultPromptAndValidationHelpers(t *testing.T) {
 	require.ErrorContains(t, validateSchemaType("count", 1.5, "integer"), "must be an integer")
 	require.ErrorContains(t, validateSchemaType("score", "x", "number"), "must be a number")
 	require.ErrorContains(t, validateSchemaType("ok", "true", "boolean"), "must be a boolean")
-	require.ErrorContains(t, validateSchemaType("obj", "x", "object"), "must be an object")
-	require.ErrorContains(t, validateSchemaType("arr", "x", "array"), "must be an array")
+	// object/array types are not enforced client-side: the SDK emits
+	// {"type": "object"} for Optional[...] params, so enforcing it would reject
+	// valid scalars passed to optional fields. The control plane is authoritative.
+	require.NoError(t, validateSchemaType("obj", "x", "object"))
+	require.NoError(t, validateSchemaType("arr", "x", "array"))
 }
 
 func TestRunReasonerListFormats(t *testing.T) {


### PR DESCRIPTION
## Problem

`af call` (the human trigger surface shipped in 0.1.86, #605) rejects valid input for any **optional** reasoner parameter. The Python SDK serializes every `Optional[...]` parameter — e.g. `pr_url: str | None` — as `{"type": "object"}` in the generated input schema, and `af call` did strict client-side type validation against that schema:

```
$ af call pr-af.review --in '{"pr_url": "https://github.com/owner/repo/pull/123"}'
Error: field "pr_url" must be an object        # rejected before the request is sent
```

The identical payload over `curl` works, because the control plane does not over-enforce the declared type. So the CLI was stricter than the server and blocked legitimate calls. Reasoners whose primary input is optional (pr-af's `pr_url`/`diff_text`, etc.) were effectively uncallable via `af call`.

## Fix

Stop enforcing `object`/`array` types in `af call`'s client-side validation. The control plane validates structured input and is the source of truth. Kept unchanged:

- **Required-field presence** check (fast feedback before a round-trip).
- **Scalar** type checks (`string`/`integer`/`number`/`boolean`) for properly-typed fields.

This is safe because the SDK collapses *all* `Optional[...]` params to `object` (optional strings, ints and lists alike), so skipping object/array is exactly what removes the false rejections, while scalar checks only ever apply to correctly-typed required fields.

## Validation contract

- Passing a concrete value to an optional (object-typed) field → **accepted** (was wrongly rejected).
- Missing a required field → **rejected** client-side (unchanged).
- Wrong-typed scalar for a properly-typed field → **rejected** client-side (unchanged).
- Server remains authoritative for structured-type validation.

Covered by a new regression test (`TestValidateInputAcceptsOptionalFieldValues`) plus updated assertions in the existing helper tests.

## Verification

Built the binary from this branch and ran it against a live `pr-af` agent on a freshly installed 0.1.86 control plane:

- `af call pr-af.review --in '{"pr_url": "..."}'` → now returns a run id; the reasoner logged `pr_url='https://github.com/owner/repo/pull/123'`.
- Optional `head_ref` accepted.
- `max_review_depth: "deep"` (should be int) → still rejected client-side.

`go build` clean and the full `internal/cli` test suite passes.

## Why it matters

This unblocks making `af call` the primary, friction-free trigger in the example-repo READMEs (the `*-af` quickstarts), which is currently broken for any reasoner with an optional primary input.