### PR TITLE
feat(sdk/python): Ed25519 JWS sign/verify for payload authenticity

### DIFF
--- a/sdk/python/agentfield/crypto.py
+++ b/sdk/python/agentfield/crypto.py
@@ -19,30 +19,48 @@ type ``X25519KeyAgreementKey2020``. The control plane never holds the private ke
 
 from __future__ import annotations
 
+import base64
 import json
 import os
 from typing import Any, Callable, Dict, Optional, Union
 
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
 from joserfc import jwe
 from joserfc.jwk import OKPKey
 
 __all__ = [
     "JWE_ALG",
     "JWE_ENC",
+    "JWS_ALG",
     "KEY_AGREEMENT_TYPE",
     "DEFAULT_PRIVATE_KEY_ENV",
     "generate_x25519_keypair",
+    "generate_ed25519_keypair",
     "load_private_key",
     "extract_key_agreement_jwk",
     "encrypt_to_jwk",
     "encrypt_for_did",
     "decrypt",
+    "sign",
+    "verify",
     "PayloadEncryptionError",
 ]
 
 # JOSE algorithm parameters. Must match the TypeScript SDK exactly for interop.
 JWE_ALG = "ECDH-ES"
 JWE_ENC = "A256GCM"
+
+# JWS signature algorithm for payload *authenticity* (EdDSA over an Ed25519 key).
+# Encryption (JWE) gives confidentiality only — anyone with the recipient's public
+# key can encrypt. Signing lets the recipient verify the payload's ORIGIN: only the
+# holder of the signing private key (e.g. hax-sdk) could have produced it. Sign then
+# encrypt (JWS-in-JWE). Pinned to EdDSA so a forged header cannot downgrade to
+# "none" or another algorithm.
+JWS_ALG = "EdDSA"
 
 # W3C verification-method type published in the DID document for the X25519 key.
 KEY_AGREEMENT_TYPE = "X25519KeyAgreementKey2020"
@@ -204,3 +222,103 @@ def decrypt(token: str, private_key: Union[OKPKey, Dict[str, Any], str]) -> byte
         return jwe.decrypt_compact(token, key).plaintext
     except Exception as exc:  # noqa: BLE001
         raise PayloadEncryptionError(f"decryption failed: {exc}") from exc
