### PR TITLE
fix(sdk-python): use AsyncConfig.from_environment() for client default async config

### DIFF
--- a/sdk/python/agentfield/client.py
+++ b/sdk/python/agentfield/client.py
@@ -160,7 +160,7 @@ class AgentFieldClient:
         self._did_authenticator = DIDAuthenticator(did=did, private_key_jwk=private_key_jwk)
 
         # Async execution components
-        self.async_config = async_config or AsyncConfig()
+        self.async_config = async_config or AsyncConfig.from_environment()
         self._async_execution_manager: Optional[AsyncExecutionManager] = None
         self._async_http_client: Optional["httpx.AsyncClient"] = None
         self._async_http_client_lock: Optional[asyncio.Lock] = None

--- a/sdk/python/tests/test_async_config.py
+++ b/sdk/python/tests/test_async_config.py
@@ -1,4 +1,5 @@
 from agentfield.async_config import AsyncConfig
+from agentfield.client import AgentFieldClient
 
 
 def test_async_config_validate_defaults_ok():
@@ -48,3 +49,24 @@ def test_from_environment_overrides(monkeypatch):
     assert cfg.enable_event_stream is True
     assert cfg.event_stream_path == "/stream"
     assert cfg.event_stream_retry_backoff == 4.5
+
+
+def test_client_default_async_config_uses_environment(monkeypatch):
+    monkeypatch.setenv("AGENTFIELD_ASYNC_MAX_EXECUTION_TIMEOUT", "321")
+    monkeypatch.setenv("AGENTFIELD_ASYNC_ENABLE_EVENT_STREAM", "true")
+    monkeypatch.setenv("AGENTFIELD_ASYNC_EVENT_STREAM_PATH", "/client-events")
+
+    client = AgentFieldClient()
+
+    assert client.async_config.max_execution_timeout == 321
+    assert client.async_config.enable_event_stream is True
+    assert client.async_config.event_stream_path == "/client-events"
+
+
+def test_client_keeps_explicit_async_config(monkeypatch):
+    monkeypatch.setenv("AGENTFIELD_ASYNC_MAX_EXECUTION_TIMEOUT", "321")
+    explicit_config = AsyncConfig(max_execution_timeout=456)
+
+    client = AgentFieldClient(async_config=explicit_config)
+
+    assert client.async_config is explicit_config


### PR DESCRIPTION
## Summary

`AgentFieldClient` built its default `async_config` with `AsyncConfig()`, which ignores the `AGENTFIELD_ASYNC_*` environment overrides that `Agent` already honors. This initializes the default from `AsyncConfig.from_environment()` so client-level async behavior (timeouts, event stream, poll intervals, etc.) can be tuned via env vars, while any explicitly passed `async_config` is preserved unchanged.

`from_environment()` starts from `AsyncConfig()` defaults and only overrides fields when the corresponding env var is set (falling back to the default on unparseable values), so this is fully backward-compatible for callers that set no env vars.

Fixes #621.

## Changes

- `sdk/python/agentfield/client.py` — default `async_config` now uses `AsyncConfig.from_environment()`.
- `sdk/python/tests/test_async_config.py` — regression coverage for both the env-backed default path and the explicit-override path.

## Provenance

Supersedes **#632** (original change by @liuzemei / neooosky). That PR is approved by the maintainer but stuck on an outstanding CLA signature from an unsigned committer. Re-authored here so it can land cleanly; thanks to the original authors for the fix.

## Test plan

- `cd sdk/python && ruff check .` — clean
- `cd sdk/python && python -m pytest --no-cov` — 1644 passed, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)