### PR TITLE
fix: Fixed the stale `_current_status` issue where status stuck on `S…

### DIFF
--- a/sdk/python/agentfield/connection_manager.py
+++ b/sdk/python/agentfield/connection_manager.py
@@ -5,6 +5,7 @@ Provides resilient connection handling for AgentField server connectivity.
 Handles automatic reconnection, graceful degradation, and connection health monitoring.
 """
 
+from agentfield.types import AgentStatus
 import asyncio
 import time
 from enum import Enum
@@ -246,6 +247,7 @@ class ConnectionManager:
         self.state = ConnectionState.CONNECTED
         self.last_successful_connection = time.time()
         self.agent.agentfield_connected = True
+        self.agent._current_status = AgentStatus.READY
 
         log_info("Connected to AgentField server")
 
@@ -259,6 +261,7 @@ class ConnectionManager:
         """Handle connection failure"""
         self.state = ConnectionState.DEGRADED
         self.agent.agentfield_connected = False
+        self.agent._current_status = AgentStatus.DEGRADED
 
         log_warn("AgentField server unavailable - running in degraded mode")
 


### PR DESCRIPTION
## Summary
- This PR fixes the stale `_current_status` issue by modifying the `_current_status` property of `Agent` class inside the `connection_manager.py` file, specifically inside `_on_connection_success()` and `_on_connection_failure()` method.
- Inside `_on_connection_success()` the `self.agent._current_status` set to `AgentStatus.READY` .
- Inside `_on_connection_failure()`` the `self.agent._current_status` set to `AgentStatus.DEGRADED` .

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] Tests only
- [ ] CI / tooling
- [ ] Breaking change

## Test plan

<!-- Concrete list of commands / steps that verify this PR. Prefer
automated tests; note any manual verification you did. Example:
- `cd control-plane && go test ./internal/services/...`
- `cd control-plane/web/client && npx vitest run src/test/pages/RunsPage.test.tsx`
-->

- [x] `./scripts/test-all.sh`
- [x] Verified the branch rebases cleanly on latest `upstream/main`.

## Test coverage

I ran the Python SDK coverage test locally because this PR only changes Python-side code.

Command used:

```bash
cd sdk/python
uv run pytest --cov=agentfield --cov-report=term-missing
```

Result:

1589 passed, 4 skipped, 12 deselected, 27 warnings
TOTAL coverage: 80%

The Python SDK test suite passes successfully. The Python coverage is currently exactly 80%, which meets the repository’s minimum per-surface coverage requirement, but it is close to the lower limit.

I also attempted to run the full repository coverage script:

`./scripts/coverage-summary.sh`

However, that full coverage run did not complete successfully. It failed during the control-plane Go test phase, specifically in:

TestStartAndStopCoverAdditionalBranches
server_coverage_additional_test.go:144
Error: Expected value not to be nil.

This failure appears to come from the control-plane/server Go test path, not from the Python SDK changes in this PR.

Because of that, I am not claiming that the full repository coverage gate has passed locally. I am only confirming that the Python SDK tests pass and that Python coverage is at 80%.

Before asking for review, please confirm:

- [x] I ran tests for the surface(s) I changed locally.
- [ ] New code paths are covered by tests in this PR (no bare additions).
- [x] If I removed code, I updated `coverage-baseline.json` in
      this PR *only if* the removal caused a legitimate regression and I
      called it out in the summary above.
- [ ] The coverage gate check is green in CI before requesting review.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) (if present) and
      [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
- [ ] Commits are signed and follow conventional-commits style.
- [x] I have linked any related issues (Fixes #123 / Closes #456).

## Related issues / PRs
Fixes #626 
<!-- Optional. Leave blank if none. -->
