### PR TITLE
feat(install): version the agentfield-package.yaml manifest schema (config_version)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,4 @@
 ## Learned Workspace Facts
 
 - Monorepo: Go control plane in `control-plane/`, SDKs in `sdk/`, embedded admin UI in `control-plane/web/client/`.
+- Agent-node manifests (`agentfield-package.yaml`) carry a `config_version` (schema version, e.g. `v1`; absent = `v0`) that is separate from the node's own `version:`. Bump `config_version` only for breaking format changes, never for additive fields. The single reader is `packages.ParsePackageMetadata` (`control-plane/internal/packages/installer.go`); the authoring contract lives in `docs/installing-agent-nodes.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,6 +252,12 @@ Storage interface is unified—services call storage layer methods, storage laye
 2. Config file (`config/agentfield.yaml` or `AGENTFIELD_CONFIG_FILE` path)
 3. Defaults in code
 
+### Agent-node manifest (`agentfield-package.yaml`)
+- Every installable node has this manifest at its repo root. It's parsed by `packages.ParsePackageMetadata` (`control-plane/internal/packages/installer.go`) — the single loader used by `af install`/`af run` and the package/agent services. Full authoring guide: [docs/installing-agent-nodes.md](docs/installing-agent-nodes.md); a real example is Agent-Field/SWE-AF's `agentfield-package.yaml`.
+- **`config_version`** declares the manifest *schema* version (e.g. `v1`) — distinct from `version:`, which is the node's own release. Absent means `v0` (legacy, pre-versioning). `CurrentConfigVersion` in `installer.go` is the highest version the binary reads; a manifest declaring a higher version is **refused** with an upgrade hint rather than mis-parsed. New manifests should set `config_version: v1`.
+- **When to bump `config_version`:** only for **breaking** format changes (a field renamed/removed, or its shape/meaning changed). Adding a new *optional* field is additive — `yaml.Unmarshal` ignores unknown keys and new readers fall back to defaults, so it does **not** need a bump. If you do change the format in a breaking way: bump `CurrentConfigVersion`, add a `case` in the `ParsePackageMetadata` version switch, and record the change in the version table in `docs/installing-agent-nodes.md`.
+- **Golden-fixture tests are the spec:** `control-plane/internal/packages/config_version_fixtures_test.go` holds one canonical manifest + structure assertion per version, with a coverage guard that fails CI if a version has no fixture. Maintenance rule (also documented in that file): grow the *current* version's fixture for additive fields; **add a net-new fixture** for a net-new version and **never rewrite old fixtures** into the new shape — they guard backwards compatibility.
+
 ### Agent-to-Agent Communication
 - Agents call each other via control plane: `await agent.call("other-agent.function", input={...})`
 - Control plane routes requests, tracks workflow DAG, injects metrics

