### PR TITLE
fix: ignore caller identity headers for tag policy(#422)

### DIFF
--- a/control-plane/internal/server/middleware/permission.go
+++ b/control-plane/internal/server/middleware/permission.go
@@ -151,16 +151,21 @@ func PermissionCheckMiddleware(
 		// Parse function name from target param for policy evaluation.
 		_, functionName, _ := parseTargetParam(target)
 
-		// Resolve caller agent identity (used by both policy evaluation and anonymous check).
+		// Resolve caller agent identity from the verified DID only. Caller identity
+		// headers are client-controlled and must not influence authorization.
 		var callerAgentID string
 		if callerDID != "" {
 			callerAgentID = didResolver.ResolveAgentIDByDID(ctx, callerDID)
-		}
-		if callerAgentID == "" {
-			callerAgentID = c.GetHeader("X-Caller-Agent-ID")
 			if callerAgentID == "" {
-				callerAgentID = c.GetHeader("X-Agent-Node-ID")
+				logger.Logger.Warn().
+					Str("caller_did", callerDID).
+					Msg("Permission middleware: verified caller DID did not resolve to an agent ID, treating caller as anonymous")
 			}
+		} else if c.GetHeader("X-Caller-Agent-ID") != "" || c.GetHeader("X-Agent-Node-ID") != "" {
+			logger.Logger.Warn().
+				Bool("x_caller_agent_id_present", c.GetHeader("X-Caller-Agent-ID") != "").
+				Bool("x_agent_node_id_present", c.GetHeader("X-Agent-Node-ID") != "").
+				Msg("Permission middleware: caller identity headers ignored without a verified DID, treating caller as anonymous")
 		}
 
 		// --- Tag-based policy evaluation ---

--- a/control-plane/internal/server/middleware/permission_test.go
+++ b/control-plane/internal/server/middleware/permission_test.go
@@ -134,7 +134,7 @@ func TestPermissionCallerDIDResolutionPrecedence(t *testing.T) {
 		expectedTags      []string
 	}{
 		{
-			name:              "vc tags win over registration tags and header fallback",
+			name:              "vc tags win over registration tags and caller identity header",
 			verifiedCallerDID: "did:caller:vc",
 			didMappings:       map[string]string{"did:caller:vc": "caller-vc"},
 			headerCallerID:    "caller-header",
@@ -160,11 +160,17 @@ func TestPermissionCallerDIDResolutionPrecedence(t *testing.T) {
 			expectedTags:      []string{"registration-tag"},
 		},
 		{
-			name:           "header caller id is final fallback",
+			name:           "caller identity header ignored without verified did",
 			didMappings:    map[string]string{},
 			headerCallerID: "caller-header",
 			tagVerifier:    &permissionTagVCVerifierStub{},
-			expectedTags:   []string{"header-tag"},
+		},
+		{
+			name:              "caller identity header ignored when verified did is unresolved",
+			verifiedCallerDID: "did:caller:missing",
+			didMappings:       map[string]string{},
+			headerCallerID:    "caller-header",
+			tagVerifier:       &permissionTagVCVerifierStub{},
 		},
 	}
 
@@ -217,6 +223,97 @@ func TestPermissionCallerDIDResolutionPrecedence(t *testing.T) {
 			require.Equal(t, "run", policy.lastFunction)
 		})
 	}
+}
+
+func TestPermissionCallerNodeHeaderWithoutVerifiedDIDIsAnonymous(t *testing.T) {
+	policy := &permissionPolicyCapture{}
+	router := setupPermissionRouter(
+		"",
+		policy,
+		&permissionTagVCVerifierStub{},
+		&permissionAgentResolverStub{
+			agents: map[string]*types.AgentNode{
+				"target-agent": {
+					ID:           "target-agent",
+					ApprovedTags: []string{"target-tag"},
+				},
+				"caller-node": {
+					ID:           "caller-node",
+					ApprovedTags: []string{"node-header-tag"},
+				},
+			},
+		},
+		&permissionDIDResolverStub{dids: map[string]string{}},
+		func(c *gin.Context) {
+			c.Status(http.StatusOK)
+		},
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/execute/target-agent.run", bytes.NewBufferString(`{"input":{"limit":5}}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Agent-Node-ID", "caller-node")
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Empty(t, policy.lastCallerTags)
+	require.Equal(t, []string{"target-tag"}, policy.lastTargetTags)
+	require.Equal(t, "run", policy.lastFunction)
+}
+
+func TestPermissionSpoofedCallerHeaderWithoutVerifiedDIDIsAnonymous(t *testing.T) {
+	policy := &permissionPolicyCapture{
+		evaluate: func(callerTags, _ []string, _ string, _ map[string]any) *types.PolicyEvaluationResult {
+			for _, tag := range callerTags {
+				if tag == "privileged" {
+					return &types.PolicyEvaluationResult{
+						Matched: true,
+						Allowed: true,
+					}
+				}
+			}
+			return &types.PolicyEvaluationResult{
+				Matched: true,
+				Allowed: false,
+			}
+		},
+	}
+	router := setupPermissionRouter(
+		"",
+		policy,
+		&permissionTagVCVerifierStub{},
+		&permissionAgentResolverStub{
+			agents: map[string]*types.AgentNode{
+				"target-agent": {
+					ID:           "target-agent",
+					ApprovedTags: []string{"target-tag"},
+				},
+				"privileged-agent": {
+					ID:           "privileged-agent",
+					ApprovedTags: []string{"privileged"},
+				},
+			},
+		},
+		&permissionDIDResolverStub{dids: map[string]string{}},
+		func(c *gin.Context) {
+			t.Fatal("handler should not be reached when only caller identity headers are present")
+		},
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/execute/target-agent.run", bytes.NewBufferString(`{"input":{"limit":5}}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Caller-Agent-ID", "privileged-agent")
+	req.Header.Set("X-Agent-Node-ID", "privileged-agent")
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusForbidden, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "access_denied")
+	require.Empty(t, policy.lastCallerTags)
+	require.Equal(t, []string{"target-tag"}, policy.lastTargetTags)
+	require.Equal(t, "run", policy.lastFunction)
 }
 
 func TestPermissionRequestBodyReadAndRestored(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a tag-policy authorization bypass where caller identity could fall back to client-controlled `X-Caller-Agent-ID` / `X-Agent-Node-ID` headers. The permission middleware now uses verified DID resolution as the only caller identity source for tag-policy evaluation and treats missing/unresolved DID identity as anonymous/untagged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] Tests only
