### PR TITLE
feat(cli): provision a requires-python-compatible interpreter for af install

### DIFF
--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/mattn/go-sqlite3 v1.14.22
+	github.com/pelletier/go-toml/v2 v2.2.3
 	github.com/prometheus/client_golang v1.19.0
 	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cobra v1.8.1
@@ -81,7 +82,6 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect

--- a/control-plane/internal/packages/installer.go
+++ b/control-plane/internal/packages/installer.go
@@ -648,11 +648,28 @@ func InstallPythonDependencies(packagePath string, pyDeps, systemDeps []string) 
 	if hasReq || hasProject || len(pyDeps) > 0 {
 		venvPath := filepath.Join(packagePath, "venv")
 
-		cmd := exec.Command("python3", "-m", "venv", venvPath)
-		if _, err := cmd.CombinedOutput(); err != nil {
-			cmd = exec.Command("python", "-m", "venv", venvPath)
+		// Pick an interpreter that satisfies the node's requires-python (when it
+		// declares one), provisioning a compatible Python via uv/pyenv if the
+		// ambient one is too old — rather than failing later with a raw pip
+		// "requires a different Python" trace.
+		interp, err := resolveVenvInterpreter(packagePath)
+		if err != nil {
+			return err
+		}
+
+		var cmd *exec.Cmd
+		if interp != "" {
+			cmd = exec.Command(interp, "-m", "venv", venvPath)
 			if output, err := cmd.CombinedOutput(); err != nil {
-				return fmt.Errorf("failed to create virtual environment: %w\nOutput: %s", err, output)
+				return fmt.Errorf("failed to create virtual environment with %s: %w\nOutput: %s", interp, err, output)
+			}
+		} else {
+			cmd = exec.Command("python3", "-m", "venv", venvPath)
+			if _, err := cmd.CombinedOutput(); err != nil {
+				cmd = exec.Command("python", "-m", "venv", venvPath)
+				if output, err := cmd.CombinedOutput(); err != nil {
+					return fmt.Errorf("failed to create virtual environment: %w\nOutput: %s", err, output)
+				}
 			}
 		}
 

--- a/control-plane/internal/packages/pyinterp.go
+++ b/control-plane/internal/packages/pyinterp.go
@@ -1,0 +1,337 @@
+package packages
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+// pyVersion is a parsed (major, minor, patch) Python version.
+type pyVersion struct {
+	major, minor, patch int
+}
+
+func (v pyVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.major, v.minor, v.patch)
+}
+
+// compare returns -1, 0, or 1 as v is less than, equal to, or greater than o.
+func (v pyVersion) compare(o pyVersion) int {
+	for _, d := range []int{v.major - o.major, v.minor - o.minor, v.patch - o.patch} {
+		if d < 0 {
+			return -1
+		}
+		if d > 0 {
+			return 1
+		}
+	}
+	return 0
+}
+
+// parsePyVersion parses a dotted version like "3.12" or "3.12.5" into a
+// pyVersion. A missing minor/patch defaults to 0. Non-numeric suffixes on a
+// component (e.g. "3.12rc1") are ignored. It reports false only when the major
+// component is absent or non-numeric.
+func parsePyVersion(s string) (pyVersion, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return pyVersion{}, false
+	}
+	parts := strings.Split(s, ".")
+	nums := [3]int{}
+	for i := 0; i < len(parts) && i < 3; i++ {
+		digits := leadingDigits(parts[i])
+		if digits == "" {
+			if i == 0 {
+				return pyVersion{}, false
+			}
+			break
+		}
+		n, err := strconv.Atoi(digits)
+		if err != nil {
+			return pyVersion{}, false
+		}
+		nums[i] = n
+	}
+	return pyVersion{nums[0], nums[1], nums[2]}, true
+}
+
+// leadingDigits returns the leading run of ASCII digits in s.
+func leadingDigits(s string) string {
+	i := 0
+	for i < len(s) && s[i] >= '0' && s[i] <= '9' {
+		i++
+	}
+	return s[:i]
+}
+
+// constraintSatisfied reports whether version v satisfies a PEP 440-style
+// requires-python constraint. The constraint is a comma-separated list of
+// clauses, each an operator (>=, >, <=, <, ==, ===, !=, ~=) followed by a
+// version, with an optional ".*" wildcard on == / !=. An empty or
+// unparseable constraint is treated as satisfied so that a manifest we cannot
+// understand never blocks installation.
+func constraintSatisfied(v pyVersion, requires string) bool {
+	requires = strings.TrimSpace(requires)
+	if requires == "" {
+		return true
+	}
+	for _, clause := range strings.Split(requires, ",") {
+		clause = strings.TrimSpace(clause)
+		if clause == "" {
+			continue
+		}
+		if !clauseSatisfied(v, clause) {
+			return false
+		}
+	}
+	return true
+}
+
+// clauseSatisfied evaluates a single constraint clause against v.
+func clauseSatisfied(v pyVersion, clause string) bool {
+	op := "=="
+	rest := clause
+	// Order matters: match the longest operators first.
+	for _, o := range []string{"===", ">=", "<=", "==", "!=", "~=", ">", "<"} {
+		if strings.HasPrefix(clause, o) {
+			op = o
+			rest = strings.TrimSpace(clause[len(o):])
+			break
+		}
+	}
+
+	wildcard := strings.HasSuffix(rest, ".*")
+	rest = strings.TrimSuffix(rest, ".*")
+	want, ok := parsePyVersion(rest)
+	if !ok {
+		return true // permissive: don't block on something we can't parse
+	}
+	cmp := v.compare(want)
+
+	switch op {
+	case ">=":
+		return cmp >= 0
+	case ">":
+		return cmp > 0
+	case "<=":
+		return cmp <= 0
+	case "<":
+		return cmp < 0
+	case "!=":
+		if wildcard {
+			return v.major != want.major || v.minor != want.minor
+		}
+		return cmp != 0
+	case "==", "===":
+		if wildcard {
+			return v.major == want.major && v.minor == want.minor
+		}
+		return cmp == 0
+	case "~=":
+		// ~=X.Y  => >=X.Y and ==X.*   ; ~=X.Y.Z => >=X.Y.Z and ==X.Y.*
+		if cmp < 0 {
+			return false
+		}
+		if strings.Count(rest, ".") >= 2 {
+			return v.major == want.major && v.minor == want.minor
+		}
+		return v.major == want.major
+	}
+	return true
+}
+
+// readRequiresPython returns the requires-python constraint declared in the
+// package's pyproject.toml, or "" when there is no pyproject.toml, no
+// [project].requires-python field, or the file cannot be parsed.
+func readRequiresPython(packagePath string) string {
+	data, err := os.ReadFile(filepath.Join(packagePath, "pyproject.toml"))
+	if err != nil {
+		return ""
+	}
+	var pp struct {
+		Project struct {
+			RequiresPython string `toml:"requires-python"`
+		} `toml:"project"`
+	}
+	if err := toml.Unmarshal(data, &pp); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(pp.Project.RequiresPython)
+}
+
+// interpreterVersion runs the interpreter and returns its reported version.
+func interpreterVersion(interp string) (pyVersion, bool) {
+	out, err := exec.Command(interp, "-c", "import sys;print('%d.%d.%d'%sys.version_info[:3])").Output()
+	if err != nil {
+		return pyVersion{}, false
+	}
+	return parsePyVersion(strings.TrimSpace(string(out)))
+}
+
+// uvRequest derives a bare "major.minor" interpreter request from a
+// requires-python constraint, taken from the first lower-bound / equality
+// clause (>=, ==, ===, ~=, >). Returns "" when no such clause is present.
+// A bare major.minor is the request form uv accepts most reliably; the caller
+// re-checks the resolved interpreter against the full constraint afterward.
+func uvRequest(requires string) string {
+	for _, clause := range strings.Split(requires, ",") {
+		clause = strings.TrimSpace(clause)
+		for _, o := range []string{"===", ">=", "==", "~=", ">"} {
+			if strings.HasPrefix(clause, o) {
+				rest := strings.TrimSuffix(strings.TrimSpace(clause[len(o):]), ".*")
+				if v, ok := parsePyVersion(rest); ok {
+					return fmt.Sprintf("%d.%d", v.major, v.minor)
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// resolveVenvInterpreter picks the interpreter to build a node's venv with,
+// honoring the package's requires-python. It returns:
+//   - ("", nil) when the package declares no constraint — the caller keeps its
+//     legacy python3 -> python fallback, so behavior is unchanged.
+//   - (interp, nil) with a concrete interpreter (command or path) to use.
+//   - ("", err) with an actionable message when a constraint is declared but no
+//     compatible interpreter is available and none can be provisioned.
+//
+// Resolution order when a constraint is present: the ambient python3/python if
+// it already satisfies, then a uv-provisioned interpreter (uv auto-downloads a
+// standalone build), then a matching pyenv-installed version.
+func resolveVenvInterpreter(packagePath string) (string, error) {
+	requires := readRequiresPython(packagePath)
+	if requires == "" {
+		return "", nil
+	}
+
+	// 1. Ambient interpreter already satisfies?
+	ambient := firstOnPath("python3", "python")
+	if ambient != "" {
+		if v, ok := interpreterVersion(ambient); ok && constraintSatisfied(v, requires) {
+			return ambient, nil
+		}
+	}
+
+	// 2. Provision via uv (downloads a standalone interpreter if needed).
+	if interp := provisionViaUv(requires); interp != "" {
+		fmt.Printf("🐍 Provisioned Python %s via uv (node requires %q)\n", displayVersion(interp), requires)
+		return interp, nil
+	}
+
+	// 3. Discover a matching pyenv-installed version.
+	if interp := provisionViaPyenv(requires); interp != "" {
+		fmt.Printf("🐍 Using pyenv Python %s (node requires %q)\n", displayVersion(interp), requires)
+		return interp, nil
+	}
+
+	found := "no python3 found on PATH"
+	if ambient != "" {
+		if v, ok := interpreterVersion(ambient); ok {
+			found = fmt.Sprintf("found %s (Python %s)", ambient, v)
+		}
+	}
+	req := uvRequest(requires)
+	if req == "" {
+		req = requires
+	}
+	return "", fmt.Errorf(
+		"this agent node requires Python %s, but no compatible interpreter is available (%s).\n"+
+			"Fix it by installing a matching Python, then reinstall:\n"+
+			"  • with uv (auto-downloads it):  uv python install %s\n"+
+			"  • or via pyenv:                 pyenv install %s\n"+
+			"  • or install Python %s from your OS package manager\n"+
+			"then ensure it is on PATH (or that uv/pyenv can see it) and run `af install` again",
+		requires, found, req, req, req)
+}
+
+// firstOnPath returns the first of the given commands found on PATH, or "".
+func firstOnPath(cmds ...string) string {
+	for _, c := range cmds {
+		if _, err := exec.LookPath(c); err == nil {
+			return c
+		}
+	}
+	return ""
+}
+
+// displayVersion returns interp's version as a string for logging, or the
+// interpreter path itself when the version cannot be determined.
+func displayVersion(interp string) string {
+	if v, ok := interpreterVersion(interp); ok {
+		return v.String()
+	}
+	return interp
+}
+
+// provisionViaUv asks uv for an interpreter satisfying requires, downloading a
+// standalone build if necessary. Returns the interpreter path, or "" when uv is
+// unavailable or cannot provide a satisfying interpreter.
+func provisionViaUv(requires string) string {
+	if _, err := exec.LookPath("uv"); err != nil {
+		return ""
+	}
+	req := uvRequest(requires)
+	if req == "" {
+		return ""
+	}
+	// Ensure a matching interpreter exists (no-op if already present).
+	_ = exec.Command("uv", "python", "install", req).Run()
+	out, err := exec.Command("uv", "python", "find", req).Output()
+	if err != nil {
+		return ""
+	}
+	interp := strings.TrimSpace(string(out))
+	if interp == "" {
+		return ""
+	}
+	if v, ok := interpreterVersion(interp); ok && constraintSatisfied(v, requires) {
+		return interp
+	}
+	return ""
+}
+
+// provisionViaPyenv returns the highest pyenv-installed interpreter that
+// satisfies requires, or "" when pyenv is unavailable or has no match. It only
+// discovers already-installed versions; it does not trigger a source build.
+func provisionViaPyenv(requires string) string {
+	if _, err := exec.LookPath("pyenv"); err != nil {
+		return ""
+	}
+	versionsOut, err := exec.Command("pyenv", "versions", "--bare").Output()
+	if err != nil {
+		return ""
+	}
+	rootOut, err := exec.Command("pyenv", "root").Output()
+	if err != nil {
+		return ""
+	}
+	pyenvRoot := strings.TrimSpace(string(rootOut))
+
+	var best string
+	var bestV pyVersion
+	for _, line := range strings.Split(string(versionsOut), "\n") {
+		name := strings.TrimSpace(line)
+		if name == "" {
+			continue
+		}
+		v, ok := parsePyVersion(name)
+		if !ok || !constraintSatisfied(v, requires) {
+			continue
+		}
+		if best != "" && v.compare(bestV) <= 0 {
+			continue
+		}
+		interp := filepath.Join(pyenvRoot, "versions", name, "bin", "python")
+		if fileExists(interp) {
+			best, bestV = interp, v
+		}
+	}
+	return best
+}

--- a/control-plane/internal/packages/pyinterp_test.go
+++ b/control-plane/internal/packages/pyinterp_test.go
@@ -1,0 +1,286 @@
+package packages
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParsePyVersion(t *testing.T) {
+	cases := []struct {
+		in    string
+		want  pyVersion
+		valid bool
+	}{
+		{"3.12", pyVersion{3, 12, 0}, true},
+		{"3.12.5", pyVersion{3, 12, 5}, true},
+		{"3", pyVersion{3, 0, 0}, true},
+		{" 3.11 ", pyVersion{3, 11, 0}, true},
+		{"3.12rc1", pyVersion{3, 12, 0}, true},
+		{"", pyVersion{}, false},
+		{"abc", pyVersion{}, false},
+	}
+	for _, c := range cases {
+		got, ok := parsePyVersion(c.in)
+		if ok != c.valid || (ok && got != c.want) {
+			t.Errorf("parsePyVersion(%q) = %v,%v; want %v,%v", c.in, got, ok, c.want, c.valid)
+		}
+	}
+}
+
+func TestConstraintSatisfied(t *testing.T) {
+	cases := []struct {
+		ver      pyVersion
+		requires string
+		want     bool
+	}{
+		// The SWE-AF repro: 3.10 must NOT satisfy >=3.12, 3.12 must.
+		{pyVersion{3, 10, 13}, ">=3.12", false},
+		{pyVersion{3, 12, 0}, ">=3.12", true},
+		{pyVersion{3, 12, 5}, ">=3.12", true},
+		{pyVersion{3, 13, 3}, ">=3.12", true},
+		// Ranges.
+		{pyVersion{3, 13, 3}, ">=3.12,<3.14", true},
+		{pyVersion{3, 14, 0}, ">=3.12,<3.14", false},
+		{pyVersion{3, 11, 0}, ">=3.12,<3.14", false},
+		// Compatible release (~=).
+		{pyVersion{3, 12, 0}, "~=3.11", true},
+		{pyVersion{4, 0, 0}, "~=3.11", false},
+		{pyVersion{3, 10, 0}, "~=3.11", false},
+		{pyVersion{3, 11, 9}, "~=3.11.5", true},
+		{pyVersion{3, 12, 0}, "~=3.11.5", false},
+		// Wildcards.
+		{pyVersion{3, 12, 7}, "==3.12.*", true},
+		{pyVersion{3, 13, 0}, "==3.12.*", false},
+		{pyVersion{3, 12, 0}, ">=3.10,!=3.11.*", true},
+		{pyVersion{3, 11, 4}, ">=3.10,!=3.11.*", false},
+		// Exact.
+		{pyVersion{3, 12, 5}, "==3.12.5", true},
+		{pyVersion{3, 12, 6}, "==3.12.5", false},
+		// Permissive: empty / unparseable never blocks.
+		{pyVersion{3, 10, 0}, "", true},
+		{pyVersion{3, 10, 0}, "not-a-constraint", true},
+	}
+	for _, c := range cases {
+		if got := constraintSatisfied(c.ver, c.requires); got != c.want {
+			t.Errorf("constraintSatisfied(%v, %q) = %v; want %v", c.ver, c.requires, got, c.want)
+		}
+	}
+}
+
+func TestUvRequest(t *testing.T) {
+	cases := []struct {
+		requires string
+		want     string
+	}{
+		{">=3.12", "3.12"},
+		{">=3.12,<3.13", "3.12"},
+		{"==3.11.*", "3.11"},
+		{"~=3.10", "3.10"},
+		{">3.12.5", "3.12"},
+		{"<3.13", ""}, // no lower bound
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := uvRequest(c.requires); got != c.want {
+			t.Errorf("uvRequest(%q) = %q; want %q", c.requires, got, c.want)
+		}
+	}
+}
+
+func TestReadRequiresPython(t *testing.T) {
+	t.Run("declared", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "pyproject.toml", "[project]\nname = \"x\"\nrequires-python = \">=3.12\"\n")
+		if got := readRequiresPython(dir); got != ">=3.12" {
+			t.Fatalf("got %q; want >=3.12", got)
+		}
+	})
+	t.Run("no field", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "pyproject.toml", "[project]\nname = \"x\"\n")
+		if got := readRequiresPython(dir); got != "" {
+			t.Fatalf("got %q; want empty", got)
+		}
+	})
+	t.Run("no file", func(t *testing.T) {
+		if got := readRequiresPython(t.TempDir()); got != "" {
+			t.Fatalf("got %q; want empty", got)
+		}
+	})
+	t.Run("malformed", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "pyproject.toml", "this is : not [ valid toml =\n")
+		if got := readRequiresPython(dir); got != "" {
+			t.Fatalf("got %q; want empty (parse failure must not block)", got)
+		}
+	})
+}
+
+// TestResolveVenvInterpreter exercises the resolution contract with a stubbed
+// PATH so no real interpreter/uv/pyenv is involved.
+func TestResolveVenvInterpreter(t *testing.T) {
+	t.Run("no constraint keeps legacy fallback", func(t *testing.T) {
+		dir := t.TempDir() // no pyproject.toml
+		interp, err := resolveVenvInterpreter(dir)
+		if err != nil || interp != "" {
+			t.Fatalf("got (%q,%v); want empty interp, nil err", interp, err)
+		}
+	})
+
+	t.Run("ambient satisfies", func(t *testing.T) {
+		bin := t.TempDir()
+		stubPython(t, bin, "python3", "3.12.5")
+		t.Setenv("PATH", bin)
+		dir := t.TempDir()
+		writeFile(t, dir, "pyproject.toml", "[project]\nrequires-python = \">=3.12\"\n")
+
+		interp, err := resolveVenvInterpreter(dir)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if interp != "python3" {
+			t.Fatalf("got %q; want python3", interp)
+		}
+	})
+
+	t.Run("incompatible and no provisioner -> actionable error", func(t *testing.T) {
+		bin := t.TempDir()
+		stubPython(t, bin, "python3", "3.10.13") // too old, no uv/pyenv on PATH
+		t.Setenv("PATH", bin)
+		dir := t.TempDir()
+		writeFile(t, dir, "pyproject.toml", "[project]\nrequires-python = \">=3.12\"\n")
+
+		interp, err := resolveVenvInterpreter(dir)
+		if interp != "" {
+			t.Fatalf("expected no interpreter, got %q", interp)
+		}
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, ">=3.12") || !strings.Contains(msg, "3.10.13") {
+			t.Fatalf("error should name required (>=3.12) and found (3.10.13) versions: %q", msg)
+		}
+	})
+
+	t.Run("provisions via uv when ambient too old", func(t *testing.T) {
+		bin := t.TempDir()
+		stubPython(t, bin, "python3", "3.10.13")
+		// A "real" target interpreter uv will hand back.
+		target := stubPython(t, bin, "managed-python", "3.12.10")
+		stubUv(t, bin, target)
+		t.Setenv("PATH", bin)
+		dir := t.TempDir()
+		writeFile(t, dir, "pyproject.toml", "[project]\nrequires-python = \">=3.12\"\n")
+
+		interp, err := resolveVenvInterpreter(dir)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if interp != target {
+			t.Fatalf("got %q; want uv-provided %q", interp, target)
+		}
+	})
+}
+
+func TestProvisionViaPyenv(t *testing.T) {
+	bin := t.TempDir()
+	root := t.TempDir()
+	// Two installed versions: 3.10.13 (too old) and 3.12.5 (satisfies >=3.12).
+	for _, v := range []string{"3.10.13", "3.12.5"} {
+		vb := filepath.Join(root, "versions", v, "bin")
+		if err := os.MkdirAll(vb, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeExecutable(t, filepath.Join(vb, "python"), "#!/bin/sh\nexit 0\n")
+	}
+	pyenv := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"versions\" ]; then printf '3.10.13\\n3.12.5\\n'; exit 0; fi\n" +
+		"if [ \"$1\" = \"root\" ]; then echo \"" + root + "\"; exit 0; fi\n" +
+		"exit 0\n"
+	writeExecutable(t, filepath.Join(bin, "pyenv"), pyenv)
+	t.Setenv("PATH", bin)
+
+	got := provisionViaPyenv(">=3.12")
+	want := filepath.Join(root, "versions", "3.12.5", "bin", "python")
+	if got != want {
+		t.Fatalf("provisionViaPyenv(>=3.12) = %q; want the highest satisfying %q", got, want)
+	}
+	if provisionViaPyenv(">=3.13") != "" {
+		t.Fatal("provisionViaPyenv(>=3.13) should find nothing installed")
+	}
+}
+
+// TestInstallPythonDependencies_ProvisionsForRequiresPython drives the public
+// API through the requires-python interpreter-selection branch: a pyproject
+// declaring >=3.12 with a satisfying ambient python must build the venv.
+func TestInstallPythonDependencies_ProvisionsForRequiresPython(t *testing.T) {
+	bin := t.TempDir()
+	stubVenvPython(t, bin, "python3", "3.12.5")
+	// Keep coreutils on PATH for the stub's mkdir/chmod; ambient already
+	// satisfies, so uv/pyenv are never consulted.
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	pkg := t.TempDir()
+	writeFile(t, pkg, "pyproject.toml", "[project]\nname = \"demo\"\nrequires-python = \">=3.12\"\n")
+
+	if err := InstallPythonDependencies(pkg, nil, nil); err != nil {
+		t.Fatalf("InstallPythonDependencies: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(pkg, "venv", "bin", "pip")); err != nil {
+		t.Fatalf("expected a venv built via the requires-python-satisfying interpreter: %v", err)
+	}
+}
+
+// --- test helpers ---
+
+// stubVenvPython writes an interpreter that reports `version` for -c and
+// creates a venv (with a no-op pip) for `-m venv`. Returns its full path.
+func stubVenvPython(t *testing.T, dir, name, version string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"-c\" ]; then echo \"" + version + "\"; exit 0; fi\n" +
+		"if [ \"$1\" = \"-m\" ] && [ \"$2\" = \"venv\" ]; then\n" +
+		"  mkdir -p \"$3/bin\"\n" +
+		"  printf '#!/bin/sh\\nexit 0\\n' > \"$3/bin/pip\"\n" +
+		"  chmod +x \"$3/bin/pip\"\n" +
+		"fi\n" +
+		"exit 0\n"
+	writeExecutable(t, p, script)
+	return p
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// stubPython writes an executable named `name` in dir that answers
+// `-c "import sys;..."` with the given version. Returns its full path.
+func stubPython(t *testing.T, dir, name, version string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"-c\" ]; then echo \"" + version + "\"; exit 0; fi\n" +
+		"exit 0\n"
+	if err := os.WriteFile(p, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// stubUv writes a fake `uv` that returns findPath for `uv python find ...`.
+func stubUv(t *testing.T, dir, findPath string) {
+	t.Helper()
+	p := filepath.Join(dir, "uv")
+	script := "#!/bin/sh\n" +
+		"if [ \"$2\" = \"find\" ]; then echo \"" + findPath + "\"; fi\n" +
+		"exit 0\n"
+	if err := os.WriteFile(p, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Problem

`af install` builds each node's per-node venv with whatever `python3` happens to be on `PATH`, then lets `pip` enforce the package's `requires-python`. When the ambient interpreter is too old, the install dies with a raw pip trace and no next step:

```
ERROR: Package 'swe-af' requires a different Python: 3.10.13 not in '>=3.12'
Error: failed to install dependencies: failed to install project (pip install .): exit status 1
```

This is exactly what happens installing **SWE-AF** (`requires-python = ">=3.12"`) on a host whose default `python3` is 3.10 — the flow is supposed to be a one-command `af install`, but the user is left to figure out interpreter management on their own.

## Fix

Select the interpreter used to build the venv based on the node's declared `requires-python`, provisioning a compatible one instead of failing:

1. **Ambient first** — if `python3`/`python` already satisfies the constraint (or the node declares none), use it. Behavior is unchanged for the common case.
2. **uv** — otherwise, provision via `uv` (`uv python install`/`find`), which auto-downloads a standalone CPython. No compiler, seconds not minutes.
3. **pyenv** — otherwise, discover a matching already-installed pyenv version (discovery only — never triggers a source build).
4. **Actionable error** — if none is available, fail with a message naming the required and found versions and how to fix it, instead of a raw pip trace.

`requires-python` is read from `pyproject.toml` via `go-toml/v2` (promoted from an existing indirect dep to direct). An empty/unparseable constraint never blocks installation.

## Validation

**End-to-end, reproducing the original failure condition** (ambient `python3` = 3.10.13, the version that failed):

```
🐍 Provisioned Python 3.12.10 via uv (node requires ">=3.12")
  ✓ Dependencies installed
✅ Package installed successfully
```

The venv was built with Python 3.12.10 and `af install https://github.com/Agent-Field/SWE-AF` — which previously failed — now completes.

**Tests** (`internal/packages/pyinterp_test.go`, contract-derived): version parsing, PEP 440-style constraint evaluation (`>= > <= < == != ~=` and `==X.Y.*`), the SWE-AF `3.10 ∉ >=3.12` repro, `requires-python` extraction, and hermetic `resolveVenvInterpreter` cases (ambient-satisfies, incompatible→actionable error, uv-provision, pyenv discovery) using PATH-stubbed interpreters. Package coverage 90.6%.

`go build ./...` clean, `internal/packages` suite green, `golangci-lint` clean on the changed files.

> Note: two unrelated tests fail on this machine (`TestDevServiceRunDev`, `TestStartAndStopCoverAdditionalBranches`) — both also fail on clean `origin/main` here (the former scans ports 8001–8999 and collides with locally-running containers). Neither touches this code path.

## Follow-ups (not in this PR)

- `af dev` builds its venv through a separate code path; it could reuse this resolver.
- Consider surfacing "provisioning Python X" earlier in the install spinner output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
