### PR TITLE
Fix multimedia OpenRouter/Fal SDK DX

### DIFF
--- a/sdk/go/ai/multimodal_test.go
+++ b/sdk/go/ai/multimodal_test.go
@@ -40,23 +40,23 @@ func TestWithAudioFile(t *testing.T) {
 	expectedBase64 := base64.StdEncoding.EncodeToString(dummyData)
 	assert.Equal(t, expectedBase64, part.InputAudio.Data)
 
-	// Validate JSON serialization 
-    jsonData, err := json.Marshal(req)
-    assert.NoError(t, err)
+	// Validate JSON serialization
+	jsonData, err := json.Marshal(req)
+	assert.NoError(t, err)
 
-    var parsed map[string]interface{}
-    err = json.Unmarshal(jsonData, &parsed)
-    assert.NoError(t, err)
+	var parsed map[string]interface{}
+	err = json.Unmarshal(jsonData, &parsed)
+	assert.NoError(t, err)
 
-    messages := parsed["messages"].([]interface{})
-    msg := messages[0].(map[string]interface{})
-    content := msg["content"].([]interface{})
-    contentPart := content[0].(map[string]interface{})
+	messages := parsed["messages"].([]interface{})
+	msg := messages[0].(map[string]interface{})
+	content := msg["content"].([]interface{})
+	contentPart := content[0].(map[string]interface{})
 
-    assert.Equal(t, "input_audio", contentPart["type"])
-    inputAudio := contentPart["input_audio"].(map[string]interface{})
-    assert.NotNil(t, inputAudio["data"])
-    assert.Equal(t, "mp3", inputAudio["format"])
+	assert.Equal(t, "input_audio", contentPart["type"])
+	inputAudio := contentPart["input_audio"].(map[string]interface{})
+	assert.NotNil(t, inputAudio["data"])
+	assert.Equal(t, "mp3", inputAudio["format"])
 }
 
 func TestWithAudioURL(t *testing.T) {
@@ -85,81 +85,178 @@ func TestWithAudioURL(t *testing.T) {
 	expectedBase64 := base64.StdEncoding.EncodeToString(dummyData)
 	assert.Equal(t, expectedBase64, part.InputAudio.Data)
 
-	// Validate JSON serialization 
-    jsonData, err := json.Marshal(req)
-    assert.NoError(t, err)
+	// Validate JSON serialization
+	jsonData, err := json.Marshal(req)
+	assert.NoError(t, err)
 
-    var parsed map[string]interface{}
-    err = json.Unmarshal(jsonData, &parsed)
-    assert.NoError(t, err)
+	var parsed map[string]interface{}
+	err = json.Unmarshal(jsonData, &parsed)
+	assert.NoError(t, err)
 
-    messages := parsed["messages"].([]interface{})
-    msg := messages[0].(map[string]interface{})
-    content := msg["content"].([]interface{})
-    contentPart := content[0].(map[string]interface{})
+	messages := parsed["messages"].([]interface{})
+	msg := messages[0].(map[string]interface{})
+	content := msg["content"].([]interface{})
+	contentPart := content[0].(map[string]interface{})
 
-    assert.Equal(t, "input_audio", contentPart["type"])
-    inputAudio := contentPart["input_audio"].(map[string]interface{})
-    assert.NotNil(t, inputAudio["data"])
-    assert.Equal(t, "wav", inputAudio["format"])
+	assert.Equal(t, "input_audio", contentPart["type"])
+	inputAudio := contentPart["input_audio"].(map[string]interface{})
+	assert.NotNil(t, inputAudio["data"])
+	assert.Equal(t, "wav", inputAudio["format"])
+}
+
+func TestWithVideoFile(t *testing.T) {
+	tempFile, err := os.CreateTemp("", "test_video_*.mp4")
+	assert.NoError(t, err)
+	defer os.Remove(tempFile.Name())
+
+	dummyData := []byte("\x00\x00\x00\x18ftypmp42")
+	_, err = tempFile.Write(dummyData)
+	assert.NoError(t, err)
+	tempFile.Close()
+
+	req := &Request{}
+	err = WithVideoFile(tempFile.Name())(req)
+	assert.NoError(t, err)
+	assert.Len(t, req.Messages, 1)
+	assert.Len(t, req.Messages[0].Content, 1)
+
+	part := req.Messages[0].Content[0]
+	assert.Equal(t, "video_url", part.Type)
+	assert.NotNil(t, part.VideoURL)
+	assert.Contains(t, part.VideoURL.URL, ";base64,")
+
+	jsonData, err := json.Marshal(req)
+	assert.NoError(t, err)
+
+	var parsed map[string]interface{}
+	err = json.Unmarshal(jsonData, &parsed)
+	assert.NoError(t, err)
+
+	messages := parsed["messages"].([]interface{})
+	msg := messages[0].(map[string]interface{})
+	content := msg["content"].([]interface{})
+	contentPart := content[0].(map[string]interface{})
+	videoURL := contentPart["video_url"].(map[string]interface{})
+	assert.Equal(t, "video_url", contentPart["type"])
+	assert.Contains(t, videoURL["url"], "data:video/mp4;base64,")
+}
+
+func TestWithVideoFile_ReadError(t *testing.T) {
+	req := &Request{}
+	err := WithVideoFile("/nonexistent/path/to/video.mp4")(req)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "read video file")
+	assert.Empty(t, req.Messages)
+}
+
+func TestWithVideoURL(t *testing.T) {
+	req := &Request{}
+	err := WithVideoURL("https://example.com/video.mp4")(req)
+
+	assert.NoError(t, err)
+	assert.Len(t, req.Messages, 1)
+	assert.Len(t, req.Messages[0].Content, 1)
+
+	part := req.Messages[0].Content[0]
+	assert.Equal(t, "video_url", part.Type)
+	assert.NotNil(t, part.VideoURL)
+	assert.Equal(t, "https://example.com/video.mp4", part.VideoURL.URL)
+}
+
+func TestWithVideoURL_AppendsToExistingMessage(t *testing.T) {
+	req := &Request{
+		Messages: []Message{
+			{Role: "user", Content: []ContentPart{{Type: "text", Text: "describe this"}}},
+		},
+	}
+
+	err := WithVideoURL("data:video/mp4;base64,dmllbw==")(req)
+
+	assert.NoError(t, err)
+	assert.Len(t, req.Messages, 1)
+	assert.Len(t, req.Messages[0].Content, 2)
+	assert.Equal(t, "video_url", req.Messages[0].Content[1].Type)
+	assert.Equal(t, "data:video/mp4;base64,dmllbw==", req.Messages[0].Content[1].VideoURL.URL)
+}
+
+func TestWithVideoBytes(t *testing.T) {
+	req := &Request{}
+	err := WithVideoBytes([]byte("video-data"), "video/webm")(req)
+
+	assert.NoError(t, err)
+	assert.Len(t, req.Messages, 1)
+	assert.Len(t, req.Messages[0].Content, 1)
+
+	part := req.Messages[0].Content[0]
+	assert.Equal(t, "video_url", part.Type)
+	assert.Equal(t, "data:video/webm;base64,dmlkZW8tZGF0YQ==", part.VideoURL.URL)
+}
+
+func TestWithVideoBytes_EmptyDataNoop(t *testing.T) {
+	req := &Request{}
+	err := WithVideoBytes(nil, "video/mp4")(req)
+
+	assert.NoError(t, err)
+	assert.Empty(t, req.Messages)
 }
 
 func TestWithFile(t *testing.T) {
-    testCases := []struct {
-        filename string
-        mimeType string
-    }{
-        {"report.pdf", "application/pdf"},
-        {"document.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"},
-        {"data.csv", "text/csv"},
-        {"config.json", "application/json"},
-        {"notes.txt", "text/plain"},
+	testCases := []struct {
+		filename string
+		mimeType string
+	}{
+		{"report.pdf", "application/pdf"},
+		{"document.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"},
+		{"data.csv", "text/csv"},
+		{"config.json", "application/json"},
+		{"notes.txt", "text/plain"},
 		{"file.html", "text/html"},
-    }
+	}
 
-    for _, tc := range testCases {
-        t.Run(tc.filename, func(t *testing.T) {
-            tempFile, err := os.CreateTemp("", tc.filename)
-            assert.NoError(t, err)
-            defer os.Remove(tempFile.Name())
+	for _, tc := range testCases {
+		t.Run(tc.filename, func(t *testing.T) {
+			tempFile, err := os.CreateTemp("", tc.filename)
+			assert.NoError(t, err)
+			defer os.Remove(tempFile.Name())
 
 			_, err = tempFile.Write([]byte("test-data"))
-			assert.NoError(t, err)            
+			assert.NoError(t, err)
 			tempFile.Close()
 
-            req := &Request{}
-            err = WithFile(tempFile.Name(), tc.mimeType)(req)
+			req := &Request{}
+			err = WithFile(tempFile.Name(), tc.mimeType)(req)
 
-            assert.NoError(t, err)
-            assert.Len(t, req.Messages, 1)
-            assert.Len(t, req.Messages[0].Content, 1)
+			assert.NoError(t, err)
+			assert.Len(t, req.Messages, 1)
+			assert.Len(t, req.Messages[0].Content, 1)
 
-            part := req.Messages[0].Content[0]
-            assert.Equal(t, "file", part.Type)
-            assert.NotNil(t, part.InputFile)
+			part := req.Messages[0].Content[0]
+			assert.Equal(t, "file", part.Type)
+			assert.NotNil(t, part.InputFile)
 
-            expectedBase64 := base64.StdEncoding.EncodeToString([]byte("test-data"))
-            expectedFileData := fmt.Sprintf("data:%s;base64,%s", tc.mimeType, expectedBase64)
-            assert.Equal(t, expectedFileData, part.InputFile.FileData)
+			expectedBase64 := base64.StdEncoding.EncodeToString([]byte("test-data"))
+			expectedFileData := fmt.Sprintf("data:%s;base64,%s", tc.mimeType, expectedBase64)
+			assert.Equal(t, expectedFileData, part.InputFile.FileData)
 
-			// Validate JSON serialization 
-            jsonData, err := json.Marshal(req)
-            assert.NoError(t, err)
+			// Validate JSON serialization
+			jsonData, err := json.Marshal(req)
+			assert.NoError(t, err)
 
-            var parsed map[string]interface{}
-            err = json.Unmarshal(jsonData, &parsed)
-            assert.NoError(t, err)
+			var parsed map[string]interface{}
+			err = json.Unmarshal(jsonData, &parsed)
+			assert.NoError(t, err)
 
-            messages := parsed["messages"].([]interface{})
-            msg := messages[0].(map[string]interface{})
-            content := msg["content"].([]interface{})
-            contentPart := content[0].(map[string]interface{})
+			messages := parsed["messages"].([]interface{})
+			msg := messages[0].(map[string]interface{})
+			content := msg["content"].([]interface{})
+			contentPart := content[0].(map[string]interface{})
 
-            assert.Equal(t, "file", contentPart["type"])
-            file := contentPart["file"].(map[string]interface{})
-            assert.Contains(t, file["file_data"].(string), fmt.Sprintf("data:%s;base64,", tc.mimeType))
-        })
-    }
+			assert.Equal(t, "file", contentPart["type"])
+			file := contentPart["file"].(map[string]interface{})
+			assert.Contains(t, file["file_data"].(string), fmt.Sprintf("data:%s;base64,", tc.mimeType))
+		})
+	}
 }
 
 func TestWithAudioFile_ReadError(t *testing.T) {

--- a/sdk/go/ai/openrouter_media.go
+++ b/sdk/go/ai/openrouter_media.go
@@ -22,11 +22,13 @@ import (
 var validJobID = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
 const (
-	defaultOpenRouterBaseURL  = "https://openrouter.ai/api/v1"
-	defaultVideoPollInterval  = 30 * time.Second
-	defaultVideoTimeout       = 10 * time.Minute
-	defaultTTSSampleRate      = 24000
-	openRouterModelMetaTTL    = 30 * time.Minute
+	defaultOpenRouterBaseURL    = "https://openrouter.ai/api/v1"
+	defaultVideoPollInterval    = 30 * time.Second
+	defaultVideoTimeout         = 10 * time.Minute
+	defaultTTSSampleRate        = 24000
+	defaultOpenRouterImageModel = "google/gemini-3.1-flash-image-preview"
+	defaultOpenRouterTTSModel   = "hexgrad/kokoro-82m"
+	openRouterModelMetaTTL      = 30 * time.Minute
 )
 
 // modelMeta holds the architecture metadata for an OpenRouter model.
@@ -79,6 +81,13 @@ func (p *OpenRouterMediaProvider) baseURL() string {
 // stripPrefix removes the "openrouter/" prefix from model names.
 func stripPrefix(model string) string {
 	return strings.TrimPrefix(model, "openrouter/")
+}
+
+func defaultVoiceForModel(model string) string {
+	if stripPrefix(model) == defaultOpenRouterTTSModel {
+		return "af_alloy"
+	}
+	return "alloy"
 }
 
 // SeedModelMeta lets callers (or tests) pre-populate the metadata cache for a
@@ -166,8 +175,8 @@ func wrapPCM16AsWAV(pcm []byte, sampleRate int) []byte {
 	_ = binary.Write(buf, binary.LittleEndian, uint32(36+dataSize))
 	buf.WriteString("WAVE")
 	buf.WriteString("fmt ")
-	_ = binary.Write(buf, binary.LittleEndian, uint32(16))           // PCM fmt chunk size
-	_ = binary.Write(buf, binary.LittleEndian, uint16(1))            // PCM format
+	_ = binary.Write(buf, binary.LittleEndian, uint32(16)) // PCM fmt chunk size
+	_ = binary.Write(buf, binary.LittleEndian, uint16(1))  // PCM format
 	_ = binary.Write(buf, binary.LittleEndian, channels)
 	_ = binary.Write(buf, binary.LittleEndian, uint32(sampleRate))
 	_ = binary.Write(buf, binary.LittleEndian, byteRate)
@@ -417,7 +426,7 @@ func (p *OpenRouterMediaProvider) buildVideoResponse(ctx context.Context, status
 func (p *OpenRouterMediaProvider) GenerateImage(ctx context.Context, req ImageRequest) (*MediaResponse, error) {
 	model := req.Model
 	if model == "" {
-		model = "openai/gpt-image-1"
+		model = defaultOpenRouterImageModel
 	}
 	model = stripPrefix(model)
 
@@ -575,9 +584,13 @@ func (p *OpenRouterMediaProvider) GenerateAudio(ctx context.Context, req AudioRe
 
 	model := req.Model
 	if model == "" {
-		model = "openai/gpt-4o-mini-tts"
+		model = defaultOpenRouterTTSModel
 	}
 	model = stripPrefix(model)
+	voice := req.Voice
+	if voice == "" {
+		voice = defaultVoiceForModel(model)
+	}
 
 	requestedFormat := req.Format
 	if requestedFormat == "" {
@@ -590,7 +603,7 @@ func (p *OpenRouterMediaProvider) GenerateAudio(ctx context.Context, req AudioRe
 		!containsString(meta.OutputModalities, "audio")
 
 	if useSpeech {
-		return p.generateAudioViaSpeechEndpoint(ctx, model, req.Text, req.Voice, requestedFormat, &req)
+		return p.generateAudioViaSpeechEndpoint(ctx, model, req.Text, voice, requestedFormat, &req)
 	}
 
 	// Chat-completions audio modality (gpt-audio family). Streaming on OpenAI
@@ -600,11 +613,7 @@ func (p *OpenRouterMediaProvider) GenerateAudio(ctx context.Context, req AudioRe
 		wireFormat = "pcm16"
 	}
 	audioConfig := map[string]string{"format": wireFormat}
-	if req.Voice != "" {
-		audioConfig["voice"] = req.Voice
-	} else {
-		audioConfig["voice"] = "alloy"
-	}
+	audioConfig["voice"] = voice
 	payload := map[string]any{
 		"model": model,
 		"messages": []map[string]any{

--- a/sdk/go/ai/openrouter_media_coverage_test.go
+++ b/sdk/go/ai/openrouter_media_coverage_test.go
@@ -161,6 +161,7 @@ func TestGenerateImageWithImageConfig(t *testing.T) {
 		ImageConfig: &ImageConfig{AspectRatio: "1:1", ImageSize: "512"},
 	})
 	require.NoError(t, err)
+	assert.Equal(t, defaultOpenRouterImageModel, got["model"])
 	assert.NotNil(t, got["image_config"])
 }
 

--- a/sdk/go/ai/openrouter_media_routing_test.go
+++ b/sdk/go/ai/openrouter_media_routing_test.go
@@ -168,6 +168,25 @@ func TestGenerateAudioSpeechDefaultsVoiceToAlloy(t *testing.T) {
 	assert.Equal(t, "alloy", seen["voice"])
 }
 
+func TestGenerateAudioDefaultsToLiveKokoroModelAndVoice(t *testing.T) {
+	var seen map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&seen))
+		w.Header().Set("Content-Type", "audio/mpeg")
+		_, _ = w.Write([]byte("x"))
+	}))
+	defer srv.Close()
+
+	p := &OpenRouterMediaProvider{APIKey: "k", BaseURL: srv.URL, Client: srv.Client()}
+	p.SeedModelMeta("hexgrad/kokoro-82m", []string{"speech"}, []string{"text"})
+	_, err := p.GenerateAudio(context.Background(), AudioRequest{
+		Text: "hi", Format: "mp3",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "hexgrad/kokoro-82m", seen["model"])
+	assert.Equal(t, "af_alloy", seen["voice"])
+}
+
 // =============================================================================
 // Video — first/last frame + auth-aware download
 // =============================================================================

--- a/sdk/go/ai/request.go
+++ b/sdk/go/ai/request.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 )
 
 // Message represents a chat message.
@@ -78,6 +79,7 @@ type ContentPart struct {
 	Type       string          `json:"type"` // "text" or "image_url" or "input_audio" or "file"
 	Text       string          `json:"text,omitempty"`
 	ImageURL   *ImageURLData   `json:"image_url,omitempty"`
+	VideoURL   *VideoURLData   `json:"video_url,omitempty"`
 	InputAudio *InputAudioData `json:"input_audio,omitempty"`
 	InputFile  *InputFileData  `json:"file,omitempty"`
 }
@@ -86,6 +88,11 @@ type ContentPart struct {
 type ImageURLData struct {
 	URL    string `json:"url"`
 	Detail string `json:"detail,omitempty"`
+}
+
+// VideoURLData holds the URL or data URL for video content parts.
+type VideoURLData struct {
+	URL string `json:"url"`
 }
 
 // InputAudioData holds the encoded data and the format for the audio content parts.
@@ -378,6 +385,68 @@ func WithImageBytes(data []byte, mimeType string) Option {
 			ImageURL: &ImageURLData{
 				URL: "data:" + mimeType + ";base64," + encoded,
 			},
+		})
+
+		return nil
+	}
+}
+
+// WithVideoFile attaches a video from a local file.
+func WithVideoFile(path string) Option {
+	return func(r *Request) error {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read video file: %w", err)
+		}
+
+		mimeType := detectMIMEType(path)
+		if !strings.HasPrefix(mimeType, "video/") {
+			mimeType = "video/mp4"
+		}
+		return WithVideoBytes(data, mimeType)(r)
+	}
+}
+
+// WithVideoURL attaches a video from a remote URL or data URL.
+func WithVideoURL(url string) Option {
+	return func(r *Request) error {
+		if len(r.Messages) == 0 {
+			r.Messages = append(r.Messages, Message{
+				Role:    "user",
+				Content: []ContentPart{},
+			})
+		}
+
+		last := &r.Messages[len(r.Messages)-1]
+		last.Content = append(last.Content, ContentPart{
+			Type:     "video_url",
+			VideoURL: &VideoURLData{URL: url},
+		})
+
+		return nil
+	}
+}
+
+// WithVideoBytes attaches a video from raw bytes.
+func WithVideoBytes(data []byte, mimeType string) Option {
+	return func(r *Request) error {
+		if len(data) == 0 {
+			return nil
+		}
+
+		encoded := base64.StdEncoding.EncodeToString(data)
+
+		if len(r.Messages) == 0 {
+			r.Messages = append(r.Messages, Message{
+				Role:    "user",
+				Content: []ContentPart{},
+			})
+		}
+
+		last := &r.Messages[len(r.Messages)-1]
+		last.Content = append(last.Content, ContentPart{
+			Type:     "video_url",
+			VideoURL: &VideoURLData{URL: "data:" + mimeType + ";base64," + encoded},
 		})
 
 		return nil

--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -3580,7 +3580,7 @@ class Agent(FastAPI):
 
         Supported Providers:
         - LiteLLM: DALL-E models like "dall-e-3", "dall-e-2"
-        - OpenRouter: Models like "openrouter/google/gemini-2.5-flash-image-preview"
+        - OpenRouter: Models like "openrouter/google/gemini-3.1-flash-image-preview"
 
         Args:
             prompt (str): Text description of the image to generate.
@@ -3604,7 +3604,7 @@ class Agent(FastAPI):
             # OpenRouter with Gemini
             result = await app.ai_generate_image(
                 "A futuristic cityscape",
-                model="openrouter/google/gemini-2.5-flash-image-preview"
+                model="openrouter/google/gemini-3.1-flash-image-preview"
             )
             ```
         """

--- a/sdk/python/agentfield/agent_ai.py
+++ b/sdk/python/agentfield/agent_ai.py
@@ -493,16 +493,34 @@ class AgentAI:
         if safe_input_limit < 1000:
             safe_input_limit = 1000
 
-        # Count actual prompt tokens using LiteLLM's token counter
+        def has_untrimmable_media(messages_to_check: List[dict]) -> bool:
+            for message in messages_to_check:
+                content = message.get("content")
+                if not isinstance(content, list):
+                    continue
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") in {
+                        "input_audio",
+                        "file",
+                    }:
+                        return True
+            return False
+
+        skip_trimming = has_untrimmable_media(messages)
+
+        # Count actual prompt tokens using LiteLLM's token counter. LiteLLM's
+        # trimming utilities do not currently handle all media parts and can
+        # dump base64 payloads in their error logs, so media payloads pass
+        # through unchanged.
         try:
-            actual_prompt_tokens = token_counter(
-                model=final_config.model, messages=messages
+            actual_prompt_tokens = (
+                0
+                if skip_trimming
+                else token_counter(model=final_config.model, messages=messages)
             )
         except Exception as e:
-            log_debug(f"Could not count prompt tokens, proceeding with trimming: {e}")
-            actual_prompt_tokens = (
-                safe_input_limit + 1
-            )  # Force trimming if we can't count
+            log_debug(f"Could not count prompt tokens; skipping trimming: {e}")
+            actual_prompt_tokens = 0
 
         # Only trim if necessary based on actual token count
         if actual_prompt_tokens > safe_input_limit:
@@ -829,7 +847,7 @@ class AgentAI:
 
     def _process_multimodal_args(self, args: tuple) -> List[Dict[str, Any]]:
         """Process multimodal arguments into LiteLLM-compatible message format"""
-        from agentfield.multimodal import Audio, File, Image, Text
+        from agentfield.multimodal import Audio, File, Image, Text, Video
 
         messages = []
         user_content = []
@@ -857,6 +875,9 @@ class AgentAI:
                 user_content.append(
                     {"type": "input_audio", "input_audio": arg.input_audio}
                 )
+
+            elif isinstance(arg, Video):
+                user_content.append({"type": "video_url", "video_url": arg.video_url})
 
             elif isinstance(arg, File):
                 # For now, treat files as text references
@@ -984,6 +1005,32 @@ class AgentAI:
                             {"type": "text", "text": "[Audio data provided]"}
                         )
 
+                elif detected_type == "video_file":
+                    try:
+                        import base64
+
+                        with open(arg, "rb") as f:
+                            video_data = base64.b64encode(f.read()).decode()
+                        ext = os.path.splitext(arg)[1].lower()
+                        mime_type = AgentUtils.get_mime_type(ext)
+                        data_url = f"data:{mime_type};base64,{video_data}"
+                        user_content.append(
+                            {"type": "video_url", "video_url": {"url": data_url}}
+                        )
+                    except Exception as e:
+                        log_warn(f"Could not read video file {arg}: {e}")
+                        user_content.append(
+                            {
+                                "type": "text",
+                                "text": f"[Video file: {os.path.basename(arg)}]",
+                            }
+                        )
+
+                elif detected_type == "video_base64":
+                    user_content.append(
+                        {"type": "video_url", "video_url": {"url": arg}}
+                    )
+
                 elif detected_type == "image_bytes":
                     # Convert bytes to base64 data URL
                     try:
@@ -1054,6 +1101,8 @@ class AgentAI:
                         "image",
                         "image_url",
                         "audio",
+                        "video",
+                        "video_url",
                     ]:
                         if key in arg:
                             if key == "text":
@@ -1082,6 +1131,18 @@ class AgentAI:
                                     # Assume it's a file path or URL
                                     user_content.append(
                                         {"type": "text", "text": f"[Audio: {arg[key]}]"}
+                                    )
+                            elif key in ["video", "video_url"]:
+                                if isinstance(arg[key], dict):
+                                    user_content.append(
+                                        {"type": "video_url", "video_url": arg[key]}
+                                    )
+                                else:
+                                    user_content.append(
+                                        {
+                                            "type": "video_url",
+                                            "video_url": {"url": arg[key]},
+                                        }
                                     )
 
                 elif detected_type == "message_dict":
@@ -1413,7 +1474,7 @@ class AgentAI:
 
         Supports both LiteLLM and OpenRouter providers:
         - LiteLLM: Use model names like "dall-e-3", "azure/dall-e-3", "bedrock/stability.stable-diffusion-xl"
-        - OpenRouter: Use model names with "openrouter/" prefix like "openrouter/google/gemini-2.5-flash-image-preview"
+        - OpenRouter: Use model names with "openrouter/" prefix like "openrouter/google/gemini-3.1-flash-image-preview"
 
         Args:
             prompt: Text prompt for image generation
@@ -1435,7 +1496,7 @@ class AgentAI:
             # OpenRouter (Gemini)
             result = await agent.ai_with_vision(
                 "A futuristic city",
-                model="openrouter/google/gemini-2.5-flash-image-preview",
+                model="openrouter/google/gemini-3.1-flash-image-preview",
                 image_config={"aspect_ratio": "16:9"}
             )
 
@@ -1528,7 +1589,7 @@ class AgentAI:
 
         Supported Providers:
         - LiteLLM: DALL-E models like "dall-e-3", "dall-e-2"
-        - OpenRouter: Models like "openrouter/google/gemini-2.5-flash-image-preview"
+        - OpenRouter: Models like "openrouter/google/gemini-3.1-flash-image-preview"
         - Fal.ai: Models like "fal-ai/flux/dev", "fal-ai/flux/schnell", "fal-ai/recraft-v3"
 
         Args:
@@ -1556,7 +1617,7 @@ class AgentAI:
             # OpenRouter with Gemini
             result = await app.ai_generate_image(
                 "A futuristic cityscape at night",
-                model="openrouter/google/gemini-2.5-flash-image-preview",
+                model="openrouter/google/gemini-3.1-flash-image-preview",
                 image_config={"aspect_ratio": "16:9"}
             )
 
@@ -1722,7 +1783,8 @@ class AgentAI:
 
         Supported Providers:
         - Fal.ai: Models like "fal-ai/minimax-video/image-to-video",
-          "fal-ai/kling-video/v1/standard", "fal-ai/luma-dream-machine"
+          "fal-ai/kling-video/v1/standard/text-to-video",
+          "fal-ai/luma-dream-machine"
 
         Args:
             prompt: Text description for the video
@@ -1748,7 +1810,7 @@ class AgentAI:
             # Text to video
             result = await app.ai_generate_video(
                 "A cat playing with yarn",
-                model="fal-ai/kling-video/v1/standard"
+                model="fal-ai/kling-video/v1/standard/text-to-video"
             )
 
             # Luma Dream Machine

--- a/sdk/python/agentfield/agent_utils.py
+++ b/sdk/python/agentfield/agent_utils.py
@@ -22,6 +22,8 @@ class AgentUtils:
                 return "image_base64"
             elif input_data.startswith("data:audio"):
                 return "audio_base64"
+            elif input_data.startswith("data:video"):
+                return "video_base64"
             elif os.path.isfile(input_data):
                 ext = os.path.splitext(input_data)[1].lower()
                 if ext in [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tiff"]:
@@ -120,6 +122,14 @@ class AgentUtils:
             ".ogg": "audio/ogg",
             ".flac": "audio/flac",
             ".aac": "audio/aac",
+            ".mp4": "video/mp4",
+            ".mpeg": "video/mpeg",
+            ".mpg": "video/mpeg",
+            ".mov": "video/quicktime",
+            ".webm": "video/webm",
+            ".avi": "video/x-msvideo",
+            ".wmv": "video/x-ms-wmv",
+            ".flv": "video/x-flv",
             ".pdf": "application/pdf",
             ".doc": "application/msword",
             ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",

--- a/sdk/python/agentfield/media_providers.py
+++ b/sdk/python/agentfield/media_providers.py
@@ -166,7 +166,7 @@ class FalProvider(MediaProvider):
     Video Models:
     - fal-ai/minimax-video/image-to-video - Image to video
     - fal-ai/luma-dream-machine - Luma Dream Machine
-    - fal-ai/kling-video/v1/standard - Kling 1.0
+    - fal-ai/kling-video/v1/standard/text-to-video - Kling 1.0 text to video
 
     Audio Models:
     - fal-ai/whisper - Speech to text
@@ -429,6 +429,10 @@ class FalProvider(MediaProvider):
 
         # Merge additional kwargs
         fal_args.update(kwargs)
+        response_format = kwargs.get("output_format") or kwargs.get(
+            "response_format"
+        )
+        output_format = response_format if isinstance(response_format, str) else format
 
         try:
             result = await client.subscribe_async(
@@ -455,7 +459,7 @@ class FalProvider(MediaProvider):
                 audio = AudioOutput(
                     url=audio_url,
                     data=None,
-                    format=format,
+                    format=output_format,
                 )
 
             return MultimodalResponse(
@@ -504,7 +508,7 @@ class FalProvider(MediaProvider):
             # Text to video
             result = await provider.generate_video(
                 "A cat playing with yarn",
-                model="fal-ai/kling-video/v1/standard"
+                model="fal-ai/kling-video/v1/standard/text-to-video"
             )
         """
         client = self._get_client()
@@ -818,7 +822,7 @@ class OpenRouterProvider(MediaProvider):
     Uses the modalities parameter with chat completions API for image generation.
 
     Supports models like:
-    - google/gemini-2.5-flash-image-preview
+    - google/gemini-3.1-flash-image-preview
     - Other OpenRouter models with image generation capabilities
     """
 
@@ -905,7 +909,8 @@ class OpenRouterProvider(MediaProvider):
 
         Args:
             prompt: Text description for image generation.
-            model: OpenRouter model (defaults to ``google/gemini-2.5-flash-image``).
+            model: OpenRouter model (defaults to
+                ``google/gemini-3.1-flash-image-preview``).
             size: Image dimensions (model-specific).
             quality: Quality hint (model-specific).
             image_urls: Optional reference / source images for image+text→image
@@ -918,28 +923,105 @@ class OpenRouterProvider(MediaProvider):
             extra: Arbitrary passthrough fields merged into the completion
                 request (e.g. model-specific switches).
         """
-        from agentfield import vision
+        import os
 
-        model = model or "openrouter/google/gemini-2.5-flash-image"
+        import aiohttp
 
-        # Ensure model has openrouter prefix
-        if not model.startswith("openrouter/"):
-            model = f"openrouter/{model}"
+        api_key = self._api_key or os.environ.get("OPENROUTER_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "OpenRouter API key required. Set OPENROUTER_API_KEY env var "
+                "or pass api_key to OpenRouterProvider."
+            )
 
+        model = model or "openrouter/google/gemini-3.1-flash-image-preview"
+
+        send_model = self._strip_or_prefix(model)
+
+        user_content: Any = prompt
         if image_urls:
-            kwargs["image_urls"] = image_urls
-        if extra:
-            kwargs.update(extra)
+            user_content = [{"type": "text", "text": prompt}] + [
+                {"type": "image_url", "image_url": {"url": url}}
+                for url in image_urls
+            ]
 
-        return await vision.generate_image_openrouter(
-            prompt=prompt,
-            model=model,
-            size=size,
-            quality=quality,
-            style=None,
-            response_format="url",
-            image_config=image_config,
-            **kwargs,
+        body: Dict[str, Any] = {
+            "model": send_model,
+            "messages": [{"role": "user", "content": user_content}],
+            "modalities": ["image"],
+        }
+        if size:
+            body["size"] = size
+        if quality:
+            body["quality"] = quality
+        if image_config is not None:
+            body["image_config"] = image_config
+        if extra:
+            body.update(extra)
+        if kwargs:
+            body.update(kwargs)
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        timeout = aiohttp.ClientTimeout(total=120.0)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                headers=headers,
+                json=body,
+            ) as resp:
+                if resp.status >= 400:
+                    detail = await resp.text()
+                    raise RuntimeError(
+                        f"OpenRouter image generation failed ({resp.status}): "
+                        f"{detail[:500]}"
+                    )
+                payload = await resp.json()
+
+        images: List[ImageOutput] = []
+        text_content = ""
+
+        def add_image_url(url: Optional[str]) -> None:
+            if not url:
+                return
+            b64_json = None
+            if url.startswith("data:image/") and "base64," in url:
+                b64_json = url.split("base64,", 1)[1]
+            images.append(
+                ImageOutput(url=url, b64_json=b64_json, revised_prompt=None)
+            )
+
+        for choice in payload.get("choices", []) or []:
+            message = choice.get("message", {}) or {}
+            content = message.get("content")
+            if isinstance(content, str):
+                text_content += content
+            elif isinstance(content, list):
+                for part in content:
+                    if not isinstance(part, dict):
+                        continue
+                    if part.get("type") == "text":
+                        text_content += str(part.get("text") or "")
+                    elif part.get("type") in ("image_url", "image"):
+                        image_url = part.get("image_url") or {}
+                        if isinstance(image_url, dict):
+                            add_image_url(image_url.get("url"))
+            for img in message.get("images", []) or []:
+                if not isinstance(img, dict):
+                    continue
+                image_url = img.get("image_url") or {}
+                if isinstance(image_url, dict):
+                    add_image_url(image_url.get("url"))
+
+        return MultimodalResponse(
+            text=text_content or prompt,
+            audio=None,
+            images=images,
+            files=[],
+            raw_response=payload,
         )
 
     async def generate_video(
@@ -1312,7 +1394,7 @@ class OpenRouterProvider(MediaProvider):
         Args:
             text: Text to convert to speech
             model: OpenRouter model ID (e.g., "openai/gpt-audio-mini",
-                "hexgrad/kokoro-82m"). Default: ``openai/gpt-4o-mini-tts``.
+                "hexgrad/kokoro-82m"). Default: ``hexgrad/kokoro-82m``.
             voice: Voice identifier (model-specific — e.g. ``alloy`` for
                 OpenAI, ``af_bella`` for Kokoro)
             format: Audio format (wav, mp3, flac, opus, pcm16). ``wav`` is
@@ -1335,7 +1417,9 @@ class OpenRouterProvider(MediaProvider):
                 "OpenRouter API key required. Set OPENROUTER_API_KEY env var or pass api_key."
             )
 
-        send_model = self._strip_or_prefix(model or "openai/gpt-4o-mini-tts")
+        send_model = self._strip_or_prefix(model or "hexgrad/kokoro-82m")
+        if send_model == "hexgrad/kokoro-82m" and voice == "alloy":
+            voice = "af_alloy"
 
         audio_format = format
         supported_formats = {"wav", "mp3", "flac", "opus", "pcm16", "pcm"}

--- a/sdk/python/agentfield/multimodal.py
+++ b/sdk/python/agentfield/multimodal.py
@@ -95,6 +95,42 @@ class Audio(BaseModel):
             raise ImportError("URL download requires requests: pip install requests")
 
 
+class Video(BaseModel):
+    """Represents video content in a multimodal prompt."""
+
+    type: Literal["video_url"] = "video_url"
+    video_url: dict = Field(
+        ...,
+        description="Video input data with a 'url' field containing an http(s) URL or data URL.",
+    )
+
+    @classmethod
+    def from_file(cls, file_path: Union[str, Path]) -> "Video":
+        """Create Video from local file by converting to a base64 data URL."""
+        file_path = Path(file_path)
+        if not file_path.exists():
+            raise FileNotFoundError(f"Video file not found: {file_path}")
+
+        with open(file_path, "rb") as f:
+            video_data = base64.b64encode(f.read()).decode()
+
+        ext = file_path.suffix.lower()
+        mime_types = {
+            ".mp4": "video/mp4",
+            ".mpeg": "video/mpeg",
+            ".mpg": "video/mpeg",
+            ".mov": "video/quicktime",
+            ".webm": "video/webm",
+        }
+        mime_type = mime_types.get(ext, "video/mp4")
+        return cls(video_url={"url": f"data:{mime_type};base64,{video_data}"})
+
+    @classmethod
+    def from_url(cls, url: str) -> "Video":
+        """Create Video from URL."""
+        return cls(video_url={"url": url})
+
+
 class File(BaseModel):
     """Represents a generic file content in a multimodal prompt."""
 
@@ -132,7 +168,7 @@ class File(BaseModel):
 
 
 # Union type for all multimodal content types
-MultimodalContent = Union[Text, Image, Audio, File]
+MultimodalContent = Union[Text, Image, Audio, Video, File]
 
 
 # Convenience functions for creating multimodal content
@@ -159,6 +195,16 @@ def audio_from_file(file_path: Union[str, Path], format: Optional[str] = None) -
 def audio_from_url(url: str, format: str = "wav") -> Audio:
     """Create audio content from URL."""
     return Audio.from_url(url, format)
+
+
+def video_from_file(file_path: Union[str, Path]) -> Video:
+    """Create video content from local file."""
+    return Video.from_file(file_path)
+
+
+def video_from_url(url: str) -> Video:
+    """Create video content from URL."""
+    return Video.from_url(url)
 
 
 def file_from_path(

--- a/sdk/python/agentfield/vision.py
+++ b/sdk/python/agentfield/vision.py
@@ -114,7 +114,7 @@ async def generate_image_openrouter(
     LiteLLM's dedicated image generation API.
 
     Supported models:
-    - google/gemini-2.5-flash-image-preview
+    - google/gemini-3.1-flash-image-preview
     - And other OpenRouter models with image generation capabilities
 
     Args:
@@ -162,7 +162,7 @@ async def generate_image_openrouter(
     # OpenRouter uses chat completions with modalities parameter
     # Request only image output — works for both image-only models (e.g.
     # x-ai/grok-imagine-image-quality) and dual-output models (e.g.
-    # google/gemini-2.5-flash-image). Image-only models 404 when "text" is
+    # google/gemini-3.1-flash-image-preview). Image-only models 404 when "text" is
     # also requested.
     completion_params = {
         "model": model,

--- a/sdk/python/tests/test_media_providers.py
+++ b/sdk/python/tests/test_media_providers.py
@@ -226,6 +226,28 @@ class TestFalProvider:
         assert result.files[0].url == "https://fal.media/video.mp4"
 
     @pytest.mark.asyncio
+    async def test_fal_provider_generate_audio_uses_output_format(
+        self, fal_provider, monkeypatch
+    ):
+        """FalProvider.generate_audio should label model-specific output_format."""
+        mock_result = {"audio": {"url": "https://fal.media/audio.mp3"}}
+
+        mock_client = MagicMock()
+        mock_client.subscribe_async = AsyncMock(return_value=mock_result)
+        monkeypatch.setattr(fal_provider, "_client", mock_client)
+
+        result = await fal_provider.generate_audio(
+            text="Say hello",
+            model="fal-ai/gemini-tts",
+            prompt="Say hello",
+            output_format="mp3",
+        )
+
+        assert result.has_audio
+        assert result.audio.url == "https://fal.media/audio.mp3"
+        assert result.audio.format == "mp3"
+
+    @pytest.mark.asyncio
     async def test_fal_provider_transcribe_audio(self, fal_provider, monkeypatch):
         """FalProvider.transcribe_audio should return transcription."""
         mock_result = {"text": "Hello world, this is a test."}

--- a/sdk/python/tests/test_multimodal.py
+++ b/sdk/python/tests/test_multimodal.py
@@ -1,4 +1,9 @@
-from agentfield.multimodal import image_from_file, audio_from_file, file_from_path
+from agentfield.multimodal import (
+    audio_from_file,
+    file_from_path,
+    image_from_file,
+    video_from_file,
+)
 
 
 def test_image_from_file_and_audio_from_file(tmp_path):
@@ -16,6 +21,12 @@ def test_image_from_file_and_audio_from_file(tmp_path):
     au = audio_from_file(wav)
     assert au.type == "input_audio"
     assert "data" in au.input_audio
+
+    mp4 = tmp_path / "v.mp4"
+    mp4.write_bytes(b"\x00\x00\x00\x18ftypmp42")
+    vi = video_from_file(mp4)
+    assert vi.type == "video_url"
+    assert vi.video_url["url"].startswith("data:video/mp4;base64,")
 
 
 def test_file_from_path(tmp_path):

--- a/sdk/typescript/src/ai/OpenRouterMediaProvider.ts
+++ b/sdk/typescript/src/ai/OpenRouterMediaProvider.ts
@@ -21,6 +21,8 @@ const API_TIMEOUT = 30_000; // 30s for API calls
 const DOWNLOAD_TIMEOUT = 120_000; // 120s for video download
 
 const MAX_CONSECUTIVE_PARSE_ERRORS = 50;
+const DEFAULT_IMAGE_MODEL = 'google/gemini-3.1-flash-image-preview';
+const DEFAULT_TTS_MODEL = 'hexgrad/kokoro-82m';
 
 /** Module-level WeakMap to keep API key off the instance (CR-03). */
 const apiKeyStore = new WeakMap<OpenRouterMediaProvider, string>();
@@ -37,6 +39,10 @@ function emptyMediaResponse(raw: unknown): MediaResponse {
 
 function stripPrefix(model: string): string {
   return model.startsWith('openrouter/') ? model.slice('openrouter/'.length) : model;
+}
+
+function defaultVoiceForModel(model: string): string {
+  return stripPrefix(model) === 'hexgrad/kokoro-82m' ? 'af_alloy' : 'alloy';
 }
 
 /**
@@ -358,7 +364,7 @@ export class OpenRouterMediaProvider implements MediaProvider {
   // ── Image ──────────────────────────────────────────────────────────
 
   async generateImage(request: ImageRequest): Promise<MediaResponse> {
-    const model = stripPrefix(request.model ?? 'openai/gpt-image-1');
+    const model = stripPrefix(request.model ?? DEFAULT_IMAGE_MODEL);
 
     // Request only image output — works for both image-only models (e.g.
     // x-ai/grok-imagine-image-quality) and dual-output models. Image-only
@@ -465,7 +471,8 @@ export class OpenRouterMediaProvider implements MediaProvider {
   // ── Audio ──────────────────────────────────────────────────────────
 
   async generateAudio(request: AudioRequest): Promise<MediaResponse> {
-    const model = stripPrefix(request.model ?? 'openai/gpt-4o-mini-tts');
+    const model = stripPrefix(request.model ?? DEFAULT_TTS_MODEL);
+    const voice = request.voice ?? defaultVoiceForModel(model);
     const requestedFormat = request.format ?? 'wav';
 
     // Route based on model capability.
@@ -485,7 +492,7 @@ export class OpenRouterMediaProvider implements MediaProvider {
       return this.generateAudioViaSpeechEndpoint(
         model,
         request.text,
-        request.voice ?? 'alloy',
+        voice,
         requestedFormat,
         request
       );
@@ -501,7 +508,7 @@ export class OpenRouterMediaProvider implements MediaProvider {
       modalities: ['text', 'audio'],
       stream: true,
       audio: {
-        voice: request.voice ?? 'alloy',
+        voice,
         format: wireFormat,
       },
     };

--- a/sdk/typescript/src/ai/multimodal.ts
+++ b/sdk/typescript/src/ai/multimodal.ts
@@ -25,6 +25,14 @@ const AUDIO_MIME_TYPES: Record<string, string> = {
   '.ogg': 'audio/ogg',
 };
 
+const VIDEO_MIME_TYPES: Record<string, string> = {
+  '.mp4': 'video/mp4',
+  '.mpeg': 'video/mpeg',
+  '.mpg': 'video/mpeg',
+  '.mov': 'video/quicktime',
+  '.webm': 'video/webm',
+};
+
 /**
  * Represents text content in a multimodal prompt.
  */
@@ -184,6 +192,58 @@ export class Audio {
 }
 
 /**
+ * Represents video content in a multimodal prompt.
+ */
+export class Video {
+  readonly type: 'video_url' = 'video_url';
+  readonly videoUrl: { url: string };
+
+  private constructor(videoUrl: { url: string }) {
+    this.videoUrl = videoUrl;
+  }
+
+  /**
+   * Create Video from a local file by converting to a base64 data URL.
+   */
+  static async fromFile(filePath: string): Promise<Video> {
+    const absolutePath = resolve(filePath);
+    const buffer = await readFile(absolutePath);
+    const base64Data = buffer.toString('base64');
+    const ext = getExtension(absolutePath).toLowerCase();
+    const mimeType = VIDEO_MIME_TYPES[ext] || 'video/mp4';
+    return new Video({ url: `data:${mimeType};base64,${base64Data}` });
+  }
+
+  /**
+   * Create Video from a URL.
+   */
+  static fromUrl(url: string): Video {
+    return new Video({ url });
+  }
+
+  /**
+   * Create Video from a buffer.
+   */
+  static async fromBuffer(
+    buffer: Buffer | Uint8Array,
+    mimeType: string = 'video/mp4'
+  ): Promise<Video> {
+    const base64Data = Buffer.from(buffer).toString('base64');
+    return new Video({ url: `data:${mimeType};base64,${base64Data}` });
+  }
+
+  /**
+   * Create Video from a base64 string.
+   */
+  static async fromBase64(
+    base64Data: string,
+    mimeType: string = 'video/mp4'
+  ): Promise<Video> {
+    return new Video({ url: `data:${mimeType};base64,${base64Data}` });
+  }
+}
+
+/**
  * Represents a generic file content in a multimodal prompt.
  */
 export class File {
@@ -264,6 +324,10 @@ function guessMimeType(filePath: string): string | null {
   // Check audio types
   if (ext in AUDIO_MIME_TYPES) {
     return AUDIO_MIME_TYPES[ext];
+  }
+
+  if (ext in VIDEO_MIME_TYPES) {
+    return VIDEO_MIME_TYPES[ext];
   }
 
   // Common document types
@@ -376,6 +440,40 @@ export async function audioFromBase64(
 }
 
 /**
+ * Create video content from a local file.
+ */
+export async function videoFromFile(filePath: string): Promise<Video> {
+  return Video.fromFile(filePath);
+}
+
+/**
+ * Create video content from a URL.
+ */
+export function videoFromUrl(url: string): Video {
+  return Video.fromUrl(url);
+}
+
+/**
+ * Create video content from a buffer.
+ */
+export async function videoFromBuffer(
+  buffer: Buffer | Uint8Array,
+  mimeType: string = 'video/mp4'
+): Promise<Video> {
+  return Video.fromBuffer(buffer, mimeType);
+}
+
+/**
+ * Create video content from a base64 string.
+ */
+export async function videoFromBase64(
+  base64Data: string,
+  mimeType: string = 'video/mp4'
+): Promise<Video> {
+  return Video.fromBase64(base64Data, mimeType);
+}
+
+/**
  * Create file content from a local file.
  */
 export async function fileFromPath(filePath: string, mimeType?: string): Promise<File> {
@@ -404,4 +502,4 @@ export async function fileFromBase64(base64Data: string, mimeType: string): Prom
 }
 
 // Type for all multimodal content types
-export type MultimodalContent = Text | Image | Audio | File;
+export type MultimodalContent = Text | Image | Audio | Video | File;

--- a/sdk/typescript/tests/multimodal.test.ts
+++ b/sdk/typescript/tests/multimodal.test.ts
@@ -3,7 +3,15 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { File, createMultimodalResponse } from '../src/index.js';
+import {
+  File,
+  Video,
+  createMultimodalResponse,
+  videoFromBase64,
+  videoFromBuffer,
+  videoFromFile,
+  videoFromUrl,
+} from '../src/index.js';
 
 describe('multimodal helpers', () => {
   let tempDir: string | null = null;
@@ -25,6 +33,54 @@ describe('multimodal helpers', () => {
 
     expect(file.file.mimeType).toBe('text/plain');
     expect(file.file.url.startsWith('data:text/plain;base64,')).toBe(true);
+  });
+
+  it('embeds local videos as video_url data URLs', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'agentfield-multimodal-'));
+    const filePath = join(tempDir, 'sample.mp4');
+    await writeFile(filePath, Buffer.from('\x00\x00\x00\x18ftypmp42'));
+
+    const video = await Video.fromFile(filePath);
+
+    expect(video.type).toBe('video_url');
+    expect(video.videoUrl.url.startsWith('data:video/mp4;base64,')).toBe(true);
+  });
+
+  it('detects video MIME types for generic file content', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'agentfield-multimodal-'));
+    const filePath = join(tempDir, 'sample.mov');
+    await writeFile(filePath, Buffer.from('mov-data'));
+
+    const file = await File.fromFile(filePath);
+
+    expect(file.file.mimeType).toBe('video/quicktime');
+    expect(file.file.url.startsWith('data:video/quicktime;base64,')).toBe(true);
+  });
+
+  it('creates videos from URLs, buffers, and base64 data', async () => {
+    const urlVideo = Video.fromUrl('https://example.com/video.mp4');
+    const bufferVideo = await Video.fromBuffer(Buffer.from('video-data'), 'video/webm');
+    const base64Video = await Video.fromBase64('dmllby1kYXRh', 'video/ogg');
+
+    expect(urlVideo.videoUrl.url).toBe('https://example.com/video.mp4');
+    expect(bufferVideo.videoUrl.url).toBe('data:video/webm;base64,dmlkZW8tZGF0YQ==');
+    expect(base64Video.videoUrl.url).toBe('data:video/ogg;base64,dmllby1kYXRh');
+  });
+
+  it('creates videos through convenience factory functions', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'agentfield-multimodal-'));
+    const filePath = join(tempDir, 'factory.webm');
+    await writeFile(filePath, Buffer.from('webm-data'));
+
+    const fileVideo = await videoFromFile(filePath);
+    const urlVideo = videoFromUrl('https://example.com/factory.mp4');
+    const bufferVideo = await videoFromBuffer(Uint8Array.from([1, 2, 3]), 'video/mp4');
+    const base64Video = await videoFromBase64('AQID', 'video/mp4');
+
+    expect(fileVideo.videoUrl.url.startsWith('data:video/webm;base64,')).toBe(true);
+    expect(urlVideo.videoUrl.url).toBe('https://example.com/factory.mp4');
+    expect(bufferVideo.videoUrl.url).toBe('data:video/mp4;base64,AQID');
+    expect(base64Video.videoUrl.url).toBe('data:video/mp4;base64,AQID');
   });
 
   it('saves URL-based multimodal outputs by downloading them', async () => {

--- a/sdk/typescript/tests/openrouter_media_routing.test.ts
+++ b/sdk/typescript/tests/openrouter_media_routing.test.ts
@@ -161,6 +161,19 @@ describe('OpenRouterMediaProvider.generateVideo: param translation', () => {
 });
 
 describe('OpenRouterMediaProvider.generateImage: imageUrls + imageConfig', () => {
+  it('uses the current live Gemini image model by default', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ choices: [] }),
+    });
+
+    const provider = new OpenRouterMediaProvider({ apiKey: 'k' });
+    await provider.generateImage({ prompt: 'fox in watercolor' });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(body.model).toBe('google/gemini-3.1-flash-image-preview');
+  });
+
   it('builds multi-part user content and snake_cases imageConfig', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -225,6 +238,23 @@ describe('OpenRouterMediaProvider.generateImage: imageUrls + imageConfig', () =>
 });
 
 describe('OpenRouterMediaProvider.generateAudio: /audio/speech extras', () => {
+  it('uses the current live Kokoro model and voice by default', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'audio/mpeg' },
+      arrayBuffer: async () => new Uint8Array([1, 2]).buffer,
+      text: async () => '',
+    });
+
+    const provider = new OpenRouterMediaProvider({ apiKey: 'k' });
+    provider.seedModelMeta('hexgrad/kokoro-82m', ['speech'], ['text']);
+    await provider.generateAudio({ text: 'hello', format: 'mp3' });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(body.model).toBe('hexgrad/kokoro-82m');
+    expect(body.voice).toBe('af_alloy');
+  });
+
   it('passes speed and extra through to the speech body', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,


### PR DESCRIPTION
## Summary
- Fix OpenRouter media provider defaults to live image/TTS models while keeping routing/provider APIs unchanged.
- Parse OpenRouter image outputs directly from chat completions so Gemini/Grok `message.images[]` responses work reliably.
- Add video input helpers across Python, TypeScript, and Go, matching the existing image/audio helper pattern.
- Avoid LiteLLM trimming on untrimmable media payloads to prevent base64 logging/failures.
- Fix Fal audio response metadata so model-specific `output_format` is reflected in `AudioOutput.format`.

## Live verification
OpenRouter:
- Python image/audio/video input and image/audio/video generation passed.
- TypeScript image/audio/video generation passed.
- Go image/audio/video input and image/audio/video generation passed.

Fal:
- Python Fal image/audio/video generation passed.

## Tests
- `uv run --project sdk/python pytest sdk/python/tests/test_multimodal.py sdk/python/tests/test_media_providers.py sdk/python/tests/test_openrouter_audio.py sdk/python/tests/test_openrouter_video.py sdk/python/tests/test_media_integration.py sdk/python/tests/test_vision.py sdk/python/tests/test_image_config.py`
- `npm run test -- --run tests/multimodal.test.ts tests/openrouter_media_routing.test.ts tests/media_provider.test.ts tests/media_integration.test.ts`
- `npm run lint`
- `GOCACHE=/tmp/agentfield-gocache go test ./ai -run 'TestWithVideo|TestWithAudio|TestGenerateImage|TestGenerateAudio|TestIntegration|TestMediaRouter|TestOpenRouter'`
