### PR TITLE
feat(harness): canonical dir model, unified permissions, incremental schema (Python)

### DIFF
--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -3495,6 +3495,8 @@ class Agent(FastAPI):
         system_prompt: Optional[str] = None,
         env: Optional[Dict[str, str]] = None,
         cwd: Optional[str] = None,
+        project_dir: Optional[str] = None,
+        schema_mode: Optional[str] = None,
         **kwargs,
     ) -> "HarnessResult":
         """
@@ -3514,7 +3516,21 @@ class Agent(FastAPI):
             permission_mode: Permission mode ("plan", "auto", None).
             system_prompt: System prompt for the agent.
             env: Environment variables for the agent.
-            cwd: Working directory for the agent.
+            cwd: Working directory for the agent process. When ``project_dir`` is
+                not set, this is also the agent's root and where the schema output
+                file is placed.
+            project_dir: Root directory the agent may read and write (maps to the
+                provider's project-root flag, e.g. opencode ``--dir``, codex
+                ``-C``, or the process cwd for gemini/claude). Set this when the
+                agent must read files across a shared repo while ``cwd`` points at
+                a nested task directory. The schema output file is then placed in
+                an isolated temp dir *under* ``project_dir`` so the provider never
+                rejects it as an external-directory write.
+            schema_mode: How schema output is produced. "single" (default) asks
+                for one Write of the whole object. "incremental" builds it one
+                top-level field at a time and recovers by patching only the
+                failing fields — more robust for large or deeply nested schemas.
+                "auto" uses incremental only when the schema is large.
             **kwargs: Additional provider-specific options.
 
         Returns:
@@ -3532,6 +3548,8 @@ class Agent(FastAPI):
             system_prompt=system_prompt,
             env=env,
             cwd=cwd,
+            project_dir=project_dir,
+            schema_mode=schema_mode,
             **kwargs,
         )
 

--- a/sdk/python/agentfield/harness/_runner.py
+++ b/sdk/python/agentfield/harness/_runner.py
@@ -5,17 +5,24 @@ import json
 import logging
 import os
 import random
+import shutil
+import tempfile
 import time
 from typing import Any, Dict, List, Optional
 
 from agentfield.harness._result import FailureType, HarnessResult, RawResult
 from agentfield.harness._schema import (
     build_followup_prompt,
+    build_incremental_followup,
+    build_incremental_prompt_suffix,
     build_prompt_suffix,
     cleanup_temp_files,
+    diagnose_field_failures,
     diagnose_output_failure,
     get_output_path,
+    is_large_schema,
     parse_and_validate,
+    schema_to_json_schema,
     try_parse_from_text,
 )
 from agentfield.harness.providers._base import HarnessProvider
@@ -132,7 +139,10 @@ async def _ai_schema_repair(
         )
         content = response.choices[0].message.content  # type: ignore[union-attr]
     except Exception as exc:
-        logger.info("AI schema repair: LLM call failed (%s); falling through to harness retry", exc)
+        logger.info(
+            "AI schema repair: LLM call failed (%s); falling through to harness retry",
+            exc,
+        )
         return None
 
     if not content:
@@ -165,6 +175,7 @@ def _resolve_options(
             "gemini_bin",
             "opencode_bin",
             "schema_max_retries",
+            "schema_mode",
         ]:
             val = getattr(config, field_name, None)
             if val is not None:
@@ -213,6 +224,7 @@ class HarnessRunner:
         system_prompt: Optional[str] = None,
         env: Optional[Dict[str, str]] = None,
         cwd: Optional[str] = None,
+        project_dir: Optional[str] = None,
         **kwargs: Any,
     ) -> HarnessResult:
         overrides = {
@@ -225,6 +237,7 @@ class HarnessRunner:
             "system_prompt": system_prompt,
             "env": env,
             "cwd": cwd,
+            "project_dir": project_dir,
             **kwargs,
         }
         options = _resolve_options(self._config, overrides)
@@ -236,14 +249,45 @@ class HarnessRunner:
                 "or pass it to .harness() call."
             )
 
-        resolved_cwd = str(options.get("cwd", "."))
+        resolved_cwd = str(options.get("cwd") or ".")
         provider_instance = self._build_provider(str(resolved_provider), options)
 
-        output_dir = resolved_cwd
+        # Where the schema output file (.agentfield_output.json) is written and
+        # read back. It MUST sit inside the agent's allowed root, or providers
+        # like OpenCode reject the write as an external-directory access
+        # (agentfield#684). When project_dir is set, the agent's root is
+        # project_dir (see each provider's --dir / -C handling), which may differ
+        # from cwd — so the output file goes in an isolated temp dir *under*
+        # project_dir, never in a sibling/nested cwd. When project_dir is unset,
+        # cwd is the root and the output file goes directly in cwd (unchanged).
+        # This mirrors the Go SDK runner.
+        resolved_project_dir = options.get("project_dir")
+        temp_output_dir: Optional[str] = None
+        if isinstance(resolved_project_dir, str) and resolved_project_dir:
+            os.makedirs(resolved_project_dir, exist_ok=True)
+            temp_output_dir = tempfile.mkdtemp(
+                prefix=".agentfield-out-", dir=resolved_project_dir
+            )
+            output_dir = temp_output_dir
+        else:
+            output_dir = resolved_cwd
+
+        # schema_mode selects how the agent is asked to produce the output:
+        #   "single"      — one Write of the whole object (default, cheapest)
+        #   "incremental" — build the object one top-level field at a time, with
+        #                   field-level recovery (robust for large/deep schemas)
+        #   "auto"        — incremental only when the schema is large, else single
+        use_incremental = self._resolve_incremental(schema, options)
+        options["_use_incremental"] = use_incremental
 
         effective_prompt = prompt
         if schema is not None:
-            effective_prompt = prompt + build_prompt_suffix(schema, output_dir)
+            suffix = (
+                build_incremental_prompt_suffix(schema, output_dir)
+                if use_incremental
+                else build_prompt_suffix(schema, output_dir)
+            )
+            effective_prompt = prompt + suffix
         options["_original_prompt"] = effective_prompt
 
         start_time = time.monotonic()
@@ -278,6 +322,24 @@ class HarnessRunner:
         finally:
             if schema is not None:
                 cleanup_temp_files(output_dir)
+            if temp_output_dir is not None:
+                shutil.rmtree(temp_output_dir, ignore_errors=True)
+
+    @staticmethod
+    def _resolve_incremental(schema: Any, options: Dict[str, Any]) -> bool:
+        """Decide whether to use the incremental field-by-field schema build."""
+        if schema is None:
+            return False
+        mode = str(options.get("schema_mode") or "single").lower()
+        if mode == "incremental":
+            return True
+        if mode == "auto":
+            try:
+                schema_json = json.dumps(schema_to_json_schema(schema))
+            except Exception:
+                return False
+            return is_large_schema(schema_json)
+        return False
 
     def _build_provider(
         self, provider_name: str, options: Dict[str, Any]
@@ -343,6 +405,16 @@ class HarnessRunner:
             options.get("schema_max_retries", DEFAULT_SCHEMA_RETRIES)
         )
 
+        # Surfaced on every terminal schema failure so callers can immediately
+        # see which directory the agent was rooted at vs. where the output file
+        # was expected — the two most common causes of "output not created"
+        # (agentfield#684, issue ask #5).
+        dir_context = (
+            f" [provider={options.get('provider')!r}, "
+            f"project_dir={options.get('project_dir')!r}, "
+            f"cwd={options.get('cwd')!r}, output_path={output_path!r}]"
+        )
+
         all_raws: List[RawResult] = [initial_raw]
 
         validated = parse_and_validate(output_path, schema)
@@ -399,7 +471,8 @@ class HarnessRunner:
                 parsed=None,
                 is_error=True,
                 error_message=(
-                    f"{provider_error} Output file was not created at {output_path}."
+                    f"{provider_error} Output file was not created at "
+                    f"{output_path}.{dir_context}"
                 ),
                 failure_type=initial_raw.failure_type,
                 cost_usd=cost,
@@ -428,9 +501,17 @@ class HarnessRunner:
                     )
                 )
             else:
-                error_detail = diagnose_output_failure(output_path, schema)
                 _orig = options.get("_original_prompt", "")
-                _followup = build_followup_prompt(error_detail, cwd, schema)
+                if options.get("_use_incremental"):
+                    # Incremental mode: patch only the fields that are missing or
+                    # invalid, one at a time, instead of regenerating the whole
+                    # object. The partial output file persists on disk between
+                    # attempts, so the agent edits it in place.
+                    field_errors = diagnose_field_failures(output_path, schema)
+                    _followup = build_incremental_followup(field_errors, cwd, schema)
+                else:
+                    error_detail = diagnose_output_failure(output_path, schema)
+                    _followup = build_followup_prompt(error_detail, cwd, schema)
                 # Keep the original goal/task on non-crash retries. Without this
                 # the agent retries with only the schema-correction text and loses
                 # the goal (e.g. PM emits a placeholder PRD that poisons the run).
@@ -499,7 +580,7 @@ class HarnessRunner:
             is_error=True,
             error_message=(
                 f"Schema validation failed after {schema_max_retries} "
-                f"retry attempt(s). Last error: {final_diagnosis}"
+                f"retry attempt(s). Last error: {final_diagnosis}{dir_context}"
             ),
             failure_type=FailureType.SCHEMA,
             cost_usd=cost,

--- a/sdk/python/agentfield/harness/_schema.py
+++ b/sdk/python/agentfield/harness/_schema.py
@@ -313,6 +313,140 @@ def diagnose_output_failure(file_path: str, schema: Any) -> str:
         )
 
 
+def get_top_level_fields(schema: Any) -> list[tuple[str, bool]]:
+    """Return [(field_name, is_required), ...] for the schema's top-level keys.
+
+    Used by incremental mode to drive a field-by-field build. Works for Pydantic
+    models (via JSON Schema) and plain dict schemas.
+    """
+    json_schema = schema_to_json_schema(schema)
+    props = json_schema.get("properties", {})
+    required = set(json_schema.get("required", []))
+    return [(name, name in required) for name in props]
+
+
+def build_incremental_prompt_suffix(schema: Any, cwd: str) -> str:
+    """OUTPUT REQUIREMENTS suffix that instructs a field-by-field build.
+
+    Unlike the single-shot suffix, this tells the agent to initialize an empty
+    object and add one top-level field at a time, re-reading the file after each
+    edit. This avoids truncation/drift on large or deeply nested schemas where
+    emitting the whole object in one Write is unreliable.
+    """
+    json_schema = schema_to_json_schema(schema)
+    schema_json = json.dumps(json_schema, indent=2)
+    output_path = get_output_path(cwd)
+
+    fields = get_top_level_fields(schema)
+    field_lines = "\n".join(
+        f"  - {name} ({'required' if req else 'optional'})" for name, req in fields
+    )
+
+    if is_large_schema(schema_json):
+        schema_path = get_schema_path(cwd)
+        write_schema_file(schema_json, cwd)
+        schema_ref = (
+            f"The full JSON Schema is at: {schema_path}\n"
+            "Read it for each field's exact shape.\n"
+        )
+    else:
+        schema_ref = f"Full JSON Schema:\n{schema_json}\n"
+
+    return (
+        "\n\n---\n"
+        "CRITICAL OUTPUT REQUIREMENTS (incremental build):\n"
+        f"Produce a single JSON object in this file using your Write/Edit tools: "
+        f"{output_path}\n"
+        "Build it ONE FIELD AT A TIME so nothing gets truncated:\n"
+        "  1. First create the file with an empty object: {}\n"
+        "  2. Then add each field listed below one at a time using Edit, and after\n"
+        "     each edit re-read the file to confirm it is still valid JSON.\n"
+        "  3. Each field's value MUST conform to its shape in the schema.\n"
+        "  4. Do not finish until every required field is present.\n\n"
+        f"Top-level fields to add:\n{field_lines}\n\n"
+        f"{schema_ref}\n"
+        f"The final file at {output_path} MUST contain ONLY the complete valid JSON "
+        "object — no markdown fences, no commentary, no extra text."
+    )
+
+
+def diagnose_field_failures(file_path: str, schema: Any) -> Dict[str, str]:
+    """Map each missing/invalid top-level field to a short reason.
+
+    Returns an empty dict when the file validates cleanly. Used by incremental
+    mode to drive targeted "patch only these fields" follow-ups instead of a
+    full re-run. Tolerant: cosmetically repairs the file before inspecting it.
+    """
+    if isinstance(schema, dict):
+        return {}
+
+    json_schema = schema_to_json_schema(schema)
+    props = list(json_schema.get("properties", {}).keys())
+    required = set(json_schema.get("required", []))
+
+    data = read_and_parse(file_path)
+    if data is None:
+        data = read_repair_and_parse(file_path)
+
+    if not isinstance(data, dict):
+        # Whole file unusable — report every required field (or all fields if
+        # none are required) as needing to be written.
+        targets = list(required) or props
+        return {name: "output file missing or not a JSON object" for name in targets}
+
+    failures: Dict[str, str] = {}
+    for name in required:
+        if name not in data:
+            failures[name] = "missing required field"
+
+    try:
+        validate_against_schema(data, schema)
+    except Exception as exc:
+        errors_fn = getattr(exc, "errors", None)
+        if callable(errors_fn):
+            try:
+                for err in errors_fn():
+                    loc = err.get("loc", ())
+                    if loc:
+                        failures.setdefault(str(loc[0]), err.get("msg", "invalid"))
+            except Exception:
+                failures.setdefault("_root", str(exc)[:200])
+        else:
+            failures.setdefault("_root", str(exc)[:200])
+
+    return failures
+
+
+def build_incremental_followup(
+    field_errors: Dict[str, str], cwd: str, schema: Any
+) -> str:
+    """Follow-up prompt that asks the agent to patch only the failing fields."""
+    output_path = get_output_path(cwd)
+    field_lines = "\n".join(
+        f"  - {name}: {reason}" for name, reason in field_errors.items()
+    )
+
+    json_schema = schema_to_json_schema(schema)
+    schema_json = json.dumps(json_schema, indent=2)
+    if is_large_schema(schema_json):
+        schema_path = get_schema_path(cwd)
+        if not os.path.exists(schema_path):
+            write_schema_file(schema_json, cwd)
+        schema_ref = f"Full schema is at: {schema_path}\n"
+    else:
+        schema_ref = f"Full schema:\n{schema_json}\n"
+
+    return (
+        f"PARTIAL OUTPUT NEEDS FIXES. The JSON at {output_path} is incomplete or "
+        "invalid.\n"
+        "Patch ONLY these fields, one at a time, using Edit, keeping the file valid "
+        "JSON after each change:\n"
+        f"{field_lines}\n\n"
+        f"{schema_ref}"
+        "Leave every already-correct field unchanged. Do NOT rewrite the whole file."
+    )
+
+
 def build_followup_prompt(error_message: str, cwd: str, schema: Any = None) -> str:
     output_path = get_output_path(cwd)
     schema_path = get_schema_path(cwd)

--- a/sdk/python/agentfield/harness/providers/claude.py
+++ b/sdk/python/agentfield/harness/providers/claude.py
@@ -41,8 +41,13 @@ class ClaudeCodeProvider:
         agent_options: dict[str, object] = {}
         if options.get("model") is not None:
             agent_options["model"] = options["model"]
-        if options.get("cwd") is not None:
-            agent_options["cwd"] = options["cwd"]
+        # Agent root: project_dir is the canonical field, fall back to cwd
+        # (agentfield#686). The SDK's cwd is both the process dir and the root
+        # the agent operates in; the runner places the schema output file under
+        # this same root.
+        root = options.get("project_dir") or options.get("cwd")
+        if root is not None:
+            agent_options["cwd"] = root
         if options.get("max_turns") is not None:
             agent_options["max_turns"] = options["max_turns"]
         if options.get("tools") is not None:

--- a/sdk/python/agentfield/harness/providers/codex.py
+++ b/sdk/python/agentfield/harness/providers/codex.py
@@ -22,12 +22,25 @@ class CodexProvider:
         self._bin = bin_path
 
     async def execute(self, prompt: str, options: dict[str, object]) -> RawResult:
-        cmd = [self._bin, "exec", "--json"]
+        # --skip-git-repo-check lets the harness run in arbitrary working dirs
+        # (temp dirs, non-repo project roots); codex exec otherwise refuses to
+        # start outside a git repo.
+        cmd = [self._bin, "exec", "--json", "--skip-git-repo-check"]
 
-        if options.get("cwd"):
-            cmd.extend(["-C", str(options["cwd"])])
-        if options.get("permission_mode") == "auto":
-            cmd.append("--full-auto")
+        # Agent root: project_dir is the canonical field, fall back to cwd. -C is
+        # codex's single working-root flag (agentfield#686).
+        root = options.get("project_dir") or options.get("cwd")
+        if isinstance(root, str):
+            cmd.extend(["-C", root])
+
+        # permission_mode → sandbox policy (agentfield#687). codex exec never
+        # prompts (approval policy is always Never); the sandbox controls what it
+        # may write. --full-auto is deprecated in favour of --sandbox.
+        permission_mode = options.get("permission_mode")
+        if permission_mode == "auto":
+            cmd.extend(["--sandbox", "workspace-write"])
+        elif permission_mode == "plan":
+            cmd.extend(["--sandbox", "read-only"])
 
         cmd.append(prompt)
 
@@ -40,10 +53,7 @@ class CodexProvider:
                 if isinstance(key, str) and isinstance(value, str)
             }
 
-        cwd: Optional[str] = None
-        cwd_value = options.get("cwd")
-        if isinstance(cwd_value, str):
-            cwd = cwd_value
+        cwd: Optional[str] = root if isinstance(root, str) else None
         start_api = time.monotonic()
 
         try:

--- a/sdk/python/agentfield/harness/providers/gemini.py
+++ b/sdk/python/agentfield/harness/providers/gemini.py
@@ -18,10 +18,16 @@ class GeminiProvider:
     async def execute(self, prompt: str, options: dict[str, object]) -> RawResult:
         cmd = [self._bin]
 
-        if options.get("cwd"):
-            cmd.extend(["-C", str(options["cwd"])])
-        if options.get("permission_mode") == "auto":
-            cmd.extend(["--sandbox"])
+        # permission_mode → approval mode (agentfield#687). NOTE: gemini's
+        # --sandbox RESTRICTS execution (runs tools in a container); it does NOT
+        # grant access. The old code used --sandbox for "auto", which was
+        # backwards. --yolo auto-approves all actions.
+        permission_mode = options.get("permission_mode")
+        if permission_mode == "auto":
+            cmd.append("--yolo")
+        elif permission_mode == "plan":
+            cmd.extend(["--approval-mode", "plan"])
+
         if options.get("model"):
             cmd.extend(["-m", str(options["model"])])
         cmd.extend(["-p", prompt])
@@ -35,10 +41,14 @@ class GeminiProvider:
                 if isinstance(key, str) and isinstance(value, str)
             }
 
+        # Gemini has NO -C/--cd flag — it rejects unknown args outright
+        # ("Unknown argument: C"), so the previous `-C <cwd>` crashed every call.
+        # The agent root is the process working directory; project_dir is the
+        # canonical field, cwd is the fallback (agentfield#686).
         cwd: Optional[str] = None
-        cwd_value = options.get("cwd")
-        if isinstance(cwd_value, str):
-            cwd = cwd_value
+        root = options.get("project_dir") or options.get("cwd")
+        if isinstance(root, str):
+            cwd = root
 
         start_api = time.monotonic()
 

--- a/sdk/python/agentfield/harness/providers/opencode.py
+++ b/sdk/python/agentfield/harness/providers/opencode.py
@@ -120,7 +120,9 @@ class OpenCodeProvider:
     # (~6–8 review_dimension phases + 3 meta-lenses); OpenRouter handles
     # this comfortably on Kimi K2.6. Lower via OPENCODE_MAX_CONCURRENT if
     # your provider has tighter per-key rate limits.
-    _MAX_CONCURRENT: ClassVar[int] = int(os.environ.get("OPENCODE_MAX_CONCURRENT", "10"))
+    _MAX_CONCURRENT: ClassVar[int] = int(
+        os.environ.get("OPENCODE_MAX_CONCURRENT", "10")
+    )
     _concurrency_sem: ClassVar[Optional[asyncio.Semaphore]] = None
 
     # Shared XDG_DATA_HOME across calls when opt-in is enabled. SQLite
@@ -152,12 +154,15 @@ class OpenCodeProvider:
         cmd = [self._bin, "run"]
         cmd.extend(["--format", "json"])
 
-        # Use --dir for project directory (replaces deprecated -c which now means --continue)
-        cwd_value = options.get("cwd")
-        if isinstance(cwd_value, str):
-            cmd.extend(["--dir", cwd_value])
-        elif isinstance(options.get("project_dir"), str):
-            cmd.extend(["--dir", str(options["project_dir"])])
+        # --dir is the project root the agent may read and write. project_dir is
+        # the canonical field; fall back to cwd when it is unset. Previously cwd
+        # took precedence, so a nested cwd under a shared project_dir made
+        # opencode treat the rest of the root as an external directory and
+        # auto-reject reads/writes of sibling paths — see agentfield#684. This
+        # now matches the Go SDK's opencode provider precedence.
+        dir_value = options.get("project_dir") or options.get("cwd")
+        if isinstance(dir_value, str):
+            cmd.extend(["--dir", dir_value])
 
         # Pass model via -m flag on the run subcommand
         if options.get("model"):
@@ -293,10 +298,7 @@ class OpenCodeProvider:
                 if clean_stderr
                 else (f"Process exited with code {returncode} and produced no output.")
             )
-        elif (
-            event_error is not None
-            and result_text is None
-        ):
+        elif event_error is not None and result_text is None:
             failure_type = FailureType.CRASH
             is_error = True
             error_message = event_error

--- a/sdk/python/agentfield/types.py
+++ b/sdk/python/agentfield/types.py
@@ -318,6 +318,15 @@ class HarnessConfig(BaseModel):
     opencode_bin: str = Field(
         default="opencode", description="Path to opencode binary."
     )
+    schema_mode: str = Field(
+        default="single",
+        description=(
+            'How schema output is produced: "single" (one Write of the whole '
+            'object, default), "incremental" (build it one top-level field at a '
+            "time with field-level recovery — robust for large/deep schemas), or "
+            '"auto" (incremental only when the schema is large).'
+        ),
+    )
 
 
 class AIConfig(BaseModel):

--- a/sdk/python/tests/test_harness_provider_claude.py
+++ b/sdk/python/tests/test_harness_provider_claude.py
@@ -194,3 +194,32 @@ def test_factory_builds_claude_provider():
 
     provider = build_provider(HarnessConfig(provider="claude-code"))
     assert isinstance(provider, ClaudeCodeProvider)
+
+
+@pytest.mark.asyncio
+async def test_claude_uses_project_dir_as_root_over_cwd(monkeypatch):
+    """agentfield#686: project_dir is the canonical agent root, beating cwd."""
+    from agentfield.harness.providers.claude import ClaudeCodeProvider
+
+    captured: dict[str, Any] = {}
+
+    class FakeClaudeAgentOptions:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+    def fake_query(*, prompt: str, options: FakeClaudeAgentOptions):
+        captured["options"] = options
+        return _AsyncStream([{"type": "result", "result": "ok", "session_id": "s"}])
+
+    fake_sdk = ModuleType("claude_agent_sdk")
+    setattr(fake_sdk, "ClaudeAgentOptions", FakeClaudeAgentOptions)
+    setattr(fake_sdk, "query", fake_query)
+    monkeypatch.setitem(__import__("sys").modules, "claude_agent_sdk", fake_sdk)
+
+    provider = ClaudeCodeProvider()
+    await provider.execute(
+        "hi",
+        {"cwd": "/root/tasks/a", "project_dir": "/root"},
+    )
+
+    assert captured["options"].kwargs["cwd"] == "/root"

