### PR TITLE
feat(cli): numbered menu for require_one_of provider selection

### DIFF
--- a/control-plane/internal/packages/env_resolver.go
+++ b/control-plane/internal/packages/env_resolver.go
@@ -6,9 +6,12 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"golang.org/x/term"
+
+	"github.com/Agent-Field/agentfield/control-plane/internal/ui"
 )
 
 // Prompter asks the user to supply a value for a missing required variable.
@@ -19,6 +22,9 @@ type Prompter interface {
 	// Prompt requests a value for the given variable. Secret types should be
 	// read without echo.
 	Prompt(v UserEnvironmentVar) (string, error)
+	// PromptLine reads a single echoed line (trimmed), used to choose among
+	// require_one_of options. It is never used for secret values.
+	PromptLine(prompt string) (string, error)
 }
 
 // EnvResolver resolves an agent node's environment variables, prompting for and
@@ -160,32 +166,86 @@ func (r *EnvResolver) resolveGroupFromSources(g RequireOneOfGroup, resolved map[
 	return found, nil
 }
 
-// promptGroup asks the user to fill in one option of a require_one_of group,
-// persisting the first non-empty answer. Options are offered in order; leaving
-// one blank moves on to the next alternative.
+// promptGroup asks the user to satisfy a require_one_of group. A single-option
+// group is prompted for directly; a multi-option group is presented as a
+// numbered menu so the user picks one provider, and only the chosen option is
+// then prompted for and persisted. Returns true once one option is supplied.
 func (r *EnvResolver) promptGroup(g RequireOneOfGroup, resolved map[string]string) (bool, error) {
+	if len(g.Options) == 1 {
+		return r.storeGroupOption(g.Options[0], resolved)
+	}
+
 	desc := g.Description
 	if desc == "" {
 		desc = "one of the following"
 	}
-	fmt.Printf("  This node needs %s — fill in one, leave the rest blank:\n    %s\n",
-		desc, strings.Join(g.OptionNames(), "  |  "))
+	fmt.Printf("\n  %s\n", ui.Title("This node needs "+desc+" — choose one:"))
 
+	width := 0
 	for _, opt := range g.Options {
-		val, err := r.promptAndValidate(opt)
+		if len(opt.Name) > width {
+			width = len(opt.Name)
+		}
+	}
+	nums := make([]string, len(g.Options))
+	for i, opt := range g.Options {
+		nums[i] = strconv.Itoa(i + 1)
+		line := fmt.Sprintf("    %s  %-*s", ui.Title("["+nums[i]+"]"), width, opt.Name)
+		if opt.Description != "" {
+			line += "  " + ui.Muted(opt.Description)
+		}
+		fmt.Println(line)
+	}
+
+	for attempt := 0; attempt < 3; attempt++ {
+		choice, err := r.Prompter.PromptLine(fmt.Sprintf("  Enter %s (or press Enter to skip): ", orJoin(nums)))
 		if err != nil {
 			return false, err
 		}
-		if val == "" {
+		choice = strings.TrimSpace(choice)
+		if choice == "" {
+			return false, nil // skipped the whole group
+		}
+		n, convErr := strconv.Atoi(choice)
+		if convErr != nil || n < 1 || n > len(g.Options) {
+			fmt.Printf("  %s\n", ui.Muted("please enter "+orJoin(nums)))
 			continue
 		}
-		if err := r.Store.Set(opt.SecretScope(r.NodeName), opt.Name, val); err != nil {
-			return false, fmt.Errorf("failed to save %s: %w", opt.Name, err)
-		}
-		resolved[opt.Name] = val
-		return true, nil
+		return r.storeGroupOption(g.Options[n-1], resolved)
 	}
 	return false, nil
+}
+
+// storeGroupOption prompts for a single group option, persisting and recording
+// a non-empty value. A blank answer leaves the group unsatisfied.
+func (r *EnvResolver) storeGroupOption(opt UserEnvironmentVar, resolved map[string]string) (bool, error) {
+	val, err := r.promptAndValidate(opt)
+	if err != nil {
+		return false, err
+	}
+	if val == "" {
+		return false, nil
+	}
+	if err := r.Store.Set(opt.SecretScope(r.NodeName), opt.Name, val); err != nil {
+		return false, fmt.Errorf("failed to save %s: %w", opt.Name, err)
+	}
+	resolved[opt.Name] = val
+	return true, nil
+}
+
+// orJoin renders a human list joined with "or": ["1"] -> "1",
+// ["1","2"] -> "1 or 2", ["1","2","3"] -> "1, 2, or 3".
+func orJoin(items []string) string {
+	switch len(items) {
+	case 0:
+		return ""
+	case 1:
+		return items[0]
+	case 2:
+		return items[0] + " or " + items[1]
+	default:
+		return strings.Join(items[:len(items)-1], ", ") + ", or " + items[len(items)-1]
+	}
 }
 
 // missingEnvError formats a single error covering unset required variables and
@@ -196,7 +256,7 @@ func missingEnvError(missing []string, groups []RequireOneOfGroup) error {
 		parts = append(parts, "missing required environment variables: "+strings.Join(missing, ", "))
 	}
 	for _, g := range groups {
-		parts = append(parts, "at least one of ["+strings.Join(g.OptionNames(), " | ")+"] is required")
+		parts = append(parts, "at least one of "+orJoin(g.OptionNames())+" is required")
 	}
 	return errors.New(strings.Join(parts, "; "))
 }
@@ -263,4 +323,15 @@ func (TTYPrompter) Prompt(v UserEnvironmentVar) (string, error) {
 		return "", fmt.Errorf("failed to read input: %w", err)
 	}
 	return line, nil
+}
+
+// PromptLine prints prompt and reads a single echoed line from stdin, trimmed.
+func (TTYPrompter) PromptLine(prompt string) (string, error) {
+	fmt.Print(prompt)
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil && line == "" {
+		return "", fmt.Errorf("failed to read input: %w", err)
+	}
+	return strings.TrimSpace(line), nil
 }

