### PR TITLE
feat(cli): require_one_of env-var groups for agent nodes

### DIFF
--- a/control-plane/internal/core/services/coverage_additional_test.go
+++ b/control-plane/internal/core/services/coverage_additional_test.go
@@ -325,10 +325,17 @@ exit 0
 		assert.Equal(t, statusError, service.statusError())
 
 		t.Setenv("OPTIONAL_KEY", "configured")
+		t.Setenv("PROVIDER_B", "set") // satisfies the second group
 		metadata := &packages.PackageMetadata{
 			Name: "env-agent",
 			UserEnvironment: packages.UserEnvironmentConfig{
 				Required: []packages.UserEnvironmentVar{{Name: "REQUIRED_KEY"}},
+				RequireOneOf: []packages.RequireOneOfGroup{
+					// Unsatisfied group (no option set), empty description → default label.
+					{ID: "g1", Options: []packages.UserEnvironmentVar{{Name: "PROVIDER_A1"}, {Name: "PROVIDER_A2"}}},
+					// Satisfied group (PROVIDER_B is set) → skipped.
+					{ID: "g2", Description: "second provider", Options: []packages.UserEnvironmentVar{{Name: "PROVIDER_B"}}},
+				},
 				Optional: []packages.UserEnvironmentVar{{Name: "OPTIONAL_KEY", Description: "optional", Default: "fallback"}},
 			},
 		}

