### PR TITLE
fix(control-plane): authorize execution note reads(#421)

### DIFF
--- a/control-plane/internal/handlers/coverage_handlers_90_test.go
+++ b/control-plane/internal/handlers/coverage_handlers_90_test.go
@@ -256,8 +256,8 @@ func TestExecutionNotesCoverageAdditional(t *testing.T) {
 
 	t.Run("get notes errors and empty results", func(t *testing.T) {
 		router := gin.New()
-		router.GET("/notes/:execution_id", GetExecutionNotesHandler(&executionNoteStorageStub{getErr: errors.New("load failed")}))
-		router.GET("/missing", GetExecutionNotesHandler(&executionNoteStorageStub{}))
+		router.GET("/notes/:execution_id", GetExecutionNotesHandler(&executionNoteStorageStub{getErr: errors.New("load failed")}, false))
+		router.GET("/missing", GetExecutionNotesHandler(&executionNoteStorageStub{}, false))
 
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/missing", nil)
@@ -271,14 +271,14 @@ func TestExecutionNotesCoverageAdditional(t *testing.T) {
 
 		rec = httptest.NewRecorder()
 		router = gin.New()
-		router.GET("/notes/:execution_id", GetExecutionNotesHandler(&executionNoteStorageStub{record: nil}))
+		router.GET("/notes/:execution_id", GetExecutionNotesHandler(&executionNoteStorageStub{record: nil}, false))
 		req = httptest.NewRequest(http.MethodGet, "/notes/exec-404", nil)
 		router.ServeHTTP(rec, req)
 		require.Equal(t, http.StatusNotFound, rec.Code)
 
 		rec = httptest.NewRecorder()
 		router = gin.New()
-		router.GET("/notes/:execution_id", GetExecutionNotesHandler(&executionNoteStorageStub{record: &types.Execution{ExecutionID: "exec-3"}}))
+		router.GET("/notes/:execution_id", GetExecutionNotesHandler(&executionNoteStorageStub{record: &types.Execution{ExecutionID: "exec-3"}}, false))
 		req = httptest.NewRequest(http.MethodGet, "/notes/exec-3?tags=debug,%20info%20", nil)
 		router.ServeHTTP(rec, req)
 		require.Equal(t, http.StatusOK, rec.Code)

--- a/control-plane/internal/handlers/execution_notes.go
+++ b/control-plane/internal/handlers/execution_notes.go
@@ -263,9 +263,30 @@ func resolveExecutionNoteAgentIDByDID(ctx context.Context, storageProvider Execu
 	return "", nil
 }
 
-// GetExecutionNotesHandler handles GET /api/v1/executions/:execution_id/notes
-// Retrieves notes for a specific execution with optional tag filtering
-func GetExecutionNotesHandler(storageProvider ExecutionNoteStorage) gin.HandlerFunc {
+func ensureExecutionNoteReadOwnership(callerAgentID string, execution *types.Execution) error {
+	ownerAgentID := strings.TrimSpace(execution.AgentNodeID)
+	if ownerAgentID == "" {
+		return &executionNoteAuthorizationError{message: "execution owner is required to read notes"}
+	}
+
+	if callerAgentID == "" {
+		return &executionNoteAuthorizationError{message: "caller agent identity is required to read notes for this execution"}
+	}
+	if callerAgentID != ownerAgentID {
+		return &executionNoteAuthorizationError{message: "this execution does not belong to the requesting agent"}
+	}
+
+	return nil
+}
+
+// GetExecutionNotesHandler handles GET /api/v1/executions/:execution_id/notes.
+// Retrieves notes for a specific execution with optional tag filtering.
+//
+// ownershipEnforced reports whether the server runs with an authentication
+// method that yields a trusted caller identity. When true, the caller must own
+// the target execution or the read is rejected with 403. When false the server
+// is fully unauthenticated, matching the write endpoint's S2 behavior.
+func GetExecutionNotesHandler(storageProvider ExecutionNoteStorage, ownershipEnforced bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		executionID := c.Param("execution_id")
 		if executionID == "" {
@@ -284,8 +305,25 @@ func GetExecutionNotesHandler(storageProvider ExecutionNoteStorage) gin.HandlerF
 			}
 		}
 
+		ctx := c.Request.Context()
+		var callerAgentID string
+		if ownershipEnforced {
+			var resolveErr error
+			callerAgentID, resolveErr = executionNoteCallerAgentID(ctx, c, storageProvider)
+			if resolveErr != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to resolve caller identity: %v", resolveErr)})
+				return
+			}
+			if callerAgentID == "" {
+				c.JSON(http.StatusForbidden, gin.H{
+					"error":   "execution_ownership_mismatch",
+					"message": "caller agent identity is required to read notes for this execution",
+				})
+				return
+			}
+		}
+
 		// Get the execution
-		ctx := context.Background()
 		execution, err := storageProvider.GetExecutionRecord(ctx, executionID)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to get execution: %v", err)})
@@ -295,6 +333,19 @@ func GetExecutionNotesHandler(storageProvider ExecutionNoteStorage) gin.HandlerF
 		if execution == nil {
 			c.JSON(http.StatusNotFound, gin.H{"error": "execution not found"})
 			return
+		}
+
+		if ownershipEnforced {
+			if err := ensureExecutionNoteReadOwnership(callerAgentID, execution); err != nil {
+				var authzErr *executionNoteAuthorizationError
+				if errors.As(err, &authzErr) {
+					c.JSON(http.StatusForbidden, gin.H{
+						"error":   "execution_ownership_mismatch",
+						"message": authzErr.message,
+					})
+					return
+				}
+			}
 		}
 
 		// Filter notes by tags if specified

--- a/control-plane/internal/handlers/execution_notes_test.go
+++ b/control-plane/internal/handlers/execution_notes_test.go
@@ -25,6 +25,16 @@ type executionNoteDIDAuthStorage struct {
 	listErr      error
 }
 
+type getCountingExecutionNoteStorage struct {
+	*testExecutionStorage
+	getCalls int
+}
+
+func (s *getCountingExecutionNoteStorage) GetExecutionRecord(ctx context.Context, executionID string) (*types.Execution, error) {
+	s.getCalls++
+	return s.testExecutionStorage.GetExecutionRecord(ctx, executionID)
+}
+
 func (s *executionNoteDIDAuthStorage) GetDIDDocument(ctx context.Context, did string) (*types.DIDDocumentRecord, error) {
 	if s.didLookupErr != nil {
 		return nil, s.didLookupErr
@@ -572,7 +582,7 @@ func TestGetExecutionNotesHandler_ReturnsFilteredNotes(t *testing.T) {
 	require.NoError(t, storage.CreateExecutionRecord(context.Background(), exec))
 
 	router := gin.New()
-	router.GET("/api/v1/executions/:execution_id/notes", GetExecutionNotesHandler(storage))
+	router.GET("/api/v1/executions/:execution_id/notes", GetExecutionNotesHandler(storage, false))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/executions/exec-2/notes?tags=debug", nil)
 	resp := httptest.NewRecorder()
@@ -585,4 +595,189 @@ func TestGetExecutionNotesHandler_ReturnsFilteredNotes(t *testing.T) {
 	require.Equal(t, executionID, payload.ExecutionID)
 	require.Equal(t, 1, payload.Total)
 	require.Equal(t, "note-one", payload.Notes[0].Message)
+}
+
+func TestGetExecutionNotesHandler_AuthorizesOwnerRead(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executionID := "exec-owned-by-a"
+	storage := newTestExecutionStorage(nil)
+	require.NoError(t, storage.CreateExecutionRecord(context.Background(), &types.Execution{
+		ExecutionID: executionID,
+		AgentNodeID: "agent-a",
+		Notes: []types.ExecutionNote{
+			{Message: "owner-visible", Tags: []string{"debug"}},
+		},
+		UpdatedAt: time.Now(),
+	}))
+
+	router := gin.New()
+	router.Use(middleware.APIKeyAuth(middleware.AuthConfig{APIKey: "secret-key"}))
+	router.GET("/api/v1/executions/:execution_id/notes", GetExecutionNotesHandler(storage, true))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/executions/exec-owned-by-a/notes", nil)
+	req.Header.Set("X-API-Key", "secret-key")
+	req.Header.Set("X-Caller-Agent-ID", "agent-a")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var payload GetNotesResponse
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &payload))
+	require.Equal(t, executionID, payload.ExecutionID)
+	require.Equal(t, 1, payload.Total)
+	require.Equal(t, "owner-visible", payload.Notes[0].Message)
+}
+
+func TestGetExecutionNotesHandler_RejectsCrossAgentRead(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	storage := newTestExecutionStorage(nil)
+	require.NoError(t, storage.CreateExecutionRecord(context.Background(), &types.Execution{
+		ExecutionID: "exec-owned-by-b",
+		AgentNodeID: "agent-b",
+		Notes: []types.ExecutionNote{
+			{Message: "sensitive reasoning trace", Tags: []string{"private"}},
+		},
+		UpdatedAt: time.Now(),
+	}))
+
+	router := gin.New()
+	router.Use(middleware.APIKeyAuth(middleware.AuthConfig{APIKey: "secret-key"}))
+	router.GET("/api/v1/executions/:execution_id/notes", GetExecutionNotesHandler(storage, true))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/executions/exec-owned-by-b/notes", nil)
+	req.Header.Set("X-API-Key", "secret-key")
+	req.Header.Set("X-Caller-Agent-ID", "agent-a")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusForbidden, resp.Code)
+	require.Contains(t, resp.Body.String(), "this execution does not belong to the requesting agent")
+	require.NotContains(t, resp.Body.String(), "sensitive reasoning trace")
+}
+
+func TestGetExecutionNotesHandler_DIDCallerOwnership(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const callerDID = "did:web:example.com:agents:agent-a"
+
+	tests := []struct {
+		name           string
+		executionOwner string
+		wantStatus     int
+		wantTotal      int
+	}{
+		{
+			name:           "owner read succeeds",
+			executionOwner: "agent-a",
+			wantStatus:     http.StatusOK,
+			wantTotal:      1,
+		},
+		{
+			name:           "non owner read forbidden",
+			executionOwner: "agent-b",
+			wantStatus:     http.StatusForbidden,
+			wantTotal:      0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executionID := "exec-did-read-" + strings.ReplaceAll(tt.name, " ", "-")
+			storage := &executionNoteDIDAuthStorage{
+				testExecutionStorage: newTestExecutionStorage(nil),
+				didDocuments: map[string]*types.DIDDocumentRecord{
+					callerDID: {
+						DID:     callerDID,
+						AgentID: "agent-a",
+					},
+				},
+			}
+			require.NoError(t, storage.CreateExecutionRecord(context.Background(), &types.Execution{
+				ExecutionID: executionID,
+				AgentNodeID: tt.executionOwner,
+				Notes: []types.ExecutionNote{
+					{Message: "did-visible-note", Tags: []string{"debug"}},
+				},
+				UpdatedAt: time.Now(),
+			}))
+
+			router := gin.New()
+			router.GET("/api/v1/executions/:execution_id/notes", func(c *gin.Context) {
+				c.Set(string(middleware.VerifiedCallerDIDKey), callerDID)
+				GetExecutionNotesHandler(storage, true)(c)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/executions/"+executionID+"/notes", nil)
+			resp := httptest.NewRecorder()
+			router.ServeHTTP(resp, req)
+
+			require.Equal(t, tt.wantStatus, resp.Code)
+			if tt.wantStatus == http.StatusOK {
+				var payload GetNotesResponse
+				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &payload))
+				require.Equal(t, tt.wantTotal, payload.Total)
+				require.Equal(t, "did-visible-note", payload.Notes[0].Message)
+			} else {
+				require.Contains(t, resp.Body.String(), "this execution does not belong to the requesting agent")
+				require.NotContains(t, resp.Body.String(), "did-visible-note")
+			}
+		})
+	}
+}
+
+func TestGetExecutionNotesHandler_SpoofedHeaderRejectedWhenEnforced(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executionID := "exec-owned-by-victim"
+	storage := &getCountingExecutionNoteStorage{testExecutionStorage: newTestExecutionStorage(nil)}
+	require.NoError(t, storage.CreateExecutionRecord(context.Background(), &types.Execution{
+		ExecutionID: executionID,
+		AgentNodeID: "victim-agent",
+		Notes: []types.ExecutionNote{
+			{Message: "must not leak", Tags: []string{"private"}},
+		},
+		UpdatedAt: time.Now(),
+	}))
+
+	router := gin.New()
+	router.GET("/api/v1/executions/:execution_id/notes", GetExecutionNotesHandler(storage, true))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/executions/exec-owned-by-victim/notes", nil)
+	req.Header.Set("X-Agent-Node-ID", "victim-agent")
+	req.Header.Set("X-Caller-Agent-ID", "victim-agent")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusForbidden, resp.Code)
+	require.Contains(t, resp.Body.String(), "caller agent identity is required to read notes for this execution")
+	require.NotContains(t, resp.Body.String(), "must not leak")
+	require.Equal(t, 0, storage.getCalls)
+}
+
+func TestGetExecutionNotesHandler_UnauthenticatedRequestRejectedBeforeFetch(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	storage := &getCountingExecutionNoteStorage{testExecutionStorage: newTestExecutionStorage(nil)}
+	require.NoError(t, storage.CreateExecutionRecord(context.Background(), &types.Execution{
+		ExecutionID: "exec-owned-by-a",
+		AgentNodeID: "agent-a",
+		Notes: []types.ExecutionNote{
+			{Message: "must not be fetched", Tags: []string{"private"}},
+		},
+		UpdatedAt: time.Now(),
+	}))
+
+	router := gin.New()
+	router.Use(middleware.APIKeyAuth(middleware.AuthConfig{APIKey: "secret-key"}))
+	router.GET("/api/v1/executions/:execution_id/notes", GetExecutionNotesHandler(storage, true))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/executions/exec-owned-by-a/notes", nil)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusUnauthorized, resp.Code)
+	require.Equal(t, 0, storage.getCalls)
 }

--- a/control-plane/internal/server/routes_core.go
+++ b/control-plane/internal/server/routes_core.go
@@ -143,7 +143,7 @@ func (s *AgentFieldServer) registerCoreRoutes(agentAPI *gin.RouterGroup) {
 
 	// Execution notes endpoints for app.note() feature
 	agentAPI.POST("/executions/note", handlers.AddExecutionNoteHandler(s.storage, s.noteOwnershipEnforced()))
-	agentAPI.GET("/executions/:execution_id/notes", handlers.GetExecutionNotesHandler(s.storage))
+	agentAPI.GET("/executions/:execution_id/notes", handlers.GetExecutionNotesHandler(s.storage, s.noteOwnershipEnforced()))
 	agentAPI.POST("/workflow/executions/events", handlers.WorkflowExecutionEventHandler(s.storage))
 
 	// Workflow endpoints will be reintroduced once the simplified execution pipeline lands.

--- a/control-plane/internal/server/routes_middleware.go
+++ b/control-plane/internal/server/routes_middleware.go
@@ -92,7 +92,7 @@ func (s *AgentFieldServer) applyGlobalMiddleware() {
 	// ownership (and any other identity-dependent guard) cannot be enforced
 	// because no trusted caller identity is established for incoming requests.
 	if !s.noteOwnershipEnforced() {
-		logger.Logger.Warn().Msg("⚠️  No authentication configured (API key and DID auth both disabled): execution-note ownership is NOT enforced. Enable API key or DID auth to protect execution notes from cross-agent writes.")
+		logger.Logger.Warn().Msg("⚠️  No authentication configured (API key and DID auth both disabled): execution-note ownership is NOT enforced. Enable API key or DID auth to protect execution notes from cross-agent reads and writes.")
 	}
 }
 

--- a/control-plane/internal/server/routes_ui.go
+++ b/control-plane/internal/server/routes_ui.go
@@ -168,7 +168,7 @@ func (s *AgentFieldServer) registerUIAPI() {
 
 			// Execution notes endpoints for UI
 			executions.POST("/note", handlers.AddExecutionNoteHandler(s.storage, s.noteOwnershipEnforced()))
-			executions.GET("/:execution_id/notes", handlers.GetExecutionNotesHandler(s.storage))
+			executions.GET("/:execution_id/notes", handlers.GetExecutionNotesHandler(s.storage, s.noteOwnershipEnforced()))
 
 			// Structured execution logs for the execution detail page
 			execLogsHandler := ui.NewExecutionLogsHandler(s.storage, s.llmHealthMonitor, func() config.ExecutionLogsConfig {


### PR DESCRIPTION
## Summary

Fixes an IDOR in the execution notes read endpoint by enforcing execution ownership before returning notes. The read handler now resolves the trusted caller identity using the same ownership-enforcement path used by the write endpoint, compares it against the target execution owner, and rejects cross-agent reads with `403`.

Specific changes:
- `control-plane/internal/handlers/execution_notes.go`: adds ownership enforcement to `GetExecutionNotesHandler`, including caller identity resolution, execution owner comparison against `execution.AgentNodeID`, and `403 execution_ownership_mismatch` responses for unauthorized reads.
- `control-plane/internal/server/routes_core.go` and `control-plane/internal/server/routes_ui.go`: pass `s.noteOwnershipEnforced()` into the read handler so API-key and DID-auth deployments enforce ownership consistently.
- `control-plane/internal/server/routes_middleware.go`: updates the no-auth warning to call out that execution-note reads and writes are not protected when both API key and DID auth are disabled.
- `control-plane/internal/handlers/execution_notes_test.go`: adds coverage for owner reads, cross-agent read rejection, DID caller ownership, spoofed caller headers, and unauthenticated rejection before storage fetch.
- `control-plane/internal/handlers/coverage_handlers_90_test.go`: updates existing handler call sites for the new read-handler signature.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] Tests only
- [ ] CI / tooling
- [ ] Breaking change

## Test plan

- [x] `cd control-plane && /usr/local/go/bin/go test ./...`
- [x] `git diff --check`
- [x] `make lint`

Note: `make lint` currently prints existing repo-wide lint findings outside this PR's changed files. The root `Makefile` masks those lint failures with `|| true`, so the command completes successfully.

## Test coverage

This repo enforces a **coverage gate** on every PR (see
[`.github/workflows/coverage.yml`](.github/workflows/coverage.yml) and
[`docs/COVERAGE.md`](docs/COVERAGE.md)).

- The gate runs `./scripts/coverage-summary.sh` and compares per-surface
  numbers against `coverage-baseline.json`.
- It **fails** if any surface drops more than **1.0 pp** below its baseline,
  if any surface is below **80%**, or if the weighted aggregate falls below
  **85%**.

Before asking for review, please confirm:

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR (no bare additions).
- [ ] If I removed code, I updated `coverage-baseline.json` in
      this PR *only if* the removal caused a legitimate regression and I
      called it out in the summary above.
- [ ] The coverage gate check is green in CI before requesting review.

No code was removed and `coverage-baseline.json` was not changed.

## Checklist

- [ ] I have read [CONTRIBUTING.md](CONTRIBUTING.md) (if present) and
      [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
- [ ] Commits are signed and follow conventional-commits style.
- [x] I have linked any related issues (Fixes #421 / Closes #421).

## Related issues / PRs

Fixes #421

Related prior authorization work: #420