### PR TITLE
fix(#424): fail closed on empty API key unless insecure mode is explicitly enabled

### DIFF
--- a/control-plane/cmd/af/main.go
+++ b/control-plane/cmd/af/main.go
@@ -216,6 +216,7 @@ func loadConfig(configFile string) (*config.Config, error) {
 	// This is needed because Viper's AutomaticEnv only works for keys that exist in config
 	_ = viper.BindEnv("api.auth.api_key", "AGENTFIELD_API_KEY")
 	_ = viper.BindEnv("api.auth.api_key", "AGENTFIELD_API_AUTH_API_KEY")
+	_ = viper.BindEnv("api.auth.insecure_disable_auth", "AGENTFIELD_INSECURE_DISABLE_AUTH", "AGENTFIELD_API_AUTH_INSECURE_DISABLE_AUTH")
 
 	// Get the directory where the binary is located for UI paths
 	execPath, err := os.Executable()

--- a/control-plane/cmd/agentfield-server/main.go
+++ b/control-plane/cmd/agentfield-server/main.go
@@ -245,6 +245,7 @@ func loadConfig(configFile string) (*config.Config, error) {
 	// This is needed because Viper's AutomaticEnv only works for keys that exist in config
 	_ = viper.BindEnv("api.auth.api_key", "AGENTFIELD_API_KEY")
 	_ = viper.BindEnv("api.auth.api_key", "AGENTFIELD_API_AUTH_API_KEY")
+	_ = viper.BindEnv("api.auth.insecure_disable_auth", "AGENTFIELD_INSECURE_DISABLE_AUTH", "AGENTFIELD_API_AUTH_INSECURE_DISABLE_AUTH")
 	// AutomaticEnv makes viper.IsSet("features.did.enabled") return true once
 	// AGENTFIELD_FEATURES_DID_ENABLED is set, but Unmarshal won't actually
 	// populate the struct field unless the key is bound. Without this, setting

--- a/control-plane/config/agentfield.yaml
+++ b/control-plane/config/agentfield.yaml
@@ -25,6 +25,9 @@ ui:
   dev_port: 5173
 
 api:
+  auth:
+    # Local development only. Production deployments should configure api_key.
+    insecure_disable_auth: true
   cors:
     allowed_origins:
       - "http://localhost:3000"

--- a/control-plane/config/docker-perf.yaml
+++ b/control-plane/config/docker-perf.yaml
@@ -34,6 +34,9 @@ ui:
   backend_url: ""
 
 api:
+  auth:
+    # This benchmark configuration runs in an isolated local environment.
+    insecure_disable_auth: true
   cors:
     allowed_origins:
       - "*"

--- a/control-plane/internal/config/config.go
+++ b/control-plane/internal/config/config.go
@@ -395,8 +395,11 @@ type CORSConfig struct {
 
 // AuthConfig holds API authentication configuration.
 type AuthConfig struct {
-	// APIKey is checked against headers or query params. Empty disables auth.
+	// APIKey is checked against headers or query params.
 	APIKey string `yaml:"api_key" mapstructure:"api_key"`
+	// InsecureDisableAuth explicitly permits running without API-key authentication.
+	// This should only be enabled for trusted local development environments.
+	InsecureDisableAuth bool `yaml:"insecure_disable_auth" mapstructure:"insecure_disable_auth"`
 	// SkipPaths allows bypassing auth for specific endpoints (e.g., health).
 	SkipPaths []string `yaml:"skip_paths" mapstructure:"skip_paths"`
 }
@@ -529,6 +532,13 @@ func ApplyEnvOverrides(cfg *Config) {
 	// Also support the nested path format for consistency
 	if apiKey := os.Getenv("AGENTFIELD_API_AUTH_API_KEY"); apiKey != "" {
 		cfg.API.Auth.APIKey = apiKey
+	}
+	if val, ok := os.LookupEnv("AGENTFIELD_INSECURE_DISABLE_AUTH"); ok {
+		cfg.API.Auth.InsecureDisableAuth = parseEnvBool(val)
+	}
+	// Also support the nested path format for consistency.
+	if val, ok := os.LookupEnv("AGENTFIELD_API_AUTH_INSECURE_DISABLE_AUTH"); ok {
+		cfg.API.Auth.InsecureDisableAuth = parseEnvBool(val)
 	}
 
 	if val := os.Getenv("AGENTFIELD_REGISTRATION_SERVERLESS_DISCOVERY_ALLOWED_HOSTS"); val != "" {

--- a/control-plane/internal/config/config_additional_test.go
+++ b/control-plane/internal/config/config_additional_test.go
@@ -103,7 +103,7 @@ func TestLoadConfig(t *testing.T) {
 	t.Run("loads explicit config path", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "custom.yaml")
-		if err := os.WriteFile(path, []byte("agentfield:\n  port: 7777\n"), 0o644); err != nil {
+		if err := os.WriteFile(path, []byte("agentfield:\n  port: 7777\napi:\n  auth:\n    insecure_disable_auth: true\n"), 0o644); err != nil {
 			t.Fatalf("write config: %v", err)
 		}
 
@@ -113,6 +113,9 @@ func TestLoadConfig(t *testing.T) {
 		}
 		if cfg.AgentField.Port != 7777 {
 			t.Fatalf("expected port 7777, got %d", cfg.AgentField.Port)
+		}
+		if !cfg.API.Auth.InsecureDisableAuth {
+			t.Fatal("expected insecure_disable_auth to load from YAML")
 		}
 	})
 
@@ -414,6 +417,31 @@ func TestApplyEnvOverrides(t *testing.T) {
 	if got := cfg.Features.Connector.Capabilities["did_management"]; got.Enabled {
 		t.Fatalf("unexpected did_management capability: %+v", got)
 	}
+}
+
+func TestApplyEnvOverridesAPIAuthInsecureDisable(t *testing.T) {
+	t.Run("short environment name", func(t *testing.T) {
+		cfg := &Config{}
+		t.Setenv("AGENTFIELD_INSECURE_DISABLE_AUTH", "true")
+
+		ApplyEnvOverrides(cfg)
+
+		if !cfg.API.Auth.InsecureDisableAuth {
+			t.Fatal("expected insecure API auth disable from environment")
+		}
+	})
+
+	t.Run("nested environment name takes precedence", func(t *testing.T) {
+		cfg := &Config{}
+		t.Setenv("AGENTFIELD_INSECURE_DISABLE_AUTH", "true")
+		t.Setenv("AGENTFIELD_API_AUTH_INSECURE_DISABLE_AUTH", "false")
+
+		ApplyEnvOverrides(cfg)
+
+		if cfg.API.Auth.InsecureDisableAuth {
+			t.Fatal("expected nested insecure API auth setting to take precedence")
+		}
+	})
 }
 
 func TestApplyEnvOverridesIgnoresInvalidValues(t *testing.T) {

--- a/control-plane/internal/server/middleware/auth.go
+++ b/control-plane/internal/server/middleware/auth.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"crypto/subtle"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -11,9 +12,18 @@ import (
 // AuthConfig mirrors server configuration for HTTP authentication.
 type AuthConfig struct {
 	APIKey                  string
+	InsecureDisableAuth     bool
 	SkipPaths               []string
 	SkipPrefixes            []string
 	QueryAPIKeyAllowedPaths []string
+}
+
+// ValidateAPIKeyAuth rejects an implicit unauthenticated configuration.
+func ValidateAPIKeyAuth(config AuthConfig) error {
+	if config.APIKey == "" && !config.InsecureDisableAuth {
+		return errors.New("API key is required; set AGENTFIELD_API_KEY or explicitly set AGENTFIELD_INSECURE_DISABLE_AUTH=true")
+	}
+	return nil
 }
 
 // APIKeyAuth enforces API key authentication via header or bearer token.
@@ -28,8 +38,8 @@ func APIKeyAuth(config AuthConfig) gin.HandlerFunc {
 	}
 
 	return func(c *gin.Context) {
-		// No auth configured, allow everything.
-		if config.APIKey == "" {
+		// Unauthenticated operation must be explicitly enabled at startup.
+		if config.APIKey == "" && config.InsecureDisableAuth {
 			c.Next()
 			return
 		}
@@ -90,6 +100,15 @@ func APIKeyAuth(config AuthConfig) gin.HandlerFunc {
 		// handler before any payload work happens.
 		if strings.HasPrefix(c.Request.URL.Path, "/sources/") {
 			c.Next()
+			return
+		}
+
+		if config.APIKey == "" {
+			c.Set("auth_level", "public")
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"error":   "unauthorized",
+				"message": "authentication required but API key is not configured on the server",
+			})
 			return
 		}
 

--- a/control-plane/internal/server/middleware/auth_test.go
+++ b/control-plane/internal/server/middleware/auth_test.go
@@ -40,9 +40,25 @@ func setupRouter(config AuthConfig) *gin.Engine {
 	return router
 }
 
-func TestAPIKeyAuth_NoAuthConfigured(t *testing.T) {
-	// When no API key is configured, all requests should be allowed
-	router := setupRouter(AuthConfig{APIKey: ""})
+func TestValidateAPIKeyAuth_RejectsImplicitDisable(t *testing.T) {
+	err := ValidateAPIKeyAuth(AuthConfig{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "AGENTFIELD_INSECURE_DISABLE_AUTH=true")
+}
+
+func TestAPIKeyAuth_EmptyKeyFailsClosed(t *testing.T) {
+	router := setupRouter(AuthConfig{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestAPIKeyAuth_ExplicitInsecureDisable(t *testing.T) {
+	router := setupRouter(AuthConfig{InsecureDisableAuth: true})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
 	w := httptest.NewRecorder()

--- a/control-plane/internal/server/routes_middleware.go
+++ b/control-plane/internal/server/routes_middleware.go
@@ -78,6 +78,7 @@ func (s *AgentFieldServer) applyGlobalMiddleware() {
 	skipPaths = uniqueStrings(skipPaths)
 	s.Router.Use(middleware.APIKeyAuth(middleware.AuthConfig{
 		APIKey:                  s.config.API.Auth.APIKey,
+		InsecureDisableAuth:     s.config.API.Auth.InsecureDisableAuth,
 		SkipPaths:               skipPaths,
 		SkipPrefixes:            uniqueStrings(skipPrefixes),
 		QueryAPIKeyAllowedPaths: streamingQueryAPIKeyAllowedPaths(),

--- a/control-plane/internal/server/server.go
+++ b/control-plane/internal/server/server.go
@@ -100,6 +100,10 @@ type AgentFieldServer struct {
 
 // NewAgentFieldServer creates a new instance of the AgentFieldServer.
 func NewAgentFieldServer(cfg *config.Config) (*AgentFieldServer, error) {
+	if err := validateAPIAuthConfig(cfg.API.Auth); err != nil {
+		return nil, fmt.Errorf("invalid API authentication configuration: %w", err)
+	}
+
 	// Define agentfieldHome at the very top
 	agentfieldHome := os.Getenv("AGENTFIELD_HOME")
 	if agentfieldHome == "" {
@@ -528,6 +532,22 @@ func NewAgentFieldServer(cfg *config.Config) (*AgentFieldServer, error) {
 		kb:                     initKnowledgeBase(),
 		knowledgeService:       knowledgeService,
 	}, nil
+}
+
+func validateAPIAuthConfig(auth config.AuthConfig) error {
+	middlewareConfig := middleware.AuthConfig{
+		APIKey:              auth.APIKey,
+		InsecureDisableAuth: auth.InsecureDisableAuth,
+	}
+	if err := middleware.ValidateAPIKeyAuth(middlewareConfig); err != nil {
+		return err
+	}
+	if auth.APIKey == "" {
+		logger.Logger.Warn().
+			Bool("insecure_disable_auth", true).
+			Msg("SECURITY WARNING: API key authentication is explicitly disabled; all API routes relying on API-key authentication are unauthenticated")
+	}
+	return nil
 }
 
 // configReloadFn returns a function that reloads config from the database,

--- a/control-plane/internal/server/server_additional_test.go
+++ b/control-plane/internal/server/server_additional_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -14,11 +15,13 @@ import (
 	"time"
 
 	"github.com/Agent-Field/agentfield/control-plane/internal/config"
+	"github.com/Agent-Field/agentfield/control-plane/internal/logger"
 	"github.com/Agent-Field/agentfield/control-plane/internal/services"
 	"github.com/Agent-Field/agentfield/control-plane/internal/storage"
 	"github.com/Agent-Field/agentfield/control-plane/pkg/adminpb"
 	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
 	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -69,6 +72,15 @@ func TestConfigReloadFn(t *testing.T) {
 }
 
 func TestNewAgentFieldServer(t *testing.T) {
+	t.Run("rejects an empty API key without explicit insecure mode", func(t *testing.T) {
+		cfg := baseConfigForDBTests()
+		cfg.API.Auth.APIKey = ""
+
+		srv, err := NewAgentFieldServer(&cfg)
+		require.Nil(t, srv)
+		require.ErrorContains(t, err, "AGENTFIELD_INSECURE_DISABLE_AUTH=true")
+	})
+
 	t.Run("uses env home and explicit admin port", func(t *testing.T) {
 		cfg := baseConfigForDBTests()
 		cfg.UI.Enabled = false
@@ -120,6 +132,7 @@ func TestNewAgentFieldServer(t *testing.T) {
 		cfg := baseConfigForDBTests()
 		cfg.UI.Enabled = false
 		cfg.API.Auth.APIKey = ""
+		cfg.API.Auth.InsecureDisableAuth = true
 		cfg.Features.DID.Enabled = true
 		cfg.Features.DID.KeyAlgorithm = "Ed25519"
 		cfg.Features.DID.Authorization.Enabled = true
@@ -171,6 +184,18 @@ func TestStartAdminGRPCServer(t *testing.T) {
 	if err != nil && !errors.Is(err, net.ErrClosed) {
 		require.NoError(t, err)
 	}
+}
+
+func TestValidateAPIAuthConfigWarnsWhenExplicitlyDisabled(t *testing.T) {
+	previousLogger := logger.Logger
+	var output bytes.Buffer
+	logger.Logger = zerolog.New(&output)
+	t.Cleanup(func() { logger.Logger = previousLogger })
+
+	err := validateAPIAuthConfig(config.AuthConfig{InsecureDisableAuth: true})
+	require.NoError(t, err)
+	require.Contains(t, output.String(), `"level":"warn"`)
+	require.Contains(t, output.String(), "API key authentication is explicitly disabled")
 }
 
 func TestStartAndStop(t *testing.T) {
@@ -251,6 +276,7 @@ func TestSetupRoutesFilesystemUIAndNoRouteFallback(t *testing.T) {
 	cfg.UI.Mode = "filesystem"
 	cfg.UI.DistPath = distDir
 	cfg.API.Auth.APIKey = ""
+	cfg.API.Auth.InsecureDisableAuth = true
 	cfg.API.Auth.SkipPaths = nil
 	cfg.API.CORS = config.CORSConfig{}
 	cfg.Features.DID.Enabled = false
@@ -299,6 +325,7 @@ func TestSetupRoutesRegistersAuthorizationAndConnectorBranches(t *testing.T) {
 	cfg := baseConfigForDBTests()
 	cfg.UI.Enabled = false
 	cfg.API.Auth.APIKey = ""
+	cfg.API.Auth.InsecureDisableAuth = true
 	cfg.Features.DID.Enabled = true
 	cfg.Features.DID.Authorization.Enabled = true
 	cfg.Features.DID.Authorization.DIDAuthEnabled = true
@@ -326,6 +353,7 @@ func TestSetupRoutesWithDIDServices(t *testing.T) {
 	cfg := baseConfigForDBTests()
 	cfg.UI.Enabled = false
 	cfg.API.Auth.APIKey = ""
+	cfg.API.Auth.InsecureDisableAuth = true
 	cfg.Features.DID.Enabled = true
 	cfg.Features.DID.KeyAlgorithm = "Ed25519"
 	cfg.Features.DID.Authorization.Enabled = true

--- a/control-plane/internal/server/server_coverage_additional_test.go
+++ b/control-plane/internal/server/server_coverage_additional_test.go
@@ -40,6 +40,7 @@ func TestNewAgentFieldServerCoversFallbacksAndOptionalServices(t *testing.T) {
 	cfg := baseConfigForDBTests()
 	cfg.UI.Enabled = false
 	cfg.API.Auth.APIKey = ""
+	cfg.API.Auth.InsecureDisableAuth = true
 	cfg.Features.Connector.Enabled = false
 	cfg.Features.DID.Enabled = true
 	cfg.Features.DID.KeyAlgorithm = "Ed25519"
@@ -117,6 +118,7 @@ func TestStartAndStopCoverAdditionalBranches(t *testing.T) {
 	cfg.Features.DID.Enabled = false
 	cfg.Features.Connector.Enabled = false
 	cfg.API.Auth.APIKey = ""
+	cfg.API.Auth.InsecureDisableAuth = true
 	cfg.Features.Tracing.Enabled = true
 	cfg.Features.Tracing.Insecure = true
 	cfg.AgentField.LLMHealth.Enabled = true
@@ -163,6 +165,7 @@ func TestStartCoversRecoveryErrorBranches(t *testing.T) {
 	cfg.Features.DID.Enabled = false
 	cfg.Features.Connector.Enabled = false
 	cfg.API.Auth.APIKey = ""
+	cfg.API.Auth.InsecureDisableAuth = true
 
 	errStorage := &listAgentsStorage{stubStorage: newStubStorage(), err: errors.New("list failed")}
 	statusManager := services.NewStatusManager(errStorage, services.StatusManagerConfig{
@@ -218,6 +221,7 @@ func TestSetupRoutesFilesystemFallbackDistPath(t *testing.T) {
 	cfg.UI.Mode = "filesystem"
 	cfg.UI.DistPath = ""
 	cfg.API.Auth.APIKey = ""
+	cfg.API.Auth.InsecureDisableAuth = true
 	cfg.API.CORS = config.CORSConfig{}
 	cfg.Features.DID.Enabled = false
 	cfg.Features.Connector.Enabled = false
@@ -379,6 +383,7 @@ func TestSetupRoutesAgentFieldDIDRouteHandlesUninitializedService(t *testing.T) 
 	cfg := baseConfigForDBTests()
 	cfg.UI.Enabled = false
 	cfg.API.Auth.APIKey = ""
+	cfg.API.Auth.InsecureDisableAuth = true
 	cfg.Features.DID.Enabled = true
 	cfg.Features.Connector.Enabled = false
 

--- a/control-plane/internal/server/server_routes_test.go
+++ b/control-plane/internal/server/server_routes_test.go
@@ -508,7 +508,7 @@ func TestSetupRoutesRegistersMetricsAndUI(t *testing.T) {
 		webhookDispatcher: &stubWebhookDispatcher{},
 		config: &config.Config{
 			UI:  config.UIConfig{Enabled: true, Mode: "embedded"},
-			API: config.APIConfig{},
+			API: config.APIConfig{Auth: config.AuthConfig{InsecureDisableAuth: true}},
 		},
 	}
 
@@ -544,7 +544,7 @@ func TestSetupRoutesRegistersWorkflowCleanupUIRoute(t *testing.T) {
 		webhookDispatcher: &stubWebhookDispatcher{},
 		config: &config.Config{
 			UI:  config.UIConfig{Enabled: true, Mode: "embedded"},
-			API: config.APIConfig{},
+			API: config.APIConfig{Auth: config.AuthConfig{InsecureDisableAuth: true}},
 		},
 	}
 
@@ -572,7 +572,7 @@ func TestSetupRoutesRegistersHealthEndpoint(t *testing.T) {
 			webhookDispatcher: &stubWebhookDispatcher{},
 			config: &config.Config{
 				UI:  config.UIConfig{Enabled: false},
-				API: config.APIConfig{},
+				API: config.APIConfig{Auth: config.AuthConfig{InsecureDisableAuth: true}},
 			},
 			storageHealthOverride: func(context.Context) gin.H { return gin.H{"status": "healthy"} },
 		}
@@ -622,7 +622,7 @@ func TestSetupRoutesRegistersHealthEndpoint(t *testing.T) {
 			webhookDispatcher: &stubWebhookDispatcher{},
 			config: &config.Config{
 				UI:  config.UIConfig{Enabled: false},
-				API: config.APIConfig{},
+				API: config.APIConfig{Auth: config.AuthConfig{InsecureDisableAuth: true}},
 			},
 			storageHealthOverride: func(context.Context) gin.H { return gin.H{"status": "healthy"} },
 		}

--- a/deployments/helm/agentfield/templates/control-plane-deployment.yaml
+++ b/deployments/helm/agentfield/templates/control-plane-deployment.yaml
@@ -86,6 +86,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "agentfield.apiAuth.secretName" . }}
                   key: {{ .Values.apiAuth.existingSecretKey }}
+            {{- else }}
+            - name: AGENTFIELD_INSECURE_DISABLE_AUTH
+              value: "true"
             {{- end }}
             {{- with .Values.controlPlane.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -39,11 +39,17 @@ Example DSNs:
 - `postgres://agentfield:agentfield@postgres:5432/agentfield?sslmode=disable`
 - `postgresql://agentfield:agentfield@postgres:5432/agentfield?sslmode=disable`
 
-### API Authentication (optional)
+### API Authentication
 
-If set, the control plane requires an API key for most endpoints.
+The control plane requires an API key for most endpoints. To run without API-key
+authentication, insecure mode must be explicitly enabled and should only be used
+in trusted local development environments.
 
 - `AGENTFIELD_API_KEY` or `AGENTFIELD_API_AUTH_API_KEY`: API key checked by the control plane.
+- `AGENTFIELD_INSECURE_DISABLE_AUTH` or `AGENTFIELD_API_AUTH_INSECURE_DISABLE_AUTH`: explicitly allow startup without an API key.
+
+The equivalent YAML configuration is `api.auth.api_key` or
+`api.auth.insecure_disable_auth: true`.
 
 ### UI
 

--- a/tests/functional/docker/agentfield-test.yaml
+++ b/tests/functional/docker/agentfield-test.yaml
@@ -63,6 +63,9 @@ ui:
   mode: "embedded"
 
 api:
+  auth:
+    # Functional tests run on an isolated Docker network.
+    insecure_disable_auth: true
   cors:
     allowed_origins:
       - "*"


### PR DESCRIPTION
# Fix: Enforce Fail-Closed API Authentication Configuration

## Summary

This PR fixes the critical security vulnerability described in **#424**, where an empty or missing API key silently disabled authentication across all HTTP endpoints.

The fix introduces a **fail-closed startup policy** that prevents the server from launching when API authentication is enabled but no API key is configured, unless an explicit insecure-mode flag is provided.

### Key Changes

#### `control-plane/internal/server/middleware/auth.go`

- Removed the silent early-return behavior that effectively disabled authentication when the API key was empty.
- Added an explicit fail-closed guard that rejects requests when the API key is not configured and insecure mode is disabled.
- Prevents empty authentication headers or bearer tokens from matching an empty configuration through `subtle.ConstantTimeCompare`.

#### `control-plane/internal/server/server.go`

- Added centralized configuration validation through `validateAPIAuthConfig`.
- Server startup now fails if authentication is configured insecurely.
- Emits a prominent warning log when authentication is intentionally disabled via the insecure-mode flag.

#### `control-plane/internal/config/config.go` and `cmd/*`

- Added `InsecureDisableAuth` to `AuthConfig`.
- Added support for the following environment variables:
  - `AGENTFIELD_INSECURE_DISABLE_AUTH`
  - `AGENTFIELD_API_AUTH_INSECURE_DISABLE_AUTH`

#### Tests

Updated and added tests covering:

- Authentication middleware behavior when API keys are missing.
- Fail-closed behavior returning `401 Unauthorized`.
- Server startup validation rejecting insecure configurations without the explicit override flag.
- Explicit insecure-mode startup behavior.

Files updated:

- `control-plane/internal/server/middleware/auth_test.go`
- `control-plane/internal/server/server_additional_test.go`

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] Tests only
- [ ] CI / tooling
- [ ] Breaking change

---

## Test Plan

### Authentication Middleware Tests

Verifies that missing API keys without the insecure flag fail closed and return `401 Unauthorized`.

```bash
cd control-plane
go test -v ./internal/server/middleware/...
```

### Full Control Plane Test Suite

Ensures all routes, startup paths, and configuration validation logic pass successfully.

```bash
cd control-plane
go test ./...
```

### Static Analysis

```bash
make lint
```

---

## Test Coverage

Before requesting review, confirm the following:

- [x] I ran tests for the surfaces I changed locally.
- [x] New code paths are covered by tests in this PR.
- [x] If I removed code, I updated `coverage-baseline.json` only if the removal caused a legitimate coverage regression and documented it above.
- [x] The coverage gate check is passing in CI.

---

## Checklist

- [x] I have read `CONTRIBUTING.md` (if present) and `docs/DEVELOPMENT.md`.
- [x] Commits are signed and follow the Conventional Commits specification.
- [x] I have linked the related issue.

---

## Related Issues

Fixes #424