### PR TITLE
fix(harness): preserve original goal on non-crash schema retries

### DIFF
--- a/sdk/python/agentfield/harness/_runner.py
+++ b/sdk/python/agentfield/harness/_runner.py
@@ -429,7 +429,12 @@ class HarnessRunner:
                 )
             else:
                 error_detail = diagnose_output_failure(output_path, schema)
-                retry_prompt = build_followup_prompt(error_detail, cwd, schema)
+                _orig = options.get("_original_prompt", "")
+                _followup = build_followup_prompt(error_detail, cwd, schema)
+                # Keep the original goal/task on non-crash retries. Without this
+                # the agent retries with only the schema-correction text and loses
+                # the goal (e.g. PM emits a placeholder PRD that poisons the run).
+                retry_prompt = (_orig + "\n\n" + _followup) if _orig else _followup
 
             detail_for_log = diagnose_output_failure(output_path, schema)
 

--- a/sdk/python/tests/test_harness_runner.py
+++ b/sdk/python/tests/test_harness_runner.py
@@ -384,3 +384,44 @@ async def test_schema_retry_accumulates_cost(tmp_path, monkeypatch):
     assert result.parsed.name == "ok"
     assert result.cost_usd == pytest.approx(0.03)  # 0.01 + 0.02
     assert result.num_turns == 2
+
+
+@pytest.mark.asyncio
+async def test_schema_retry_preserves_original_goal_in_prompt(tmp_path, monkeypatch):
+    """Regression for the data-flow bug: on a non-crash schema retry the retry
+    prompt MUST still carry the original goal, not only the schema-correction
+    followup. Previously the PM lost its goal on retry and emitted a placeholder
+    PRD that poisoned every downstream reasoner (architect/sprint/merger)."""
+    GOAL = "IMPLEMENT_24_ENDPOINTS_SENTINEL_GOAL"
+    prompts: list[str] = []
+
+    class BadJsonCapturingProvider(MockProvider):
+        async def execute(self, prompt, options):
+            prompts.append(prompt)
+            output_path = get_output_path(str(options.get("cwd", ".")))
+            with open(output_path, "w", encoding="utf-8") as file_obj:
+                file_obj.write('{"name": "ok"}')  # missing 'count' -> invalid, non-crash
+            return await super().execute(prompt, options)
+
+    async def _no_repair(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("agentfield.harness._runner._ai_schema_repair", _no_repair)
+
+    provider = BadJsonCapturingProvider()
+    runner = HarnessRunner()
+    with patch("agentfield.harness._runner.build_provider", return_value=provider):
+        await runner.run(
+            GOAL,
+            provider="codex",
+            schema=DemoSchema,
+            cwd=str(tmp_path),
+            schema_max_retries=2,
+        )
+
+    assert len(prompts) >= 2, f"expected a retry; got {len(prompts)} call(s)"
+    retry_prompt = prompts[1]
+    assert GOAL in retry_prompt, (
+        "retry prompt dropped the original goal -- the agent retries blind. "
+        "First 400 chars:\n" + retry_prompt[:400]
+    )


### PR DESCRIPTION
## What

Fixes the non-crash schema-retry path in `HarnessRunner._handle_schema_with_retry` so retries keep the original goal instead of sending only the schema-correction followup.

Closes #636.

## Why

When a reasoner's first attempt fails schema validation in a non-crash way (output file invalid, or not written without a crash), the retry prompt was built from `build_followup_prompt(error_detail, cwd, schema)` alone — which contains only "PREVIOUS ATTEMPT FAILED… here is the schema… write the file" and **not the original goal**. The crash branch already preserved the goal via `options["_original_prompt"]`; this branch didn't.

In practice the agent retried goal-blind and could emit placeholder output (we saw a PM produce a "no goal supplied" PRD) that then poisoned every downstream reasoner — a silent, hard-to-trace failure.

## Change

```python
else:
    error_detail = diagnose_output_failure(output_path, schema)
    _orig = options.get("_original_prompt", "")
    _followup = build_followup_prompt(error_detail, cwd, schema)
    retry_prompt = (_orig + "\n\n" + _followup) if _orig else _followup
```

`_original_prompt` is already populated earlier in `run()`, so this is a minimal, local change.

## Test

Adds `test_schema_retry_preserves_original_goal_in_prompt`: drives a non-crash schema-invalid first attempt and asserts the retry prompt sent to the provider still contains the original goal. Verified **red** before the fix (retry prompt was only `"PREVIOUS ATTEMPT FAILED…"`) and **green** after; the full `test_harness_runner.py` suite (15 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