--- a/control-plane/internal/packages/config_version_fixtures_test.go
+++ b/control-plane/internal/packages/config_version_fixtures_test.go
@@ -1,0 +1,248 @@
+package packages
+
+import (
+	"fmt"
+	"testing"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MAINTENANCE CONTRACT — read this before touching agentfield-package.yaml parsing
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// This file is the executable spec for the manifest schema version (`config_version`).
+// Each supported version has ONE golden fixture below: a canonical, fully-populated
+// agentfield-package.yaml plus an assertion of the exact structure the reader is
+// expected to extract from it. Keep these fixtures in lockstep with the human docs
+// in docs/installing-agent-nodes.md — if you change what a version means in the
+// docs, a fixture here should change too, and vice-versa.
+//
+// The rules, enforced by TestConfigVersionFixtureCoverage:
+//
+//  1. NET-NEW VERSION → NET-NEW FIXTURE. When you bump CurrentConfigVersion (a
+//     breaking format change), ADD a new versionFixture entry for it. The coverage
+//     guard fails until every version in [0, CurrentConfigVersion] has a fixture.
+//
+//  2. DON'T REWRITE OLD FIXTURES INTO THE NEW SHAPE. An older version's fixture is
+//     a backwards-compatibility guarantee: manifests authored at v(N) must keep
+//     parsing forever. Edit an old fixture only to keep it *valid* (e.g. a helper
+//     rename), never to migrate it to the new structure. The new structure belongs
+//     in the new version's fixture.
+//
+//  3. ADDITIVE CHANGES DON'T BUMP THE VERSION (so they don't get a new fixture).
+//     A new *optional* field is not breaking — extend the CURRENT version's fixture
+//     to cover it and assert the reader picks it up. Reserve version bumps (and new
+//     fixtures) for changes that alter or remove existing fields.
+//
+// So: growing the current format = edit the current fixture. Breaking the format =
+// bump CurrentConfigVersion + add a fixture. Old fixtures are append-only history.
+
+// versionFixture is one golden agentfield-package.yaml sample for a schema version,
+// paired with an assertion of the structure a correct reader extracts from it.
+type versionFixture struct {
+	version int
+	// sample is a complete, representative manifest for this schema version. It
+	// should exercise every section a reader is expected to understand at this
+	// version so the test genuinely proves structure extraction, not just that the
+	// file parses.
+	sample string
+	// verify asserts the parsed structure matches what this version promises.
+	verify func(t *testing.T, md *PackageMetadata)
+}
+
+// versionFixtures holds exactly one entry per supported config_version. Append a
+// new entry when CurrentConfigVersion is bumped; never delete or migrate an entry.
+var versionFixtures = []versionFixture{
+	{
+		// v0 — the original, pre-versioning format: no `config_version` key at all.
+		// This fixture guards that legacy manifests keep parsing unchanged forever.
+		version: 0,
+		sample: `name: legacy-node
+version: 0.1.0
+description: A node authored before config_version existed
+author: Agent-Field
+entrypoint:
+  start: python -m legacy_node.app
+  healthcheck: /healthz
+agent_node:
+  node_id: legacy-node
+  default_port: 8010
+dependencies:
+  python:
+    - httpx>=0.27
+  nodes:
+    - af://registry/swe-planner
+user_environment:
+  required:
+    - name: OPENROUTER_API_KEY
+      description: LLM provider key
+      type: secret
+      scope: global
+  optional:
+    - name: LEGACY_MODEL
+      description: Override the model
+      default: openrouter/moonshotai/kimi-k2
+`,
+		verify: func(t *testing.T, md *PackageMetadata) {
+			t.Helper()
+			if md.ConfigVersion != "" {
+				t.Errorf("v0 fixture should omit config_version, got %q", md.ConfigVersion)
+			}
+			if md.Name != "legacy-node" || md.Version != "0.1.0" {
+				t.Errorf("basics: name=%q version=%q", md.Name, md.Version)
+			}
+			if md.Entrypoint.Start != "python -m legacy_node.app" {
+				t.Errorf("entrypoint.start = %q", md.Entrypoint.Start)
+			}
+			if got := md.HealthcheckPath(); got != "/healthz" {
+				t.Errorf("HealthcheckPath() = %q, want /healthz", got)
+			}
+			if md.AgentNode.NodeID != "legacy-node" || md.AgentNode.DefaultPort != 8010 {
+				t.Errorf("agent_node = %+v", md.AgentNode)
+			}
+			if len(md.Dependencies.Python) != 1 || md.Dependencies.Python[0] != "httpx>=0.27" {
+				t.Errorf("dependencies.python = %v", md.Dependencies.Python)
+			}
+			if len(md.Dependencies.Nodes) != 1 || md.Dependencies.Nodes[0] != "af://registry/swe-planner" {
+				t.Errorf("dependencies.nodes = %v", md.Dependencies.Nodes)
+			}
+			if len(md.UserEnvironment.Required) != 1 {
+				t.Fatalf("expected 1 required env var, got %d", len(md.UserEnvironment.Required))
+			}
+			req := md.UserEnvironment.Required[0]
+			if req.Name != "OPENROUTER_API_KEY" || req.Type != "secret" || req.SecretScope("legacy-node") != "global" {
+				t.Errorf("required[0] = %+v (scope=%s)", req, req.SecretScope("legacy-node"))
+			}
+			if len(md.UserEnvironment.Optional) != 1 || md.UserEnvironment.Optional[0].Default != "openrouter/moonshotai/kimi-k2" {
+				t.Errorf("optional = %+v", md.UserEnvironment.Optional)
+			}
+		},
+	},
+	{
+		// v1 — same fields as v0, now explicitly versioned. Mirrors the documented
+		// example in docs/installing-agent-nodes.md. Extend THIS fixture when the
+		// current format grows an additive optional field.
+		version: 1,
+		sample: `config_version: v1
+name: pr-af
+version: 0.2.0
+description: Opens draft PRs from a task description
+author: Agent-Field
+entrypoint:
+  start: python -m pr_af.app
+  healthcheck: /health
+agent_node:
+  node_id: pr-af
+  default_port: 8004
+dependencies:
+  python:
+    - httpx>=0.27
+  nodes:
+    - af://registry/swe-planner
+user_environment:
+  required:
+    - name: GH_TOKEN
+      description: GitHub token
+      type: secret
+      scope: global
+  require_one_of:
+    - id: llm_provider
+      description: an LLM provider key
+      options:
+        - name: ANTHROPIC_API_KEY
+          description: Anthropic key (Claude)
+          type: secret
+        - name: OPENROUTER_API_KEY
+          description: OpenRouter key
+          type: secret
+  optional:
+    - name: PR_AF_MODEL
+      description: Override the default model
+      default: openrouter/moonshotai/kimi-k2
+`,
+		verify: func(t *testing.T, md *PackageMetadata) {
+			t.Helper()
+			if md.ConfigVersion != "v1" {
+				t.Errorf("v1 fixture should declare config_version: v1, got %q", md.ConfigVersion)
+			}
+			if md.Name != "pr-af" || md.Version != "0.2.0" {
+				t.Errorf("basics: name=%q version=%q", md.Name, md.Version)
+			}
+			if got := md.StartCommand(); len(got) == 0 || got[0] != "python" {
+				t.Errorf("StartCommand() = %v", got)
+			}
+			if md.AgentNode.NodeID != "pr-af" || md.AgentNode.DefaultPort != 8004 {
+				t.Errorf("agent_node = %+v", md.AgentNode)
+			}
+			if len(md.Dependencies.Nodes) != 1 || md.Dependencies.Nodes[0] != "af://registry/swe-planner" {
+				t.Errorf("dependencies.nodes = %v", md.Dependencies.Nodes)
+			}
+			if len(md.UserEnvironment.Required) != 1 || md.UserEnvironment.Required[0].Name != "GH_TOKEN" {
+				t.Errorf("required = %+v", md.UserEnvironment.Required)
+			}
+			// require_one_of is an additive field (added without a config_version
+			// bump): the current-version fixture must exercise that the reader
+			// extracts the group and its alternatives.
+			if len(md.UserEnvironment.RequireOneOf) != 1 {
+				t.Fatalf("expected 1 require_one_of group, got %d", len(md.UserEnvironment.RequireOneOf))
+			}
+			grp := md.UserEnvironment.RequireOneOf[0]
+			if grp.ID != "llm_provider" {
+				t.Errorf("require_one_of[0].id = %q", grp.ID)
+			}
+			if got := grp.OptionNames(); len(got) != 2 || got[0] != "ANTHROPIC_API_KEY" || got[1] != "OPENROUTER_API_KEY" {
+				t.Errorf("require_one_of[0] options = %v", got)
+			}
+			if len(md.UserEnvironment.Optional) != 1 || md.UserEnvironment.Optional[0].Name != "PR_AF_MODEL" {
+				t.Errorf("optional = %+v", md.UserEnvironment.Optional)
+			}
+		},
+	},
+}
+
+// TestConfigVersionFixtures parses each version's golden manifest through the real
+// reader and asserts the reader (a) treats it as the expected schema version and
+// (b) extracts the structure that version promises.
+func TestConfigVersionFixtures(t *testing.T) {
+	for _, fx := range versionFixtures {
+		fx := fx
+		t.Run(fmt.Sprintf("v%d", fx.version), func(t *testing.T) {
+			dir := t.TempDir()
+			writeTestPackage(t, dir, fx.sample)
+
+			md, err := ParsePackageMetadata(dir)
+			if err != nil {
+				t.Fatalf("v%d fixture failed to parse: %v", fx.version, err)
+			}
+			if got := md.ConfigVersionNumber(); got != fx.version {
+				t.Fatalf("reader saw config version v%d, fixture declares v%d", got, fx.version)
+			}
+			fx.verify(t, md)
+		})
+	}
+}
+
+// TestConfigVersionFixtureCoverage is the forcing function for the maintenance
+// contract at the top of this file: there must be exactly one fixture for every
+// version from 0 through CurrentConfigVersion, and none beyond it. Bumping
+// CurrentConfigVersion without adding the matching fixture fails here.
+func TestConfigVersionFixtureCoverage(t *testing.T) {
+	seen := map[int]bool{}
+	maxVer := 0
+	for _, fx := range versionFixtures {
+		if seen[fx.version] {
+			t.Errorf("duplicate fixture for v%d — one fixture per version", fx.version)
+		}
+		seen[fx.version] = true
+		if fx.version > maxVer {
+			maxVer = fx.version
+		}
+	}
+	for v := 0; v <= CurrentConfigVersion; v++ {
+		if !seen[v] {
+			t.Errorf("missing golden fixture for config_version v%d — add a versionFixture entry (see MAINTENANCE CONTRACT)", v)
+		}
+	}
+	if maxVer != CurrentConfigVersion {
+		t.Errorf("highest fixture is v%d but CurrentConfigVersion is v%d — fixtures and the reader are out of step", maxVer, CurrentConfigVersion)
+	}
+}

--- a/control-plane/internal/packages/config_version_test.go
+++ b/control-plane/internal/packages/config_version_test.go
@@ -1,0 +1,110 @@
+package packages
+
+import (
+	"strings"
+	"testing"
+)
+
+// Validation contract for the manifest schema version (config_version):
+//   - absent  -> v0 (legacy) and parses fine
+//   - "v1"    -> the current version, parses fine
+//   - a version newer than this binary understands is refused with a clear error
+//   - a malformed version fails loudly (not silently treated as v0)
+//   - the "v" prefix is optional/case-insensitive
+//   - a manifest at the current version tolerates fields the reader doesn't know
+//     (additive changes must not require a version bump)
+
+func TestParseConfigVersion(t *testing.T) {
+	cases := []struct {
+		raw     string
+		want    int
+		wantErr bool
+	}{
+		{"", 0, false},    // absent -> v0
+		{"  ", 0, false},  // whitespace -> v0
+		{"v0", 0, false},  // explicit v0
+		{"v1", 1, false},  // current
+		{"V1", 1, false},  // case-insensitive prefix
+		{"1", 1, false},   // bare integer accepted
+		{"v2", 2, false},  // parses (rejection happens against CurrentConfigVersion)
+		{"v1.0", 0, true}, // not an int form
+		{"latest", 0, true},
+		{"v-1", 0, true},
+	}
+	for _, c := range cases {
+		got, err := parseConfigVersion(c.raw)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("parseConfigVersion(%q): expected error, got %d", c.raw, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseConfigVersion(%q): unexpected error: %v", c.raw, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("parseConfigVersion(%q) = %d, want %d", c.raw, got, c.want)
+		}
+	}
+}
+
+func TestParsePackageMetadataConfigVersion(t *testing.T) {
+	t.Run("absent config_version reads as v0", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestPackage(t, dir, "name: legacy-node\nversion: 0.1.0\n")
+		md, err := ParsePackageMetadata(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := md.ConfigVersionNumber(); got != 0 {
+			t.Fatalf("ConfigVersionNumber() = %d, want 0", got)
+		}
+	})
+
+	t.Run("explicit v1 accepted", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestPackage(t, dir, "config_version: v1\nname: n\nversion: 0.1.0\n")
+		md, err := ParsePackageMetadata(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := md.ConfigVersionNumber(); got != 1 {
+			t.Fatalf("ConfigVersionNumber() = %d, want 1", got)
+		}
+	})
+
+	t.Run("future version rejected with a helpful error", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestPackage(t, dir, "config_version: v99\nname: n\nversion: 0.1.0\n")
+		_, err := ParsePackageMetadata(dir)
+		if err == nil {
+			t.Fatal("expected error for future config_version, got nil")
+		}
+		if !strings.Contains(err.Error(), "upgrade AgentField") {
+			t.Fatalf("error should tell the user to upgrade, got: %v", err)
+		}
+	})
+
+	t.Run("malformed version fails loudly", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestPackage(t, dir, "config_version: latest\nname: n\nversion: 0.1.0\n")
+		if _, err := ParsePackageMetadata(dir); err == nil {
+			t.Fatal("expected error for malformed config_version, got nil")
+		}
+	})
+
+	t.Run("additive unknown fields do not break the current-version reader", func(t *testing.T) {
+		dir := t.TempDir()
+		// A field this reader has never heard of must be ignored, not fatal —
+		// additive changes are allowed without a config_version bump.
+		writeTestPackage(t, dir, "config_version: v1\nname: n\nversion: 0.1.0\nsome_future_key: hello\n")
+		md, err := ParsePackageMetadata(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if md.Name != "n" {
+			t.Fatalf("Name = %q, want n", md.Name)
+		}
+	})
+}

