### PR TITLE
chore: add .github/github-buddy.yml with CLA sweep config

### DIFF
--- a/.github/github-buddy.yml
+++ b/.github/github-buddy.yml
@@ -1,0 +1,25 @@
+# Per-repo github-buddy configuration.
+# Read from the default branch by github-buddy's load_repo_config reasoner.
+
+# CLA reminder / auto-close tuning for the cla_reminder_sweep scheduled reasoner.
+#
+# NOTE: this block only *tunes* behaviour. The on/off switch is the
+# GITHUB_BUDDY_CLA_REPOS env roster on the github-buddy deployment — a repo is
+# only ever acted on if it is listed there.
+cla_reminders:
+  # This repo's CLA gate is the hosted cla-assistant.io app, which publishes a
+  # classic commit *status* with context "license/cla". This is deliberately
+  # different from github-buddy's own repo, whose self-hosted
+  # contributor-assistant action reports a *check-run* named "cla". Pin the
+  # context explicitly so the sweep reads the right signal (and nobody copies
+  # the "cla" override over from github-buddy's config by mistake).
+  status_context: "license/cla"
+
+  # Days after a PR opens before the gentle reminder / auto-close fire, if the
+  # CLA is still unsigned. Defaults shown explicitly.
+  reminder_days: 2
+  close_days: 7
+
+  # PRs carrying any of these labels are skipped entirely.
+  exempt_labels:
+    - cla-exempt


### PR DESCRIPTION
## What

Adds `.github/github-buddy.yml` to configure github-buddy's CLA reminder / auto-close sweep for this repo.

## Why

We're pointing this repo's webhooks at github-buddy and want its `cla_reminder_sweep` to work against our CLA gate. This repo uses the **hosted cla-assistant.io** app, which publishes a commit **status** with context `license/cla`.

That differs from github-buddy's own repo, which uses the self-hosted contributor-assistant action (a **check-run** named `cla`). github-buddy's detector matches `status_context` against both signals, so this file pins the context to `license/cla` explicitly — both as documentation and to avoid the `cla` override being copied over by mistake.

`license/cla` is also github-buddy's built-in default, so this file mainly makes the intent explicit and sets reminder/close timing + an exempt label.

## Effect

No behavior change until this repo is added to the `GITHUB_BUDDY_CLA_REPOS` roster on the github-buddy deployment. Verified read-only that github-buddy's `get_commit_cla_status` reads this repo's `license/cla` status correctly (unsigned → `pending`, signed → `success`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)