### PR TITLE
fix(security): Enforce fail-closed for empty admin token (#425)

### DIFF
--- a/control-plane/internal/config/config.go
+++ b/control-plane/internal/config/config.go
@@ -307,8 +307,12 @@ type AuthorizationConfig struct {
 	// DefaultApprovalDurationHours is the default duration for permission approvals
 	DefaultApprovalDurationHours int `yaml:"default_approval_duration_hours" mapstructure:"default_approval_duration_hours" default:"720"`
 	// AdminToken is a separate token required for admin operations (tag approval,
-	// policy management). If empty, admin routes fall back to the standard API key.
+	// policy management). When empty and InsecureDisableAdminAuth is false, admin
+	// routes will reject requests at startup or return 401.
 	AdminToken string `yaml:"admin_token" mapstructure:"admin_token"`
+	// InsecureDisableAdminAuth explicitly permits running admin routes without
+	// an admin token. This should only be enabled for trusted local development.
+	InsecureDisableAdminAuth bool `yaml:"insecure_disable_admin_auth" mapstructure:"insecure_disable_admin_auth"`
 	// InternalToken is sent as Authorization: Bearer header when the control plane
 	// forwards execution requests to agents. Agents with RequireOriginAuth enabled
 	// validate this token, preventing direct access to their HTTP ports.
@@ -657,6 +661,13 @@ func ApplyEnvOverrides(cfg *Config) {
 	}
 	if val := os.Getenv("AGENTFIELD_AUTHORIZATION_ADMIN_TOKEN"); val != "" {
 		cfg.Features.DID.Authorization.AdminToken = val
+	}
+	if val, ok := os.LookupEnv("AGENTFIELD_INSECURE_ADMIN_NO_TOKEN"); ok {
+		cfg.Features.DID.Authorization.InsecureDisableAdminAuth = parseEnvBool(val)
+	}
+	// Also support the nested path format for consistency.
+	if val, ok := os.LookupEnv("AGENTFIELD_AUTHORIZATION_INSECURE_DISABLE_ADMIN_AUTH"); ok {
+		cfg.Features.DID.Authorization.InsecureDisableAdminAuth = parseEnvBool(val)
 	}
 	if val := os.Getenv("AGENTFIELD_AUTHORIZATION_INTERNAL_TOKEN"); val != "" {
 		cfg.Features.DID.Authorization.InternalToken = val

--- a/control-plane/internal/config/config_additional_test.go
+++ b/control-plane/internal/config/config_additional_test.go
@@ -295,6 +295,7 @@ func TestApplyEnvOverrides(t *testing.T) {
 		"AGENTFIELD_AUTHORIZATION_DID_AUTH_ENABLED":                  "1",
 		"AGENTFIELD_AUTHORIZATION_DOMAIN":                            "auth.local",
 		"AGENTFIELD_AUTHORIZATION_ADMIN_TOKEN":                       "admin-token",
+		"AGENTFIELD_INSECURE_ADMIN_NO_TOKEN":                         "true",
 		"AGENTFIELD_AUTHORIZATION_INTERNAL_TOKEN":                    "internal-token",
 		"AGENTFIELD_AUTHORIZATION_DEFAULT_DENY":                      "true",
 		"AGENTFIELD_NODE_LOG_PROXY_CONNECT_TIMEOUT":                  "21s",
@@ -379,6 +380,7 @@ func TestApplyEnvOverrides(t *testing.T) {
 		!cfg.Features.DID.Authorization.DIDAuthEnabled ||
 		cfg.Features.DID.Authorization.Domain != "auth.local" ||
 		cfg.Features.DID.Authorization.AdminToken != "admin-token" ||
+		!cfg.Features.DID.Authorization.InsecureDisableAdminAuth ||
 		cfg.Features.DID.Authorization.InternalToken != "internal-token" ||
 		!cfg.Features.DID.Authorization.DefaultDeny {
 		t.Fatalf("unexpected authorization overrides: %+v", cfg.Features.DID.Authorization)
@@ -440,6 +442,31 @@ func TestApplyEnvOverridesAPIAuthInsecureDisable(t *testing.T) {
 
 		if cfg.API.Auth.InsecureDisableAuth {
 			t.Fatal("expected nested insecure API auth setting to take precedence")
+		}
+	})
+}
+
+func TestApplyEnvOverridesInsecureAdminNoToken(t *testing.T) {
+	t.Run("short environment name", func(t *testing.T) {
+		cfg := &Config{}
+		t.Setenv("AGENTFIELD_INSECURE_ADMIN_NO_TOKEN", "true")
+
+		ApplyEnvOverrides(cfg)
+
+		if !cfg.Features.DID.Authorization.InsecureDisableAdminAuth {
+			t.Fatal("expected insecure admin auth disable from environment")
+		}
+	})
+
+	t.Run("nested environment name takes precedence", func(t *testing.T) {
+		cfg := &Config{}
+		t.Setenv("AGENTFIELD_INSECURE_ADMIN_NO_TOKEN", "true")
+		t.Setenv("AGENTFIELD_AUTHORIZATION_INSECURE_DISABLE_ADMIN_AUTH", "false")
+
+		ApplyEnvOverrides(cfg)
+
+		if cfg.Features.DID.Authorization.InsecureDisableAdminAuth {
+			t.Fatal("expected nested insecure admin auth setting to take precedence")
 		}
 	})
 }

--- a/control-plane/internal/server/middleware/auth.go
+++ b/control-plane/internal/server/middleware/auth.go
@@ -173,20 +173,44 @@ func queryAPIKeyAllowed(c *gin.Context, allowedPaths map[string]struct{}) bool {
 	return false
 }
 
+// AdminAuthConfig mirrors server configuration for admin token authentication.
+type AdminAuthConfig struct {
+	AdminToken               string
+	InsecureDisableAdminAuth bool
+}
+
+// ValidateAdminTokenAuth rejects an implicit unauthenticated admin configuration.
+func ValidateAdminTokenAuth(config AdminAuthConfig) error {
+	if config.AdminToken == "" && !config.InsecureDisableAdminAuth {
+		return errors.New("admin token is required when authorization is enabled; set AGENTFIELD_AUTHORIZATION_ADMIN_TOKEN or explicitly set AGENTFIELD_INSECURE_ADMIN_NO_TOKEN=true")
+	}
+	return nil
+}
+
 // AdminTokenAuth enforces a separate admin token for admin routes.
-// If adminToken is empty, the middleware is a no-op (falls back to global API key auth).
 // Admin tokens must be sent via the X-Admin-Token header only (not Bearer) to avoid
 // collision with the API key Bearer token namespace.
-func AdminTokenAuth(adminToken string) gin.HandlerFunc {
+func AdminTokenAuth(config AdminAuthConfig) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if adminToken == "" {
+		// Unauthenticated admin operation must be explicitly enabled at startup.
+		if config.AdminToken == "" && config.InsecureDisableAdminAuth {
 			c.Next()
+			return
+		}
+
+		// Fail-closed: if the admin token is not configured and insecure mode
+		// was not explicitly enabled, reject all requests.
+		if config.AdminToken == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"error":   "unauthorized",
+				"message": "admin authentication required but admin token is not configured on the server",
+			})
 			return
 		}
 
 		token := c.GetHeader("X-Admin-Token")
 
-		if subtle.ConstantTimeCompare([]byte(token), []byte(adminToken)) != 1 {
+		if subtle.ConstantTimeCompare([]byte(token), []byte(config.AdminToken)) != 1 {
 			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
 				"error":   "forbidden",
 				"message": "admin token required for this operation (use X-Admin-Token header)",

--- a/control-plane/internal/server/middleware/auth_admin_additional_test.go
+++ b/control-plane/internal/server/middleware/auth_admin_additional_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -9,34 +10,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestValidateAdminTokenAuth_RejectsImplicitDisable(t *testing.T) {
+	err := ValidateAdminTokenAuth(AdminAuthConfig{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "AGENTFIELD_INSECURE_ADMIN_NO_TOKEN=true")
+}
+
+func TestValidateAdminTokenAuth_AcceptsExplicitInsecure(t *testing.T) {
+	err := ValidateAdminTokenAuth(AdminAuthConfig{InsecureDisableAdminAuth: true})
+	require.NoError(t, err)
+}
+
+func TestValidateAdminTokenAuth_AcceptsConfiguredToken(t *testing.T) {
+	err := ValidateAdminTokenAuth(AdminAuthConfig{AdminToken: "admin-secret"})
+	require.NoError(t, err)
+}
+
 func TestAdminTokenAuth(t *testing.T) {
 	tests := []struct {
 		name        string
-		adminToken  string
+		config      AdminAuthConfig
 		headerToken string
 		wantStatus  int
+		wantBody    string
 	}{
 		{
-			name:       "disabled allows request through",
-			adminToken: "",
+			name:       "empty token with explicit insecure allows request through",
+			config:     AdminAuthConfig{InsecureDisableAdminAuth: true},
 			wantStatus: http.StatusOK,
 		},
 		{
+			name:       "empty token without insecure flag returns 401",
+			config:     AdminAuthConfig{},
+			wantStatus: http.StatusUnauthorized,
+			wantBody:   "admin authentication required but admin token is not configured",
+		},
+		{
 			name:        "valid admin token",
-			adminToken:  "admin-secret",
+			config:      AdminAuthConfig{AdminToken: "admin-secret"},
 			headerToken: "admin-secret",
 			wantStatus:  http.StatusOK,
 		},
 		{
-			name:        "missing admin token header",
-			adminToken:  "admin-secret",
-			wantStatus:  http.StatusForbidden,
+			name:       "missing admin token header",
+			config:     AdminAuthConfig{AdminToken: "admin-secret"},
+			wantStatus: http.StatusForbidden,
+			wantBody:   "admin token required",
 		},
 		{
 			name:        "invalid admin token header",
-			adminToken:  "admin-secret",
+			config:      AdminAuthConfig{AdminToken: "admin-secret"},
 			headerToken: "wrong-secret",
 			wantStatus:  http.StatusForbidden,
+			wantBody:    "admin token required",
 		},
 	}
 
@@ -44,7 +70,7 @@ func TestAdminTokenAuth(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gin.SetMode(gin.TestMode)
 			router := gin.New()
-			router.Use(AdminTokenAuth(tt.adminToken))
+			router.Use(AdminTokenAuth(tt.config))
 			router.GET("/admin", func(c *gin.Context) {
 				c.String(http.StatusOK, "ok")
 			})
@@ -58,9 +84,49 @@ func TestAdminTokenAuth(t *testing.T) {
 			router.ServeHTTP(recorder, req)
 
 			require.Equal(t, tt.wantStatus, recorder.Code)
-			if tt.wantStatus == http.StatusForbidden {
-				require.Contains(t, recorder.Body.String(), "admin token required")
+			if tt.wantBody != "" {
+				require.Contains(t, recorder.Body.String(), tt.wantBody)
 			}
 		})
 	}
+}
+
+func TestAdminTokenAuth_EmptyTokenFailsClosed(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(AdminTokenAuth(AdminAuthConfig{}))
+	router.GET("/admin/tags", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	// Request with only a valid API key (simulated via no admin token header)
+	// should be rejected because admin token is not configured.
+	req := httptest.NewRequest(http.MethodGet, "/admin/tags", nil)
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusUnauthorized, recorder.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
+	require.Equal(t, "unauthorized", resp["error"])
+	require.Contains(t, resp["message"], "admin token is not configured")
+}
+
+func TestAdminTokenAuth_APIKeyOnlyReturns401WhenAdminTokenConfigured(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(AdminTokenAuth(AdminAuthConfig{AdminToken: "admin-secret"}))
+	router.GET("/admin/policies", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	// Request with API key header but NO admin token — should return 403
+	req := httptest.NewRequest(http.MethodGet, "/admin/policies", nil)
+	req.Header.Set("X-API-Key", "some-api-key")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusForbidden, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "admin token required")
 }

--- a/control-plane/internal/server/routes_admin.go
+++ b/control-plane/internal/server/routes_admin.go
@@ -17,7 +17,10 @@ func (s *AgentFieldServer) registerAdminRoutes(agentAPI *gin.RouterGroup) {
 	// Admin routes for tag approval and access policy management (VC-based authorization)
 	if s.config.Features.DID.Authorization.Enabled {
 		adminGroup := agentAPI.Group("")
-		adminGroup.Use(middleware.AdminTokenAuth(s.config.Features.DID.Authorization.AdminToken))
+		adminGroup.Use(middleware.AdminTokenAuth(middleware.AdminAuthConfig{
+			AdminToken:               s.config.Features.DID.Authorization.AdminToken,
+			InsecureDisableAdminAuth: s.config.Features.DID.Authorization.InsecureDisableAdminAuth,
+		}))
 
 		// Tag approval admin routes
 		if s.tagApprovalService != nil {

--- a/control-plane/internal/server/server.go
+++ b/control-plane/internal/server/server.go
@@ -104,6 +104,12 @@ func NewAgentFieldServer(cfg *config.Config) (*AgentFieldServer, error) {
 		return nil, fmt.Errorf("invalid API authentication configuration: %w", err)
 	}
 
+	if cfg.Features.DID.Authorization.Enabled {
+		if err := validateAdminAuthConfig(cfg.Features.DID.Authorization); err != nil {
+			return nil, fmt.Errorf("invalid admin authentication configuration: %w", err)
+		}
+	}
+
 	// Define agentfieldHome at the very top
 	agentfieldHome := os.Getenv("AGENTFIELD_HOME")
 	if agentfieldHome == "" {
@@ -285,9 +291,6 @@ func NewAgentFieldServer(cfg *config.Config) (*AgentFieldServer, error) {
 		didWebService = services.NewDIDWebService(domain, didService, storageProvider)
 
 		if cfg.Features.DID.Authorization.Enabled {
-			if cfg.Features.DID.Authorization.AdminToken == "" {
-				logger.Logger.Error().Msg("⚠️  SECURITY WARNING: Authorization is enabled but no admin_token is configured! Admin routes (tag approval, policy management) are unprotected. Set AGENTFIELD_AUTHORIZATION_ADMIN_TOKEN for production use.")
-			}
 			if cfg.Features.DID.Authorization.TagApprovalRules.DefaultMode == "" || cfg.Features.DID.Authorization.TagApprovalRules.DefaultMode == "auto" {
 				logger.Logger.Warn().Msg("⚠️  Tag approval default_mode is 'auto' — all agent tags will be auto-approved. Set tag_approval_rules.default_mode to 'manual' for production.")
 			}
@@ -546,6 +549,22 @@ func validateAPIAuthConfig(auth config.AuthConfig) error {
 		logger.Logger.Warn().
 			Bool("insecure_disable_auth", true).
 			Msg("SECURITY WARNING: API key authentication is explicitly disabled; all API routes relying on API-key authentication are unauthenticated")
+	}
+	return nil
+}
+
+func validateAdminAuthConfig(authz config.AuthorizationConfig) error {
+	adminConfig := middleware.AdminAuthConfig{
+		AdminToken:               authz.AdminToken,
+		InsecureDisableAdminAuth: authz.InsecureDisableAdminAuth,
+	}
+	if err := middleware.ValidateAdminTokenAuth(adminConfig); err != nil {
+		return err
+	}
+	if authz.AdminToken == "" {
+		logger.Logger.Warn().
+			Bool("insecure_disable_admin_auth", true).
+			Msg("SECURITY WARNING: Admin token authentication is explicitly disabled; admin routes (tag approval, policy management) are unauthenticated")
 	}
 	return nil
 }

--- a/control-plane/internal/server/server_additional_test.go
+++ b/control-plane/internal/server/server_additional_test.go
@@ -139,6 +139,7 @@ func TestNewAgentFieldServer(t *testing.T) {
 		cfg.Features.DID.Authorization.DIDAuthEnabled = true
 		cfg.Features.DID.Authorization.Domain = "example.com"
 		cfg.Features.DID.Authorization.InternalToken = "internal-token"
+		cfg.Features.DID.Authorization.InsecureDisableAdminAuth = true
 		cfg.Features.DID.Authorization.TagApprovalRules.DefaultMode = "manual"
 		cfg.Features.Connector.Enabled = false
 
@@ -196,6 +197,31 @@ func TestValidateAPIAuthConfigWarnsWhenExplicitlyDisabled(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, output.String(), `"level":"warn"`)
 	require.Contains(t, output.String(), "API key authentication is explicitly disabled")
+}
+
+func TestValidateAdminAuthConfigWarnsWhenExplicitlyDisabled(t *testing.T) {
+	previousLogger := logger.Logger
+	var output bytes.Buffer
+	logger.Logger = zerolog.New(&output)
+	t.Cleanup(func() { logger.Logger = previousLogger })
+
+	err := validateAdminAuthConfig(config.AuthorizationConfig{InsecureDisableAdminAuth: true})
+	require.NoError(t, err)
+	require.Contains(t, output.String(), `"level":"warn"`)
+	require.Contains(t, output.String(), "Admin token authentication is explicitly disabled")
+}
+
+func TestNewAgentFieldServerRejectsEmptyAdminToken(t *testing.T) {
+	cfg := baseConfigForDBTests()
+	cfg.API.Auth.APIKey = ""
+	cfg.API.Auth.InsecureDisableAuth = true
+	cfg.Features.DID.Enabled = false
+	cfg.Features.DID.Authorization.Enabled = true
+	cfg.Features.DID.Authorization.AdminToken = ""
+
+	srv, err := NewAgentFieldServer(&cfg)
+	require.Nil(t, srv)
+	require.ErrorContains(t, err, "AGENTFIELD_INSECURE_ADMIN_NO_TOKEN=true")
 }
 
 func TestStartAndStop(t *testing.T) {
@@ -360,6 +386,7 @@ func TestSetupRoutesWithDIDServices(t *testing.T) {
 	cfg.Features.DID.Authorization.DIDAuthEnabled = true
 	cfg.Features.DID.Authorization.Domain = "example.com"
 	cfg.Features.DID.Authorization.InternalToken = "internal-token"
+	cfg.Features.DID.Authorization.InsecureDisableAdminAuth = true
 	cfg.Features.DID.Authorization.TagApprovalRules.DefaultMode = "manual"
 	cfg.Features.Connector.Enabled = false
 

--- a/control-plane/internal/server/server_coverage_additional_test.go
+++ b/control-plane/internal/server/server_coverage_additional_test.go
@@ -45,6 +45,7 @@ func TestNewAgentFieldServerCoversFallbacksAndOptionalServices(t *testing.T) {
 	cfg.Features.DID.Enabled = true
 	cfg.Features.DID.KeyAlgorithm = "Ed25519"
 	cfg.Features.DID.Authorization.Enabled = true
+	cfg.Features.DID.Authorization.InsecureDisableAdminAuth = true
 	cfg.Features.DID.Authorization.Domain = ""
 	cfg.Features.DID.Authorization.TagApprovalRules.DefaultMode = "auto"
 	cfg.Features.DID.Authorization.AccessPolicies = []config.AccessPolicyConfig{


### PR DESCRIPTION
## Summary

Fixes the issue where an empty admin token silently disabled route protection. 

* **`internal/server/middleware/auth.go`**: Added `ValidateAdminTokenAuth` and updated `AdminTokenAuth` middleware to return 401 instead of letting requests through when no token is set.
* **`internal/config/config.go`**: Added `InsecureDisableAdminAuth` field to configuration and mapped the `AGENTFIELD_INSECURE_ADMIN_NO_TOKEN` env var.
* **`internal/server/server.go`**: Added startup validation that stops the server from launching if the admin token is missing, unless insecure mode is explicitly configured.
* **`internal/server/routes_admin.go`**: Updated route registration to pass the new config structure to the middleware.
* **`tests`**: Added and updated unit tests to verify the new startup validations, env override flags, and 401/403 responses.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] Tests only
- [ ] CI / tooling
- [ ] Breaking change

## Test plan

Run the following test commands locally to verify the new startup validations, the middleware's fail-closed unauthorized/forbidden assertions, and configuration override behavior:

- `cd control-plane && go test -v ./internal/server/...`
- `cd control-plane && go test -v ./internal/server/middleware/...`
- `cd control-plane && go test -v ./internal/config/...`

## Test coverage

Before asking for review, please confirm:

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR (no bare additions).
- [x] If I removed code, I updated `coverage-baseline.json` in this PR *only if* the removal caused a legitimate regression and I called it out in the summary above.
- [ ] The coverage gate check is green in CI before requesting review.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) (if present) and [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
- [x] Commits are signed and follow conventional-commits style.
- [x] I have linked any related issues (Fixes #123 / Closes #456).

## Related issues / PRs

Closes #425
