### PR TITLE
Draft: clarify run-scoped cancellation

### DIFF
--- a/control-plane/internal/cli/execution.go
+++ b/control-plane/internal/cli/execution.go
@@ -21,6 +21,7 @@ func NewExecutionCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(newCancelExecutionCommand())
+	cmd.AddCommand(newCancelRunCommand())
 	cmd.AddCommand(newPauseExecutionCommand())
 	cmd.AddCommand(newResumeExecutionCommand())
 	cmd.AddCommand(newRestartExecutionCommand())
@@ -92,6 +93,7 @@ func newCancelExecutionCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cancel <execution_id>",
 		Short: "Cancel a workflow execution",
+		Long:  "Cancel one execution by execution_id. This preserves the historical per-execution behavior; use `af execution cancel-run <run_id>` to stop every non-terminal execution in a run.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			_, err := runExecutionAction(executionActionConfig{
@@ -100,6 +102,7 @@ func newCancelExecutionCommand() *cobra.Command {
 				endpoint:    "/api/v1/executions/%s/cancel",
 				opts:        &opts,
 				executionID: args[0],
+				targetKind:  "execution",
 				withReason:  true,
 			})
 			return err
@@ -107,6 +110,33 @@ func newCancelExecutionCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.reason, "reason", "", "Reason for cancelling the execution")
+	bindExecutionActionFlags(cmd, &opts)
+	return cmd
+}
+
+func newCancelRunCommand() *cobra.Command {
+	opts := defaultExecutionActionOptions()
+
+	cmd := &cobra.Command{
+		Use:   "cancel-run <run_id>",
+		Short: "Cancel every active execution in a run",
+		Long:  "Cancel every non-terminal execution belonging to a run, bottom-up. This is the safe command when the intent is to stop a whole workflow with child executions.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			_, err := runExecutionAction(executionActionConfig{
+				actionName:  "cancel",
+				successVerb: "cancelled",
+				endpoint:    "/api/v1/workflows/%s/cancel-tree",
+				opts:        &opts,
+				executionID: args[0],
+				targetKind:  "run",
+				withReason:  true,
+			})
+			return err
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.reason, "reason", "", "Reason for cancelling the run")
 	bindExecutionActionFlags(cmd, &opts)
 	return cmd
 }
@@ -125,6 +155,7 @@ func newPauseExecutionCommand() *cobra.Command {
 				endpoint:    "/api/v1/executions/%s/pause",
 				opts:        &opts,
 				executionID: args[0],
+				targetKind:  "execution",
 				withReason:  true,
 			})
 			return err
@@ -150,6 +181,7 @@ func newResumeExecutionCommand() *cobra.Command {
 				endpoint:    "/api/v1/executions/%s/resume",
 				opts:        &opts,
 				executionID: args[0],
+				targetKind:  "execution",
 			})
 			return err
 		},