+
+
+# --- JWS signing: payload authenticity (Ed25519 / EdDSA) --------------------
+
+
+def generate_ed25519_keypair() -> tuple[Dict[str, Any], Dict[str, Any]]:
+    """Generate a fresh Ed25519 signing keypair.
+
+    Returns ``(private_jwk, public_jwk)`` as plain dicts. Hold ``private_jwk`` in
+    the signing party's environment (e.g. hax-sdk's ``HAX_SDK_SIGNING_PRIVATE_KEY``)
+    and pin ``public_jwk`` as the verifier's trust anchor (e.g. the aggregator's
+    ``HAX_SDK_SIGNING_PUBLIC_KEY``).
+    """
+    key = OKPKey.generate_key("Ed25519", private=True)
+    return key.as_dict(private=True), key.as_dict(private=False)
+
+
+def _b64u_decode(segment: str) -> bytes:
+    """Decode a base64url segment, tolerating absent padding (per RFC 7515)."""
+    return base64.urlsafe_b64decode(segment + "=" * (-len(segment) % 4))
+
+
+def _b64u_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _ed25519_jwk(key: Union[OKPKey, Dict[str, Any], str]) -> Dict[str, Any]:
+    """Normalise an Ed25519 key (OKPKey / JWK dict / JWK JSON string) to a dict."""
+    if isinstance(key, OKPKey):
+        return key.as_dict(private=key.is_private)
+    if isinstance(key, dict):
+        return key
+    try:
+        return json.loads(key)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise PayloadEncryptionError(
+            "Ed25519 key must be an OKPKey, JWK dict, or JWK JSON string"
+        ) from exc
+
+
+def sign(payload: Payload, private_key: Union[OKPKey, Dict[str, Any], str]) -> str:
+    """Sign ``payload`` with an Ed25519 private key, returning a compact JWS.
+
+    Wire-compatible with the TypeScript SDK's compact JWS (``jose`` ``CompactSign``
+    with ``{alg: "EdDSA"}``, RFC 7515 + RFC 8037): a token signed there verifies
+    here and vice-versa. Implemented directly over ``cryptography`` rather than via
+    ``joserfc`` so the EdDSA wire name stays stable for cross-language interop.
+    """
+    jwk = _ed25519_jwk(private_key)
+    if jwk.get("crv") != "Ed25519" or "d" not in jwk:
+        raise PayloadEncryptionError(
+            "signing requires an Ed25519 private key (JWK with a 'd' component)"
+        )
+    try:
+        priv = Ed25519PrivateKey.from_private_bytes(_b64u_decode(jwk["d"]))
+    except Exception as exc:  # noqa: BLE001
+        raise PayloadEncryptionError(f"invalid Ed25519 private key: {exc}") from exc
+    protected = _b64u_encode(
+        json.dumps({"alg": JWS_ALG}, separators=(",", ":")).encode("utf-8")
+    )
+    body = _b64u_encode(_payload_bytes(payload))
+    signing_input = f"{protected}.{body}".encode("ascii")
+    return f"{protected}.{body}.{_b64u_encode(priv.sign(signing_input))}"
+
+
+def verify(token: str, public_key: Union[OKPKey, Dict[str, Any], str]) -> bytes:
+    """Verify a compact JWS against an Ed25519 public key; return the payload bytes.
+
+    Raises :class:`PayloadEncryptionError` on a missing, malformed, or invalid
+    signature, or a non-EdDSA algorithm. The ``alg`` header is pinned to ``EdDSA``
+    so a forged header (e.g. ``none``) cannot bypass verification.
+    """
+    jwk = _ed25519_jwk(public_key)
+    if jwk.get("crv") != "Ed25519" or "x" not in jwk:
+        raise PayloadEncryptionError("verification requires an Ed25519 public key")
+    parts = token.split(".") if isinstance(token, str) else []
+    if len(parts) != 3 or not all(parts):
+        raise PayloadEncryptionError("malformed compact JWS (expected 3 parts)")
+    protected_b64, body_b64, signature_b64 = parts
+    try:
+        header = json.loads(_b64u_decode(protected_b64))
+    except Exception as exc:  # noqa: BLE001
+        raise PayloadEncryptionError(f"invalid JWS header: {exc}") from exc
+    if not isinstance(header, dict) or header.get("alg") != JWS_ALG:
+        raise PayloadEncryptionError(
+            f"unexpected JWS alg {header.get('alg') if isinstance(header, dict) else None!r}; "
+            f"expected {JWS_ALG}"
+        )
+    try:
+        pub = Ed25519PublicKey.from_public_bytes(_b64u_decode(jwk["x"]))
+    except Exception as exc:  # noqa: BLE001
+        raise PayloadEncryptionError(f"invalid Ed25519 public key: {exc}") from exc
+    signing_input = f"{protected_b64}.{body_b64}".encode("ascii")
+    try:
+        pub.verify(_b64u_decode(signature_b64), signing_input)
+    except InvalidSignature as exc:
+        raise PayloadEncryptionError("signature verification failed") from exc
+    except Exception as exc:  # noqa: BLE001
+        raise PayloadEncryptionError(f"signature verification failed: {exc}") from exc
+    return _b64u_decode(body_b64)

--- a/sdk/python/tests/test_crypto.py
+++ b/sdk/python/tests/test_crypto.py
@@ -1,5 +1,6 @@
 """Unit tests for DID-based payload encryption (agentfield.crypto)."""
 
+import base64
 import json
 
 import pytest
@@ -120,3 +121,82 @@ def test_load_private_key_missing_env(monkeypatch):
     monkeypatch.delenv(crypto.DEFAULT_PRIVATE_KEY_ENV, raising=False)
     with pytest.raises(PayloadEncryptionError, match="no X25519 private key"):
         crypto.load_private_key()
