### PR TITLE
fix(tests): default serverless test bind host to 127.0.0.1 (closes #35)

### DIFF
--- a/tests/functional/tests/test_serverless_agents.py
+++ b/tests/functional/tests/test_serverless_agents.py
@@ -29,7 +29,7 @@ from fastapi.responses import JSONResponse
 
 from utils import run_go_agent, unique_node_id
 
-TEST_BIND_HOST = os.environ.get("TEST_AGENT_BIND_HOST", "0.0.0.0")
+TEST_BIND_HOST = os.environ.get("TEST_AGENT_BIND_HOST", "127.0.0.1")
 TEST_CALLBACK_HOST = os.environ.get("TEST_AGENT_CALLBACK_HOST", "test-runner")
 
 


### PR DESCRIPTION
## Summary
- CodeQL alert [#35](https://github.com/Agent-Field/agentfield/security/code-scanning/35) (`py/bind-socket-all-network-interfaces`) flagged `tests/functional/tests/test_serverless_agents.py:38` for binding the free-port helper to `0.0.0.0` by default.
- Changed the default of `TEST_BIND_HOST` from `0.0.0.0` to `127.0.0.1`, matching the rest of the functional test suite (`tests/functional/conftest.py`, `tests/functional/utils/agent_server.py`, `tests/functional/tests/test_quick_start.py`).
- Docker Compose configurations still override `TEST_AGENT_BIND_HOST` explicitly when `0.0.0.0` is required for cross-container traffic, so CI behaviour is preserved.

## Test plan
- [x] Functional tests run locally with the loopback default
- [x] Docker Compose configs already set `TEST_AGENT_BIND_HOST=0.0.0.0` when needed (verified in `tests/functional/docker/docker-compose.local.yml` and `docker-compose.postgres.yml`)

Closes #35