### PR TITLE
 fix(control-plane): flush SSE headers immediately in memory events handler

### DIFF
--- a/control-plane/internal/handlers/memory_events.go
+++ b/control-plane/internal/handlers/memory_events.go
@@ -113,32 +113,44 @@ func (h *MemoryEventsHandler) WebSocketHandler(c *gin.Context) {
 // SSEHandler handles Server-Sent Events connections for memory events.
 func (h *MemoryEventsHandler) SSEHandler(c *gin.Context) {
 	ctx := c.Request.Context()
-	// Set headers for SSE
-	c.Writer.Header().Set("Content-Type", "text/event-stream")
-	c.Writer.Header().Set("Cache-Control", "no-cache")
-	c.Writer.Header().Set("Connection", "keep-alive")
 
 	// Parse query parameters for filtering
 	scope := c.Query("scope")
 	scopeID := c.Query("scope_id")
 	patterns := normalizePatterns(c.Query("patterns"))
 
-	// Subscribe to memory changes
+	// Subscribe to memory changes before flushing headers so we can still
+	// return a proper HTTP error status on failure.
 	eventChan, err := h.storage.SubscribeToMemoryChanges(ctx, scope, scopeID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to subscribe to events"})
 		return
 	}
 
-	// Create a channel to notify when the client disconnects
-	clientClosed := c.Writer.CloseNotify()
+	// Set headers for SSE and flush immediately so the client receives the
+	// response and can begin reading the body without waiting for the first event.
+	c.Writer.Header().Set("Content-Type", "text/event-stream")
+	c.Writer.Header().Set("Cache-Control", "no-cache")
+	c.Writer.Header().Set("Connection", "keep-alive")
+	c.Writer.WriteHeader(http.StatusOK)
+	c.Writer.Flush()
+
+	// Send an initial comment frame as a keepalive marker so clients know
+	// the connection is established.
+	_, _ = c.Writer.WriteString(": connected\n\n")
+	c.Writer.Flush()
 
 	for {
 		select {
-		case <-clientClosed:
+		case <-ctx.Done():
 			// Client disconnected
 			return
-		case event := <-eventChan:
+		case event, ok := <-eventChan:
+			if !ok {
+				// Channel closed
+				return
+			}
+
 			// Apply pattern matching
 			if len(patterns) > 0 {
 				match := false

--- a/control-plane/internal/handlers/memory_events_test.go
+++ b/control-plane/internal/handlers/memory_events_test.go
@@ -208,13 +208,6 @@ func TestMemoryEventsHandler_WebSocketUpgradeAndPatternFilter(t *testing.T) {
 }
 
 func TestMemoryEventsHandler_SSEHappyPathHonorsScopeFilter(t *testing.T) {
-	// NOTE: The SSE handler in memory_events.go does not flush response
-	// headers until it writes its first matching event, so http.Client.Do
-	// would block waiting for headers if we did the request synchronously.
-	// We work around it here by running the request in a goroutine and
-	// publishing events after the subscription is registered. The source
-	//-side flush refactor is tracked in #358; once that lands, this test
-	// can be simplified.
 	gin.SetMode(gin.TestMode)
 
 	store := newMemoryEventStorageStub()
@@ -227,10 +220,8 @@ func TestMemoryEventsHandler_SSEHappyPathHonorsScopeFilter(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/sse?scope=session&scope_id=s1", nil)
 	require.NoError(t, err)
 
-	// The SSE handler does not flush headers until it writes the first event,
-	// so http.Client.Do blocks until something is published. Run the request in
-	// a goroutine and publish from the main goroutine once the subscription is
-	// active.
+	// Run the request in a goroutine; headers are flushed immediately but we
+	// still need to wait for the subscription to be active before publishing.
 	type doResult struct {
 		resp *http.Response
 		err  error


### PR DESCRIPTION
## Summary

The `SSEHandler` in memory events deferred header flush until the first matching event arrived, causing SSE clients to hang indefinitely on `http.Client.Do` when no events matched immediately. This also replaces the deprecated `CloseNotify()` with `ctx.Done()` for disconnect detection.

Closes #358

## Type of change

- [x] Bug fix

## Test plan

- [x] `cd control-plane && go test ./internal/handlers/ -run "TestMemoryEvents" -v -count=1`
- [x] `cd control-plane && CGO_ENABLED=0 GOOS=linux go build ./cmd/agentfield-server`
- [x] `golangci-lint run ./internal/handlers/memory_events.go` zero issues

## Test coverage

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR (no bare additions).
- [ ] If I removed code, I updated `coverage-baseline.json` in this PR *only if* the removal caused a legitimate regression and I called it out in the summary above.
- [ ] The coverage gate check is green in CI before requesting review.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) (if present) and [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
- [x] Commits are signed and follow conventional-commits style.
- [x] I have linked any related issues (Fixes #358).

## Related issues / PRs

Fixes #358