### PR TITLE
fix(security): restrict query API key auth to streaming routes (#423)

### DIFF
--- a/control-plane/internal/handlers/agentic/coverage_additional_test.go
+++ b/control-plane/internal/handlers/agentic/coverage_additional_test.go
@@ -105,7 +105,7 @@ func TestGetAuthLevel_AdditionalFallbacks(t *testing.T) {
 		{
 			name:     "api key query parameter",
 			url:      "/test?api_key=abc",
-			expected: "api_key",
+			expected: "public",
 		},
 		{
 			name:     "non string context falls back to public",

--- a/control-plane/internal/handlers/agentic/helpers.go
+++ b/control-plane/internal/handlers/agentic/helpers.go
@@ -70,7 +70,7 @@ func getAuthLevel(c *gin.Context) string {
 	level, exists := c.Get("auth_level")
 	if !exists {
 		// Check if API key header is present as a fallback
-		if c.GetHeader("X-API-Key") != "" || strings.HasPrefix(c.GetHeader("Authorization"), "Bearer ") || c.Query("api_key") != "" {
+		if c.GetHeader("X-API-Key") != "" || strings.HasPrefix(c.GetHeader("Authorization"), "Bearer ") {
 			return "api_key"
 		}
 		return "public"

--- a/control-plane/internal/server/middleware/auth.go
+++ b/control-plane/internal/server/middleware/auth.go
@@ -10,15 +10,20 @@ import (
 
 // AuthConfig mirrors server configuration for HTTP authentication.
 type AuthConfig struct {
-	APIKey    string
-	SkipPaths []string
+	APIKey                  string
+	SkipPaths               []string
+	QueryAPIKeyAllowedPaths []string
 }
 
-// APIKeyAuth enforces API key authentication via header, bearer token, or query param.
+// APIKeyAuth enforces API key authentication via header or bearer token.
 func APIKeyAuth(config AuthConfig) gin.HandlerFunc {
 	skipPathSet := make(map[string]struct{}, len(config.SkipPaths))
 	for _, p := range config.SkipPaths {
 		skipPathSet[p] = struct{}{}
+	}
+	queryAPIKeyAllowedPathSet := make(map[string]struct{}, len(config.QueryAPIKeyAllowedPaths))
+	for _, p := range config.QueryAPIKeyAllowedPaths {
+		queryAPIKeyAllowedPathSet[p] = struct{}{}
 	}
 
 	return func(c *gin.Context) {
@@ -94,8 +99,10 @@ func APIKeyAuth(config AuthConfig) gin.HandlerFunc {
 			}
 		}
 
-		// SSE/WebSocket friendly: api_key query parameter
-		if apiKey == "" {
+		// Browser EventSource and WebSocket clients cannot set custom
+		// authentication headers, so query-string API key auth is restricted
+		// to an explicit streaming route allowlist.
+		if apiKey == "" && queryAPIKeyAllowed(c, queryAPIKeyAllowedPathSet) {
 			apiKey = c.Query("api_key")
 		}
 
@@ -104,7 +111,7 @@ func APIKeyAuth(config AuthConfig) gin.HandlerFunc {
 			c.Set("auth_level", "public")
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
 				"error":   "unauthorized",
-				"message": "invalid or missing API key. Provide via X-API-Key header, Authorization: Bearer <token>, or ?api_key= query param",
+				"message": "invalid or missing API key. Provide via X-API-Key header or Authorization: Bearer <token>",
 				"help": map[string]string{
 					"kb":              "GET /api/v1/agentic/kb/topics (public, no auth required)",
 					"guide":           "GET /api/v1/agentic/kb/guide?goal=<your goal> (public)",
@@ -124,6 +131,20 @@ func APIKeyAuth(config AuthConfig) gin.HandlerFunc {
 		}
 		c.Next()
 	}
+}
+
+func queryAPIKeyAllowed(c *gin.Context, allowedPaths map[string]struct{}) bool {
+	if len(allowedPaths) == 0 {
+		return false
+	}
+	if _, ok := allowedPaths[c.Request.URL.Path]; ok {
+		return true
+	}
+	if fullPath := c.FullPath(); fullPath != "" {
+		_, ok := allowedPaths[fullPath]
+		return ok
+	}
+	return false
 }
 
 // AdminTokenAuth enforces a separate admin token for admin routes.

--- a/control-plane/internal/server/middleware/auth_test.go
+++ b/control-plane/internal/server/middleware/auth_test.go
@@ -80,7 +80,7 @@ func TestAPIKeyAuth_ValidBearerToken(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-func TestAPIKeyAuth_ValidQueryParam(t *testing.T) {
+func TestAPIKeyAuth_QueryParamRejectedOnStandardRESTRoute(t *testing.T) {
 	router := setupRouter(AuthConfig{APIKey: "secret-key"})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/test?api_key=secret-key", nil)
@@ -88,7 +88,67 @@ func TestAPIKeyAuth_ValidQueryParam(t *testing.T) {
 
 	router.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	msg, _ := resp["message"].(string)
+	assert.NotContains(t, msg, "?api_key=", "standard REST 401s must not advertise query-string auth")
+}
+
+func TestAPIKeyAuth_QueryParamAllowedOnConfiguredStreamingRoutes(t *testing.T) {
+	router := gin.New()
+	router.Use(APIKeyAuth(AuthConfig{
+		APIKey: "secret-key",
+		QueryAPIKeyAllowedPaths: []string{
+			"/api/v1/stream/events",
+			"/api/v1/executions/:execution_id/events",
+		},
+	}))
+	router.GET("/api/v1/stream/events", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "stream"})
+	})
+	router.GET("/api/v1/executions/:execution_id/events", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "dynamic stream"})
+	})
+
+	for _, url := range []string{
+		"/api/v1/stream/events?api_key=secret-key",
+		"/api/v1/executions/exec-1/events?api_key=secret-key",
+	} {
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code, "url %s should accept query auth because the streaming route is allowlisted", url)
+	}
+}
+
+func TestAPIKeyAuth_QueryParamRejectedWhenRouteNotAllowlisted(t *testing.T) {
+	router := gin.New()
+	router.Use(APIKeyAuth(AuthConfig{
+		APIKey:                  "secret-key",
+		QueryAPIKeyAllowedPaths: []string{"/api/v1/stream/events"},
+	}))
+	router.GET("/api/v1/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "success"})
+	})
+	router.GET("/api/v1/stream/events/history", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "history"})
+	})
+
+	for _, url := range []string{
+		"/api/v1/test?api_key=secret-key",
+		"/api/v1/stream/events/history?api_key=secret-key",
+	} {
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusUnauthorized, w.Code, "url %s should reject query auth because the route is not allowlisted", url)
+	}
 }
 
 func TestAPIKeyAuth_SetsCallerAgentIDContext(t *testing.T) {
@@ -160,7 +220,7 @@ func TestAPIKeyAuth_InvalidKey(t *testing.T) {
 			headerValue: "Bearer wrong-key",
 		},
 		{
-			name:       "wrong query param",
+			name:       "query param on standard route",
 			queryParam: "wrong-key",
 		},
 		{

--- a/control-plane/internal/server/routes_middleware.go
+++ b/control-plane/internal/server/routes_middleware.go
@@ -61,13 +61,16 @@ func (s *AgentFieldServer) applyGlobalMiddleware() {
 		c.Next()
 	})
 
-	// API key authentication (supports headers + api_key query param)
+	// API key authentication. Header auth is supported for every protected
+	// route; query-string auth is restricted to browser streaming endpoints
+	// because EventSource and WebSocket clients cannot set custom headers.
 	// Note: The approval webhook callback is authenticated via HMAC signature,
 	// not the global API key. Always bypass API-key auth on that endpoint.
 	skipPaths := uniqueStrings(append(append([]string{}, s.config.API.Auth.SkipPaths...), "/api/v1/webhooks/approval-response"))
 	s.Router.Use(middleware.APIKeyAuth(middleware.AuthConfig{
-		APIKey:    s.config.API.Auth.APIKey,
-		SkipPaths: skipPaths,
+		APIKey:                  s.config.API.Auth.APIKey,
+		SkipPaths:               skipPaths,
+		QueryAPIKeyAllowedPaths: streamingQueryAPIKeyAllowedPaths(),
 	}))
 	if s.config.API.Auth.APIKey != "" {
 		logger.Logger.Info().Msg("🔐 API key authentication enabled")
@@ -106,6 +109,20 @@ func (s *AgentFieldServer) noteOwnershipEnforced() bool {
 		return true
 	}
 	return s.config.Features.DID.Enabled && s.config.Features.DID.Authorization.DIDAuthEnabled && s.didWebService != nil
+}
+
+func streamingQueryAPIKeyAllowedPaths() []string {
+	return []string{
+		"/api/ui/v1/nodes/events",
+		"/api/ui/v1/executions/events",
+		"/api/ui/v1/executions/:execution_id/logs/stream",
+		"/api/ui/v1/workflows/:workflowId/notes/events",
+		"/api/ui/v1/reasoners/events",
+		"/api/v1/executions/:execution_id/events",
+		"/api/v1/memory/events/ws",
+		"/api/v1/memory/events/sse",
+		"/api/v1/triggers/:trigger_id/events/stream",
+	}
 }
 
 func uniqueStrings(in []string) []string {


### PR DESCRIPTION
## Summary

This PR removes the global `?api_key=` fallback from API key authentication on normal REST routes, because putting a secret in the URL can leak it into access logs, proxy logs, browser history, and Referer headers.

The change is intentionally scoped:
- `control-plane/internal/server/middleware/auth.go` now only accepts query-string API keys on an explicit allowlist of streaming routes.
- `control-plane/internal/server/routes_middleware.go` defines the allowlist for browser-driven SSE/WebSocket endpoints that cannot reliably send custom headers.
- `control-plane/internal/server/middleware/auth_test.go` now verifies that standard REST routes reject `?api_key=` with `401`, while allowlisted streaming routes still accept it.
- `control-plane/internal/handlers/agentic/helpers.go` and its coverage test were updated so query-string API keys are no longer treated as a general auth signal outside the middleware allowlist.

This keeps header-based auth unchanged, preserves the embedded UI’s streaming auth flow, and closes the security hole on ordinary API routes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] Tests only
- [ ] CI / tooling
- [x] Breaking change

## Test plan

- [x] `cd control-plane && go test ./...`
- [x] `make lint` (the target ran; local `golangci-lint` / `ruff` are not installed in this environment, so the wrapper completed but the tools themselves were not available)

## Test coverage

This repo enforces a **coverage gate** on every PR (see
[`.github/workflows/coverage.yml`](.github/workflows/coverage.yml) and
[`docs/COVERAGE.md`](docs/COVERAGE.md)).

- The gate runs `./scripts/coverage-summary.sh` and compares per-surface
  numbers against `coverage-baseline.json`.
- It **fails** if any surface drops more than **1.0 pp** below its baseline,
  if any surface is below **80%**, or if the weighted aggregate falls below
  **85%**.

Before asking for review, please confirm:

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR (no bare additions).
- [x] If I removed code, I updated `coverage-baseline.json` in
      this PR only if the removal caused a legitimate regression and I
      called it out in the summary above.
- [ ] The coverage gate check is green in CI before requesting review.

> **For AI coding agents:** if the `Coverage Summary` GitHub Actions job
> fails, read the sticky PR comment titled "📊 Coverage report" — it lists
> the specific surface that regressed, the delta, and the exact command to
> reproduce locally. Add tests for the uncovered lines in this same PR
> before requesting review again. Do *not* lower baselines to silence the
> gate unless the regression is intentional and explicitly called out in
> the PR summary.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) (if present) and
      [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
- [ ] Commits are signed and follow conventional-commits style.
- [x] I have linked any related issues (Fixes #123 / Closes #456).

## Related issues / PRs

Fixes #423