--- a/sdk/python/tests/test_harness_provider_codex.py
+++ b/sdk/python/tests/test_harness_provider_codex.py
@@ -147,9 +147,11 @@ async def test_codex_provider_constructs_command_and_maps_result(
         "/usr/local/bin/codex",
         "exec",
         "--json",
+        "--skip-git-repo-check",
         "-C",
         "/tmp/work",
-        "--full-auto",
+        "--sandbox",
+        "workspace-write",
         "hello",
     ]
     assert captured["env"] == {"A": "1"}
@@ -240,3 +242,39 @@ def test_factory_builds_codex_provider_with_config_bin() -> None:
 
     assert isinstance(provider, CodexProvider)
     assert provider._bin == "/opt/codex"
+
+
+@pytest.mark.asyncio
+async def test_codex_project_dir_is_root_and_plan_maps_to_read_only(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """agentfield#686/#687: project_dir wins as -C root; plan -> read-only sandbox."""
+    captured: dict[str, Any] = {}
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        _ = (env, timeout)
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        return '{"type":"turn.completed","text":"x"}\n', "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.codex.run_cli", fake_run_cli)
+
+    provider = CodexProvider()
+    await provider.execute(
+        "hi",
+        {
+            "cwd": "/root/tasks/a",
+            "project_dir": "/root",
+            "permission_mode": "plan",
+        },
+    )
+
+    cmd = captured["cmd"]
+    dir_idx = cmd.index("-C")
+    assert cmd[dir_idx + 1] == "/root"  # project_dir wins over nested cwd
+    assert "/root/tasks/a" not in cmd
+    sb_idx = cmd.index("--sandbox")
+    assert cmd[sb_idx + 1] == "read-only"
+    assert "--full-auto" not in cmd
+    assert "--skip-git-repo-check" in cmd
+    assert captured["cwd"] == "/root"