- [ ] CI / tooling
- [ ] Breaking change

## Test plan

- [x] `cd control-plane && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-modcache /usr/local/go/bin/go test ./internal/server/middleware`
- [x] `cd control-plane && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-modcache /usr/local/go/bin/go test ./...`
- [x] `cd control-plane && GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-modcache /usr/local/go/bin/go vet ./...`

Note: `make lint` was attempted locally, but `golangci-lint` and `ruff` are not installed in this environment, and the Makefile masks missing-tool failures with `|| true`.

## Test coverage

This repo enforces a **coverage gate** on every PR (see
[`.github/workflows/coverage.yml`](.github/workflows/coverage.yml) and
[`docs/COVERAGE.md`](docs/COVERAGE.md)).

- The gate runs `./scripts/coverage-summary.sh` and compares per-surface
  numbers against `coverage-baseline.json`.
- It **fails** if any surface drops more than **1.0 pp** below its baseline,
  if any surface is below **80%**, or if the weighted aggregate falls below
  **85%**.

Before asking for review, please confirm:

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR (no bare additions).
- [ ] If I removed code, I updated `coverage-baseline.json` in
      this PR *only if* the removal caused a legitimate regression and I
      called it out in the summary above.
- [ ] The coverage gate check is green in CI before requesting review.

## Checklist

- [ ] I have read [CONTRIBUTING.md](CONTRIBUTING.md) (if present) and
      [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
- [x] Commits are signed and follow conventional-commits style.
- [x] I have linked any related issues .

## Related issues / PRs

Fixes #422