@@ -172,6 +204,7 @@ type executionActionConfig struct {
 	endpoint    string
 	opts        *executionActionOptions
 	executionID string
+	targetKind  string
 	withReason  bool
 	withBody    bool
 	body        map[string]interface{}
@@ -248,7 +281,7 @@ func runExecutionAction(cfg executionActionConfig) (map[string]any, error) {
 	}
 
 	if resp.StatusCode >= 300 {
-		return nil, formatExecutionActionError(resp.StatusCode, cfg.actionName, cfg.executionID, parsed)
+		return nil, formatExecutionActionError(resp.StatusCode, cfg.actionName, cfg.targetKind, cfg.executionID, parsed)
 	}
 
 	if cfg.opts.jsonOutput {
@@ -319,10 +352,23 @@ func parseRestartInput(value string) (map[string]interface{}, error) {
 func printExecutionActionHumanOutput(parsed map[string]any, successVerb string) {
 	executionID, _ := parsed["execution_id"].(string)
 	previousStatus, _ := parsed["previous_status"].(string)
+	runID, _ := parsed["run_id"].(string)
 	newRunID, _ := parsed["run_id"].(string)
 	sourceRunID, _ := parsed["source_run_id"].(string)
 	sourceExecutionID, _ := parsed["source_execution_id"].(string)
 	reuse, _ := parsed["replay_mode"].(string)
+
+	if successVerb == "cancelled" && runID != "" && executionID == "" {
+		fmt.Printf("Run %s cancelled", runID)
+		cancelled, hasCancelled := numberAsInt(parsed["cancelled_count"])
+		skipped, hasSkipped := numberAsInt(parsed["skipped_count"])
+		errors, hasErrors := numberAsInt(parsed["error_count"])
+		if hasCancelled || hasSkipped || hasErrors {
+			fmt.Printf(": %d cancelled, %d skipped, %d errors", cancelled, skipped, errors)
+		}
+		fmt.Println()
+		return
+	}
 
 	if successVerb == "restarted" && newRunID != "" {
 		if sourceRunID != "" && sourceExecutionID != "" {
@@ -349,9 +395,39 @@ func printExecutionActionHumanOutput(parsed map[string]any, successVerb string) 
 	if strings.TrimSpace(reason) != "" {
 		fmt.Printf("Reason: %s\n", reason)
 	}
+	warning, _ := parsed["warning"].(string)
+	if strings.TrimSpace(warning) != "" {
+		fmt.Printf("Warning: %s\n", warning)
+	}
+	suggestedEndpoint, _ := parsed["suggested_endpoint"].(string)
+	if strings.TrimSpace(suggestedEndpoint) != "" {
+		fmt.Printf("Suggestion: POST %s\n", suggestedEndpoint)
+	}
 }
 
-func formatExecutionActionError(statusCode int, actionName, executionID string, parsed map[string]any) error {
+func numberAsInt(value any) (int, bool) {
+	switch typed := value.(type) {
+	case int:
+		return typed, true
+	case int64:
+		return int(typed), true
+	case float64:
+		return int(typed), true
+	case json.Number:
+		asInt, err := typed.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return int(asInt), true
+	default:
+		return 0, false
+	}
+}
+
+func formatExecutionActionError(statusCode int, actionName, targetKind, executionID string, parsed map[string]any) error {
+	if strings.TrimSpace(targetKind) == "" {
+		targetKind = "execution"
+	}
 	message := ""
 	if v, ok := parsed["message"].(string); ok {
 		message = strings.TrimSpace(v)
@@ -365,18 +441,18 @@ func formatExecutionActionError(statusCode int, actionName, executionID string, 
 	switch statusCode {
 	case http.StatusNotFound:
 		if message != "" {
-			return fmt.Errorf("execution %s not found: %s", executionID, message)
+			return fmt.Errorf("%s %s not found: %s", targetKind, executionID, message)
 		}
-		return fmt.Errorf("execution %s not found", executionID)
+		return fmt.Errorf("%s %s not found", targetKind, executionID)
 	case http.StatusConflict:
 		if message != "" {
-			return fmt.Errorf("cannot %s execution %s: %s", actionName, executionID, message)
+			return fmt.Errorf("cannot %s %s %s: %s", actionName, targetKind, executionID, message)
 		}
-		return fmt.Errorf("cannot %s execution %s in its current state", actionName, executionID)
+		return fmt.Errorf("cannot %s %s %s in its current state", actionName, targetKind, executionID)
 	default:
 		if message != "" {
-			return fmt.Errorf("failed to %s execution %s (%d): %s", actionName, executionID, statusCode, message)
+			return fmt.Errorf("failed to %s %s %s (%d): %s", actionName, targetKind, executionID, statusCode, message)
 		}
-		return fmt.Errorf("failed to %s execution %s (%d)", actionName, executionID, statusCode)
+		return fmt.Errorf("failed to %s %s %s (%d)", actionName, targetKind, executionID, statusCode)
 	}
 }

--- a/control-plane/internal/cli/execution_additional_test.go
+++ b/control-plane/internal/cli/execution_additional_test.go
@@ -106,6 +106,43 @@ func TestRunExecutionActionSuccessAndErrors(t *testing.T) {
 		require.Contains(t, output, `"execution_id": "ex-2"`)
 	})
 
+	t.Run("single execution cancel prints remaining-run warning", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/api/v1/executions/ex-root/cancel", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"execution_id":"ex-root",
+				"previous_status":"running",
+				"status":"cancelled",
+				"run_id":"run-1",
+				"scope":"execution",
+				"remaining_active_in_run":2,
+				"suggested_endpoint":"/api/v1/workflows/run-1/cancel-tree",
+				"warning":"Cancelled only execution ex-root; 2 other non-terminal execution(s) remain in run run-1. Use cancel-tree to stop the whole run."
+			}`))
+		}))
+		defer server.Close()
+
+		output := captureOutput(t, func() {
+			_, err := runExecutionAction(executionActionConfig{
+				actionName:  "cancel",
+				successVerb: "cancelled",
+				endpoint:    "/api/v1/executions/%s/cancel",
+				executionID: "ex-root",
+				targetKind:  "execution",
+				withReason:  true,
+				opts: &executionActionOptions{
+					serverURL: server.URL,
+					timeout:   time.Second,
+				},
+			})
+			require.NoError(t, err)
+		})
+		require.Contains(t, output, "Execution ex-root cancelled (was: running)")
+		require.Contains(t, output, "Warning: Cancelled only execution ex-root")
+		require.Contains(t, output, "Suggestion: POST /api/v1/workflows/run-1/cancel-tree")
+	})
+
 	t.Run("not found and conflict errors", func(t *testing.T) {
 		cases := []struct {
 			name       string
@@ -220,6 +257,34 @@ func TestResumeExecutionCommand(t *testing.T) {
 		require.NoError(t, cmd.Execute())
 	})
 	require.Contains(t, output, "Execution ex-9 resumed")
+}
+
+func TestCancelRunCommandUsesCancelTree(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/workflows/run-9/cancel-tree", r.URL.Path)
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		var payload map[string]string
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		require.Equal(t, "operator stop", payload["reason"])
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"run_id":"run-9",
+			"total_nodes":3,
+			"cancelled_count":2,
+			"skipped_count":1,
+			"error_count":0,
+			"nodes":[],
+			"cancelled_at":"2026-07-02T03:35:00Z"
+		}`))
+	}))
+	defer server.Close()
+
+	cmd := newCancelRunCommand()
+	cmd.SetArgs([]string{"run-9", "--server", server.URL, "--timeout", "1s", "--reason", "operator stop"})
+	output := captureOutput(t, func() {
+		require.NoError(t, cmd.Execute())
+	})
+	require.Contains(t, output, "Run run-9 cancelled: 2 cancelled, 1 skipped, 0 errors")
 }
 
 func TestRestartExecutionCommandPostsRestartBody(t *testing.T) {

--- a/control-plane/internal/handlers/execute_cancel.go
+++ b/control-plane/internal/handlers/execute_cancel.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -21,11 +22,16 @@ type cancelExecutionRequest struct {
 }
 
 type cancelExecutionResponse struct {
-	ExecutionID    string  `json:"execution_id"`
-	PreviousStatus string  `json:"previous_status"`
-	Status         string  `json:"status"`
-	Reason         *string `json:"reason,omitempty"`
-	CancelledAt    string  `json:"cancelled_at"`
+	ExecutionID          string  `json:"execution_id"`
+	PreviousStatus       string  `json:"previous_status"`
+	Status               string  `json:"status"`
+	Reason               *string `json:"reason,omitempty"`
+	CancelledAt          string  `json:"cancelled_at"`
+	Scope                string  `json:"scope"`
+	RunID                string  `json:"run_id,omitempty"`
+	RemainingActiveInRun int     `json:"remaining_active_in_run,omitempty"`
+	SuggestedEndpoint    string  `json:"suggested_endpoint,omitempty"`
+	Warning              string  `json:"warning,omitempty"`
 }
 
 func CancelExecutionHandler(store ExecutionStore) gin.HandlerFunc {
@@ -154,7 +160,52 @@ func CancelExecutionHandler(store ExecutionStore) gin.HandlerFunc {
 			Status:         types.ExecutionStatusCancelled,
 			Reason:         reasonPtr,
 			CancelledAt:    now.Format(time.RFC3339),
+			Scope:          "execution",
+			RunID:          exec.RunID,
+		}
+		remaining, queryErr := countRemainingActiveInRun(reqCtx, store, exec.RunID, executionID)
+		if queryErr != nil {
+			logger.Logger.Warn().Err(queryErr).Str("run_id", exec.RunID).Str("execution_id", executionID).Msg("failed to inspect run after single-execution cancel")
+		} else if remaining > 0 {
+			response.RemainingActiveInRun = remaining
+			response.SuggestedEndpoint = fmt.Sprintf("/api/v1/workflows/%s/cancel-tree", exec.RunID)
+			response.Warning = fmt.Sprintf(
+				"Cancelled only execution %s; %d other non-terminal execution(s) remain in run %s. Use cancel-tree to stop the whole run.",
+				executionID,
+				remaining,
+				exec.RunID,
+			)
 		}
 		c.JSON(http.StatusOK, response)
 	}
+}
+
+func countRemainingActiveInRun(ctx context.Context, store ExecutionStore, runID string, cancelledExecutionID string) (int, error) {
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return 0, nil
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			logger.Logger.Warn().Interface("panic", recovered).Str("run_id", runID).Str("execution_id", cancelledExecutionID).Msg("single-execution cancel advisory query panicked")
+		}
+	}()
+	executions, err := store.QueryExecutionRecords(ctx, types.ExecutionFilter{
+		RunID:          &runID,
+		SortBy:         "started_at",
+		SortDescending: false,
+	})
+	if err != nil {
+		return 0, err
+	}
+	remaining := 0
+	for _, exec := range executions {
+		if exec == nil || exec.ExecutionID == cancelledExecutionID {
+			continue
+		}
+		if !types.IsTerminalExecutionStatus(exec.Status) {
+			remaining++
+		}
+	}
+	return remaining, nil
 }