--- a/sdk/python/tests/test_harness_provider_gemini.py
+++ b/sdk/python/tests/test_harness_provider_gemini.py
@@ -37,11 +37,12 @@ async def test_gemini_provider_constructs_command_and_maps_result(
         },
     )
 
+    # gemini has no -C flag (it crashes on unknown args); the working dir is set
+    # via the process cwd. --yolo is the auto-approve flag (not --sandbox, which
+    # restricts execution). See agentfield#686, #687.
     assert captured["cmd"] == [
         "/usr/local/bin/gemini",
-        "-C",
-        "/tmp/work",
-        "--sandbox",
+        "--yolo",
         "-p",
         "hello",
     ]
@@ -148,3 +149,55 @@ async def test_gemini_cost_none_without_model(monkeypatch: pytest.MonkeyPatch):
     raw = await provider.execute("hello", {})
 
     assert raw.metrics.total_cost_usd is None
+
+
+@pytest.mark.asyncio
+async def test_gemini_never_uses_dash_C_and_project_dir_is_cwd(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """agentfield#686/#687: gemini has no -C (it crashes); project_dir is the
+    process cwd; plan -> --approval-mode plan; never --sandbox for permissions."""
+    captured: dict[str, Any] = {}
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        _ = (env, timeout)
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        return "ok\n", "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.gemini.run_cli", fake_run_cli)
+
+    provider = GeminiProvider()
+    await provider.execute(
+        "hi",
+        {
+            "cwd": "/root/tasks/a",
+            "project_dir": "/root",
+            "permission_mode": "plan",
+        },
+    )
+
+    cmd = captured["cmd"]
+    assert "-C" not in cmd  # gemini rejects -C ("Unknown argument: C")
+    assert captured["cwd"] == "/root"  # project_dir is the process root
+    am_idx = cmd.index("--approval-mode")
+    assert cmd[am_idx + 1] == "plan"
+    assert "--sandbox" not in cmd
+
+
+@pytest.mark.asyncio
+async def test_gemini_auto_uses_yolo_not_sandbox(monkeypatch: pytest.MonkeyPatch):
+    captured: dict[str, Any] = {}
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        _ = (env, cwd, timeout)
+        captured["cmd"] = cmd
+        return "ok\n", "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.gemini.run_cli", fake_run_cli)
+
+    provider = GeminiProvider()
+    await provider.execute("hi", {"permission_mode": "auto"})
+
+    assert "--yolo" in captured["cmd"]
+    assert "--sandbox" not in captured["cmd"]

