### PR TITLE
fix(harness): stream output with idle watchdog and explicit stdin null (#695)

### DIFF
--- a/sdk/go/harness/cli.go
+++ b/sdk/go/harness/cli.go
@@ -4,12 +4,33 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
+
+// defaultIdleSeconds is the no-progress watchdog window used when the env var
+// AGENTFIELD_HARNESS_IDLE_SECONDS is unset or invalid. A value <= 0 disables it.
+const defaultIdleSeconds = 120
+
+// resolveIdleSeconds reads the idle watchdog window from the environment,
+// falling back to defaultIdleSeconds. A value <= 0 disables the watchdog.
+func resolveIdleSeconds() int {
+	raw := os.Getenv("AGENTFIELD_HARNESS_IDLE_SECONDS")
+	if raw == "" {
+		return defaultIdleSeconds
+	}
+	v, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil {
+		return defaultIdleSeconds
+	}
+	return v
+}
 
 var ansiRe = regexp.MustCompile(`\x1B\[[0-?]*[ -/]*[@-~]`)
 
@@ -73,11 +94,97 @@ func RunCLI(ctx context.Context, cmd []string, env map[string]string, cwd string
 		c.Dir = cwd
 	}
 
-	var stdout, stderr bytes.Buffer
-	c.Stdout = &stdout
-	c.Stderr = &stderr
+	// Explicit null stdin so the child gets an immediate EOF instead of
+	// inheriting the parent's stdin (a hang risk if the child reads stdin).
+	c.Stdin = bytes.NewReader(nil)
 
-	err := c.Run()
+	// Run the child in its own process group so the idle watchdog can kill
+	// the whole tree, not just the leader. setProcessGroup is platform-guarded.
+	setProcessGroup(c)
+
+	stdoutPipe, err := c.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	stderrPipe, err := c.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := c.Start(); err != nil {
+		if isExecNotFound(err) {
+			return nil, err
+		}
+		return nil, err
+	}
+
+	var (
+		mu           sync.Mutex
+		stdout       bytes.Buffer
+		stderr       bytes.Buffer
+		lastActivity = time.Now()
+		wg           sync.WaitGroup
+	)
+
+	// Drain both pipes concurrently to avoid a pipe-buffer deadlock: if we
+	// read stdout fully before stderr, a child that fills the stderr pipe
+	// blocks forever.
+	drain := func(r io.Reader, buf *bytes.Buffer) {
+		defer wg.Done()
+		chunk := make([]byte, 65536)
+		for {
+			n, readErr := r.Read(chunk)
+			if n > 0 {
+				mu.Lock()
+				buf.Write(chunk[:n])
+				lastActivity = time.Now()
+				mu.Unlock()
+			}
+			if readErr != nil {
+				return
+			}
+		}
+	}
+	wg.Add(2)
+	go drain(stdoutPipe, &stdout)
+	go drain(stderrPipe, &stderr)
+
+	// Wait for the child to exit on a separate goroutine so the watchdog
+	// loop below can observe idle stalls and abort early.
+	waitDone := make(chan error, 1)
+	go func() {
+		wg.Wait() // ensure all output is flushed before reaping
+		waitDone <- c.Wait()
+	}()
+
+	idleSeconds := resolveIdleSeconds()
+	idleTimedOut := false
+	var waitErr error
+
+	if idleSeconds > 0 {
+		idle := time.Duration(idleSeconds) * time.Second
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+	loop:
+		for {
+			select {
+			case waitErr = <-waitDone:
+				break loop
+			case <-ticker.C:
+				mu.Lock()
+				stalledFor := time.Since(lastActivity)
+				mu.Unlock()
+				if stalledFor >= idle {
+					idleTimedOut = true
+					killProcessGroup(c)
+					waitErr = <-waitDone
+					break loop
+				}
+			}
+		}
+	} else {
+		waitErr = <-waitDone
+	}
 
 	result := &CLIResult{
 		Stdout:     stdout.String(),
@@ -85,13 +192,17 @@ func RunCLI(ctx context.Context, cmd []string, env map[string]string, cwd string
 		ReturnCode: 0,
 	}
 
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
+	if idleTimedOut {
+		return result, fmt.Errorf("CLI command made no progress for %ds: %s", idleSeconds, strings.Join(cmd, " "))
+	}
+
+	if waitErr != nil {
+		if exitErr, ok := waitErr.(*exec.ExitError); ok {
 			result.ReturnCode = exitErr.ExitCode()
 		} else if ctx.Err() != nil {
 			return result, fmt.Errorf("CLI command timed out after %ds: %s", timeout, strings.Join(cmd, " "))
 		} else {
-			return nil, err
+			return nil, waitErr
 		}
 	}
 

--- a/sdk/go/harness/cli_unix.go
+++ b/sdk/go/harness/cli_unix.go
@@ -1,0 +1,33 @@
+//go:build !windows
+
+package harness
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setProcessGroup makes the child the leader of a new process group so the
+// idle watchdog can signal the whole tree at once.
+func setProcessGroup(c *exec.Cmd) {
+	if c.SysProcAttr == nil {
+		c.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	c.SysProcAttr.Setpgid = true
+}
+
+// killProcessGroup hard-kills the child's process group. It falls back to
+// killing just the process if the group signal fails.
+func killProcessGroup(c *exec.Cmd) {
+	if c.Process == nil {
+		return
+	}
+	pid := c.Process.Pid
+	if pid > 0 {
+		// Negative pid signals the entire process group.
+		if err := syscall.Kill(-pid, syscall.SIGKILL); err == nil {
+			return
+		}
+	}
+	_ = c.Process.Kill()
+}

--- a/sdk/go/harness/cli_windows.go
+++ b/sdk/go/harness/cli_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package harness
+
+import "os/exec"
+
+// setProcessGroup is a no-op on Windows (process-group semantics differ).
+func setProcessGroup(_ *exec.Cmd) {}
+
+// killProcessGroup kills the child process. Windows lacks POSIX process groups,
+// so this kills the leader directly.
+func killProcessGroup(c *exec.Cmd) {
+	if c.Process != nil {
+		_ = c.Process.Kill()
+	}
+}

--- a/sdk/go/harness/coverage_helpers_test.go
+++ b/sdk/go/harness/coverage_helpers_test.go
@@ -61,16 +61,24 @@ printf '%s\n' "KEEP_ME=$KEEP_ME"
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Equal(t, 0, result.ReturnCode)
-		assert.Contains(t, result.Stdout, "PWD="+dir)
+		// Resolve symlinks: on macOS /var is a symlink to /private/var, so the
+		// child's $PWD may differ textually from t.TempDir()'s path.
+		resolvedDir, evalErr := filepath.EvalSymlinks(dir)
+		require.NoError(t, evalErr)
+		assert.True(t,
+			strings.Contains(result.Stdout, "PWD="+dir) || strings.Contains(result.Stdout, "PWD="+resolvedDir),
+			"stdout %q missing PWD=%s or PWD=%s", result.Stdout, dir, resolvedDir)
 		assert.Contains(t, result.Stdout, "REMOVE_ME=unset")
 		assert.Contains(t, result.Stdout, "KEEP_ME=set")
 	})
 
 	t.Run("context cancellation returns a killed-process result with partial stdout", func(t *testing.T) {
 		dir := t.TempDir()
+		// Flush the line, give the reader a beat, then stall so the kill lands
+		// during the sleep (not before the forked shell runs printf).
 		script := writeTestScript(t, dir, "sleepy", "#!/bin/sh\nprintf 'before-timeout'\nsleep 5\n")
 
-		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 		defer cancel()
 
 		result, err := RunCLI(ctx, []string{script}, nil, "", 0)
@@ -78,6 +86,38 @@ printf '%s\n' "KEEP_ME=$KEEP_ME"
 		require.NotNil(t, result)
 		assert.NotEqual(t, 0, result.ReturnCode)
 		assert.Equal(t, "before-timeout", result.Stdout)
+	})
+
+	t.Run("idle watchdog aborts a stalled child before the wall-clock cap", func(t *testing.T) {
+		dir := t.TempDir()
+		// Prints one line, then stalls far longer than the idle window.
+		script := writeTestScript(t, dir, "staller", "#!/bin/sh\nprintf 'started\\n'\nsleep 600\n")
+
+		// Idle window of 1s; generous 60s wall-clock cap. Watchdog should fire first.
+		t.Setenv("AGENTFIELD_HARNESS_IDLE_SECONDS", "1")
+
+		start := time.Now()
+		result, err := RunCLI(context.Background(), []string{script}, nil, "", 60)
+		elapsed := time.Since(start)
+
+		require.Error(t, err)
+		require.NotNil(t, result)
+		assert.Contains(t, err.Error(), "no progress")
+		assert.Contains(t, result.Stdout, "started")
+		assert.Less(t, elapsed, 15*time.Second, "idle watchdog did not fire promptly")
+	})
+
+	t.Run("fast command returns full output even with a short idle window", func(t *testing.T) {
+		dir := t.TempDir()
+		script := writeTestScript(t, dir, "fast", "#!/bin/sh\nprintf 'line1\\nline2\\n'\n")
+
+		t.Setenv("AGENTFIELD_HARNESS_IDLE_SECONDS", "1")
+
+		result, err := RunCLI(context.Background(), []string{script}, nil, "", 10)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, 0, result.ReturnCode)
+		assert.Equal(t, "line1\nline2\n", result.Stdout)
 	})
 }
 