--- a/control-plane/internal/packages/env_resolver_additional_test.go
+++ b/control-plane/internal/packages/env_resolver_additional_test.go
@@ -15,6 +15,7 @@ func (errPrompter) Interactive() bool { return true }
 func (e errPrompter) Prompt(UserEnvironmentVar) (string, error) {
 	return "", e.err
 }
+func (e errPrompter) PromptLine(string) (string, error) { return "", e.err }
 
 // resolverWithBrokenScope builds a resolver whose node-scope secret file is a
 // directory, so any Store.Get for that node fails on load.
@@ -192,5 +193,29 @@ func TestTTYPrompter_ReadsPlainLine(t *testing.T) {
 	}
 	if strings.TrimSpace(got) != "us-east-1" {
 		t.Fatalf("Prompt = %q, want us-east-1", got)
+	}
+}
+
+// Contract: PromptLine reads a single echoed line from stdin and returns it
+// trimmed — this is the require_one_of menu selection input.
+func TestTTYPrompter_PromptLineReadsTrimmedLine(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.WriteString("  2  \n"); err != nil {
+		t.Fatal(err)
+	}
+	_ = w.Close()
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	got, err := TTYPrompter{}.PromptLine("  Enter 1 or 2: ")
+	if err != nil {
+		t.Fatalf("PromptLine: %v", err)
+	}
+	if got != "2" {
+		t.Fatalf("PromptLine = %q, want trimmed \"2\"", got)
 	}
 }

--- a/control-plane/internal/packages/env_resolver_group_test.go
+++ b/control-plane/internal/packages/env_resolver_group_test.go
@@ -49,7 +49,11 @@ func TestResolve_OneOfGroupPersistErrorSurfaces(t *testing.T) {
 	r := &EnvResolver{
 		Store:    store,
 		NodeName: "swe-planner",
-		Prompter: &fakePrompter{interactive: true, answers: map[string]string{"OPENROUTER_API_KEY": "sk-or"}},
+		Prompter: &fakePrompter{
+			interactive: true,
+			choices:     []string{"2"}, // pick OPENROUTER_API_KEY from the menu
+			answers:     map[string]string{"OPENROUTER_API_KEY": "sk-or"},
+		},
 	}
 	_, err = r.Resolve(llmGroupCfg())
 	if err == nil || !strings.Contains(err.Error(), "failed to save") {
@@ -89,6 +93,165 @@ func TestCheckEnvironmentVariables_ShowsGroups(t *testing.T) {
 			Optional: []UserEnvironmentVar{{Name: "OPT", Default: "d"}},
 		},
 	})
