### PR TITLE
fix(sdk/python): bind trigger payload to first non-injected param (stop "got multiple values for argument 'trigger'")

### DIFF
--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -443,6 +443,49 @@ class _PauseManager:
             self._exec_to_request.clear()
 
 
+# Parameters the runtime injects by name into trigger/webhook-invoked reasoners.
+# They must never receive the event payload positionally — see
+# _bind_trigger_payload.
+_INJECTED_TRIGGER_PARAMS = frozenset({"trigger", "webhook", "execution_context"})
+
+
+def _bind_trigger_payload(
+    signature: inspect.Signature, payload: Any
+) -> tuple[tuple, dict]:
+    """Build (args, kwargs) for the event payload of a trigger-invoked reasoner.
+
+    For trigger/webhook invocations the event payload is the event object, and
+    the framework separately injects the ``trigger`` / ``webhook`` /
+    ``execution_context`` parameters by name (see _execute_reasoner_endpoint).
+    The payload therefore binds to the first parameter that is *not* one of
+    those injected slots.
+
+    When that parameter is an ordinary positional-or-keyword parameter we bind
+    it by **keyword**, so a leading injected parameter (e.g. ``def r(trigger,
+    event)``) can never shift the payload onto the wrong slot positionally. This
+    mirrors the test harness' ``_bind_reasoner_args`` so the runtime and
+    ``simulate_trigger`` invoke a reasoner identically.
+
+    A reasoner whose only parameter is an injected slot (e.g.
+    ``def r(trigger=None)``) has no home for the payload, so it is dropped and
+    the trigger context is delivered by keyword — instead of crashing with
+    "got multiple values for argument 'trigger'".
+    """
+    for name, param in signature.parameters.items():
+        if name in _INJECTED_TRIGGER_PARAMS:
+            continue
+        if param.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.VAR_POSITIONAL,
+        ):
+            return (payload,), {}
+        if param.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD:
+            return (), {name: payload}
+        # KEYWORD_ONLY / VAR_KEYWORD have no positional home; the payload falls
+        # through to the parameter's default, matching _bind_reasoner_args.
+    return (), {}
+
+
 class Agent(FastAPI):
     """
     AgentField Agent - FastAPI subclass for creating AI agent nodes.
@@ -2167,11 +2210,16 @@ class Agent(FastAPI):
                 )
 
             # When invoked via an inbound trigger, the (possibly transformed)
-            # payload IS the first positional argument — it's the provider's
-            # event itself, not a dict of named kwargs. Direct app.call()
-            # invocations keep the historical kwargs-from-dict shape.
+            # payload IS the event object — it binds to the first parameter that
+            # the framework does not itself inject (trigger / webhook /
+            # execution_context). Binding through _bind_trigger_payload (rather
+            # than blindly passing it as the first positional) is what prevents
+            # `def r(trigger=None)` from receiving the payload positionally AND
+            # the trigger by keyword — the "got multiple values for argument
+            # 'trigger'" crash. Direct app.call() invocations keep the
+            # historical kwargs-from-dict shape.
             if execution_context.trigger is not None:
-                args, kwargs = (payload_dict,), {}
+                args, kwargs = _bind_trigger_payload(signature, payload_dict)
             else:
                 try:
                     if should_convert_args(func):

--- a/sdk/python/tests/test_trigger_param_binding.py
+++ b/sdk/python/tests/test_trigger_param_binding.py
@@ -1,0 +1,266 @@
+"""Trigger/webhook parameter binding — runtime invocation contract.
+
+Regression coverage for the production failure where a scheduled reasoner
+declared with the documented ``trigger`` parameter crashed every time it fired:
+
+    cla_reminder_sweep() got multiple values for argument 'trigger'
+
+Root cause: when a reasoner is invoked by a trigger, the runtime passed the
+event payload as the FIRST POSITIONAL argument *and* separately injected
+``trigger=`` as a keyword. For a reasoner whose only parameter is ``trigger``
+(``def r(trigger=None)``) both filled the same slot → TypeError. The unit-test
+harness (``simulate_trigger`` / ``_bind_reasoner_args``) bound correctly, so the
+bug was invisible to existing tests — the runtime and the harness disagreed.
+
+Validation Contract (behaviours, not implementation):
+  C1. Firing a trigger at a reasoner whose only parameter is ``trigger``
+      succeeds (HTTP 200) and ``trigger`` receives the TriggerContext.
+  C2. ``def r(event, trigger=None)`` binds the event payload to ``event`` and
+      the TriggerContext to ``trigger``.
+  C3. The ``webhook`` alias behaves exactly like ``trigger``.
+  C4. ``def r(payload)`` (no trigger param) still receives the event payload.
+  C5. The runtime binds a payload to the first parameter that is NOT a
+      framework-injected slot (trigger / webhook / execution_context); a
+      reasoner declaring only injected slots drops the payload rather than
+      colliding.
+  C6. Non-trigger ``app.call`` invocations (plain kwargs dict) are unchanged.
+
+The HTTP tests below exercise the REAL runtime path (route → envelope unwrap →
+``_execute_reasoner_endpoint`` → reasoner call), which is the path that was
+broken; the unit tests pin the binding helper directly.
+"""
+
+import inspect
+
+import httpx
+import pytest
+
+from agentfield import ScheduleTrigger, TriggerContext
+from agentfield.agent import Agent, _bind_trigger_payload
+from agentfield.agent_registry import (
+    clear_current_agent,
+    get_current_agent_instance,
+    set_current_agent,
+)
+from agentfield.logger import get_logger, set_cp_client
+
+from tests.helpers import create_test_agent
+
+
+@pytest.fixture(autouse=True)
+def _restore_global_agent_state():
+    """Constructing an Agent has two process-wide side effects that these tests
+    must not leak into later tests:
+
+      1. ``Agent.__init__`` calls ``set_cp_client(self.client)``, repointing the
+         GLOBAL logger's control-plane client at this test's fake client (which
+         has no ``post_execution_logs``). test_workflow_parent_child assumes the
+         global client is ``None`` and dispatches execution logs to it — a leaked
+         fake makes it raise ``AttributeError`` mid-reasoner.
+      2. Driving a reasoner over HTTP marks its Agent as the process-wide
+         "current agent" (``Agent._current_agent`` + the current-agent contextvar).
+
+    Snapshot and restore both so this module is hermetic regardless of order."""
+    prev_cp_client = get_logger()._cp_client
+    prev_class_attr = getattr(Agent, "_current_agent", None)
+    prev_contextvar = get_current_agent_instance()
+    try:
+        yield
+    finally:
+        set_cp_client(prev_cp_client)
+        Agent._current_agent = prev_class_attr
+        if prev_contextvar is None:
+            clear_current_agent()
+        else:
+            set_current_agent(prev_contextvar)
+
+
+def _envelope(event: dict) -> dict:
+    """A dispatcher trigger envelope as the control plane forwards it."""
+    return {
+        "event": event,
+        "_meta": {
+            "trigger_id": "trg_sched_1",
+            "source": "schedule",
+            "event_type": "schedule.fired",
+            "event_id": "evt_1",
+            "idempotency_key": "evt_1_key",
+            "received_at": "2026-06-08T09:00:00+00:00",
+        },
+    }
+
+
+async def _fire(agent, path: str, event: dict) -> httpx.Response:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=agent), base_url="http://test"
+    ) as client:
+        return await client.post(
+            path,
+            json=_envelope(event),
+            headers={"x-workflow-id": "wf-1", "x-execution-id": "exec-1"},
+        )
+
+
+def _inline(agent):
+    """Run reasoners synchronously in-process (no async dispatch / network)."""
+    agent.async_config.enable_async_execution = False
+    agent.agentfield_server = None
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end runtime path (the path that crashed in production)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_schedule_reasoner_with_only_trigger_param_succeeds(monkeypatch):
+    """C1: the exact cla_reminder_sweep shape — only a ``trigger`` parameter."""
+    agent, _ = create_test_agent(monkeypatch)
+    _inline(agent)
+    seen = {}
+
+    @agent.reasoner(tags=["scheduled"], triggers=[ScheduleTrigger(cron="0 9 * * *")])
+    async def cla_reminder_sweep(trigger: TriggerContext | None = None) -> dict:
+        seen["trigger"] = trigger
+        return {"ran": True, "source": getattr(trigger, "source", None)}
+
+    resp = await _fire(
+        agent,
+        "/reasoners/cla_reminder_sweep",
+        {
+            "expression": "0 9 * * *",
+            "fired_at": "2026-06-08T09:00:00Z",
+            "timezone": "UTC",
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"ran": True, "source": "schedule"}
+    assert isinstance(seen["trigger"], TriggerContext)
+    assert seen["trigger"].source == "schedule"
+
+
+@pytest.mark.asyncio
+async def test_trigger_reasoner_with_event_and_trigger_binds_both(monkeypatch):
+    """C2: payload → first non-injected param; context → ``trigger``."""
+    agent, _ = create_test_agent(monkeypatch)
+    _inline(agent)
+    seen = {}
+
+    @agent.reasoner(triggers=[ScheduleTrigger(cron="0 9 * * *")])
+    async def handler(
+        event: dict | None = None, trigger: TriggerContext | None = None
+    ) -> dict:
+        seen["event"] = event
+        seen["trigger"] = trigger
+        return {"ok": True}
+
+    resp = await _fire(agent, "/reasoners/handler", {"k": "v"})
+
+    assert resp.status_code == 200, resp.text
+    assert seen["event"] == {"k": "v"}
+    assert isinstance(seen["trigger"], TriggerContext)
+
+
+@pytest.mark.asyncio
+async def test_webhook_alias_only_param_succeeds(monkeypatch):
+    """C3: ``webhook`` behaves like ``trigger``."""
+    agent, _ = create_test_agent(monkeypatch)
+    _inline(agent)
+    seen = {}
+
+    @agent.reasoner(triggers=[ScheduleTrigger(cron="0 9 * * *")])
+    async def hook(webhook: TriggerContext | None = None) -> dict:
+        seen["webhook"] = webhook
+        return {"ran": True}
+
+    resp = await _fire(agent, "/reasoners/hook", {"any": "thing"})
+
+    assert resp.status_code == 200, resp.text
+    assert isinstance(seen["webhook"], TriggerContext)
+
+
+@pytest.mark.asyncio
+async def test_trigger_reasoner_with_plain_payload_param(monkeypatch):
+    """C4: a reasoner with no trigger param still receives the event payload."""
+    agent, _ = create_test_agent(monkeypatch)
+    _inline(agent)
+    seen = {}
+
+    @agent.reasoner(triggers=[ScheduleTrigger(cron="0 9 * * *")])
+    async def consume(payload: dict | None = None) -> dict:
+        seen["payload"] = payload
+        return {"ran": True}
+
+    resp = await _fire(agent, "/reasoners/consume", {"n": 1})
+
+    assert resp.status_code == 200, resp.text
+    assert seen["payload"] == {"n": 1}
+
+
+# --------------------------------------------------------------------------- #
+# Binding helper — exhaustive signature shapes (C5)
+# --------------------------------------------------------------------------- #
+
+PAYLOAD = {"hello": "world"}
+
+
+def _sig(fn) -> inspect.Signature:
+    return inspect.signature(fn)
+
+
+def test_bind_only_trigger_drops_payload():
+    def r(trigger=None): ...
+
+    assert _bind_trigger_payload(_sig(r), PAYLOAD) == ((), {})
+
+
+def test_bind_only_webhook_drops_payload():
+    def r(webhook=None): ...
+
+    assert _bind_trigger_payload(_sig(r), PAYLOAD) == ((), {})
+
+
+def test_bind_event_then_trigger_binds_event_by_keyword():
+    def r(event, trigger=None): ...
+
+    assert _bind_trigger_payload(_sig(r), PAYLOAD) == ((), {"event": PAYLOAD})
+
+
+def test_bind_payload_only():
+    def r(payload): ...
+
+    assert _bind_trigger_payload(_sig(r), PAYLOAD) == ((), {"payload": PAYLOAD})
+
+
+def test_bind_skips_execution_context():
+    def r(event, execution_context=None): ...
+
+    assert _bind_trigger_payload(_sig(r), PAYLOAD) == ((), {"event": PAYLOAD})
+
+
+def test_bind_trigger_before_event_does_not_collide():
+    """Pathological ordering: injected param first. Payload must still land on
+    ``event`` (by keyword) so it never fills the injected slot positionally."""
+
+    def r(trigger=None, event=None): ...
+
+    assert _bind_trigger_payload(_sig(r), PAYLOAD) == ((), {"event": PAYLOAD})
+
+
+def test_bind_positional_only_uses_positional():
+    def r(event, /, trigger=None): ...
+
+    assert _bind_trigger_payload(_sig(r), PAYLOAD) == ((PAYLOAD,), {})
+
+
+def test_bind_var_positional_uses_positional():
+    def r(*events, trigger=None): ...
+
+    assert _bind_trigger_payload(_sig(r), PAYLOAD) == ((PAYLOAD,), {})
+
+
+def test_bind_no_params_drops_payload():
+    def r(): ...
+
+    assert _bind_trigger_payload(_sig(r), PAYLOAD) == ((), {})


### PR DESCRIPTION
## Problem

Trigger/webhook-invoked reasoners that declare the **documented** `trigger` (or `webhook`) parameter crash on **every** invocation:

```
cla_reminder_sweep() got multiple values for argument 'trigger'
```

This has been failing the daily github-buddy CLA reminder sweep (`ScheduleTrigger(cron="0 9 * * *")`) every morning since 2026-06-02 — the reasoner is `async def cla_reminder_sweep(trigger: TriggerContext | None = None)`.

## Root cause

On the trigger path, `_execute_reasoner_endpoint` passed the event payload as the first **positional** argument *and* separately injected `trigger=` / `webhook=` as a keyword:

```python
if execution_context.trigger is not None:
    args, kwargs = (payload_dict,), {}      # payload positional
...
if "trigger" in signature.parameters:
    kwargs["trigger"] = execution_context.trigger   # trigger keyword
# -> func(payload_dict, trigger=ctx)
```

When the reasoner's first positional parameter **is** an injected name (`def r(trigger=None)`), the payload fills `trigger` positionally and `trigger=` fills it again → `TypeError`.

The test harness (`_bind_reasoner_args` / `simulate_trigger`) **already** bound this correctly — it skips injected params when assigning the positional payload — so unit tests passed while production crashed. The runtime and the harness disagreed; that divergence is the deeper bug.

## Fix

New `_bind_trigger_payload(signature, payload)` binds the payload to the first parameter that is **not** a framework-injected slot (`trigger` / `webhook` / `execution_context`), and binds it **by keyword** for positional-or-keyword params so a leading injected parameter can never shift it onto the wrong slot. This mirrors `_bind_reasoner_args`, so the runtime and `simulate_trigger` now invoke a reasoner identically.

A reasoner whose only parameter is an injected slot (e.g. `def r(trigger=None)`) now receives the context by keyword and the payload is dropped — instead of crashing.

Behaviour for all other shapes is unchanged (`def r(event, trigger=None)`, `def r(payload)`, etc. bind exactly as before).

## Tests — `tests/test_trigger_param_binding.py`

Test-first: the e2e tests were confirmed **red** on the old runtime (with the exact production error) before the fix.

- **4 end-to-end tests** through the **real runtime path** (HTTP route → trigger-envelope unwrap → `_execute_reasoner_endpoint` → reasoner call) — the path that was broken. Includes the exact `cla_reminder_sweep` shape, the `webhook` alias, `event`+`trigger`, and payload-only.
- **9 unit tests** pinning the binding across signature shapes: only-trigger, only-webhook, event+trigger, payload-only, `execution_context` excluded, injected-param-first ordering, positional-only, var-positional, no-params.

A module-level validation contract (C1–C6) documents the intended behaviours. An autouse fixture restores two process-wide globals the tests would otherwise leak (the logger CP client set by `Agent.__init__`, and the current-agent), keeping the module hermetic.

**Full SDK suite green: `1547 passed, 4 skipped`. `ruff check .` clean.**

## Rollout note

This is an SDK-level fix. For the production CLA sweep to recover, a new `agentfield` release must be cut and **github-buddy's `agentfield>=…` floor bumped past it** — the Docker layer cache pins the resolved version, so a flexible constraint alone won't pull the new release. The github-buddy reasoner itself needs no change once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)