--- a/control-plane/internal/packages/installer.go
+++ b/control-plane/internal/packages/installer.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -14,6 +15,40 @@ import (
 	"golang.org/x/term"
 	"gopkg.in/yaml.v3"
 )
+
+// CurrentConfigVersion is the highest agentfield-package.yaml schema version this
+// control plane knows how to read. A manifest may declare `config_version` up to
+// this value; anything higher was authored for a newer AgentField and is refused
+// rather than mis-parsed.
+//
+// When to bump this (and stamp manifests with the new version): ONLY when a change
+// is *breaking* — a field is renamed or removed, or its shape/meaning changes such
+// that an old reader would mis-handle a new manifest (or a new reader would
+// mis-handle an old one). Purely *additive* changes (new optional keys) do NOT
+// require a bump: yaml.Unmarshal ignores unknown keys, so old readers skip new
+// fields and new readers fall back to defaults. Keep this list of versions and
+// their breaking change in docs/installing-agent-nodes.md.
+const CurrentConfigVersion = 1
+
+// parseConfigVersion normalizes the manifest's `config_version` string to an int.
+//
+//   - absent / empty  -> 0  (v0: pre-versioning legacy manifests)
+//   - "v1", "V1", "1" -> 1  (the "v" prefix is optional and case-insensitive)
+//
+// Any other form is an error, so a typo fails loudly instead of silently reading
+// as v0.
+func parseConfigVersion(raw string) (int, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return 0, nil
+	}
+	s = strings.TrimPrefix(strings.ToLower(s), "v")
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("invalid config_version %q (expected a form like \"v1\")", raw)
+	}
+	return n, nil
+}
 
 // UserEnvironmentVar represents a user-configurable environment variable
 type UserEnvironmentVar struct {
@@ -64,6 +99,12 @@ type UserEnvironmentConfig struct {
 
 // PackageMetadata represents the structure of agentfield-package.yaml
 type PackageMetadata struct {
+	// ConfigVersion is the *schema* version of this manifest (e.g. "v1"), NOT the
+	// package's own release version (that is the Version field below). It lets the
+	// reader stay compatible as the manifest format evolves. Absent means "v0" —
+	// the pre-versioning format — which is read leniently. See CurrentConfigVersion
+	// for the bump policy (breaking changes only).
+	ConfigVersion   string                 `yaml:"config_version"`
 	Name            string                 `yaml:"name"`
 	Version         string                 `yaml:"version"`
 	Description     string                 `yaml:"description"`
@@ -552,6 +593,15 @@ func NodeDepName(ref string) string {
 	return ""
 }
 
+// ConfigVersionNumber returns the manifest's normalized schema version as an int
+// (absent/"v0" -> 0, "v1" -> 1). It ignores malformed values, returning 0; callers
+// that need to surface a parse error should go through ParsePackageMetadata, which
+// rejects both malformed and too-new versions.
+func (m *PackageMetadata) ConfigVersionNumber() int {
+	n, _ := parseConfigVersion(m.ConfigVersion)
+	return n
+}
+
 // HealthcheckPath returns the readiness path, defaulting to "/health".
 func (m *PackageMetadata) HealthcheckPath() string {
 	if p := strings.TrimSpace(m.Entrypoint.Healthcheck); p != "" {
@@ -572,6 +622,26 @@ func ParsePackageMetadata(dir string) (*PackageMetadata, error) {
 	var metadata PackageMetadata
 	if err := yaml.Unmarshal(data, &metadata); err != nil {
 		return nil, fmt.Errorf("failed to parse agentfield-package.yaml: %w", err)
+	}
+
+	// Version-dependent read: decide how to interpret the manifest from the schema
+	// version the author declared, so we don't mis-parse a format we don't know.
+	ver, err := parseConfigVersion(metadata.ConfigVersion)
+	if err != nil {
+		return nil, fmt.Errorf("agentfield-package.yaml: %w", err)
+	}
+	if ver > CurrentConfigVersion {
+		return nil, fmt.Errorf(
+			"agentfield-package.yaml declares config_version %q, but this AgentField reads up to v%d — upgrade AgentField to install this node",
+			metadata.ConfigVersion, CurrentConfigVersion)
+	}
+	// v0 (legacy, unversioned) and v1 currently share one decoder because v1 only
+	// *introduces* the version marker without changing any field. A future breaking
+	// version adds its own case here (e.g. a migrateFromV1 step) — the switch is the
+	// single place that fans out on version.
+	switch ver {
+	case 0, 1:
+		// nothing version-specific to do yet; metadata is already decoded above.
 	}
 
 	// Validate required fields

--- a/control-plane/internal/skillkit/skill_data/agentfield/references/cli-toolkit.md
+++ b/control-plane/internal/skillkit/skill_data/agentfield/references/cli-toolkit.md
@@ -100,6 +100,8 @@ See [docs/installing-agent-nodes.md](../../../docs/installing-agent-nodes.md) fo
 
 Install an agent node from a local directory, a git/GitHub URL, or a registry name. The node is described by its `agentfield-package.yaml` manifest; its Python deps are installed into a per-node venv. If the manifest declares `dependencies.nodes` (e.g. `af://registry/swe-planner`), those nodes are installed recursively.
 
+When you author an `agentfield-package.yaml`, set `config_version: v1` at the top — the manifest *schema* version, distinct from the node's own `version:`. Omitting it means `v0` (the legacy format). Only bump `config_version` for **breaking** format changes (a field renamed/removed or its shape changed); adding a new optional field does **not** need a bump. A version newer than the installed `af` understands is refused with a clear error. Full contract + a real example (Agent-Field/SWE-AF): [docs/installing-agent-nodes.md](../../../docs/installing-agent-nodes.md).
+
 ### `af run <agent-node-name>`
 
 Start an installed node in the background. Brings up the node's declared node dependencies first. Resolves the node's required environment from the encrypted secret store, **prompting once** for anything missing (hidden input for `type: secret`) and remembering it encrypted. Secrets are injected only into the node process — never written to disk in plaintext. Exports `AGENTFIELD_SERVER` + `PORT` to the node.

--- a/docs/installing-agent-nodes.md
+++ b/docs/installing-agent-nodes.md
@@ -34,8 +34,9 @@ and a way to start (either `entrypoint.start` or a top-level `main.py`) are
 required; everything else is optional.
 
 ```yaml
+config_version: v1            # manifest *schema* version (see below). Omit = v0 (legacy).
 name: pr-af
-version: 0.1.0
+version: 0.1.0                # the node's own release version — unrelated to config_version
 description: Opens draft PRs from a task description
 author: Agent-Field
 
@@ -78,6 +79,39 @@ user_environment:
       description: Override the default model
       default: openrouter/moonshotai/kimi-k2
 ```
+
+A published, real-world manifest to copy from:
+[Agent-Field/SWE-AF `agentfield-package.yaml`](https://github.com/Agent-Field/SWE-AF/blob/main/agentfield-package.yaml).
+
+### Manifest schema version (`config_version`)
+
+`config_version` declares which version of the **manifest format** your file was
+written against, so the control plane knows how to read it as the format evolves —
+you're never locked into whatever shape shipped the day you authored the file.
+
+- It is **not** the same as `version`. `version` is your node's own release
+  (semver of the agent); `config_version` is the schema version of this file.
+- **Omitting it means `v0`** — the original, pre-versioning format. Existing
+  manifests keep working untouched.
+- The current version is **`v1`**. New manifests should set `config_version: v1`.
+- The `v` prefix is optional and case-insensitive (`v1`, `V1`, and `1` are equal).
+  A value the control plane doesn't recognize (a typo, or a version **newer** than
+  your `af` binary understands) fails the install with a clear message rather than
+  being silently mis-read — upgrade `af` to install a node authored for a newer
+  schema.
+
+**When does `config_version` get bumped?** Only for **breaking** changes to the
+format — a field renamed or removed, or its shape/meaning changed such that an old
+reader would mis-handle a new file (or vice-versa). **Adding** a new optional field
+is *not* breaking and does **not** bump the version: unknown keys are ignored by
+older readers, and newer readers fall back to defaults. So most format growth needs
+no bump at all; you only stamp a new `config_version` when the structure of an
+existing config actually changes.
+
+| `config_version` | Reader behavior                                             |
+| ---------------- | ---------------------------------------------------------- |
+| absent / `v0`    | Legacy format, read leniently. Every field below is optional except the manifest basics. |
+| `v1`             | Same fields as v0, now explicitly versioned. Current default for new manifests. |
 
 ### `require_one_of` — "at least one of these"
 

--- a/skills/agentfield/references/cli-toolkit.md
+++ b/skills/agentfield/references/cli-toolkit.md
@@ -100,6 +100,8 @@ See [docs/installing-agent-nodes.md](../../../docs/installing-agent-nodes.md) fo
 
 Install an agent node from a local directory, a git/GitHub URL, or a registry name. The node is described by its `agentfield-package.yaml` manifest; its Python deps are installed into a per-node venv. If the manifest declares `dependencies.nodes` (e.g. `af://registry/swe-planner`), those nodes are installed recursively.
 
+When you author an `agentfield-package.yaml`, set `config_version: v1` at the top — the manifest *schema* version, distinct from the node's own `version:`. Omitting it means `v0` (the legacy format). Only bump `config_version` for **breaking** format changes (a field renamed/removed or its shape changed); adding a new optional field does **not** need a bump. A version newer than the installed `af` understands is refused with a clear error. Full contract + a real example (Agent-Field/SWE-AF): [docs/installing-agent-nodes.md](../../../docs/installing-agent-nodes.md).
+
 ### `af run <agent-node-name>`
 
 Start an installed node in the background. Brings up the node's declared node dependencies first. Resolves the node's required environment from the encrypted secret store, **prompting once** for anything missing (hidden input for `type: secret`) and remembering it encrypted. Secrets are injected only into the node process — never written to disk in plaintext. Exports `AGENTFIELD_SERVER` + `PORT` to the node.


### PR DESCRIPTION
## Summary

Adds a **`config_version`** field to the agent-node manifest (`agentfield-package.yaml`) so the control plane can read it as the format evolves, without locking authors into whatever shape shipped the day they wrote the file. This is the future-proofing hook: authors declare which schema version they built against, and the reader knows how to interpret it.

`config_version` is **distinct from `version:`** — `version` is the node's own release semver; `config_version` is the schema version of the manifest itself.

## Behavior

`packages.ParsePackageMetadata` (the single loader behind `af install`/`af run` and the package/agent services) now does a version-dependent read:

- **Absent → `v0`** — the original, pre-versioning format, read leniently. Existing manifests keep working untouched.
- **`v1`** — current. New manifests should set `config_version: v1`.
- **Newer than the binary understands → refused** with an "upgrade AgentField" error, instead of being silently mis-parsed.
- The `v` prefix is optional/case-insensitive (`v1` = `V1` = `1`); a malformed value fails loudly rather than defaulting to v0.

**Bump policy:** `config_version` bumps only for **breaking** format changes (a field renamed/removed, or its shape/meaning changed). Purely **additive** optional fields (e.g. the existing `require_one_of`) do **not** bump it — `yaml.Unmarshal` ignores unknown keys and new readers fall back to defaults.

## Tests (the spec is executable)

- `config_version_test.go` — parse/normalize, future-version + malformed rejection, additive-field tolerance.
- `config_version_fixtures_test.go` — one **canonical golden manifest + structure assertion per schema version**, plus a **coverage guard** that fails if a version has no fixture (or the highest fixture and `CurrentConfigVersion` drift). This forces the maintenance rule for future contributors: *grow the current fixture for additive fields; add a net-new fixture for a net-new version; never rewrite old fixtures* (they guard backwards compatibility). Verified the guard actually trips when the version is bumped without a fixture.

## Docs (so humans and coding agents author these correctly)

- `docs/installing-agent-nodes.md` — new "Manifest schema version" section, version table, and a link to Agent-Field/SWE-AF's manifest as a real example.
- Coding-agent CLI reference (`cli-toolkit.md` + embedded skill mirror), `CLAUDE.md`, `AGENTS.md` — the field, the reader location, the bump policy, and a pointer to the golden-fixture suite as the thing to maintain.

## Test plan

- [x] `go build ./...` (control-plane) — green
- [x] `go test ./internal/packages/... ./internal/core/services/...` — green
- [x] New version/fixture tests pass; coverage-guard failure path verified
- [x] `golangci-lint run` — no issues in changed files
- [x] Embedded skill mirror in sync (`scripts/sync-embedded-skills.sh --check`)

## Note (not addressed here)

While rebasing on latest `main` I found `internal/server`'s `TestStartAndStopCoverAdditionalBranches` fails on pristine `main` (reproduced 3/3, commit 2c9254c4) — pre-existing and unrelated to this change, which touches no files under `internal/server`. Flagging separately rather than bundling a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)