+}
+
+// Contract: the menu prompts only for the option the user picks, resolves and
+// persists just that one, and leaves the alternatives untouched.
+func TestResolve_OneOfGroupMenuSelectsChosenOption(t *testing.T) {
+	p := &fakePrompter{
+		interactive: true,
+		choices:     []string{"1"}, // pick ANTHROPIC_API_KEY
+		answers:     map[string]string{"ANTHROPIC_API_KEY": "sk-ant"},
+	}
+	r := newResolver(t, "swe-planner", p)
+	got, err := r.Resolve(llmGroupCfg())
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got["ANTHROPIC_API_KEY"] != "sk-ant" {
+		t.Fatalf("chosen option not resolved: %v", got)
+	}
+	if _, ok := got["OPENROUTER_API_KEY"]; ok {
+		t.Fatal("non-selected option must not be resolved")
+	}
+	if len(p.asked) != 1 || p.asked[0] != "ANTHROPIC_API_KEY" {
+		t.Fatalf("only the chosen option should be prompted, asked=%v", p.asked)
+	}
+	if v, ok, _ := r.Store.Get("swe-planner", "ANTHROPIC_API_KEY"); !ok || v != "sk-ant" {
+		t.Fatalf("chosen option not persisted: %q ok=%v", v, ok)
+	}
+}
+
+// Contract: selecting the second menu entry resolves that alternative.
+func TestResolve_OneOfGroupMenuSelectsSecondOption(t *testing.T) {
+	p := &fakePrompter{
+		interactive: true,
+		choices:     []string{"2"},
+		answers:     map[string]string{"OPENROUTER_API_KEY": "sk-or"},
+	}
+	r := newResolver(t, "swe-planner", p)
+	got, err := r.Resolve(llmGroupCfg())
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got["OPENROUTER_API_KEY"] != "sk-or" {
+		t.Fatalf("second option not resolved: %v", got)
+	}
+	if _, ok := got["ANTHROPIC_API_KEY"]; ok {
+		t.Fatal("unselected option resolved")
+	}
+	if p.asked[0] != "OPENROUTER_API_KEY" {
+		t.Fatalf("wrong option prompted: %v", p.asked)
+	}
+}
+
+// Contract: an out-of-range / non-numeric selection re-prompts rather than
+// picking anything, and a later valid choice still works.
+func TestResolve_OneOfGroupMenuRetriesOnInvalidChoice(t *testing.T) {
+	p := &fakePrompter{
+		interactive: true,
+		choices:     []string{"9", "abc", "1"}, // two bad, then valid
+		answers:     map[string]string{"ANTHROPIC_API_KEY": "sk-ant"},
+	}
+	r := newResolver(t, "swe-planner", p)
+	got, err := r.Resolve(llmGroupCfg())
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got["ANTHROPIC_API_KEY"] != "sk-ant" {
+		t.Fatalf("retry should have selected option 1: %v", got)
+	}
+}
+
+// Contract: pressing Enter at the menu skips the whole group — no option is
+// prompted — and the group is reported missing.
+func TestResolve_OneOfGroupMenuSkipLeavesGroupMissing(t *testing.T) {
+	p := &fakePrompter{interactive: true} // no choices -> PromptLine returns "" (Enter)
+	r := newResolver(t, "swe-planner", p)
+	if _, err := r.Resolve(llmGroupCfg()); err == nil {
+		t.Fatal("skipping the group should surface a missing-env error")
+	}
+	if len(p.asked) != 0 {
+		t.Fatalf("no option should be prompted when the menu is skipped, asked=%v", p.asked)
+	}
+}
+
+// Contract: exhausting the invalid-choice retries leaves the group unsatisfied
+// without ever prompting for a secret.
+func TestResolve_OneOfGroupMenuExhaustsInvalidChoices(t *testing.T) {
+	p := &fakePrompter{interactive: true, choices: []string{"5", "6", "7"}}
+	r := newResolver(t, "swe-planner", p)
+	if _, err := r.Resolve(llmGroupCfg()); err == nil {
+		t.Fatal("expected missing-env error after exhausting invalid choices")
+	}
+	if len(p.asked) != 0 {
+		t.Fatalf("no secret should be prompted, asked=%v", p.asked)
+	}
+}
+
+// Contract: picking an option but leaving its value blank leaves the group
+// unsatisfied (nothing persisted).
+func TestResolve_OneOfGroupSelectedButBlankLeavesGroupMissing(t *testing.T) {
+	p := &fakePrompter{interactive: true, choices: []string{"1"}, answers: map[string]string{}}
+	r := newResolver(t, "swe-planner", p)
+	if _, err := r.Resolve(llmGroupCfg()); err == nil {
+		t.Fatal("blank value after selection should leave the group unsatisfied")
+	}
+	if len(p.asked) != 1 || p.asked[0] != "ANTHROPIC_API_KEY" {
+		t.Fatalf("selected option should have been prompted once: %v", p.asked)
+	}
+}
+
+// Contract: a single-option group prompts for it directly — no numbered menu.
+func TestResolve_OneOfGroupSingleOptionPromptsDirectly(t *testing.T) {
+	cfg := UserEnvironmentConfig{RequireOneOf: []RequireOneOfGroup{{
+		ID:          "solo",
+		Description: "a token",
+		Options:     []UserEnvironmentVar{{Name: "ONLY_KEY", Type: "secret"}},
+	}}}
+	p := &fakePrompter{interactive: true, answers: map[string]string{"ONLY_KEY": "v"}}
+	r := newResolver(t, "swe-planner", p)
+	got, err := r.Resolve(cfg)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got["ONLY_KEY"] != "v" {
+		t.Fatalf("single-option group not resolved: %v", got)
+	}
+	if p.ci != 0 {
+		t.Fatal("single-option group must not consult the selection menu")
+	}
+}
+
+// Contract: user-facing group enumeration joins option names with "or", not "|".
+func TestMissingEnvError_JoinsGroupOptionsWithOr(t *testing.T) {
+	err := missingEnvError(nil, []RequireOneOfGroup{{
+		Options: []UserEnvironmentVar{{Name: "A"}, {Name: "B"}},
+	}})
+	if !strings.Contains(err.Error(), "A or B") {
+		t.Fatalf("group options should be joined with 'or': %q", err)
+	}
+	if strings.Contains(err.Error(), "|") {
+		t.Fatalf("pipe separator should be gone: %q", err)
+	}
+}
+
+func TestOrJoin(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"none", nil, ""},
+		{"one", []string{"1"}, "1"},
+		{"two", []string{"1", "2"}, "1 or 2"},
+		{"three", []string{"1", "2", "3"}, "1, 2, or 3"},
+	}
+	for _, c := range cases {
+		if got := orJoin(c.in); got != c.want {
+			t.Errorf("%s: orJoin(%v)=%q want %q", c.name, c.in, got, c.want)
+		}
+	}
 }
 
 func TestEnvGroupSatisfied(t *testing.T) {

--- a/control-plane/internal/packages/env_resolver_test.go
+++ b/control-plane/internal/packages/env_resolver_test.go
@@ -5,17 +5,29 @@ import (
 	"testing"
 )
 
-// fakePrompter returns canned answers and records what it was asked.
+// fakePrompter returns canned answers and records what it was asked. choices
+// feeds PromptLine (the require_one_of menu selection) in order; once exhausted
+// it returns "" (i.e. the user pressed Enter to skip).
 type fakePrompter struct {
 	interactive bool
 	answers     map[string]string
 	asked       []string
+	choices     []string
+	ci          int
 }
 
 func (f *fakePrompter) Interactive() bool { return f.interactive }
 func (f *fakePrompter) Prompt(v UserEnvironmentVar) (string, error) {
 	f.asked = append(f.asked, v.Name)
 	return f.answers[v.Name], nil
+}
+func (f *fakePrompter) PromptLine(string) (string, error) {
+	if f.ci >= len(f.choices) {
+		return "", nil
+	}
+	v := f.choices[f.ci]
+	f.ci++
+	return v, nil
 }
 
 func newResolver(t *testing.T, node string, p Prompter) *EnvResolver {
@@ -233,11 +245,15 @@ func TestResolve_OneOfNonInteractiveErrorsNamingOptions(t *testing.T) {
 	}
 }
 
-// Contract: interactively, filling in one option (leaving the other blank)
-// satisfies the group and persists just that option encrypted.
+// Contract: interactively, choosing one option from the menu satisfies the
+// group and persists just that option encrypted.
 func TestResolve_OneOfPromptFillsOneAndPersists(t *testing.T) {
-	// User skips Anthropic (empty answer), provides OpenRouter.
-	p := &fakePrompter{interactive: true, answers: map[string]string{"OPENROUTER_API_KEY": "sk-or-prompted"}}
+	// User picks OpenRouter (option 2) and provides its key.
+	p := &fakePrompter{
+		interactive: true,
+		choices:     []string{"2"},
+		answers:     map[string]string{"OPENROUTER_API_KEY": "sk-or-prompted"},
+	}
 	r := newResolver(t, "swe-planner", p)
 
 	got, err := r.Resolve(llmGroup())
@@ -299,3 +315,4 @@ func (r *retryPrompter) Prompt(v UserEnvironmentVar) (string, error) {
 	r.i++
 	return val, nil
 }
+func (r *retryPrompter) PromptLine(string) (string, error) { return "", nil }


### PR DESCRIPTION
## Summary

Fixes the `require_one_of` provider prompt in `af run` / `af install`. When a
node needed *one of* several keys (e.g. SWE-AF's `ANTHROPIC_API_KEY` **or**
`OPENROUTER_API_KEY`), the old flow prompted for each option in sequence and
told the user to "fill in one, leave the rest blank" — so to pick OpenRouter you
had to *know* to press Enter past the Anthropic prompt. There was no visible way
to select. It also rendered the options as `ANTHROPIC_API_KEY  |  OPENROUTER_API_KEY`,
which reads poorly.

## Before

```
  This node needs an LLM provider key — fill in one, leave the rest blank:
    ANTHROPIC_API_KEY  |  OPENROUTER_API_KEY
  Enter ANTHROPIC_API_KEY (Anthropic API key (Claude)) [hidden]:
```

## After

```
  This node needs an LLM provider key — choose one:
    [1]  ANTHROPIC_API_KEY   Anthropic API key (Claude)
    [2]  OPENROUTER_API_KEY  OpenRouter API key (DeepSeek/Qwen/Llama/… — 200+ models)
  Enter 1 or 2 (or press Enter to skip): 2
  Enter OPENROUTER_API_KEY (…) [hidden]:
```

Typing `2` prompts **only** OpenRouter — no more guessing which blank does what.

## Changes

- **Numbered menu** for groups with 2+ options: each option on its own line with
  its description; a single line of input selects one, and only the chosen
  provider is then prompted for and persisted. A single-option group still
  prompts directly (no menu).
- **"or" instead of "|"** everywhere options are enumerated — the menu prompt
  ("Enter 1 or 2 …") and the missing-env error ("at least one of A or B is
  required"), via a small `orJoin` helper.
- Adds `PromptLine` to the `Prompter` interface (an echoed, trimmed line read for
  the selection — never used for secret values); `TTYPrompter` implements it.

## Validation contract / tests

- Menu prompts **only** the picked option; resolves & persists just that one.
- Selecting the 2nd entry resolves that alternative.
- Invalid / out-of-range selection re-prompts (bounded); exhausting attempts
  leaves the group unsatisfied without prompting for a secret.
- Empty line skips the whole group (→ missing-env error), nothing prompted.
- Selecting an option but leaving its value blank leaves the group unsatisfied.
- Single-option group prompts directly, never consulting the menu.
- `orJoin` / missing-env wording joins with "or", never "|".
- `PromptLine` reads a trimmed line from stdin.

Verified end-to-end by driving a real `af run swe-planner` through a PTY (menu
rendered, selection routed to the right key). `internal/packages` + `internal/ui`
suites green; changed files are lint-clean. New functions: `promptGroup` 90%,
`storeGroupOption` 89%, `orJoin` 100%, `PromptLine` 83% (only error-return
branches uncovered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
