### PR TITLE
chore: patch transitive tmp and uuid lockfiles

### DIFF
--- a/control-plane/web/client/pnpm-lock.yaml
+++ b/control-plane/web/client/pnpm-lock.yaml
@@ -3410,8 +3410,8 @@ packages:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
@@ -7120,7 +7120,7 @@ snapshots:
       quick-lru: 5.1.1
       reduce-css-calc: 2.1.8
       resolve: 1.22.10
-      tmp: 0.2.5
+      tmp: 0.2.7
     transitivePeerDependencies:
       - ts-node
 
@@ -7185,7 +7185,7 @@ snapshots:
     dependencies:
       tldts-core: 6.1.86
 
-  tmp@0.2.5: {}
+  tmp@0.2.7: {}
 
   to-regex-range@5.0.1:
     dependencies:

--- a/examples/benchmarks/100k-scale/mastra-bench/package-lock.json
+++ b/examples/benchmarks/100k-scale/mastra-bench/package-lock.json
@@ -4111,9 +4111,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"


### PR DESCRIPTION
## Summary
- bump `tmp` from `0.2.5` to `0.2.7` in `control-plane/web/client/pnpm-lock.yaml`
- bump `uuid` from `11.1.0` to `11.1.1` in `examples/benchmarks/100k-scale/mastra-bench/package-lock.json`
- leave `@ai-sdk/provider-utils` alone because the current GitHub advisory does not publish a patched version

## Verification
- `cd control-plane && go test ./internal/storage -run "TestLocalStorageConfigLifecycle|TestStorageConfigCRUDPostgresAndDeleteMiss" -count=1`
- `cd control-plane/web/client && pnpm install --frozen-lockfile`
- `cd examples/benchmarks/100k-scale/mastra-bench && npm ci`
- `cd examples/benchmarks/100k-scale/mastra-bench && npm ls uuid @a2a-js/sdk && npm audit --omit=dev --audit-level=moderate`

## Notes
- `cd control-plane/web/client && pnpm test` currently fails on missing `date-fns` imports in existing workflow visualization tests. That failure is pre-existing and unrelated to these lockfile changes.