### PR TITLE
fix(cli): don't dump usage/help block on runtime errors

### DIFF
--- a/control-plane/internal/cli/root.go
+++ b/control-plane/internal/cli/root.go
@@ -40,6 +40,12 @@ func NewRootCommand(runServerFunc func(cmd *cobra.Command, args []string), versi
 		Long: `AgentField is a comprehensive AI agent platform for building, managing, and deploying AI agent capabilities.
 
 AI Agent? Run "af agent help" for structured JSON output optimized for programmatic use.`,
+		// Don't dump the full usage/help block when a command fails at runtime
+		// (e.g. `af run` failing to start an agent). Usage text is for
+		// mis-invocation, not runtime errors; main.go already surfaces the
+		// error message itself. Set on the root so it applies to every
+		// subcommand (cobra suppresses usage when the root has this set).
+		SilenceUsage: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// Initialize logging based on verbose flag
 			logger.InitLogger(verbose)

--- a/control-plane/internal/cli/root_test.go
+++ b/control-plane/internal/cli/root_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -34,6 +36,30 @@ func TestRootCommandDisplaysHelp(t *testing.T) {
 	cmd.SetArgs([]string{"--help"})
 
 	require.NoError(t, cmd.Execute())
+}
+
+// Contract: when a subcommand fails at runtime, the CLI must NOT print the
+// usage/help block — usage is for mis-invocation, not runtime errors.
+func TestRootCommand_RuntimeErrorDoesNotPrintUsage(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	resetCLIStateForTest()
+
+	cmd := NewRootCommand(func(cmd *cobra.Command, args []string) {}, VersionInfo{})
+	cmd.AddCommand(&cobra.Command{
+		Use: "boom",
+		RunE: func(*cobra.Command, []string) error {
+			return errors.New("kaboom")
+		},
+	})
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"boom"})
+
+	err := cmd.Execute()
+	require.Error(t, err) // the error still propagates to main.go
+	require.NotContains(t, buf.String(), "Usage:", "runtime error must not dump the usage block")
 }
 
 func TestRootCommandServerFlags(t *testing.T) {


### PR DESCRIPTION
## Summary

When a command failed at **runtime** — e.g. `af run <node>` hitting a readiness timeout — cobra printed the entire usage/help block (flags, global flags, subcommand usage) *after* the error. Usage text is for mis-invocation, not runtime failures, so it buried the actual error in noise.

## Before

```
❌ Failed to run agent: agent node failed to start: ... did not become ready within 10s
Error: agent node failed to start: ... did not become ready within 10s
Usage:
  af run <agent-node-name> [flags]

Flags:
  -d, --detach     ...
  -p, --port int   ...
Global Flags:
  ...
```

## After

```
❌ Failed to run agent: agent node failed to start: ... did not become ready within 10s
```

(The error still propagates to `main.go`, which surfaces it — nothing is hidden.)

## Change

One line: `SilenceUsage: true` on the root command. Cobra suppresses the usage block for **any** subcommand when the root has this set, so it fixes every command at once. Genuine bad-invocation errors (wrong arg count, unknown flag) still print their concise error message — verified with `af run` (no args) → `Error: accepts 1 arg(s), received 0`, no usage wall.

## Test

`TestRootCommand_RuntimeErrorDoesNotPrintUsage` — a subcommand whose `RunE` returns an error must not emit `Usage:` while the error still propagates. `internal/cli` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)