### PR TITLE
test(web-ui): wait for empty events state in triggers test

### DIFF
--- a/control-plane/web/client/src/test/pages/triggers-pages.test.tsx
+++ b/control-plane/web/client/src/test/pages/triggers-pages.test.tsx
@@ -297,7 +297,15 @@ describe("trigger management pages", () => {
     expect(await screen.findByText(/This trigger is paused/i)).toBeInTheDocument();
     expect(screen.getByText("Code-managed")).toBeInTheDocument();
     expect(screen.getAllByText("All events").length).toBeGreaterThan(0);
-    expect(screen.getByText("No events received yet. Events appear here after the first inbound delivery.")).toBeInTheDocument();
+    // The events list is fetched asynchronously after the sheet opens
+    // (TriggerSheet useEffect → refreshEvents). The empty-state copy only
+    // renders once `loadingEvents` flips back to false, so this must wait
+    // for the fetch to resolve — use findByText, not getByText.
+    expect(
+      await screen.findByText(
+        "No events received yet. Events appear here after the first inbound delivery.",
+      ),
+    ).toBeInTheDocument();
 
     const destructiveButtons = screen.getAllByRole("button").filter((button) =>
       button.getAttribute("title")?.includes("Code-managed triggers"),


### PR DESCRIPTION
## Summary

Fixes #644 — the flaky `coverage (web-ui)` failure in `control-plane/web/client/src/test/pages/triggers-pages.test.tsx:300`.

The empty-state copy `"No events received yet. Events appear here after the first inbound delivery."` is rendered inside `TriggerSheet` only after `refreshEvents()` resolves and `loadingEvents` flips back to `false`. The test used a synchronous `getByText`, which raced the in-flight fetch under CI load and intermittently failed with `TestingLibraryElementError`.

The fix switches the assertion to `findByText` so it awaits the loading state, matching the pattern already used elsewhere in the same file for async-mounted UI (see the `EventRow` toggle around line 242).

No production code is touched.

## Test plan

- [x] `npx vitest run src/test/pages/triggers-pages.test.tsx` — passes locally
- [x] Re-ran the test 5x in a tight loop — passes 5/5
- [x] Verified the only diff against `main` is the `findByText` swap + a short comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)