### PR TITLE
fix(control-plane): correct observability-webhook paths in KB + API catalog

### DIFF
--- a/control-plane/internal/server/apicatalog/catalog_entries.go
+++ b/control-plane/internal/server/apicatalog/catalog_entries.go
@@ -128,9 +128,13 @@ func DefaultEntries() []EndpointEntry {
 		{Method: "GET", Path: "/api/v1/agentic/kb/guide", Group: "agentic-kb", Summary: "Goal-oriented reading path for building agents", AuthLevel: "public", Tags: []string{"kb", "guide", "learning", "onboarding"}},
 
 		// --- Settings ---
-		{Method: "GET", Path: "/api/v1/settings/webhooks", Group: "settings", Summary: "List observability webhooks", AuthLevel: "api_key", Tags: []string{"settings", "webhooks", "observability"}},
-		{Method: "POST", Path: "/api/v1/settings/webhooks", Group: "settings", Summary: "Create observability webhook", AuthLevel: "api_key", Tags: []string{"settings", "webhooks", "observability"}},
-		{Method: "DELETE", Path: "/api/v1/settings/webhooks/:webhook_id", Group: "settings", Summary: "Delete observability webhook", AuthLevel: "api_key", Tags: []string{"settings", "webhooks"}},
+		{Method: "GET", Path: "/api/v1/settings/observability-webhook", Group: "settings", Summary: "Get the observability webhook config (singleton)", AuthLevel: "api_key", Tags: []string{"settings", "webhooks", "observability"}},
+		{Method: "POST", Path: "/api/v1/settings/observability-webhook", Group: "settings", Summary: "Create or update the observability webhook config", AuthLevel: "api_key", Tags: []string{"settings", "webhooks", "observability"}},
+		{Method: "DELETE", Path: "/api/v1/settings/observability-webhook", Group: "settings", Summary: "Delete the observability webhook config", AuthLevel: "api_key", Tags: []string{"settings", "webhooks", "observability"}},
+		{Method: "GET", Path: "/api/v1/settings/observability-webhook/status", Group: "settings", Summary: "Observability webhook delivery status and queue depth", AuthLevel: "api_key", Tags: []string{"settings", "webhooks", "observability"}},
+		{Method: "POST", Path: "/api/v1/settings/observability-webhook/redrive", Group: "settings", Summary: "Retry dead-lettered observability webhook deliveries", AuthLevel: "api_key", Tags: []string{"settings", "webhooks", "observability"}},
+		{Method: "GET", Path: "/api/v1/settings/observability-webhook/dlq", Group: "settings", Summary: "Inspect the observability webhook dead-letter queue", AuthLevel: "api_key", Tags: []string{"settings", "webhooks", "observability"}},
+		{Method: "DELETE", Path: "/api/v1/settings/observability-webhook/dlq", Group: "settings", Summary: "Clear the observability webhook dead-letter queue", AuthLevel: "api_key", Tags: []string{"settings", "webhooks", "observability"}},
 
 		// --- Admin ---
 		{Method: "GET", Path: "/api/v1/admin/tags/pending", Group: "admin", Summary: "List pending tag approval requests", AuthLevel: "admin", Tags: []string{"admin", "tags", "approval"}},

--- a/control-plane/internal/server/knowledgebase/content.go
+++ b/control-plane/internal/server/knowledgebase/content.go
@@ -500,17 +500,43 @@ Point your Grafana instance at the /metrics endpoint for dashboards.
 
 	kb.Add(Article{
 		ID: "observability/webhooks", Topic: "observability", Title: "Observability Webhooks",
-		Summary:    "Configure webhooks for execution events and status changes",
+		Summary:    "Configure the outbound webhook that receives execution lifecycle events",
 		Difficulty: "intermediate",
 		Tags:       []string{"webhooks", "events", "notifications"},
 		Content: `# Observability Webhooks
 
-## API Endpoints
-- GET /api/v1/settings/webhooks — List webhooks
-- POST /api/v1/settings/webhooks — Create webhook
-- DELETE /api/v1/settings/webhooks/:id — Delete webhook
+The control plane can forward execution lifecycle events to a single, global
+outbound webhook. The configuration is a singleton (one webhook per control
+plane), so POST upserts it and there is no per-webhook :id.
 
-Webhooks fire on execution state changes (started, completed, failed).
+## API Endpoints
+- GET /api/v1/settings/observability-webhook — Get the current webhook config
+- POST /api/v1/settings/observability-webhook — Create or update the webhook config
+- DELETE /api/v1/settings/observability-webhook — Remove the webhook config
+- GET /api/v1/settings/observability-webhook/status — Delivery status and queue depth
+- POST /api/v1/settings/observability-webhook/redrive — Retry dead-lettered deliveries
+- GET /api/v1/settings/observability-webhook/dlq — Inspect the dead-letter queue
+- DELETE /api/v1/settings/observability-webhook/dlq — Clear the dead-letter queue
+
+## Request body (POST)
+` + "```json" + `
+{ "url": "https://example.com/hook", "secret": "optional", "enabled": true, "headers": {} }
+` + "```" + `
+
+## Signing
+When a secret is configured, each delivery carries an
+"X-AgentField-Signature: sha256=<hex>" header — an HMAC-SHA256 of the raw
+request body, keyed by the secret.
+
+## Events
+Deliveries fire on execution lifecycle events: created, completed, failed,
+cancelled, paused, and resumed.
+
+## Note: this is not the approval webhook
+This observability webhook is outbound — the control plane calls your URL. It is
+distinct from the inbound, HMAC-signed approval webhook
+(POST /api/v1/webhooks/approval-response), which resolves executions that are
+paused awaiting approval.
 `,
 	})
 


### PR DESCRIPTION
## Problem

The platform's **embedded Knowledge Base** article (`observability/webhooks`) and the **machine-readable API catalog** both documented:

```
GET/POST/DELETE /api/v1/settings/webhooks
```

…which is **not a registered route** and **404s**. The server's own Smart404 handler confirms it: `"GET /api/v1/settings/webhooks does not exist"` with `"suggestions": null`. Both surfaces are user/agent-facing (the public `/api/v1/agentic/kb/articles/...` endpoint and the `/api/v1/agentic/discover` + `.well-known/ai-catalog.json` catalog), so the wrong paths were externally visible.

The real endpoint is the **singleton** `GET/POST/DELETE /api/v1/settings/observability-webhook` (plus `/status`, `/redrive`, `/dlq`), registered in `registerObservabilityRoutes`.

This was surfaced while investigating #726 — the KB read as if there were a general-purpose HMAC completion webhook at a path that doesn't exist. The mechanism *does* exist; the docs just pointed at the wrong URL. (Separately, the inbound approval webhook `POST /api/v1/webhooks/approval-response` is the pause/approval one — now explicitly distinguished in the article.)

## Changes

- **KB article** (`knowledgebase/content.go`): repoint to the real `observability-webhook` endpoints; note the config is a singleton (POST upserts, no `:id`); document the `X-AgentField-Signature: sha256=<hex>` HMAC signing (when a secret is set) and the lifecycle events it fires on (created/completed/failed/cancelled/paused/resumed); clarify it's the **outbound** observability webhook, distinct from the **inbound** approval webhook.
- **API catalog** (`apicatalog/catalog_entries.go`): replace the three dead `/settings/webhooks` entries with the seven real `/settings/observability-webhook*` endpoints.

## Verification (live)

Built the control plane and ran it on a non-default port; hit every path:

| Path | Before | After |
|---|---|---|
| `GET/POST/DELETE /api/v1/settings/webhooks` (documented) | **404** | 404 (correctly gone from docs) |
| `GET/POST/DELETE /api/v1/settings/observability-webhook` + `/status`,`/redrive`,`/dlq` | 200 (undocumented) | **200, now documented** |

- Fetched the **served** KB article — now shows the real paths, dead path gone.
- Every path the article advertises resolves (no 404).
- `go build ./...` clean; edited packages + consumers (`agentic` discover/smart404, `ard`) tests pass; change is lint-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)