--- a/sdk/python/agentfield/agent_ai.py
+++ b/sdk/python/agentfield/agent_ai.py
@@ -123,13 +123,64 @@ def _resolve_timeout_retries() -> int:
     return _AI_TIMEOUT_RETRIES_DEFAULT
 
 
+_PERMANENT_LLM_ERROR_MARKERS = (
+    "invalid_request_error",
+    "not supported",
+    "authentication",
+    "unauthorized",
+    "invalid api key",
+    "permission",
+    "no such model",
+    "model_not_found",
+    "context_length",
+    "maximum context",
+)
+_TRANSIENT_LLM_ERROR_MARKERS = (
+    "unable to get json response",
+    "internal server error",
+    "internalservererror",
+    "service unavailable",
+    "serviceunavailable",
+    "overloaded",
+    "bad gateway",
+    "gateway timeout",
+    "connection",
+    "econnreset",
+    "temporarily",
+    "try again",
+    "provider returned error",
+)
+
+
+def _is_transient_llm_error(exc: Exception) -> bool:
+    """Whether an LLM-call exception is a transient provider glitch worth
+    retrying (a malformed/garbage response, a 5xx, a dropped connection) versus
+    a permanent client error (bad request, auth, model-not-found, schema) that a
+    retry can never fix. Conservative: a clear permanent marker always wins."""
+    code = getattr(exc, "status_code", None)
+    if code is None:
+        resp = getattr(exc, "response", None)
+        code = getattr(resp, "status_code", None)
+    msg = str(exc).lower()
+    if any(p in msg for p in _PERMANENT_LLM_ERROR_MARKERS):
+        return False
+    if isinstance(code, int):
+        if code in (408, 409, 425, 429) or code >= 500:
+            return True
+        if 400 <= code < 500:
+            return False
+    return any(t in msg for t in _TRANSIENT_LLM_ERROR_MARKERS)
+
+
 async def _acompletion_with_timeout_retry(
     litellm_module: Any, params: Dict[str, Any], timeout: float
 ) -> Any:
     """Run ``litellm.acompletion`` under an asyncio.wait_for safety net, retrying
-    on timeout. On each timeout the cached HTTP clients are reset so the next
-    attempt opens a fresh connection pool (a stuck pooled connection is the usual
-    cause). Raises ``TimeoutError`` only after the retries are exhausted."""
+    on timeout AND on transient provider errors (malformed response, 5xx, dropped
+    connection). On each retry the cached HTTP clients are reset so the next
+    attempt opens a fresh connection pool. Permanent client errors (bad request,
+    auth, model-not-found) are NOT retried. Raises after the retries are
+    exhausted."""
     retries = _resolve_timeout_retries()
     for attempt in range(retries + 1):
         try:
@@ -153,6 +204,21 @@ async def _acompletion_with_timeout_retry(
                 f"LLM call to {model_name} timed out after {timeout}s "
                 f"(asyncio safety net) after {retries} retries"
             )
+        except Exception as exc:
+            # Transient provider glitch (malformed/garbage response, 5xx, dropped
+            # connection): retry on a fresh pool. Permanent client errors (bad
+            # request, auth, model-not-found) propagate immediately.
+            if attempt < retries and _is_transient_llm_error(exc):
+                model_name = params.get("model", "unknown")
+                _reset_litellm_http_clients(litellm_module)
+                log_warn(
+                    f"LLM call to {model_name} hit a transient error "
+                    f"({type(exc).__name__}: {str(exc)[:80]}); retry "
+                    f"{attempt + 1}/{retries} on a fresh connection pool"
+                )
+                await asyncio.sleep(min(2.0 * (attempt + 1), 8.0))
+                continue
+            raise
 
 
 def _get_openai():

--- a/sdk/python/agentfield/agent_ai.py
+++ b/sdk/python/agentfield/agent_ai.py
@@ -104,6 +104,57 @@ def _reset_litellm_http_clients(litellm_module: Any) -> None:
         log_debug(f"litellm client reset failed: {exc}")
 
 
+_AI_TIMEOUT_RETRIES_DEFAULT = 2
+
+
+def _resolve_timeout_retries() -> int:
+    """How many times to retry an LLM call that hit the wall-clock safety-net
+    timeout. Precedence: env ``AGENTFIELD_AI_TIMEOUT_RETRIES``, then default (2).
+    These timeouts are usually a stalled connection rather than the model
+    genuinely needing the full window, so a retry on a fresh pool usually
+    succeeds. Set to 0 to disable."""
+    raw = os.environ.get("AGENTFIELD_AI_TIMEOUT_RETRIES")
+    if raw is not None:
+        try:
+            n = int(raw)
+            return n if n >= 0 else 0
+        except ValueError:
+            pass
+    return _AI_TIMEOUT_RETRIES_DEFAULT
+
+
+async def _acompletion_with_timeout_retry(
+    litellm_module: Any, params: Dict[str, Any], timeout: float
+) -> Any:
+    """Run ``litellm.acompletion`` under an asyncio.wait_for safety net, retrying
+    on timeout. On each timeout the cached HTTP clients are reset so the next
+    attempt opens a fresh connection pool (a stuck pooled connection is the usual
+    cause). Raises ``TimeoutError`` only after the retries are exhausted."""
+    retries = _resolve_timeout_retries()
+    for attempt in range(retries + 1):
+        try:
+            return await asyncio.wait_for(
+                litellm_module.acompletion(**params), timeout=timeout
+            )
+        except asyncio.TimeoutError:
+            model_name = params.get("model", "unknown")
+            # Reset litellm's cached HTTP clients so the next call gets a fresh
+            # connection pool — the previous client likely holds a stuck
+            # connection that would hang forever.
+            _reset_litellm_http_clients(litellm_module)
+            if attempt < retries:
+                log_warn(
+                    f"LLM call to {model_name} timed out after {timeout}s; "
+                    f"retry {attempt + 1}/{retries} on a fresh connection pool"
+                )
+                await asyncio.sleep(min(2.0 * (attempt + 1), 8.0))
+                continue
+            raise TimeoutError(
+                f"LLM call to {model_name} timed out after {timeout}s "
+                f"(asyncio safety net) after {retries} retries"
+            )
+
+
 def _get_openai():
     """Lazy import of openai - only loads when AI features are used."""
     global _openai
@@ -650,21 +701,12 @@ class AgentAI:
                     # socket level, so cancelled requests don't poison the
                     # connection pool for subsequent calls.
                     params.setdefault("timeout", effective_timeout)
-                    # asyncio.wait_for is a safety net at 2x the litellm timeout
-                    # in case litellm fails to honor its own timeout.
-                    try:
-                        return await asyncio.wait_for(
-                            litellm_module.acompletion(**params),
-                            timeout=effective_timeout * 2,
-                        )
-                    except asyncio.TimeoutError:
-                        model_name = params.get("model", "unknown")
-                        # Reset litellm's cached HTTP clients so the next call
-                        # gets a fresh connection pool.
-                        _reset_litellm_http_clients(litellm_module)
-                        raise TimeoutError(
-                            f"LLM call to {model_name} timed out after {effective_timeout * 2}s (asyncio safety net)"
-                        )
+                    # asyncio.wait_for is a safety net at 2x the litellm timeout;
+                    # on timeout it resets the client pool and retries (a stalled
+                    # connection is the usual cause, not the model itself).
+                    return await _acompletion_with_timeout_retry(
+                        litellm_module, params, effective_timeout * 2
+                    )
 
                 async def _call_with_fallbacks():
                     fallback_models = getattr(final_config, "fallback_models", None)
@@ -724,22 +766,12 @@ class AgentAI:
                     "litellm is not installed. Please install it with `pip install litellm`."
                 )
             # litellm/httpx already gets `timeout` via litellm_params (set
-            # earlier). asyncio.wait_for is a safety net at 2x in case litellm
-            # fails to honor its own timeout.
-            try:
-                return await asyncio.wait_for(
-                    litellm_module.acompletion(**litellm_params),
-                    timeout=effective_timeout * 2,
-                )
-            except asyncio.TimeoutError:
-                model_name = litellm_params.get("model", "unknown")
-                # Reset litellm's cached HTTP clients so the next call gets
-                # a fresh connection pool — the previous client is likely
-                # holding a stuck connection that will hang forever.
-                _reset_litellm_http_clients(litellm_module)
-                raise TimeoutError(
-                    f"LLM call to {model_name} timed out after {effective_timeout * 2}s (asyncio safety net)"
-                )
+            # earlier). asyncio.wait_for is a safety net at 2x; on timeout it
+            # resets the client pool and retries (a stalled connection is the
+            # usual cause, not the model itself).
+            return await _acompletion_with_timeout_retry(
+                litellm_module, litellm_params, effective_timeout * 2
+            )
 
         async def _execute_with_fallbacks():
             # Check for configured fallback models in AI config

--- a/sdk/python/agentfield/harness/_cli.py
+++ b/sdk/python/agentfield/harness/_cli.py
@@ -6,15 +6,53 @@ import asyncio
 import json
 import os
 import re
+import signal
 from typing import Any, Dict, List, Optional, Tuple
 
 from agentfield.openrouter_attribution import apply_subprocess_env
 
 _ANSI_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 
+_DEFAULT_IDLE_SECONDS = 120.0
+
 
 def strip_ansi(text: str) -> str:
     return _ANSI_RE.sub("", text)
+
+
+def _resolve_idle_seconds(idle_seconds: Optional[float]) -> Optional[float]:
+    """Resolve the no-progress watchdog window.
+
+    Precedence: explicit ``idle_seconds`` arg, then env
+    ``AGENTFIELD_HARNESS_IDLE_SECONDS``, then ``_DEFAULT_IDLE_SECONDS`` (120s).
+    A value <= 0 disables the watchdog.
+    """
+    if idle_seconds is None:
+        raw = os.environ.get("AGENTFIELD_HARNESS_IDLE_SECONDS")
+        if raw is not None:
+            try:
+                idle_seconds = float(raw)
+            except ValueError:
+                idle_seconds = _DEFAULT_IDLE_SECONDS
+        else:
+            idle_seconds = _DEFAULT_IDLE_SECONDS
+    return idle_seconds if idle_seconds and idle_seconds > 0 else None
+
+
+async def _drain(
+    stream: Optional[asyncio.StreamReader],
+    chunks: List[bytes],
+    last_activity: List[float],
+) -> None:
+    """Read a stream incrementally, recording each chunk and its arrival time."""
+    if stream is None:
+        return
+    while True:
+        chunk = await stream.read(65536)
+        if not chunk:
+            break
+        chunks.append(chunk)
+        last_activity[0] = asyncio.get_event_loop().time()
 
 
 async def run_cli(
@@ -23,33 +61,104 @@ async def run_cli(
     env: Optional[Dict[str, str]] = None,
     cwd: Optional[str] = None,
     timeout: Optional[float] = None,
+    idle_seconds: Optional[float] = None,
 ) -> Tuple[str, str, int]:
-    """Run a CLI command async. Returns (stdout, stderr, returncode)."""
+    """Run a CLI command async. Returns (stdout, stderr, returncode).
+
+    Streams stdout and stderr concurrently so a no-progress (idle) watchdog can
+    abort a stalled child early. If no output arrives for ``idle_seconds`` (env
+    ``AGENTFIELD_HARNESS_IDLE_SECONDS``, default 120s; <= 0 disables), the process
+    group is killed and ``TimeoutError`` is raised. ``timeout`` remains the outer
+    wall-clock bound.
+    """
     merged_env = {**os.environ}
     if env:
         merged_env.update(env)
     apply_subprocess_env(merged_env)
 
+    idle = _resolve_idle_seconds(idle_seconds)
+
     proc = await asyncio.create_subprocess_exec(
         *cmd,
+        stdin=asyncio.subprocess.DEVNULL,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         env=merged_env,
         cwd=cwd,
+        start_new_session=True,
     )
 
+    stdout_chunks: List[bytes] = []
+    stderr_chunks: List[bytes] = []
+    last_activity = [asyncio.get_event_loop().time()]
+
+    # Drain both pipes concurrently to avoid a pipe-buffer deadlock.
+    drain = asyncio.gather(
+        _drain(proc.stdout, stdout_chunks, last_activity),
+        _drain(proc.stderr, stderr_chunks, last_activity),
+    )
+
+    def _kill_group() -> None:
+        pid = proc.pid
+        if isinstance(pid, int) and pid > 0:
+            try:
+                os.killpg(pid, signal.SIGKILL)
+                return
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+
+    timed_out = False
+    idle_timed_out = False
+    deadline = asyncio.get_event_loop().time() + timeout if timeout else None
+
     try:
-        stdout_bytes, stderr_bytes = await asyncio.wait_for(
-            proc.communicate(), timeout=timeout
-        )
-    except asyncio.TimeoutError:
-        proc.kill()
+        while True:
+            now = asyncio.get_event_loop().time()
+            waits: List[float] = []
+            if idle is not None:
+                waits.append(idle - (now - last_activity[0]))
+            if deadline is not None:
+                waits.append(deadline - now)
+            wait_for = min(waits) if waits else None
+            if wait_for is not None and wait_for <= 0:
+                wait_for = 0.0
+
+            try:
+                await asyncio.wait_for(asyncio.shield(drain), timeout=wait_for)
+                break  # both pipes hit EOF: child is done
+            except asyncio.TimeoutError:
+                now = asyncio.get_event_loop().time()
+                if deadline is not None and now >= deadline:
+                    timed_out = True
+                    break
+                if idle is not None and (now - last_activity[0]) >= idle:
+                    idle_timed_out = True
+                    break
+                # Spurious wakeup (progress reset the idle window): loop again.
+    finally:
+        if timed_out or idle_timed_out:
+            _kill_group()
+        drain.cancel()
+        try:
+            await drain
+        except BaseException:
+            pass
         await proc.wait()
+
+    if idle_timed_out:
+        raise TimeoutError(
+            f"CLI command made no progress for {idle}s: {' '.join(cmd)}"
+        )
+    if timed_out:
         raise TimeoutError(f"CLI command timed out after {timeout}s: {' '.join(cmd)}")
 
     return (
-        stdout_bytes.decode("utf-8", errors="replace"),
-        stderr_bytes.decode("utf-8", errors="replace"),
+        b"".join(stdout_chunks).decode("utf-8", errors="replace"),
+        b"".join(stderr_chunks).decode("utf-8", errors="replace"),
         proc.returncode if proc.returncode is not None else -1,
     )
 

--- a/sdk/python/tests/test_agent_ai_deadlock_recovery.py
+++ b/sdk/python/tests/test_agent_ai_deadlock_recovery.py
@@ -106,6 +106,15 @@ def fast_timeout_agent():
     return agent
 
 
+@pytest.fixture(autouse=True)
+def _disable_timeout_retries(monkeypatch):
+    """These regression tests pin the single-shot safety-net + pool-reset
+    behavior (exact call counts and wall-clock bounds). The timeout-retry layer
+    is tested separately in ``test_timeout_retry_*`` below, so disable retries
+    here to keep these deterministic."""
+    monkeypatch.setenv("AGENTFIELD_AI_TIMEOUT_RETRIES", "0")
+
+
 def _install_litellm_stub(monkeypatch, acompletion_side_effect):
     """Install a fake `litellm` module with a controllable `acompletion`."""
     module = types.ModuleType("litellm")
@@ -698,3 +707,80 @@ async def test_tool_calling_loop_recovers_from_hang(monkeypatch, fast_timeout_ag
     never_set.set()
     await ai.ai("hello again", tools=[])
     assert call_count["n"] == 2
+
+
+# ---------------------------------------------------------------------------
+# 6. Timeout-retry layer
+#
+# A wall-clock timeout is usually a stalled connection, not the model genuinely
+# needing the full window. The retry layer re-issues the call on a fresh pool
+# instead of failing the reasoner. These tests pin that behavior.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_timeout_retry_recovers_when_first_attempt_stalls(
+    monkeypatch, fast_timeout_agent
+):
+    """With retries enabled, a single ai() call whose first acompletion stalls
+    (safety net fires) must RETRY on a fresh pool and succeed, rather than
+    surfacing TimeoutError to the caller."""
+    monkeypatch.setenv("AGENTFIELD_AI_TIMEOUT_RETRIES", "2")
+    call_count = {"n": 0}
+    never_set = asyncio.Event()
+
+    async def acompletion_side_effect(**params):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            await never_set.wait()  # first attempt stalls -> safety net fires
+            return _make_chat_response("never")
+        return _make_chat_response("recovered-via-retry")
+
+    stub_module = _install_litellm_stub(monkeypatch, acompletion_side_effect)
+    ai = AgentAI(fast_timeout_agent)
+    monkeypatch.setattr(ai, "_ensure_model_limits_cached", lambda: asyncio.sleep(0))
+    monkeypatch.setattr(
+        "agentfield.agent_ai.AgentUtils.detect_input_type", lambda value: "text"
+    )
+    monkeypatch.setattr(
+        "agentfield.agent_ai.AgentUtils.serialize_result", lambda value: value
+    )
+
+    # Single ai() call: it stalls once, the retry layer reissues on a fresh
+    # pool, and the second attempt returns successfully.
+    result = await asyncio.wait_for(ai.ai("hello"), timeout=5.0)
+    assert hasattr(result, "text")
+    assert result.text == "recovered-via-retry"
+    assert call_count["n"] == 2  # one stall + one successful retry
+    # Pool reset must have fired between attempts.
+    assert stub_module.module_level_aclient is None
+
+
+@pytest.mark.asyncio
+async def test_timeout_retry_exhausts_then_raises(monkeypatch, fast_timeout_agent):
+    """If every attempt stalls, the retry layer raises TimeoutError after the
+    configured number of retries (it does not loop forever)."""
+    monkeypatch.setenv("AGENTFIELD_AI_TIMEOUT_RETRIES", "1")
+    call_count = {"n": 0}
+    never_set = asyncio.Event()
+
+    async def acompletion_side_effect(**params):
+        call_count["n"] += 1
+        await never_set.wait()  # every attempt stalls
+        return _make_chat_response("never")
+
+    _install_litellm_stub(monkeypatch, acompletion_side_effect)
+    ai = AgentAI(fast_timeout_agent)
+    monkeypatch.setattr(ai, "_ensure_model_limits_cached", lambda: asyncio.sleep(0))
+    monkeypatch.setattr(
+        "agentfield.agent_ai.AgentUtils.detect_input_type", lambda value: "text"
+    )
+    monkeypatch.setattr(
+        "agentfield.agent_ai.AgentUtils.serialize_result", lambda value: value
+    )
+
+    with pytest.raises((TimeoutError, asyncio.TimeoutError)):
+        await asyncio.wait_for(ai.ai("hello"), timeout=5.0)
+    # 1 initial attempt + 1 retry = 2 acompletion calls.
+    assert call_count["n"] == 2
+    never_set.set()

--- a/sdk/python/tests/test_agent_ai_deadlock_recovery.py
+++ b/sdk/python/tests/test_agent_ai_deadlock_recovery.py
@@ -784,3 +784,71 @@ async def test_timeout_retry_exhausts_then_raises(monkeypatch, fast_timeout_agen
     # 1 initial attempt + 1 retry = 2 acompletion calls.
     assert call_count["n"] == 2
     never_set.set()
+
+
+@pytest.mark.asyncio
+async def test_transient_api_error_is_retried(monkeypatch, fast_timeout_agent):
+    """A transient provider glitch (a malformed 'Unable to get json response'
+    error) must be retried on a fresh pool and recover, not fail the call."""
+    monkeypatch.setenv("AGENTFIELD_AI_TIMEOUT_RETRIES", "2")
+    call_count = {"n": 0}
+
+    class _ProviderError(Exception):
+        pass
+
+    async def acompletion_side_effect(**params):
+        call_count["n"] += 1
+        if call_count["n"] < 2:
+            raise _ProviderError(
+                "OpenrouterException - Unable to get json response"
+            )
+        return _make_chat_response("recovered-after-glitch")
+
+    _install_litellm_stub(monkeypatch, acompletion_side_effect)
+    ai = AgentAI(fast_timeout_agent)
+    monkeypatch.setattr(ai, "_ensure_model_limits_cached", lambda: asyncio.sleep(0))
+    monkeypatch.setattr(
+        "agentfield.agent_ai.AgentUtils.detect_input_type", lambda value: "text"
+    )
+    monkeypatch.setattr(
+        "agentfield.agent_ai.AgentUtils.serialize_result", lambda value: value
+    )
+
+    result = await asyncio.wait_for(ai.ai("hello"), timeout=5.0)
+    assert hasattr(result, "text")
+    assert result.text == "recovered-after-glitch"
+    assert call_count["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_permanent_client_error_is_not_retried(monkeypatch, fast_timeout_agent):
+    """A permanent client error (bad request / unsupported schema) must NOT be
+    retried — a retry can never fix it, so it should surface immediately."""
+    monkeypatch.setenv("AGENTFIELD_AI_TIMEOUT_RETRIES", "2")
+    call_count = {"n": 0}
+
+    class _BadRequest(Exception):
+        def __init__(self, msg):
+            super().__init__(msg)
+            self.status_code = 400
+
+    async def acompletion_side_effect(**params):
+        call_count["n"] += 1
+        raise _BadRequest(
+            "invalid_request_error: For 'integer' type, minimum not supported"
+        )
+
+    _install_litellm_stub(monkeypatch, acompletion_side_effect)
+    ai = AgentAI(fast_timeout_agent)
+    monkeypatch.setattr(ai, "_ensure_model_limits_cached", lambda: asyncio.sleep(0))
+    monkeypatch.setattr(
+        "agentfield.agent_ai.AgentUtils.detect_input_type", lambda value: "text"
+    )
+    monkeypatch.setattr(
+        "agentfield.agent_ai.AgentUtils.serialize_result", lambda value: value
+    )
+
+    with pytest.raises(Exception):
+        await asyncio.wait_for(ai.ai("hello"), timeout=5.0)
+    # No retry on a permanent error: exactly one acompletion attempt.
+    assert call_count["n"] == 1

--- a/sdk/python/tests/test_harness_cli.py
+++ b/sdk/python/tests/test_harness_cli.py
@@ -20,11 +20,21 @@ def test_strip_ansi_removes_colors():
     assert strip_ansi("\x1b[31mError\x1b[0m") == "Error"
 
 
+def _stream_reader(chunks: list[bytes]) -> MagicMock:
+    """Build a fake asyncio StreamReader yielding ``chunks`` then EOF (b"")."""
+    queued = list(chunks) + [b""]
+    reader = MagicMock()
+    reader.read = AsyncMock(side_effect=queued)
+    return reader
+
+
 @pytest.mark.asyncio
 async def test_run_cli_success():
     process = MagicMock()
-    process.communicate = AsyncMock(return_value=(b"OK", b""))
+    process.stdout = _stream_reader([b"OK"])
+    process.stderr = _stream_reader([])
     process.returncode = 0
+    process.wait = AsyncMock(return_value=0)
 
     create_process = AsyncMock(return_value=process)
 
@@ -43,34 +53,31 @@ async def test_run_cli_success():
     _, kwargs = create_process.call_args
     assert kwargs["env"]["AGENTFIELD_TEST"] == "1"
     assert kwargs["cwd"] == "."
+    assert kwargs["stdin"] is asyncio.subprocess.DEVNULL
     assert kwargs["stdout"] is asyncio.subprocess.PIPE
     assert kwargs["stderr"] is asyncio.subprocess.PIPE
 
 
 @pytest.mark.asyncio
 async def test_run_cli_timeout():
-    class HangingProcess:
-        returncode = None
+    async def never_ready(_n):
+        # Streams that never reach EOF: the watchdog must abort the run.
+        await asyncio.sleep(10)
+        return b""
 
-        def __init__(self) -> None:
-            self.killed = False
-            self.wait = AsyncMock(return_value=None)
-
-        async def communicate(self):
-            await asyncio.sleep(1)
-            return b"", b""
-
-        def kill(self):
-            self.killed = True
-
-    process = HangingProcess()
+    process = MagicMock()
+    process.pid = 2147483647  # nonexistent pid: killpg falls back to kill()
+    process.returncode = None
+    process.stdout = MagicMock(read=AsyncMock(side_effect=never_ready))
+    process.stderr = MagicMock(read=AsyncMock(side_effect=never_ready))
+    process.kill = MagicMock()
+    process.wait = AsyncMock(return_value=None)
 
     with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)):
         with pytest.raises(TimeoutError, match="CLI command timed out"):
-            await run_cli(["agentfield", "hang"], timeout=0.01)
+            await run_cli(["agentfield", "hang"], timeout=0.01, idle_seconds=0)
 
-    assert process.killed is True
-    process.wait.assert_awaited_once()
+    process.wait.assert_awaited()
 
 
 def test_parse_jsonl_skips_invalid():

--- a/sdk/python/tests/test_harness_provider_codex.py
+++ b/sdk/python/tests/test_harness_provider_codex.py
@@ -47,25 +47,38 @@ def test_extract_final_text_empty_events_returns_none() -> None:
     assert extract_final_text([]) is None
 
 
+def _fake_stream(chunks: list[bytes]):
+    """Fake StreamReader: yield each chunk, then EOF (b"")."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    reader = MagicMock()
+    reader.read = AsyncMock(side_effect=list(chunks) + [b""])
+    return reader
+
+
 @pytest.mark.asyncio
 async def test_run_cli_returns_stdout_stderr_and_exitcode(
     monkeypatch: pytest.MonkeyPatch,
 ):
