### PR TITLE
fix(sdk): attribute app.call parent from task-local context, not shared agent state

### DIFF
--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -3858,8 +3858,32 @@ class Agent(FastAPI):
                 for i, arg in enumerate(args):
                     final_kwargs[f"arg_{i}"] = arg
 
-        # Get current execution context
-        current_context = self._get_current_execution_context()
+        # Resolve the parent execution for this call from the TASK-LOCAL
+        # context ONLY — not via _get_current_execution_context(), which falls
+        # back to the process-global self._current_execution_context.
+        #
+        # That shared attribute holds whichever reasoner was most recently
+        # dispatched in this process. When a call originates OUTSIDE any
+        # execution — e.g. a webhook handler's fire-and-forget asyncio task,
+        # which has no task-local context of its own — the fallback would
+        # attribute this independent call to whatever unrelated reasoner
+        # happens to be in flight (possibly paused on a human-in-the-loop
+        # approval for hours). That chains unrelated runs into one bogus
+        # workflow DAG and cross-wires the pause-clock / budget cascades that
+        # key off parent_execution_id.
+        #
+        # The contextvar is the only concurrency-safe source: asyncio.create_task
+        # copies it, so genuine sub-calls made from within a reasoner still
+        # nest correctly. When it is absent we mint a fresh root so the call
+        # starts its own workflow (matching cold-process behavior).
+        from agentfield.execution_context import get_current_context
+
+        current_context = get_current_context()
+        if current_context is None:
+            current_context = ExecutionContext.create_new(
+                agent_node_id=self.node_id,
+                workflow_name=f"{self.node_id}_workflow",
+            )
 
         # 🔧 DEBUG: Validate context before creating child
         if self.dev_mode:

--- a/sdk/python/tests/test_agent_call.py
+++ b/sdk/python/tests/test_agent_call.py
@@ -408,3 +408,119 @@ async def test_call_still_falls_back_on_transport_errors():
         "blips and 502/503s."
     )
     assert result == {"recovered": True}
+
+
+@pytest.mark.asyncio
+async def test_call_does_not_inherit_stale_agent_level_context():
+    """A call made with NO task-local execution context must not be parented
+    to whatever execution happens to be cached on the shared agent-level
+    attribute.
+
+    Regression for the parent-attribution bug: in a process running multiple
+    concurrent executions, ``self._current_execution_context`` holds whichever
+    reasoner was most recently dispatched — an unrelated, possibly in-flight
+    execution. A fire-and-forget ``app.call`` (e.g. from a webhook handler)
+    that has no contextvar of its own must start a FRESH ROOT, not chain
+    itself under that bystander execution.
+    """
+    from agentfield.execution_context import ExecutionContext
+
+    agent = object.__new__(Agent)
+    agent.node_id = "node"
+    agent.agentfield_connected = True
+    agent.dev_mode = False
+    agent.async_config = SimpleNamespace(
+        enable_async_execution=False, fallback_to_sync=False
+    )
+    agent._async_execution_manager = None
+
+    # Simulate an unrelated, still-registered concurrent execution having
+    # stamped its context onto the shared instance attribute.
+    agent._current_execution_context = ExecutionContext(
+        run_id="run_OTHER",
+        execution_id="exec_OTHER",
+        agent_instance=agent,
+        reasoner_name="unrelated_reasoner",
+        registered=True,
+    )
+
+    recorded = {}
+
+    async def fake_execute(target, input_data, headers):
+        recorded["headers"] = headers
+        return {"result": {"ok": True}}
+
+    agent.client = SimpleNamespace(execute=fake_execute)
+
+    set_current_agent(agent)
+    try:
+        # No set_execution_context(...) → no task-local context for this call.
+        result = await agent.call("other.remote_reasoner", 1)
+    finally:
+        clear_current_agent()
+
+    assert result == {"ok": True}
+    assert recorded["headers"]["X-Parent-Execution-ID"] != "exec_OTHER", (
+        "call inherited the stale, unrelated concurrent execution as its parent"
+    )
+    assert recorded["headers"]["X-Run-ID"] != "run_OTHER", (
+        "call was bundled into the stale execution's workflow run"
+    )
+
+
+@pytest.mark.asyncio
+async def test_call_uses_task_local_context_as_parent():
+    """When a call IS made from inside an executing reasoner (task-local
+    contextvar set), the parent must be that execution — no regression to the
+    normal nesting that builds the workflow DAG."""
+    from agentfield.execution_context import (
+        ExecutionContext,
+        reset_execution_context,
+        set_execution_context,
+    )
+
+    agent = object.__new__(Agent)
+    agent.node_id = "node"
+    agent.agentfield_connected = True
+    agent.dev_mode = False
+    agent.async_config = SimpleNamespace(
+        enable_async_execution=False, fallback_to_sync=False
+    )
+    agent._async_execution_manager = None
+    # A stale bystander on the shared attribute must be ignored in favor of the
+    # task-local context.
+    agent._current_execution_context = ExecutionContext(
+        run_id="run_OTHER",
+        execution_id="exec_OTHER",
+        agent_instance=agent,
+        reasoner_name="unrelated_reasoner",
+        registered=True,
+    )
+
+    recorded = {}
+
+    async def fake_execute(target, input_data, headers):
+        recorded["headers"] = headers
+        return {"result": {"ok": True}}
+
+    agent.client = SimpleNamespace(execute=fake_execute)
+
+    ctx_a = ExecutionContext(
+        run_id="run_A",
+        execution_id="exec_A",
+        agent_instance=agent,
+        reasoner_name="reasoner_a",
+        registered=True,
+    )
+
+    set_current_agent(agent)
+    token = set_execution_context(ctx_a)
+    try:
+        result = await agent.call("other.remote_reasoner", 1)
+    finally:
+        reset_execution_context(token)
+        clear_current_agent()
+
+    assert result == {"ok": True}
+    assert recorded["headers"]["X-Parent-Execution-ID"] == "exec_A"
+    assert recorded["headers"]["X-Run-ID"] == "run_A"