+
+
+# --- JWS signing: payload authenticity (Ed25519 / EdDSA) --------------------
+
+# A compact JWS produced by the TypeScript SDK (jose CompactSign, alg=EdDSA) over
+# {"scope":{"tier":"workspace","workspace_id":"ws_demo"}}, signed with the Ed25519
+# key whose public half is _ED25519_PUB. Frozen here so cross-language interop
+# (TS sign -> Python verify) is asserted without a node toolchain at test time.
+_ED25519_PUB = {
+    "crv": "Ed25519",
+    "x": "LZG6OR6azeoR7_cVXjZOTY1wBIpFp-loce90N1_XOiY",
+    "kty": "OKP",
+}
+_TS_JWS_VECTOR = (
+    "eyJhbGciOiJFZERTQSJ9"
+    ".eyJzY29wZSI6eyJ0aWVyIjoid29ya3NwYWNlIiwid29ya3NwYWNlX2lkIjoid3NfZGVtbyJ9fQ"
+    ".xNm_F_9qbMP4QFbFEHD5WRj-7CcIXPz5uNz3JoXddktyYWPXCC5Y0xgfms41h50aJem4fiPjqv-zaUeoFhPyDw"
+)
+
+
+def test_sign_verify_roundtrip_dict():
+    priv, pub = crypto.generate_ed25519_keypair()
+    payload = {"scope": {"tier": "project", "workspace_id": "ws_1", "project_id": "p_2"}}
+    assert json.loads(crypto.verify(crypto.sign(payload, priv), pub)) == payload
+
+
+def test_sign_verify_str_and_bytes():
+    priv, pub = crypto.generate_ed25519_keypair()
+    assert crypto.verify(crypto.sign("hello", priv), pub) == b"hello"
+    assert crypto.verify(crypto.sign(b"raw", priv), pub) == b"raw"
+
+
+def test_ts_signed_jws_verifies_in_python():
+    """A jose (TypeScript) compact JWS must verify here — cross-language interop."""
+    assert json.loads(crypto.verify(_TS_JWS_VECTOR, _ED25519_PUB)) == {
+        "scope": {"tier": "workspace", "workspace_id": "ws_demo"}
+    }
+
+
+def test_verify_rejects_wrong_key():
+    _priv, other_pub = crypto.generate_ed25519_keypair()
+    with pytest.raises(PayloadEncryptionError, match="signature verification failed"):
+        crypto.verify(_TS_JWS_VECTOR, other_pub)
+
+
+def test_verify_rejects_tampered_payload():
+    head, body, sig = _TS_JWS_VECTOR.split(".")
+    forged = f"{head}.{body[:-2]}AA.{sig}"
+    with pytest.raises(PayloadEncryptionError):
+        crypto.verify(forged, _ED25519_PUB)
+
+
+def test_verify_rejects_alg_none():
+    """An unsigned 'alg: none' token (empty signature) must not bypass verification."""
+    _head, body, _sig = _TS_JWS_VECTOR.split(".")
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    # Real 'none' tokens carry an empty signature segment -> rejected as malformed;
+    # a 'none' header kept with a non-empty signature is rejected at the alg gate
+    # (see test_verify_rejects_non_eddsa_alg). Either way it never verifies.
+    with pytest.raises(PayloadEncryptionError):
+        crypto.verify(f"{header}.{body}.", _ED25519_PUB)
+
+
+def test_verify_rejects_non_eddsa_alg():
+    _head, body, sig = _TS_JWS_VECTOR.split(".")
+    header = base64.urlsafe_b64encode(b'{"alg":"HS256"}').rstrip(b"=").decode()
+    with pytest.raises(PayloadEncryptionError, match="alg"):
+        crypto.verify(f"{header}.{body}.{sig}", _ED25519_PUB)
+
+
+def test_verify_rejects_malformed():
+    with pytest.raises(PayloadEncryptionError, match="3 parts"):
+        crypto.verify("only.two", _ED25519_PUB)
+
+
+def test_sign_requires_private_key():
+    _priv, pub = crypto.generate_ed25519_keypair()
+    with pytest.raises(PayloadEncryptionError, match="private key"):
+        crypto.sign("x", pub)  # a public-only JWK cannot sign


### PR DESCRIPTION
## What

Adds `crypto.sign` / `crypto.verify` (+ `generate_ed25519_keypair`) to the Python SDK — compact JWS over an Ed25519 key, wire-compatible with the TypeScript SDK's `jose` `CompactSign`.

## Why

JWE encryption proves **confidentiality** (only the recipient can read), not **origin** (anyone with the recipient's *public* key can encrypt). The discuss/aggregator split needs the aggregator to accept only payloads **minted by hax-sdk** — so hax-sdk signs the payload, then encrypts it (sign-then-encrypt), and the aggregator verifies the signature before honouring the scope. This closes a cross-tenant forgery gap where anyone able to resolve the aggregator's (public) DID could craft a scoped payload.

## Notes

- Implemented directly over `cryptography`'s Ed25519 rather than `joserfc` — joserfc rejects `alg=EdDSA` for signing (RFC 9864 deprecation) and warns on use. The `alg` header is pinned to `EdDSA`, so a forged header cannot downgrade to `none`.
- Interop verified **both directions** (jose ⇄ this implementation) and negative cases: wrong key, tampered payload, `alg=none`, `alg=HS256`, malformed token.
- 21 crypto tests pass; `ruff check .` clean. Additive + isolated to `crypto.py` (no behavior change to existing JWE paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)