--- a/sdk/python/tests/test_harness_provider_opencode.py
+++ b/sdk/python/tests/test_harness_provider_opencode.py
@@ -253,6 +253,37 @@ async def test_opencode_uses_project_dir_when_no_cwd(
 
 
 @pytest.mark.asyncio
+async def test_opencode_project_dir_takes_precedence_over_cwd(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Regression for agentfield#684: when BOTH cwd and project_dir are set,
+    --dir must be project_dir (the agent's root), not the nested cwd. Otherwise
+    reading a sibling path under the shared root looks external to opencode and
+    gets auto-rejected, so the schema output file is never written.
+    """
+    captured_cmd: list[str] | None = None
+
+    async def capture_cmd(cmd: list[str], *, env=None, cwd=None, timeout=None):
+        nonlocal captured_cmd
+        captured_cmd = cmd
+        return "result", "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", capture_cmd)
+
+    provider = OpenCodeProvider()
+    await provider.execute(
+        "read a sibling file",
+        {"cwd": "/research-lab/tasks/a", "project_dir": "/research-lab"},
+    )
+
+    assert captured_cmd is not None
+    dir_idx = captured_cmd.index("--dir")
+    assert captured_cmd[dir_idx + 1] == "/research-lab"
+    # The nested cwd must NOT be used as the project root.
+    assert "/research-lab/tasks/a" not in captured_cmd
+
+
+@pytest.mark.asyncio
 async def test_opencode_exit0_with_error_stderr_is_treated_as_failure(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -345,7 +376,7 @@ async def test_opencode_exit_nonzero_uses_extracted_error_not_truncated_prelude(
 ):
     """Non-zero exit + long migration prelude in stderr should still surface
     the real Error: line, not just the first 1000 chars of the prelude."""
-    long_prelude = ("Performing one time database migration line\n" * 30)
+    long_prelude = "Performing one time database migration line\n" * 30
     stderr = long_prelude + "Error: AuthenticationError: bad key\n"
 
     async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):

--- a/sdk/python/tests/test_harness_runner.py
+++ b/sdk/python/tests/test_harness_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from types import SimpleNamespace
 
 import pytest
@@ -48,6 +49,70 @@ class FileWritingProvider(MockProvider):
         with open(output_path, "w", encoding="utf-8") as file_obj:
             file_obj.write(self.payload)
         return await super().execute(prompt, options)
+
+
+class PromptPathWritingProvider(MockProvider):
+    """Mock that writes valid JSON to the absolute output path named in the
+    prompt suffix — faithfully mimicking how a real coding agent learns where
+    to write (it never sees the runner's internal output_dir, only the prompt).
+    """
+
+    def __init__(self, payload: str):
+        super().__init__([RawResult(result="ok")])
+        self.payload = payload
+        self.output_path_in_prompt: str | None = None
+
+    async def execute(self, prompt: str, options: dict) -> RawResult:
+        match = re.search(r"(\S*\.agentfield_output\.json)", prompt)
+        assert match, "schema prompt suffix must name the output file path"
+        self.output_path_in_prompt = match.group(1)
+        with open(self.output_path_in_prompt, "w", encoding="utf-8") as file_obj:
+            file_obj.write(self.payload)
+        return await super().execute(prompt, options)
+
+
+@pytest.mark.asyncio
+async def test_run_with_project_dir_places_output_under_project_dir(tmp_path):
+    """Regression for agentfield#684.
+
+    When project_dir is the agent's root and cwd is a nested task dir, the
+    schema output file must be created under project_dir — not in the nested
+    cwd — so providers like OpenCode never reject it as an external-directory
+    write. Mirrors the Go SDK runner, which already does this.
+    """
+    root = tmp_path / "root"
+    nested = root / "tasks" / "a"
+    nested.mkdir(parents=True)
+    (root / "source.md").write_text("hello", encoding="utf-8")
+
+    provider = PromptPathWritingProvider(json.dumps({"name": "x", "count": 1}))
+
+    runner = HarnessRunner()
+    with patch("agentfield.harness._runner.build_provider", return_value=provider):
+        result = await runner.run(
+            "Read source.md and summarize.",
+            schema=DemoSchema,
+            provider="opencode",
+            cwd=str(nested),
+            project_dir=str(root),
+        )
+
+    assert result.is_error is False
+    assert result.parsed == DemoSchema(name="x", count=1)
+
+    # The output path the agent was told to write must live under project_dir,
+    # NOT under the nested cwd.
+    assert provider.output_path_in_prompt is not None
+    assert provider.output_path_in_prompt.startswith(str(root))
+    assert str(nested) not in provider.output_path_in_prompt
+
+    # Provider still sees the real cwd + project_dir for its own --dir handling.
+    assert provider.last_options is not None
+    assert provider.last_options["cwd"] == str(nested)
+    assert provider.last_options["project_dir"] == str(root)
+
+    # The temp output dir is cleaned up after the run.
+    assert list(root.glob(".agentfield-out-*")) == []
 
 
 def test_resolve_options_merges_config_and_overrides_per_call_wins():
@@ -400,7 +465,9 @@ async def test_schema_retry_preserves_original_goal_in_prompt(tmp_path, monkeypa
             prompts.append(prompt)
             output_path = get_output_path(str(options.get("cwd", ".")))
             with open(output_path, "w", encoding="utf-8") as file_obj:
-                file_obj.write('{"name": "ok"}')  # missing 'count' -> invalid, non-crash
+                file_obj.write(
+                    '{"name": "ok"}'
+                )  # missing 'count' -> invalid, non-crash
             return await super().execute(prompt, options)
 
     async def _no_repair(*args, **kwargs):
@@ -425,3 +492,83 @@ async def test_schema_retry_preserves_original_goal_in_prompt(tmp_path, monkeypa
         "retry prompt dropped the original goal -- the agent retries blind. "
         "First 400 chars:\n" + retry_prompt[:400]
     )
+
+
+class IncrementalRecoveryProvider(MockProvider):
+    """Writes a partial object (missing a required field) on the first call,
+    then the complete object on the retry — exercising incremental field-level
+    recovery without a real coding agent."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.prompts: list[str] = []
+
+    async def execute(self, prompt: str, options: dict) -> RawResult:
+        self.prompts.append(prompt)
+        match = re.search(r"(\S*\.agentfield_output\.json)", prompt)
+        assert match
+        output_path = match.group(1)
+        payload = (
+            json.dumps({"name": "x"})  # first attempt: missing 'count'
+            if self.call_count == 0
+            else json.dumps({"name": "x", "count": 5})  # retry: complete
+        )
+        with open(output_path, "w", encoding="utf-8") as file_obj:
+            file_obj.write(payload)
+        return await super().execute(prompt, options)
+
+
+@pytest.mark.asyncio
+async def test_incremental_mode_uses_incremental_suffix(tmp_path):
+    provider = PromptPathWritingProvider(json.dumps({"name": "x", "count": 1}))
+    runner = HarnessRunner()
+    with patch("agentfield.harness._runner.build_provider", return_value=provider):
+        result = await runner.run(
+            "do it",
+            schema=DemoSchema,
+            provider="opencode",
+            cwd=str(tmp_path),
+            schema_mode="incremental",
+        )
+    assert result.is_error is False
+    assert provider.last_prompt is not None
+    assert "incremental build" in provider.last_prompt.lower()
+
+
+@pytest.mark.asyncio
+async def test_auto_mode_small_schema_stays_single_shot(tmp_path):
+    provider = PromptPathWritingProvider(json.dumps({"name": "x", "count": 1}))
+    runner = HarnessRunner()
+    with patch("agentfield.harness._runner.build_provider", return_value=provider):
+        result = await runner.run(
+            "do it",
+            schema=DemoSchema,
+            provider="opencode",
+            cwd=str(tmp_path),
+            schema_mode="auto",
+        )
+    assert result.is_error is False
+    # DemoSchema is tiny, so auto stays single-shot (no incremental instructions).
+    assert "incremental build" not in (provider.last_prompt or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_incremental_mode_recovers_by_patching_missing_field(tmp_path):
+    provider = IncrementalRecoveryProvider()
+    runner = HarnessRunner()
+    with patch("agentfield.harness._runner.build_provider", return_value=provider):
+        result = await runner.run(
+            "do it",
+            schema=DemoSchema,
+            provider="opencode",
+            cwd=str(tmp_path),
+            schema_mode="incremental",
+        )
+
+    assert result.is_error is False
+    assert result.parsed == DemoSchema(name="x", count=5)
+    # The retry prompt must be a targeted field patch, naming the failing field.
+    assert len(provider.prompts) >= 2
+    retry_prompt = provider.prompts[1].lower()
+    assert "patch only" in retry_prompt
+    assert "count" in retry_prompt

--- a/sdk/python/tests/test_harness_schema.py
+++ b/sdk/python/tests/test_harness_schema.py
@@ -5,11 +5,15 @@ from pydantic import BaseModel
 from agentfield.harness._schema import (
     LARGE_SCHEMA_TOKEN_THRESHOLD,
     build_followup_prompt,
+    build_incremental_followup,
+    build_incremental_prompt_suffix,
     build_prompt_suffix,
     cleanup_temp_files,
     cosmetic_repair,
+    diagnose_field_failures,
     get_output_path,
     get_schema_path,
+    get_top_level_fields,
     is_large_schema,
     parse_and_validate,
     read_and_parse,
@@ -22,6 +26,11 @@ from agentfield.harness._schema import (
 class TestSchema(BaseModel):
     name: str
     count: int
+
+
+class OptionalFieldSchema(BaseModel):
+    name: str
+    note: str = ""
 
 
 def test_get_output_path_returns_deterministic_path(tmp_path):
@@ -159,3 +168,57 @@ def test_build_followup_prompt_includes_error_and_output_path(tmp_path):
     prompt = build_followup_prompt("count is required", str(tmp_path))
     assert "count is required" in prompt
     assert str(tmp_path / ".agentfield_output.json") in prompt
+
+
+def test_get_top_level_fields_reports_names_and_required():
+    fields = get_top_level_fields(TestSchema)
+    assert ("name", True) in fields
+    assert ("count", True) in fields
+
+    optional_fields = dict(get_top_level_fields(OptionalFieldSchema))
+    assert optional_fields["name"] is True
+    assert optional_fields["note"] is False
+
+
+def test_build_incremental_prompt_suffix_lists_fields_and_instructions(tmp_path):
+    suffix = build_incremental_prompt_suffix(TestSchema, str(tmp_path))
+    assert "incremental build" in suffix.lower()
+    assert "one field at a time" in suffix.lower() or "one at a time" in suffix.lower()
+    assert "name" in suffix
+    assert "count" in suffix
+    assert str(tmp_path / ".agentfield_output.json") in suffix
+
+
+def test_diagnose_field_failures_flags_missing_required_field(tmp_path):
+    path = tmp_path / ".agentfield_output.json"
+    path.write_text(json.dumps({"name": "ok"}))  # missing 'count'
+    failures = diagnose_field_failures(str(path), TestSchema)
+    assert "count" in failures
+
+
+def test_diagnose_field_failures_flags_invalid_field_type(tmp_path):
+    path = tmp_path / ".agentfield_output.json"
+    path.write_text(json.dumps({"name": "ok", "count": "not-an-int"}))
+    failures = diagnose_field_failures(str(path), TestSchema)
+    assert "count" in failures
+
+
+def test_diagnose_field_failures_empty_when_valid(tmp_path):
+    path = tmp_path / ".agentfield_output.json"
+    path.write_text(json.dumps({"name": "ok", "count": 3}))
+    assert diagnose_field_failures(str(path), TestSchema) == {}
+
+
+def test_diagnose_field_failures_missing_file_reports_required(tmp_path):
+    path = tmp_path / ".agentfield_output.json"  # never created
+    failures = diagnose_field_failures(str(path), TestSchema)
+    assert "name" in failures and "count" in failures
+
+
+def test_build_incremental_followup_lists_only_failing_fields(tmp_path):
+    followup = build_incremental_followup(
+        {"count": "missing required field"}, str(tmp_path), TestSchema
+    )
+    assert "count" in followup
+    assert "patch only" in followup.lower()
+    assert str(tmp_path / ".agentfield_output.json") in followup


### PR DESCRIPTION
## Summary

Reworks the Python harness so the directory, permission, and schema-output contracts are consistent across all four providers (claude-code, codex, gemini, opencode) and match the Go SDK reference. Defined in Python first; TS/Go ports tracked separately.

Closes #684
Closes #686
Closes #687
Closes #688

## 1. Directory model (#684, #686)

`project_dir` is the canonical agent root; `cwd` is the process working dir. The schema output file always lands inside the agent root: when `project_dir` is set the runner writes it to an isolated temp dir **under** `project_dir` (mirrors the Go runner), so providers like OpenCode no longer reject it as an `external_directory` write.

- opencode: `--dir` now prefers `project_dir` over `cwd` (the precedence was inverted — the #684 bug).
- codex: `-C` uses `project_dir or cwd`; added `--skip-git-repo-check` so the harness can run in non-repo working dirs.
- gemini: removed the `-C` flag, which gemini rejects outright (`Unknown argument: C`) and crashed every call; the root is now the process cwd.
- claude-code: SDK `cwd` uses `project_dir or cwd`.
- Terminal schema-failure errors now include effective `provider / project_dir / cwd / output_path` (#684 ask #5).

## 2. Permissions (#687)

Canonical `permission_mode` contract: `None` (safe default) | `"auto"` (autonomous, no prompts) | `"plan"` (read-only).

- codex: `"auto"` → `--sandbox workspace-write` (was the now-deprecated `--full-auto`); `"plan"` → `--sandbox read-only`.
- gemini: `"auto"` → `--yolo` (was `--sandbox`, which *restricts* execution — backwards); `"plan"` → `--approval-mode plan`.
- claude/opencode mappings unchanged.

Flags were verified against installed `codex 0.141`/`gemini 0.40.1` binaries plus upstream source, not from memory.

## 3. Incremental schema (#688)

New `schema_mode`: `"single"` (default, unchanged) | `"incremental"` | `"auto"`.

- incremental instructs the agent to build the JSON object one top-level field at a time, and recovers by patching only the missing/invalid fields instead of re-running the whole task.
- auto switches to incremental above the large-schema threshold.

`project_dir` and `schema_mode` are now first-class params on `app.harness()` and `HarnessConfig`.

## Test plan

- [x] `ruff check .` clean (the blocking CI lint).
- [x] Full Python SDK suite: 1631 passed, 4 skipped (unrelated), 12 deselected (harness_live).
- [x] New regression tests:
  - opencode: `project_dir` wins as `--dir`; runner-level #684 repro (nested cwd under shared root) places output under project_dir and validates.
  - codex: `project_dir` is `-C` root; `plan` → `--sandbox read-only`; `--skip-git-repo-check` present.
  - gemini: never emits `-C`; `project_dir` is the process cwd; `auto` → `--yolo`; `plan` → `--approval-mode plan`.
  - claude: `project_dir` used as SDK root over `cwd`.
  - incremental schema: incremental suffix selected; auto stays single-shot for small schemas; field-level recovery patches a missing required field on retry.
- [x] Diff kept minimal — no unrelated reformatting churn.

## Not in this PR (follow-ups)

- Port the same contracts to the TypeScript SDK (still has the old `cwd`-wins precedence) and Go (directory model already correct; needs the permission + incremental work).
- Harness provider availability / `harness doctor` preflight (#685).
