### PR TITLE
fix(sdk-go): make agent outbound call timeout configurable

### DIFF
--- a/sdk/go/agent/agent.go
+++ b/sdk/go/agent/agent.go
@@ -365,6 +365,13 @@ type Config struct {
 	// plane does not expect heartbeats.
 	LeaseRefreshInterval time.Duration
 
+	// CallTimeout bounds every outbound HTTP call this agent makes as a
+	// client - cross-agent Call()s, memory backend requests, etc.
+	// Optional. Default: 15s. A reasoning-model-backed reasoner chained
+	// behind Call() (search + a large max_tokens reasoning response) can
+	// easily exceed the old hardcoded 15s, so raise this for such workloads.
+	CallTimeout time.Duration
+
 	// DisableLeaseLoop disables automatic periodic lease refreshes.
 	// Optional. Default: false. When true, node registration reports
 	// HeartbeatInterval as "0s" to signal that the agent does not heartbeat.
@@ -538,8 +545,11 @@ func New(cfg Config) (*Agent, error) {
 		cfg.Logger = log.New(os.Stdout, "[agent] ", log.LstdFlags)
 	}
 
+	if cfg.CallTimeout <= 0 {
+		cfg.CallTimeout = 15 * time.Second
+	}
 	httpClient := &http.Client{
-		Timeout: 15 * time.Second,
+		Timeout: cfg.CallTimeout,
 	}
 
 	// Initialize AI client if config provided

--- a/sdk/go/agent/agent_test.go
+++ b/sdk/go/agent/agent_test.go
@@ -71,6 +71,33 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
+			name: "CallTimeout defaults to 15s when unset",
+			cfg: Config{
+				NodeID:        "node-1",
+				Version:       "1.0.0",
+				AgentFieldURL: "https://api.example.com",
+			},
+			wantErr: false,
+			check: func(t *testing.T, a *Agent) {
+				assert.Equal(t, 15*time.Second, a.cfg.CallTimeout)
+				assert.Equal(t, 15*time.Second, a.httpClient.Timeout)
+			},
+		},
+		{
+			name: "CallTimeout is honored when set",
+			cfg: Config{
+				NodeID:        "node-1",
+				Version:       "1.0.0",
+				AgentFieldURL: "https://api.example.com",
+				CallTimeout:   90 * time.Second,
+			},
+			wantErr: false,
+			check: func(t *testing.T, a *Agent) {
+				assert.Equal(t, 90*time.Second, a.cfg.CallTimeout)
+				assert.Equal(t, 90*time.Second, a.httpClient.Timeout)
+			},
+		},
+		{
 			name: "defaults applied",
 			cfg: Config{
 				NodeID:        "node-1",


### PR DESCRIPTION
Fixes #720

## What

Adds `agent.Config.CallTimeout` to make the previously-hardcoded 15s outbound-call timeout configurable, defaulting to 15s when unset (no behavior change unless you opt in).

## Why

`agent.New()` built its client `http.Client` with a hardcoded 15-second timeout, used for every outbound call the agent makes as a client - cross-agent `srv.Call(...)` and the control-plane memory backend's requests. Found this building a recursive research-agent demo: a reasoner chained behind `Call()` that used a reasoning-capable model (search + a large `max_tokens` "thinking" response) routinely took 15-30s, so the *caller* failed with a client-side `context deadline exceeded` while the callee kept running and completed successfully on its own a few seconds later. No config existed to raise it.

## How

```go
if cfg.CallTimeout <= 0 {
    cfg.CallTimeout = 15 * time.Second
}
httpClient := &http.Client{
    Timeout: cfg.CallTimeout,
}
```

## Testing

- New test cases in `TestNew`: default (15s, unchanged) and explicit override, asserting both `a.cfg.CallTimeout` and the actual `a.httpClient.Timeout`.
- `cd sdk/go && go build ./... && go test ./...` - all green.

## Scope

2 files, +38/-1. No breaking changes; default behavior is identical for anyone not setting the new field.
