### PR TITLE
fix(sdk): satisfy OpenAI strict response_format schema rules

### DIFF
--- a/sdk/python/agentfield/agent_ai.py
+++ b/sdk/python/agentfield/agent_ai.py
@@ -140,6 +140,42 @@ litellm = _LazyModule(_get_litellm)
 openai = _LazyModule(_get_openai)
 
 
+def _strictify_openai_schema(schema: Any) -> Any:
+    """Make a Pydantic-generated JSON schema satisfy OpenAI's strict
+    structured-output rules.
+
+    OpenAI's ``response_format`` with ``strict: True`` requires every object to
+    (a) set ``additionalProperties: false`` and (b) list ALL of its properties in
+    ``required``. Pydantic's ``model_json_schema()`` emits neither, so OpenAI
+    rejects the request with::
+
+        BadRequestError: Invalid schema ... 'additionalProperties' is required
+        to be supplied and to be false.
+
+    This walks the entire schema — including ``$defs``/``definitions`` and nested
+    ``properties``/``items``/``anyOf`` — and returns a corrected copy. Forcing
+    every property into ``required`` is OpenAI's documented requirement for strict
+    mode (truly-optional fields should be modelled as nullable); it never makes a
+    previously-valid schema invalid.
+    """
+
+    def walk(node: Any) -> Any:
+        if isinstance(node, dict):
+            node = {key: walk(value) for key, value in node.items()}
+            props = node.get("properties")
+            if isinstance(props, dict) and (
+                node.get("type") == "object" or "type" not in node
+            ):
+                node["additionalProperties"] = False
+                node["required"] = list(props.keys())
+            return node
+        if isinstance(node, list):
+            return [walk(item) for item in node]
+        return node
+
+    return walk(schema)
+
+
 class AgentAI:
     """AI/LLM Integration functionality for AgentField Agent"""
 
@@ -568,7 +604,10 @@ class AgentAI:
             litellm_params["response_format"] = {
                 "type": "json_schema",
                 "json_schema": {
-                    "schema": schema.model_json_schema(),
+                    # OpenAI strict mode requires additionalProperties:false +
+                    # all-properties-required on every object; Pydantic emits
+                    # neither, so sanitize before sending (else BadRequestError).
+                    "schema": _strictify_openai_schema(schema.model_json_schema()),
                     "name": schema.__name__,
                     "strict": True,
                 },

--- a/sdk/python/tests/test_strict_openai_schema.py
+++ b/sdk/python/tests/test_strict_openai_schema.py
@@ -1,0 +1,80 @@
+"""Unit tests for `_strictify_openai_schema` — the OpenAI strict structured-output
+schema sanitizer used by `AgentAI.ai(schema=...)`.
+
+Contract (OpenAI strict `response_format` rules):
+- Every object node sets `additionalProperties: false`.
+- Every object node's `required` lists ALL of its properties (incl. optionals).
+- Correction applies recursively, including nested models under `$defs`.
+- A schema with no objects is returned unchanged in structure.
+"""
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+from agentfield.agent_ai import _strictify_openai_schema
+
+
+def _assert_strict(node):
+    """Recursively assert every object node is OpenAI-strict-compliant."""
+    if isinstance(node, dict):
+        props = node.get("properties")
+        if isinstance(props, dict) and (node.get("type") == "object" or "type" not in node):
+            assert node.get("additionalProperties") is False, f"missing additionalProperties:false in {node}"
+            assert set(node.get("required", [])) == set(props.keys()), (
+                f"required {node.get('required')} != properties {list(props.keys())}"
+            )
+        for value in node.values():
+            _assert_strict(value)
+    elif isinstance(node, list):
+        for item in node:
+            _assert_strict(item)
+
+
+def test_flat_model_gets_additional_properties_false_and_required():
+    class DiscussAnswer(BaseModel):
+        answer: str
+
+    out = _strictify_openai_schema(DiscussAnswer.model_json_schema())
+    assert out["additionalProperties"] is False
+    assert out["required"] == ["answer"]
+
+
+def test_optional_field_is_still_required_in_strict_mode():
+    class WithOptional(BaseModel):
+        answer: str
+        note: Optional[str] = None
+
+    out = _strictify_openai_schema(WithOptional.model_json_schema())
+    # OpenAI strict requires EVERY property in `required`, even optional ones.
+    assert set(out["required"]) == {"answer", "note"}
+    assert out["additionalProperties"] is False
+
+
+def test_nested_model_defs_are_corrected_recursively():
+    class Citation(BaseModel):
+        label: str
+        url: Optional[str] = None
+
+    class Answer(BaseModel):
+        body: str
+        citations: List[Citation]
+
+    out = _strictify_openai_schema(Answer.model_json_schema())
+    # The nested Citation lives under $defs and must also be strict.
+    assert "$defs" in out and "Citation" in out["$defs"]
+    _assert_strict(out)
+
+
+def test_idempotent_and_does_not_mutate_already_strict_schema():
+    class M(BaseModel):
+        x: int
+
+    once = _strictify_openai_schema(M.model_json_schema())
+    twice = _strictify_openai_schema(once)
+    assert once == twice
+
+
+def test_non_object_schema_passthrough():
+    # A bare scalar schema has no object to correct; structure is preserved.
+    assert _strictify_openai_schema({"type": "string"}) == {"type": "string"}


### PR DESCRIPTION
## Problem

`AgentAI.ai(schema=...)` builds an OpenAI `response_format` with `strict: True` from Pydantic's raw `model_json_schema()`. That schema omits `additionalProperties: false` and a complete `required` list, both of which OpenAI's strict structured-output mode **requires**. OpenAI therefore rejects the request:

```
litellm.BadRequestError: OpenAIException - Invalid schema for response_format 'X':
'additionalProperties' is required to be supplied and to be false.
```

Every `app.ai(schema=...)` call against an OpenAI model fails and the caller silently degrades to unstructured text. Surfaced while deploying the discuss agent (its LLM phrasing fell back to raw retrieved context on every call).

## Fix

Add `_strictify_openai_schema`, which recursively rewrites the Pydantic schema to be OpenAI-strict-compliant before sending:
- sets `additionalProperties: false` on every object node, and
- lists **all** properties in `required` (OpenAI strict requires every property present; nested models under `$defs` are corrected too).

Applied at the single `response_format` construction site in `agent_ai.py`.

## Validation contract → tests (`tests/test_strict_openai_schema.py`)
- Flat model → root gets `additionalProperties:false` + `required`.
- Optional field → still listed in `required` (strict-mode rule).
- Nested model under `$defs` → corrected recursively.
- Idempotent (re-running doesn't change an already-strict schema).
- Non-object scalar schema → passed through unchanged.

## Gates
- `ruff check .` clean
- full SDK pytest suite green (exit 0; only the usual server-source integration skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)