### PR DESCRIPTION
## Summary

`Agent.call()` resolved the parent execution via `_get_current_execution_context()`, which falls back to the **process-global** `self._current_execution_context` when no task-local context is set. That attribute is a single slot, overwritten at the top of every reasoner invocation, so in a server running overlapping executions it holds whichever reasoner was **most recently dispatched**.

When a call originates **outside any execution** — e.g. a webhook handler's fire-and-forget `asyncio` task — it has no task-local context, so the fallback attributed it to an unrelated, possibly still-in-flight execution (e.g. one paused on a human-in-the-loop approval for hours). The control plane then recorded that bystander as the new run's parent.

### Observed impact

Three independent webhook-triggered runs (an `implement_from_issue` build, a PR review, and an issue triage) got chained into **one bogus workflow DAG** — each parented to whichever prior run was still in flight. Beyond the misleading DAG, `parent_execution_id` is the key for the cross-reasoner **pause-clock / budget cascade**, so a bystander's HITL pause could pause/resume the wrong run's budget clock.

## Fix

Resolve the parent in `call()` from the **task-local contextvar only** (`get_current_context()`):

- `asyncio.create_task` copies the contextvar, so genuine sub-calls made *from within* a reasoner still nest correctly.
- When the contextvar is absent (a call from outside any execution), mint a **fresh root** so the call starts its own workflow — matching cold-process behavior.
- `_get_current_execution_context()` is left unchanged for its other consumers (`pause`/`note`/VC), which run within an execution where the contextvar is set.

## Changes

- `sdk/python/agentfield/agent.py` — parent resolution in `call()` uses the contextvar; mints a fresh root when none.
- `sdk/python/tests/test_agent_call.py` — two regression tests:
  - a call with a stale bystander on the shared attr but **no** task-local context must start a fresh root (not inherit it);
  - a call from **within** an execution still nests under that execution.

## Test Plan

- [x] `ruff check .` clean
- [x] Full suite green: `./scripts/run_pytest.sh` (exit 0, 94% coverage)
- [x] New regression tests pass and fail without the fix

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)