--- a/control-plane/internal/core/services/package_service.go
+++ b/control-plane/internal/core/services/package_service.go
@@ -610,13 +610,14 @@ func (ps *DefaultPackageService) updateRegistry(metadata *packages.PackageMetada
 
 // checkEnvironmentVariables checks for required environment variables and provides setup guidance
 func (ps *DefaultPackageService) checkEnvironmentVariables(metadata *packages.PackageMetadata) {
-	if len(metadata.UserEnvironment.Required) == 0 && len(metadata.UserEnvironment.Optional) == 0 {
+	env := metadata.UserEnvironment
+	if len(env.Required) == 0 && len(env.RequireOneOf) == 0 && len(env.Optional) == 0 {
 		return // No user environment variables configured
 	}
 
 	// Check required environment variables
 	missingRequired := []packages.UserEnvironmentVar{}
-	for _, envVar := range metadata.UserEnvironment.Required {
+	for _, envVar := range env.Required {
 		if os.Getenv(envVar.Name) == "" {
 			missingRequired = append(missingRequired, envVar)
 		}
@@ -626,6 +627,29 @@ func (ps *DefaultPackageService) checkEnvironmentVariables(metadata *packages.Pa
 		fmt.Printf("\n%s %s\n", ps.yellow("⚠"), ps.bold("Missing required environment variables:"))
 		for _, envVar := range missingRequired {
 			fmt.Printf("  %s\n", ps.cyan(fmt.Sprintf("af secrets set %s", envVar.Name)))
+		}
+		fmt.Printf("  %s\n", ps.gray("(or you'll be prompted on first 'af run')"))
+	}
+
+	// Check require_one_of groups (at least one option must be set).
+	for _, g := range env.RequireOneOf {
+		satisfied := false
+		for _, opt := range g.Options {
+			if os.Getenv(opt.Name) != "" {
+				satisfied = true
+				break
+			}
+		}
+		if satisfied {
+			continue
+		}
+		label := g.Description
+		if label == "" {
+			label = "one of these"
+		}
+		fmt.Printf("\n%s %s (%s):\n", ps.yellow("⚠"), ps.bold("Set at least one of"), label)
+		for _, opt := range g.Options {
+			fmt.Printf("  %s\n", ps.cyan(fmt.Sprintf("af secrets set %s", opt.Name)))
 		}
 		fmt.Printf("  %s\n", ps.gray("(or you'll be prompted on first 'af run')"))
 	}

--- a/control-plane/internal/packages/env_resolver.go
+++ b/control-plane/internal/packages/env_resolver.go
@@ -68,7 +68,11 @@ func (r *EnvResolver) Resolve(env UserEnvironmentConfig) (map[string]string, err
 	}
 
 	for _, g := range env.RequireOneOf {
-		if r.resolveGroupFromSources(g, resolved) {
+		satisfied, err := r.resolveGroupFromSources(g, resolved)
+		if err != nil {
+			return nil, err
+		}
+		if satisfied {
 			continue
 		}
 		if r.Prompter == nil || !r.Prompter.Interactive() {
@@ -139,17 +143,21 @@ func (r *EnvResolver) promptAndStore(v UserEnvironmentVar) (string, error) {
 }
 
 // resolveGroupFromSources injects every option of a require_one_of group that is
-// already available (env/store/default) and reports whether at least one was.
-func (r *EnvResolver) resolveGroupFromSources(g RequireOneOfGroup, resolved map[string]string) bool {
+// already available (env/store/default) and reports whether at least one was. A
+// store read failure aborts, consistent with required/optional resolution.
+func (r *EnvResolver) resolveGroupFromSources(g RequireOneOfGroup, resolved map[string]string) (bool, error) {
 	found := false
 	for _, opt := range g.Options {
 		val, err := r.lookup(opt)
-		if err == nil && val != "" {
+		if err != nil {
+			return false, err
+		}
+		if val != "" {
 			resolved[opt.Name] = val
 			found = true
 		}
 	}
-	return found
+	return found, nil
 }
 
 // promptGroup asks the user to fill in one option of a require_one_of group,

--- a/control-plane/internal/packages/env_resolver.go
+++ b/control-plane/internal/packages/env_resolver.go
@@ -2,6 +2,7 @@ package packages
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -36,68 +37,160 @@ type EnvResolver struct {
 //  3. manifest default
 //  4. (required only) prompt the user, validate, and persist encrypted
 //
-// Required variables that remain unset after prompting (or in a non-interactive
-// session) are returned as a list of missing names alongside an error.
+// require_one_of groups are satisfied when at least one option resolves; when
+// none is set in an interactive session the user is asked to fill one in.
+//
+// Required variables (or groups) that remain unset after prompting (or in a
+// non-interactive session) produce an error naming what is missing.
 func (r *EnvResolver) Resolve(env UserEnvironmentConfig) (map[string]string, error) {
 	resolved := map[string]string{}
 	var missing []string
-
-	resolveOne := func(v UserEnvironmentVar, required bool) error {
-		// 1. Process environment wins and is never written to disk.
-		if val, ok := os.LookupEnv(v.Name); ok && val != "" {
-			resolved[v.Name] = val
-			return nil
-		}
-		// 2. Secret store (node overrides global).
-		if val, ok, err := r.Store.Get(r.NodeName, v.Name); err != nil {
-			return err
-		} else if ok {
-			resolved[v.Name] = val
-			return nil
-		}
-		// 3. Manifest default.
-		if v.Default != "" {
-			resolved[v.Name] = v.Default
-			return nil
-		}
-		if !required {
-			return nil // optional and unset: leave it out
-		}
-		// 4. Prompt (required only).
-		if r.Prompter == nil || !r.Prompter.Interactive() {
-			missing = append(missing, v.Name)
-			return nil
-		}
-		val, err := r.promptAndValidate(v)
-		if err != nil {
-			return err
-		}
-		if val == "" {
-			missing = append(missing, v.Name)
-			return nil
-		}
-		if err := r.Store.Set(v.SecretScope(r.NodeName), v.Name, val); err != nil {
-			return fmt.Errorf("failed to save %s: %w", v.Name, err)
-		}
-		resolved[v.Name] = val
-		return nil
-	}
+	var missingGroups []RequireOneOfGroup
 
 	for _, v := range env.Required {
-		if err := resolveOne(v, true); err != nil {
+		val, err := r.lookup(v)
+		if err != nil {
 			return nil, err
 		}
-	}
-	for _, v := range env.Optional {
-		if err := resolveOne(v, false); err != nil {
+		if val != "" {
+			resolved[v.Name] = val
+			continue
+		}
+		got, err := r.promptAndStore(v)
+		if err != nil {
 			return nil, err
+		}
+		if got == "" {
+			missing = append(missing, v.Name)
+		} else {
+			resolved[v.Name] = got
 		}
 	}
 
-	if len(missing) > 0 {
-		return nil, fmt.Errorf("missing required environment variables: %s", strings.Join(missing, ", "))
+	for _, g := range env.RequireOneOf {
+		if r.resolveGroupFromSources(g, resolved) {
+			continue
+		}
+		if r.Prompter == nil || !r.Prompter.Interactive() {
+			missingGroups = append(missingGroups, g)
+			continue
+		}
+		got, err := r.promptGroup(g, resolved)
+		if err != nil {
+			return nil, err
+		}
+		if !got {
+			missingGroups = append(missingGroups, g)
+		}
+	}
+
+	for _, v := range env.Optional {
+		val, err := r.lookup(v)
+		if err != nil {
+			return nil, err
+		}
+		if val != "" {
+			resolved[v.Name] = val
+		}
+	}
+
+	if len(missing) > 0 || len(missingGroups) > 0 {
+		return nil, missingEnvError(missing, missingGroups)
 	}
 	return resolved, nil
+}
+
+// lookup resolves a variable from the process environment, the secret store
+// (node overriding global), then its manifest default — without prompting.
+// It returns "" when the variable is unset from all of those sources.
+func (r *EnvResolver) lookup(v UserEnvironmentVar) (string, error) {
+	if val, ok := os.LookupEnv(v.Name); ok && val != "" {
+		return val, nil
+	}
+	if val, ok, err := r.Store.Get(r.NodeName, v.Name); err != nil {
+		return "", err
+	} else if ok {
+		return val, nil
+	}
+	if v.Default != "" {
+		return v.Default, nil
+	}
+	return "", nil
+}
+
+// promptAndStore prompts for a variable (interactive only), persists the value
+// encrypted, and returns it. It returns "" when there is no interactive prompt
+// or the user skips.
+func (r *EnvResolver) promptAndStore(v UserEnvironmentVar) (string, error) {
+	if r.Prompter == nil || !r.Prompter.Interactive() {
+		return "", nil
+	}
+	val, err := r.promptAndValidate(v)
+	if err != nil {
+		return "", err
+	}
+	if val == "" {
+		return "", nil
+	}
+	if err := r.Store.Set(v.SecretScope(r.NodeName), v.Name, val); err != nil {
+		return "", fmt.Errorf("failed to save %s: %w", v.Name, err)
+	}
+	return val, nil
+}
+
+// resolveGroupFromSources injects every option of a require_one_of group that is
+// already available (env/store/default) and reports whether at least one was.
+func (r *EnvResolver) resolveGroupFromSources(g RequireOneOfGroup, resolved map[string]string) bool {
+	found := false
+	for _, opt := range g.Options {
+		val, err := r.lookup(opt)
+		if err == nil && val != "" {
+			resolved[opt.Name] = val
+			found = true
+		}
+	}
+	return found
+}
+
+// promptGroup asks the user to fill in one option of a require_one_of group,
+// persisting the first non-empty answer. Options are offered in order; leaving
+// one blank moves on to the next alternative.
+func (r *EnvResolver) promptGroup(g RequireOneOfGroup, resolved map[string]string) (bool, error) {
+	desc := g.Description
+	if desc == "" {
+		desc = "one of the following"
+	}
+	fmt.Printf("  This node needs %s — fill in one, leave the rest blank:\n    %s\n",
+		desc, strings.Join(g.OptionNames(), "  |  "))
+
+	for _, opt := range g.Options {
+		val, err := r.promptAndValidate(opt)
+		if err != nil {
+			return false, err
+		}
+		if val == "" {
+			continue
+		}
+		if err := r.Store.Set(opt.SecretScope(r.NodeName), opt.Name, val); err != nil {
+			return false, fmt.Errorf("failed to save %s: %w", opt.Name, err)
+		}
+		resolved[opt.Name] = val
+		return true, nil
+	}
+	return false, nil
+}
+
+// missingEnvError formats a single error covering unset required variables and
+// any unsatisfied require_one_of groups.
+func missingEnvError(missing []string, groups []RequireOneOfGroup) error {
+	var parts []string
+	if len(missing) > 0 {
+		parts = append(parts, "missing required environment variables: "+strings.Join(missing, ", "))
+	}
+	for _, g := range groups {
+		parts = append(parts, "at least one of ["+strings.Join(g.OptionNames(), " | ")+"] is required")
+	}
+	return errors.New(strings.Join(parts, "; "))
 }
 
 // promptAndValidate prompts until the value satisfies the variable's validation

--- a/control-plane/internal/packages/env_resolver_group_test.go
+++ b/control-plane/internal/packages/env_resolver_group_test.go
@@ -1,0 +1,103 @@
+package packages
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func llmGroupCfg() UserEnvironmentConfig {
+	return UserEnvironmentConfig{
+		RequireOneOf: []RequireOneOfGroup{{
+			ID:          "llm_provider",
+			Description: "an LLM provider key",
+			Options: []UserEnvironmentVar{
+				{Name: "ANTHROPIC_API_KEY", Type: "secret"},
+				{Name: "OPENROUTER_API_KEY", Type: "secret"},
+			},
+		}},
+	}
+}
+
+// Contract: a store read failure while resolving a require_one_of group aborts
+// the whole resolve — same as for required/optional variables.
+func TestResolve_OneOfGroupStoreReadErrorAborts(t *testing.T) {
+	r := resolverWithBrokenScope(t, "swe-planner", &fakePrompter{interactive: true})
+	if _, err := r.Resolve(llmGroupCfg()); err == nil {
+		t.Fatal("expected Resolve to fail when the store cannot be read for a group option")
+	}
+}
+
+// Contract: when the chosen group option cannot be persisted, Resolve surfaces
+// the save error.
+func TestResolve_OneOfGroupPersistErrorSurfaces(t *testing.T) {
+	home := t.TempDir()
+	store, err := NewSecretStoreWithProvider(home, fixedProvider{pass: "test-pass-phrase"})
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	secretsDir := filepath.Join(home, "secrets")
+	if err := os.MkdirAll(secretsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(secretsDir, 0o500); err != nil { // read-only: writes fail
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(secretsDir, 0o700) }()
+
+	r := &EnvResolver{
+		Store:    store,
+		NodeName: "swe-planner",
+		Prompter: &fakePrompter{interactive: true, answers: map[string]string{"OPENROUTER_API_KEY": "sk-or"}},
+	}
+	_, err = r.Resolve(llmGroupCfg())
+	if err == nil || !strings.Contains(err.Error(), "failed to save") {
+		t.Fatalf("expected save error, got %v", err)
+	}
+}
+
+// Contract: a non-interactive session missing both a required var and a group
+// reports both in one error.
+func TestResolve_MissingRequiredAndGroupCombined(t *testing.T) {
+	cfg := llmGroupCfg()
+	cfg.Required = []UserEnvironmentVar{{Name: "GH_TOKEN", Type: "secret"}}
+	r := newResolver(t, "swe-planner", &fakePrompter{interactive: false})
+	_, err := r.Resolve(cfg)
+	if err == nil {
+		t.Fatal("expected error for missing required var and group")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "GH_TOKEN") || !strings.Contains(msg, "ANTHROPIC_API_KEY") {
+		t.Fatalf("error should mention both the missing required var and the group: %q", msg)
+	}
+}
+
+// Contract: the install-time warning lists an unsatisfied require_one_of group
+// and skips a satisfied one, without touching required-only output paths.
+func TestCheckEnvironmentVariables_ShowsGroups(t *testing.T) {
+	t.Setenv("SET_PROVIDER", "yes") // satisfies the second group
+	pi := &PackageInstaller{}
+	pi.checkEnvironmentVariables(&PackageMetadata{
+		Name: "llm-node",
+		UserEnvironment: UserEnvironmentConfig{
+			Required: []UserEnvironmentVar{{Name: "UNSET_REQUIRED"}},
+			RequireOneOf: []RequireOneOfGroup{
+				{ID: "g1", Options: []UserEnvironmentVar{{Name: "A1"}, {Name: "A2"}}}, // unsatisfied, empty desc
+				{ID: "g2", Description: "second", Options: []UserEnvironmentVar{{Name: "SET_PROVIDER"}}}, // satisfied
+			},
+			Optional: []UserEnvironmentVar{{Name: "OPT", Default: "d"}},
+		},
+	})
+}
+
+func TestEnvGroupSatisfied(t *testing.T) {
+	g := RequireOneOfGroup{Options: []UserEnvironmentVar{{Name: "GK1"}, {Name: "GK2"}}}
+	if envGroupSatisfied(g) {
+		t.Fatal("group with no options set should be unsatisfied")
+	}
+	t.Setenv("GK2", "v")
+	if !envGroupSatisfied(g) {
+		t.Fatal("group with one option set should be satisfied")
+	}
+}

--- a/control-plane/internal/packages/env_resolver_test.go
+++ b/control-plane/internal/packages/env_resolver_test.go
@@ -1,6 +1,7 @@
 package packages
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -162,6 +163,125 @@ func TestResolve_ValidationRegexRejectsThenAccepts(t *testing.T) {
 	}
 	if got["CODE"] != "GOOD123" {
 		t.Fatalf("CODE = %q, want GOOD123", got["CODE"])
+	}
+}
+
+// llmGroup is the motivating require_one_of case: an Anthropic key OR an
+// OpenRouter key, at least one required.
+func llmGroup() UserEnvironmentConfig {
+	return UserEnvironmentConfig{
+		RequireOneOf: []RequireOneOfGroup{{
+			ID:          "llm_provider",
+			Description: "an LLM provider key",
+			Options: []UserEnvironmentVar{
+				{Name: "ANTHROPIC_API_KEY", Type: "secret"},
+				{Name: "OPENROUTER_API_KEY", Type: "secret"},
+			},
+		}},
+	}
+}
+
+// Contract: a require_one_of group is satisfied when one option is in the
+// environment; the other option is not required and not prompted.
+func TestResolve_OneOfSatisfiedByEnv(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "sk-or-env")
+	p := &fakePrompter{interactive: true}
+	r := newResolver(t, "swe-planner", p)
+
+	got, err := r.Resolve(llmGroup())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got["OPENROUTER_API_KEY"] != "sk-or-env" {
+		t.Fatalf("group option not injected: %v", got)
+	}
+	if _, ok := got["ANTHROPIC_API_KEY"]; ok {
+		t.Fatalf("the other option must not be set")
+	}
+	if len(p.asked) != 0 {
+		t.Fatalf("a satisfied group must not prompt, asked=%v", p.asked)
+	}
+}
+
+// Contract: a satisfied group's stored option is reused non-interactively.
+func TestResolve_OneOfSatisfiedByStore(t *testing.T) {
+	store, _ := NewSecretStore(t.TempDir())
+	if err := store.Set("global", "ANTHROPIC_API_KEY", "sk-ant-stored"); err != nil {
+		t.Fatal(err)
+	}
+	r := &EnvResolver{Store: store, NodeName: "swe-planner", Prompter: &fakePrompter{interactive: false}}
+	got, err := r.Resolve(llmGroup())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got["ANTHROPIC_API_KEY"] != "sk-ant-stored" {
+		t.Fatalf("stored group option not reused: %v", got)
+	}
+}
+
+// Contract: an unsatisfied group in a non-interactive session errors, naming
+// every option so the caller knows the alternatives.
+func TestResolve_OneOfNonInteractiveErrorsNamingOptions(t *testing.T) {
+	r := newResolver(t, "swe-planner", &fakePrompter{interactive: false})
+	_, err := r.Resolve(llmGroup())
+	if err == nil {
+		t.Fatal("expected error for unsatisfied require_one_of group")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "ANTHROPIC_API_KEY") || !strings.Contains(msg, "OPENROUTER_API_KEY") {
+		t.Fatalf("error should name both options: %q", msg)
+	}
+}
+
+// Contract: interactively, filling in one option (leaving the other blank)
+// satisfies the group and persists just that option encrypted.
+func TestResolve_OneOfPromptFillsOneAndPersists(t *testing.T) {
+	// User skips Anthropic (empty answer), provides OpenRouter.
+	p := &fakePrompter{interactive: true, answers: map[string]string{"OPENROUTER_API_KEY": "sk-or-prompted"}}
+	r := newResolver(t, "swe-planner", p)
+
+	got, err := r.Resolve(llmGroup())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got["OPENROUTER_API_KEY"] != "sk-or-prompted" {
+		t.Fatalf("chosen option not resolved: %v", got)
+	}
+	if _, ok := got["ANTHROPIC_API_KEY"]; ok {
+		t.Fatalf("skipped option must not be set")
+	}
+	if v, ok, _ := r.Store.Get("swe-planner", "OPENROUTER_API_KEY"); !ok || v != "sk-or-prompted" {
+		t.Fatalf("chosen option not persisted encrypted")
+	}
+	if _, ok, _ := r.Store.Get("swe-planner", "ANTHROPIC_API_KEY"); ok {
+		t.Fatalf("skipped option must not be persisted")
+	}
+}
+
+// Contract: if the user skips every option, the group stays unsatisfied and
+// Resolve errors.
+func TestResolve_OneOfPromptAllSkippedErrors(t *testing.T) {
+	p := &fakePrompter{interactive: true, answers: map[string]string{}} // all answers empty
+	r := newResolver(t, "swe-planner", p)
+	if _, err := r.Resolve(llmGroup()); err == nil {
+		t.Fatal("expected error when every group option is skipped")
+	}
+}
+
+// Contract: required vars and groups coexist — a set required var plus a
+// satisfied group both resolve.
+func TestResolve_RequiredAndGroupTogether(t *testing.T) {
+	t.Setenv("GH_TOKEN", "ghp_x")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant")
+	cfg := llmGroup()
+	cfg.Required = []UserEnvironmentVar{{Name: "GH_TOKEN", Type: "secret"}}
+	r := newResolver(t, "swe-planner", &fakePrompter{interactive: false})
+	got, err := r.Resolve(cfg)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got["GH_TOKEN"] != "ghp_x" || got["ANTHROPIC_API_KEY"] != "sk-ant" {
+		t.Fatalf("required+group not both resolved: %v", got)
 	}
 }
 

--- a/control-plane/internal/packages/installer.go
+++ b/control-plane/internal/packages/installer.go
@@ -34,10 +34,31 @@ func (v UserEnvironmentVar) SecretScope(nodeName string) string {
 	return globalScope
 }
 
-// UserEnvironmentConfig represents user-configurable environment variables
+// RequireOneOfGroup is a set of alternative variables where at least one must be
+// provided (e.g. an Anthropic key OR an OpenRouter key). The group is satisfied
+// as soon as any one of its Options resolves to a value.
+type RequireOneOfGroup struct {
+	ID          string               `yaml:"id"`
+	Description string               `yaml:"description"`
+	Options     []UserEnvironmentVar `yaml:"options"`
+}
+
+// OptionNames returns the option variable names in declaration order.
+func (g RequireOneOfGroup) OptionNames() []string {
+	names := make([]string, len(g.Options))
+	for i, o := range g.Options {
+		names[i] = o.Name
+	}
+	return names
+}
+
+// UserEnvironmentConfig represents user-configurable environment variables.
+// Required vars must all be set; each RequireOneOf group needs at least one of
+// its options; Optional vars fall back to their default.
 type UserEnvironmentConfig struct {
-	Required []UserEnvironmentVar `yaml:"required"`
-	Optional []UserEnvironmentVar `yaml:"optional"`
+	Required     []UserEnvironmentVar `yaml:"required"`
+	RequireOneOf []RequireOneOfGroup  `yaml:"require_one_of"`
+	Optional     []UserEnvironmentVar `yaml:"optional"`
 }
 
 // PackageMetadata represents the structure of agentfield-package.yaml
@@ -271,14 +292,26 @@ func (pi *PackageInstaller) InstallPackage(sourcePath string, force bool) error 
 }
 
 // checkEnvironmentVariables checks for required environment variables and provides setup guidance
+// envGroupSatisfied reports whether at least one option of a require_one_of
+// group is present in the process environment.
+func envGroupSatisfied(g RequireOneOfGroup) bool {
+	for _, opt := range g.Options {
+		if os.Getenv(opt.Name) != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func (pi *PackageInstaller) checkEnvironmentVariables(metadata *PackageMetadata) {
-	if len(metadata.UserEnvironment.Required) == 0 && len(metadata.UserEnvironment.Optional) == 0 {
+	env := metadata.UserEnvironment
+	if len(env.Required) == 0 && len(env.RequireOneOf) == 0 && len(env.Optional) == 0 {
 		return // No user environment variables configured
 	}
 
 	// Check required environment variables
 	missingRequired := []UserEnvironmentVar{}
-	for _, envVar := range metadata.UserEnvironment.Required {
+	for _, envVar := range env.Required {
 		if os.Getenv(envVar.Name) == "" {
 			missingRequired = append(missingRequired, envVar)
 		}
@@ -288,6 +321,21 @@ func (pi *PackageInstaller) checkEnvironmentVariables(metadata *PackageMetadata)
 		fmt.Printf("\n%s %s\n", Yellow("⚠"), Bold("Missing required environment variables:"))
 		for _, envVar := range missingRequired {
 			fmt.Printf("  %s\n", Cyan(fmt.Sprintf("af config %s --set %s=your-value-here", metadata.Name, envVar.Name)))
+		}
+	}
+
+	// Check require_one_of groups (at least one option must be set).
+	for _, g := range env.RequireOneOf {
+		if envGroupSatisfied(g) {
+			continue
+		}
+		label := g.Description
+		if label == "" {
+			label = "one of these"
+		}
+		fmt.Printf("\n%s %s (%s):\n", Yellow("⚠"), Bold("Set at least one of"), label)
+		for _, opt := range g.Options {
+			fmt.Printf("  %s\n", Cyan(fmt.Sprintf("af config %s --set %s=your-value-here", metadata.Name, opt.Name)))
 		}
 	}
 

--- a/docs/installing-agent-nodes.md
+++ b/docs/installing-agent-nodes.md
@@ -58,16 +58,42 @@ dependencies:
 # Variables the node needs. Required ones are prompted for on first run and
 # remembered (encrypted). type: secret hides the input and stores it encrypted.
 user_environment:
-  required:
-    - name: OPENROUTER_API_KEY
-      description: LLM provider key
+  required:                     # every one of these must be set
+    - name: GH_TOKEN
+      description: GitHub token
       type: secret
       scope: global           # global (default) = shared across nodes; node = this node only
+  require_one_of:               # each group needs AT LEAST ONE option set
+    - id: llm_provider
+      description: an LLM provider key
+      options:
+        - name: ANTHROPIC_API_KEY
+          description: Anthropic key (Claude)
+          type: secret
+        - name: OPENROUTER_API_KEY
+          description: OpenRouter key (DeepSeek/Qwen/Llama/…)
+          type: secret
   optional:
     - name: PR_AF_MODEL
       description: Override the default model
       default: openrouter/moonshotai/kimi-k2
 ```
+
+### `require_one_of` — "at least one of these"
+
+Some nodes accept alternatives — e.g. either an Anthropic key **or** an
+OpenRouter key. List them under `require_one_of` as a group of `options`. A group
+is satisfied as soon as **one** option resolves (from the process environment,
+the secret store, or a manifest default).
+
+On `af run`, if no option of a group is set, you're asked to fill in one and
+leave the rest blank — the value you enter is validated and stored encrypted,
+exactly like a required secret. In a non-interactive session an unsatisfied group
+is a clean error listing the alternatives (`at least one of [ANTHROPIC_API_KEY |
+OPENROUTER_API_KEY] is required`) instead of a runtime failure inside the node.
+
+`required` (all must be set), `require_one_of` (at least one per group), and
+`optional` (falls back to `default`) can all be used together in one manifest.
 
 ### Python dependencies
 


### PR DESCRIPTION
## Problem

Agent-node manifests (`agentfield-package.yaml`) could only mark each user
environment variable as independently **required** or **optional**. There was no
way to say *"at least one of these"* — which is exactly what a node like SWE-AF
needs: it runs with **either** an `ANTHROPIC_API_KEY` **or** an
`OPENROUTER_API_KEY` (its code already supports both providers). Today its
manifest has to over-require one provider, or make both optional and let the node
fail opaquely at runtime.

## What this adds

A `require_one_of` section — a list of groups, each satisfied when **at least one**
of its options resolves:

```yaml
user_environment:
  required:                     # all must be set
    - name: GH_TOKEN
      type: secret
  require_one_of:               # each group needs one option
    - id: llm_provider
      description: an LLM provider key
      options:
        - name: ANTHROPIC_API_KEY
          type: secret
        - name: OPENROUTER_API_KEY
          type: secret
  optional:
    - name: LLM_MODEL
      default: openrouter/deepseek/deepseek-v4-flash
```

**Run-time (`af run`):** a group is resolved from the process env / encrypted
secret store / manifest default. If none is set and the session is interactive,
the user is asked to fill in one option and leave the rest blank — the value is
validated and **persisted encrypted**, exactly like an existing required secret.
Non-interactive → a clean error (`at least one of [ANTHROPIC_API_KEY |
OPENROUTER_API_KEY] is required`) instead of a failure inside the node.

**Install-time (`af install`):** unsatisfied groups are surfaced next to required
vars, so you know what to set.

`required` / `require_one_of` / `optional` compose in a single manifest. The
change is backward-compatible — manifests without `require_one_of` behave exactly
as before.

## Validation

Contract-derived tests in `env_resolver_test.go`: group satisfied by env / store,
non-interactive error naming options, interactive "fill one, skip the rest"
(persists only the chosen option), all-skipped error, and required+group
coexisting. All pre-existing resolver tests still pass (backward-compat).

End-to-end through the built binary — installing a local node with a
`require_one_of` group:

```
⚠ Missing required environment variables:
  af secrets set GH_TOKEN
⚠ Set at least one of (an LLM provider key):
  af secrets set ANTHROPIC_API_KEY
  af secrets set OPENROUTER_API_KEY
ℹ Optional environment variables (with defaults):
  LLM_MODEL:  (default: openrouter/deepseek/deepseek-v4-flash)
```

`go build ./...` clean; `internal/packages` + `internal/core/services` suites green; lint clean on changed lines.

## Follow-up (separate PR)

Update SWE-AF's `agentfield-package.yaml` to declare this `llm_provider` group
(Anthropic **or** OpenRouter) plus a `deepseek/deepseek-v4-flash` default on the
OpenRouter path — SWE-AF's code already supports both providers, so it's a
manifest-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