--- a/control-plane/internal/handlers/execute_cancel_test.go
+++ b/control-plane/internal/handlers/execute_cancel_test.go
@@ -61,6 +61,34 @@ func (s *cancelHandlerStorage) seedExecution(executionID, status string) {
 	}
 }
 
+func (s *cancelHandlerStorage) seedExecutionWithParent(executionID, status string, parentID *string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now().UTC()
+	runID := "run-1"
+	statusCopy := status
+	s.executionRecords[executionID] = &types.Execution{
+		ExecutionID:       executionID,
+		RunID:             runID,
+		AgentNodeID:       "agent-1",
+		Status:            statusCopy,
+		StartedAt:         now,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+		StatusReason:      nil,
+		ParentExecutionID: parentID,
+	}
+	s.workflowExecutions[executionID] = &types.WorkflowExecution{
+		ExecutionID:       executionID,
+		WorkflowID:        "wf-1",
+		RunID:             &runID,
+		AgentNodeID:       "agent-1",
+		Status:            statusCopy,
+		StartedAt:         now,
+		ParentExecutionID: parentID,
+	}
+}
+
 func (s *cancelHandlerStorage) GetExecutionRecord(ctx context.Context, executionID string) (*types.Execution, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -127,6 +155,20 @@ func (s *cancelHandlerStorage) StoreWorkflowExecutionEvent(ctx context.Context, 
 	defer s.mu.Unlock()
 	s.workflowEvents = append(s.workflowEvents, event)
 	return nil
+}
+
+func (s *cancelHandlerStorage) QueryExecutionRecords(ctx context.Context, filter types.ExecutionFilter) ([]*types.Execution, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*types.Execution, 0, len(s.executionRecords))
+	for _, exec := range s.executionRecords {
+		if filter.RunID != nil && exec.RunID != *filter.RunID {
+			continue
+		}
+		clone := *exec
+		out = append(out, &clone)
+	}
+	return out, nil
 }
 
 func TestCancelExecutionHandler_StateTransitions(t *testing.T) {
@@ -224,6 +266,39 @@ func TestCancelExecutionHandler_WithReason(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, wfExec.StatusReason)
 	require.Equal(t, "operator requested stop", *wfExec.StatusReason)
+}
+
+func TestCancelExecutionHandler_WarnsWhenRunStillHasActiveExecutions(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := newCancelHandlerStorage()
+	root := "exec-root"
+	store.seedExecutionWithParent(root, types.ExecutionStatusRunning, nil)
+	store.seedExecutionWithParent("exec-child-running", types.ExecutionStatusRunning, &root)
+	store.seedExecutionWithParent("exec-child-succeeded", types.ExecutionStatusSucceeded, &root)
+
+	router := gin.New()
+	router.POST("/api/v1/executions/:execution_id/cancel", CancelExecutionHandler(store))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/executions/"+root+"/cancel", bytes.NewReader([]byte(`{"reason":"operator requested stop"}`)))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var payload cancelExecutionResponse
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &payload))
+	require.Equal(t, root, payload.ExecutionID)
+	require.Equal(t, "execution", payload.Scope)
+	require.Equal(t, "run-1", payload.RunID)
+	require.Equal(t, 1, payload.RemainingActiveInRun)
+	require.Equal(t, "/api/v1/workflows/run-1/cancel-tree", payload.SuggestedEndpoint)
+	require.Contains(t, payload.Warning, "Cancelled only execution exec-root")
+	require.Contains(t, payload.Warning, "1 other non-terminal execution(s) remain")
+
+	child, err := store.GetExecutionRecord(context.Background(), "exec-child-running")
+	require.NoError(t, err)
+	require.Equal(t, types.ExecutionStatusRunning, child.Status, "single-execution cancel must remain non-cascading")
 }
 
 func TestCancelExecutionHandler_WithoutReasonOmitsReasonField(t *testing.T) {

--- a/control-plane/web/client/src/services/executionsApi.ts
+++ b/control-plane/web/client/src/services/executionsApi.ts
@@ -49,6 +49,11 @@ export interface CancelExecutionResponse {
   status: string;
   reason?: string;
   cancelled_at: string;
+  scope?: "execution";
+  run_id?: string;
+  remaining_active_in_run?: number;
+  suggested_endpoint?: string;
+  warning?: string;
 }
 
 export interface PauseExecutionResponse {


### PR DESCRIPTION
## Summary
- Keep `POST /executions/:id/cancel` single-execution compatible.
- Add warning metadata when that narrow cancel leaves other non-terminal executions in the same run.
- Add `af execution cancel-run <run_id>` for the existing bottom-up `cancel-tree` run cancel path.

## Why
- Single-execution cancel updates only the requested execution and publishes one cancel event: `control-plane/internal/handlers/execute_cancel.go:79`, `control-plane/internal/handlers/execute_cancel.go:124`.
- Worker cancellation is keyed by the exact execution id: `sdk/python/agentfield/cancel.py:65`.
- The existing run-level endpoint already documents why tree cancel is needed: `control-plane/internal/handlers/execute_cancel_tree.go:22`.
- The UI already uses run-level cancel for this reason: `control-plane/web/client/src/pages/RunDetailPage.tsx:1271`.

## Compatibility
- No semantic change to the existing execution cancel endpoint.
- New JSON fields are additive: `scope`, `run_id`, `remaining_active_in_run`, `suggested_endpoint`, `warning`.
- New CLI command is additive; existing `af execution cancel <execution_id>` remains unchanged.

## Tested
- `go test ./internal/handlers -run 'TestCancelExecutionHandler|TestCancelWorkflowTreeHandler'`
- `go test ./internal/cli -run 'TestRunExecutionActionSuccessAndErrors|TestCancelRunCommandUsesCancelTree|TestUtilityAndExecutionCommandCoverage|TestResumeExecutionCommand|TestRestartExecutionCommandPostsRestartBody|TestPrintExecutionActionHumanOutput'`
- `go test ./internal/handlers ./internal/cli`

Not run: web client tests; `control-plane/web/client/node_modules` is not installed locally.