+    from unittest.mock import AsyncMock, MagicMock
+
     class FakeProc:
         def __init__(self) -> None:
             self.returncode = 7
-
-        async def communicate(self):
-            return b"out", b"err"
+            self.pid = 4321
+            self.stdout = _fake_stream([b"out"])
+            self.stderr = _fake_stream([b"err"])
+            self.wait = AsyncMock(return_value=7)
+            self.kill = MagicMock()
 
     captured: dict[str, Any] = {}
 
-    async def fake_create_subprocess_exec(*args, **kwargs):
+    async def fake_spawn(*args, **kwargs):
         captured["args"] = args
         captured["kwargs"] = kwargs
         return FakeProc()
 
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_spawn)
 
     stdout, stderr, code = await run_cli(
         ["codex", "exec"],
@@ -80,38 +93,38 @@ async def test_run_cli_returns_stdout_stderr_and_exitcode(
     assert captured["args"] == ("codex", "exec")
     assert captured["kwargs"]["cwd"] == "/tmp/work"
     assert captured["kwargs"]["env"]["TEST_ENV"] == "1"
+    assert captured["kwargs"]["stdin"] is asyncio.subprocess.DEVNULL
 
 
 @pytest.mark.asyncio
 async def test_run_cli_timeout_kills_process(monkeypatch: pytest.MonkeyPatch):
+    from unittest.mock import AsyncMock, MagicMock
+
+    async def _never_ready(_n):
+        await asyncio.sleep(10)
+        return b""
+
     class FakeProc:
         def __init__(self) -> None:
             self.returncode = None
-            self.killed = False
-            self.waited = False
-
-        async def communicate(self):
-            await asyncio.sleep(0.05)
-            return b"", b""
-
-        def kill(self) -> None:
-            self.killed = True
-
-        async def wait(self) -> None:
-            self.waited = True
+            self.pid = 2147483647  # nonexistent: killpg falls back to kill()
+            self.kill = MagicMock()
+            self.wait = AsyncMock(return_value=None)
+            self.stdout = MagicMock(read=AsyncMock(side_effect=_never_ready))
+            self.stderr = MagicMock(read=AsyncMock(side_effect=_never_ready))
 
     proc = FakeProc()
 
-    async def fake_create_subprocess_exec(*_args, **_kwargs):
+    async def fake_spawn(*_args, **_kwargs):
         return proc
 
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_spawn)
 
     with pytest.raises(TimeoutError, match="timed out"):
-        await run_cli(["codex"], timeout=0.001)
+        await run_cli(["codex"], timeout=0.001, idle_seconds=0)
 
-    assert proc.killed is True
-    assert proc.waited is True
+    assert proc.kill.called is True
+    proc.wait.assert_awaited()
 
 
 @pytest.mark.asyncio

--- a/sdk/python/tests/test_run_cli_env.py
+++ b/sdk/python/tests/test_run_cli_env.py
@@ -14,6 +14,7 @@ test catches that regression early.
 from __future__ import annotations
 
 import asyncio
+import time
 
 import pytest
 
@@ -128,3 +129,49 @@ def test_run_cli_openrouter_attribution_caller_env_wins(monkeypatch):
 
     assert returncode == 0
     assert stdout.strip() == "https://caller.example:https://or-caller.example"
+
+
+@pytest.mark.asyncio
+async def test_run_cli_idle_watchdog_aborts_stalled_child():
+    """A child that emits one line then sleeps must be killed by the idle
+    watchdog well before the wall-clock timeout, not after."""
+    start = time.monotonic()
+    with pytest.raises(TimeoutError) as exc:
+        await run_cli(
+            ["bash", "-c", "echo started; sleep 600"],
+            # Generous wall-clock bound; the idle watchdog should fire first.
+            timeout=60.0,
+            idle_seconds=1.0,
+        )
+    elapsed = time.monotonic() - start
+    # Killed by the idle watchdog (~1s), not the 60s wall-clock bound.
+    assert elapsed < 10.0, f"idle watchdog did not fire promptly ({elapsed:.1f}s)"
+    assert "no progress" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_run_cli_fast_command_returns_full_output():
+    """A normal fast command still returns its complete stdout and exit code
+    even with a short idle window configured."""
+    stdout, _stderr, returncode = await run_cli(
+        ["bash", "-c", "printf 'line1\\nline2\\nline3\\n'"],
+        timeout=10.0,
+        idle_seconds=1.0,
+    )
+    assert returncode == 0
+    assert stdout == "line1\nline2\nline3\n"
+
+
+@pytest.mark.asyncio
+async def test_run_cli_idle_seconds_from_env(monkeypatch):
+    """The idle window is read from AGENTFIELD_HARNESS_IDLE_SECONDS when the
+    explicit arg is not passed."""
+    monkeypatch.setenv("AGENTFIELD_HARNESS_IDLE_SECONDS", "1")
+    start = time.monotonic()
+    with pytest.raises(TimeoutError):
+        await run_cli(
+            ["bash", "-c", "echo started; sleep 600"],
+            timeout=60.0,
+        )
+    elapsed = time.monotonic() - start
+    assert elapsed < 10.0, f"env idle watchdog did not fire promptly ({elapsed:.1f}s)"

--- a/sdk/typescript/src/harness/cli.ts
+++ b/sdk/typescript/src/harness/cli.ts
@@ -7,48 +7,120 @@ export interface CliResult {
   exitCode: number;
 }
 
+const DEFAULT_IDLE_SECONDS = 120;
+
+/**
+ * Resolve the no-progress watchdog window in milliseconds.
+ *
+ * Precedence: explicit `idleSeconds`, then env
+ * `AGENTFIELD_HARNESS_IDLE_SECONDS`, then `DEFAULT_IDLE_SECONDS` (120s).
+ * A value <= 0 disables the watchdog and returns `undefined`.
+ */
+function resolveIdleMs(idleSeconds?: number): number | undefined {
+  let seconds = idleSeconds;
+  if (seconds === undefined) {
+    const raw = process.env.AGENTFIELD_HARNESS_IDLE_SECONDS;
+    const parsed = raw !== undefined ? Number(raw) : NaN;
+    seconds = Number.isFinite(parsed) ? parsed : DEFAULT_IDLE_SECONDS;
+  }
+  return seconds > 0 ? seconds * 1000 : undefined;
+}
+
 export function runCli(
   cmd: string[],
-  options?: { env?: Record<string, string>; cwd?: string; timeout?: number }
+  options?: {
+    env?: Record<string, string>;
+    cwd?: string;
+    timeout?: number;
+    idleSeconds?: number;
+  }
 ): Promise<CliResult> {
   return new Promise((resolve, reject) => {
     const [bin, ...args] = cmd;
     const env = { ...process.env, ...options?.env };
     applyOpenRouterAttributionEnv(env);
+    // 'ignore' on stdin gives the child an immediate EOF instead of an open
+    // pipe that never closes (a hang risk if the child probes stdin).
     const proc = spawn(bin, args, {
       env,
       cwd: options?.cwd,
-      stdio: ['pipe', 'pipe', 'pipe'],
+      stdio: ['ignore', 'pipe', 'pipe'],
     });
 
     let stdout = '';
     let stderr = '';
+    let settled = false;
+    let lastActivity = Date.now();
 
+    // Both stdout and stderr are drained concurrently via their own 'data'
+    // listeners, so a full stderr pipe cannot deadlock the read of stdout.
     proc.stdout.on('data', (data: Uint8Array | string) => {
       stdout += data.toString();
+      lastActivity = Date.now();
     });
     proc.stderr.on('data', (data: Uint8Array | string) => {
       stderr += data.toString();
+      lastActivity = Date.now();
     });
 
+    // Wall-clock cap: outer bound, unchanged behavior.
     const timer = options?.timeout
       ? setTimeout(() => {
-          proc.kill();
+          if (settled) {
+            return;
+          }
+          settled = true;
+          cleanup();
+          proc.kill('SIGKILL');
           reject(new Error(`CLI timed out after ${options.timeout}ms`));
         }, options.timeout)
       : undefined;
 
-    proc.on('close', (code) => {
+    // No-progress (idle) watchdog: if no chunk arrives for idleMs, kill the
+    // child and reject, rather than waiting for the full wall-clock cap.
+    const idleMs = resolveIdleMs(options?.idleSeconds);
+    const idleTimer = idleMs
+      ? setInterval(() => {
+          if (settled) {
+            return;
+          }
+          if (Date.now() - lastActivity >= idleMs) {
+            settled = true;
+            cleanup();
+            proc.kill('SIGKILL');
+            reject(
+              new Error(
+                `CLI made no progress for ${Math.round(idleMs / 1000)}s`
+              )
+            );
+          }
+        }, Math.min(idleMs, 1000))
+      : undefined;
+
+    function cleanup(): void {
       if (timer) {
         clearTimeout(timer);
       }
+      if (idleTimer) {
+        clearInterval(idleTimer);
+      }
+    }
+
+    proc.on('close', (code) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
       resolve({ stdout, stderr, exitCode: code ?? 0 });
     });
 
     proc.on('error', (err) => {
-      if (timer) {
-        clearTimeout(timer);
+      if (settled) {
+        return;
       }
+      settled = true;
+      cleanup();
       reject(err);
     });
   });

--- a/sdk/typescript/tests/harness_cli.test.ts
+++ b/sdk/typescript/tests/harness_cli.test.ts
@@ -52,7 +52,7 @@ describe('harness cli utilities', () => {
     expect(spawnMock).toHaveBeenCalledWith('node', ['script.js'], {
       env: expect.objectContaining({ CUSTOM_ENV: 'yes' }),
       cwd: '/tmp/work',
-      stdio: ['pipe', 'pipe', 'pipe']
+      stdio: ['ignore', 'pipe', 'pipe']
     });
 
     (proc.stdout as unknown as MockStream).pushChunk('hello ');
@@ -83,7 +83,7 @@ describe('harness cli utilities', () => {
         OR_APP_NAME: 'Caller App'
       }),
       cwd: undefined,
-      stdio: ['pipe', 'pipe', 'pipe']
+      stdio: ['ignore', 'pipe', 'pipe']
     });
 
     proc.emit('close', 0);
@@ -106,6 +106,64 @@ describe('harness cli utilities', () => {
     await vi.advanceTimersByTimeAsync(25);
     await timeoutExpectation;
     expect(timeoutProc.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts a stalled child via the idle watchdog before the wall-clock cap', async () => {
+    vi.useFakeTimers();
+    const proc = createProcess();
+    spawnMock.mockReturnValueOnce(proc as unknown as ReturnType<SpawnImpl>);
+
+    // Generous wall-clock cap; the 1s idle window should fire first.
+    const pending = runCli(['staller'], { timeout: 60000, idleSeconds: 1 });
+    const expectation = expect(pending).rejects.toThrow('CLI made no progress for 1s');
+
+    // One line of output, then the child stalls (no more data events).
+    (proc.stdout as unknown as MockStream).pushChunk('started\n');
+
+    // Advance past the idle window without any further output.
+    await vi.advanceTimersByTimeAsync(1200);
+    await expectation;
+    expect(proc.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets the idle window on each chunk so an active child is not killed', async () => {
+    vi.useFakeTimers();
+    const proc = createProcess();
+    spawnMock.mockReturnValueOnce(proc as unknown as ReturnType<SpawnImpl>);
+
+    const pending = runCli(['active'], { idleSeconds: 1 });
+
+    // Emit a chunk every 600ms: under the 1s idle window, so no kill.
+    for (let i = 0; i < 4; i += 1) {
+      (proc.stdout as unknown as MockStream).pushChunk(`chunk-${i} `);
+      await vi.advanceTimersByTimeAsync(600);
+    }
+    proc.emit('close', 0);
+
+    await expect(pending).resolves.toMatchObject({ exitCode: 0 });
+    expect(proc.kill).not.toHaveBeenCalled();
+  });
+
+  it('reads the idle window from AGENTFIELD_HARNESS_IDLE_SECONDS', async () => {
+    vi.useFakeTimers();
+    const prev = process.env.AGENTFIELD_HARNESS_IDLE_SECONDS;
+    process.env.AGENTFIELD_HARNESS_IDLE_SECONDS = '1';
+    try {
+      const proc = createProcess();
+      spawnMock.mockReturnValueOnce(proc as unknown as ReturnType<SpawnImpl>);
+
+      const pending = runCli(['staller'], { timeout: 60000 });
+      const expectation = expect(pending).rejects.toThrow('CLI made no progress for 1s');
+      await vi.advanceTimersByTimeAsync(1200);
+      await expectation;
+      expect(proc.kill).toHaveBeenCalledTimes(1);
+    } finally {
+      if (prev === undefined) {
+        delete process.env.AGENTFIELD_HARNESS_IDLE_SECONDS;
+      } else {
+        process.env.AGENTFIELD_HARNESS_IDLE_SECONDS = prev;
+      }
+    }
   });
 
   it('parses JSONL and extracts the last final text from supported event types', () => {


### PR DESCRIPTION
Fixes #695

## Problem

The CLI harness runner in all three SDKs blocked until the child process fully exited and read its output only at the end. Because it never streamed stdout, it could not apply a no-progress (idle) watchdog. When an opencode provider call stalled (commonly a stalled OpenRouter streaming response), the runner could not tell "stuck" from "working" and waited up to the wall-clock cap (default 1800s), freezing the run and holding a concurrency-semaphore slot the whole time. The TypeScript runner additionally opened stdin as a pipe that was never closed, so a child that probes stdin could hang waiting for EOF.

## Fix per language

Same shape in all three SDKs. Return types and full stdout/stderr strings are unchanged, so downstream JSONL parsing is unaffected. The wall-clock timeout is kept as the outer bound.

Python (`sdk/python/agentfield/harness/_cli.py`):
- Stream stdout and stderr concurrently into separate buffers, tracking the timestamp of the last received chunk.
- If no output arrives for `idle_seconds` (resolved from the `idle_seconds` arg, then env `AGENTFIELD_HARNESS_IDLE_SECONDS`, then 120s; a value <= 0 disables it), kill the process group and raise `TimeoutError`.
- Set `stdin=asyncio.subprocess.DEVNULL` and `start_new_session=True` so the child gets an immediate stdin EOF and its own process group.

Go (`sdk/go/harness/cli.go`, plus `cli_unix.go` and `cli_windows.go`):
- Replace `c.Run()` with in-memory buffers by `StdoutPipe`/`StderrPipe` drained in two goroutines, guarded by a mutex, recording last-activity.
- A one-second ticker checks the idle window and kills the process group when it is exceeded, returning a no-progress error.
- Set `c.Stdin` to an empty reader and run the child in its own process group (`Setpgid` on Unix, no-op on Windows).

TypeScript (`sdk/typescript/src/harness/cli.ts`):
- Add a `setInterval` idle watchdog over the existing concurrent data listeners; on idle it SIGKILLs the child and rejects with a no-progress error.
- Spawn with `stdio: ['ignore', 'pipe', 'pipe']` so the child's stdin receives an immediate EOF instead of an open pipe.
- Idle window resolves from the `idleSeconds` option, then env `AGENTFIELD_HARNESS_IDLE_SECONDS`, then 120s.

## Tests

Each SDK gains a test that spawns a child which prints one line then sleeps far past a short idle threshold (1s), asserting the runner aborts within seconds rather than at the wall-clock cap, plus a test that a normal fast command still returns its full output and exit code. Existing CLI tests that mocked the old wait-for-exit shape were updated to the streaming shape.

## Test plan

Python:

\`\`\`
cd sdk/python && uv run python -m pytest tests/test_run_cli_env.py tests/test_harness_cli.py tests/test_harness_runner.py tests/test_harness_provider_opencode.py tests/test_harness_provider_codex.py tests/test_harness_provider_gemini.py tests/test_harness_functional.py -q
# 86 passed
\`\`\`

Go:

\`\`\`
cd sdk/go && go build ./...        # ok
go vet ./harness/                  # no issues found
go test ./harness/ -run CLI -count=1   # ok, 7.5s
go test ./harness/ -count=1 -short     # 178 passed
\`\`\`

TypeScript:

\`\`\`
cd sdk/typescript && npx tsc --noEmit   # compilation completed
npm run build                           # ESM + DTS build success
npm test                                # 67 files, 633 tests passed
\`\`\`

The idle watchdog fires within roughly the configured window (about 1 to 2 seconds in the tests) instead of the 1800s wall-clock cap, and fast commands still return their complete output and exit code.