### PR TITLE
fix(af run): eliminate startup port race that killed healthy nodes

### DIFF
--- a/control-plane/internal/core/services/agent_service.go
+++ b/control-plane/internal/core/services/agent_service.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -120,7 +121,7 @@ func (as *DefaultAgentService) runAgentGuarded(name string, options domain.RunOp
 	if metadata, err := packages.ParsePackageMetadata(agentNode.Path); err == nil {
 		healthPath = metadata.HealthcheckPath()
 	}
-	if err := as.waitForAgentNode(port, healthPath, 10*time.Second); err != nil {
+	if err := as.waitForAgentNode(port, healthPath, nodeReadyTimeout()); err != nil {
 		// Kill the process if it failed to start properly
 		if stopErr := as.processManager.Stop(pid); stopErr != nil {
 			return nil, fmt.Errorf("agent node failed to start: %w (additionally failed to stop process: %v)", err, stopErr)
@@ -513,6 +514,11 @@ func (as *DefaultAgentService) buildProcessConfig(agentNode packages.InstalledPa
 	serverURL := resolveServerURL()
 	env := os.Environ()
 	env = append(env, fmt.Sprintf("PORT=%d", port))
+	// Tell the SDK to bind exactly this port and fail fast if it is unavailable,
+	// rather than silently moving to another port that the runner is not polling
+	// (the readiness check below targets this exact port). Gated by this signal so
+	// standalone `python -m <node>.app` keeps its lenient auto-port fallback.
+	env = append(env, "AGENTFIELD_STRICT_PORT=1")
 	env = append(env, fmt.Sprintf("AGENTFIELD_SERVER=%s", serverURL))
 	env = append(env, fmt.Sprintf("AGENTFIELD_SERVER_URL=%s", serverURL))
 
@@ -614,6 +620,20 @@ func (as *DefaultAgentService) resolveNodeEnvironment(nodeName string, metadata 
 	}
 	resolver := &packages.EnvResolver{Store: store, NodeName: nodeName, Prompter: packages.TTYPrompter{}}
 	return resolver.Resolve(env)
+}
+
+// nodeReadyTimeout is how long to wait for a freshly started node to answer its
+// health check. Import-heavy nodes (large dependency graphs) routinely take more
+// than the old hardcoded 10s to boot, which produced spurious "did not become
+// ready" failures on nodes that were actually starting fine. Default 30s,
+// overridable via AGENTFIELD_NODE_READY_TIMEOUT (whole seconds).
+func nodeReadyTimeout() time.Duration {
+	if v := os.Getenv("AGENTFIELD_NODE_READY_TIMEOUT"); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	return 30 * time.Second
 }
 
 // waitForAgentNode waits for the agent node to become ready

--- a/control-plane/internal/infrastructure/process/port_manager.go
+++ b/control-plane/internal/infrastructure/process/port_manager.go
@@ -4,6 +4,7 @@ package process
 import (
 	"fmt"
 	"net"
+	"sync"
 
 	"github.com/Agent-Field/agentfield/control-plane/internal/core/interfaces"
 )
@@ -11,6 +12,7 @@ import (
 // DefaultPortManager provides a default implementation for managing network ports.
 // It keeps track of reserved ports in memory.
 type DefaultPortManager struct {
+	mu            sync.Mutex
 	reservedPorts map[int]bool
 }
 
@@ -26,10 +28,10 @@ func NewPortManager() interfaces.PortManager {
 // It checks both system availability and internal reservations.
 // Returns the first free port found, or an error if no port is available in the range.
 func (pm *DefaultPortManager) FindFreePort(startPort int) (int, error) {
-	// The search range is typically small, e.g., 100 ports.
-	// This can be made configurable if needed.
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
 	for port := startPort; port <= startPort+100; port++ {
-		if pm.IsPortAvailable(port) && !pm.reservedPorts[port] {
+		if !pm.reservedPorts[port] && pm.IsPortAvailable(port) {
 			return port, nil
 		}
 	}
@@ -53,6 +55,8 @@ func (pm *DefaultPortManager) IsPortAvailable(port int) bool {
 // It first checks if the port is system-available before reserving.
 // Returns an error if the port is not available or cannot be reserved.
 func (pm *DefaultPortManager) ReservePort(port int) error {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
 	if !pm.IsPortAvailable(port) {
 		return fmt.Errorf("port %d is not available at the system level", port)
 	}
@@ -67,6 +71,8 @@ func (pm *DefaultPortManager) ReservePort(port int) error {
 // This makes the port available for future reservations by this manager.
 // It does not affect the system-level availability of the port.
 func (pm *DefaultPortManager) ReleasePort(port int) error {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
 	if _, ok := pm.reservedPorts[port]; !ok {
 		return fmt.Errorf("port %d was not reserved by this manager", port)
 	}

--- a/sdk/python/agentfield/agent_server.py
+++ b/sdk/python/agentfield/agent_server.py
@@ -677,7 +677,26 @@ class AgentServer:
             env_port = os.getenv("PORT")
             if env_port and env_port.isdigit():
                 suggested_port = int(env_port)
-                if AgentUtils.is_port_available(suggested_port):
+                if os.getenv("AGENTFIELD_STRICT_PORT") == "1":
+                    # The AgentField runner assigned this exact port and polls it
+                    # for readiness. Bind it authoritatively — never silently move
+                    # to another port, or the runner would poll a port nothing is
+                    # listening on and kill us for "not becoming ready". If it is
+                    # genuinely unavailable, exit fast with a clear error so the
+                    # runner surfaces a real failure instead of a phantom timeout.
+                    if not AgentUtils.is_port_available(suggested_port):
+                        log_error(
+                            f"AGENTFIELD_STRICT_PORT set but the assigned port "
+                            f"{suggested_port} is unavailable; exiting so the "
+                            f"control plane can reallocate and retry"
+                        )
+                        raise RuntimeError(
+                            f"assigned port {suggested_port} is unavailable"
+                        )
+                    port = suggested_port
+                    if self.agent.dev_mode:
+                        log_debug(f"Using assigned port from AgentField CLI: {port}")
+                elif AgentUtils.is_port_available(suggested_port):
                     port = suggested_port
                     if self.agent.dev_mode:
                         log_debug(f"Using port from AgentField CLI: {port}")


### PR DESCRIPTION
## Problem

\`af run <node>\` intermittently fails with:

\`\`\`
❌ agent node failed to start: agent node did not become ready within 10s
\`\`\`

It's worst for import-heavy nodes (pr-af failed almost every run), and lighter nodes hit it occasionally. The node actually comes up fine — on the *wrong* port.

## Root cause — a runner ↔ SDK check-then-exec race (not the node)

1. The runner (`agent_service.go`) probes a free port via `PortManager.FindFreePort` (which binds a socket to test, then **immediately releases it**), exports `PORT=N`, and then polls **only** port `N` in `waitForAgentNode`.
2. The SDK (`agent_server.py`), if it finds the injected `PORT` unavailable at the instant it checks, **silently bumps** to `get_free_port(start_port=N)` → binds `N+1` with no error. The runner never learns the new port, polls the dead `N` for the full timeout, and kills a node that started fine on `N+1`.
3. The 10s readiness window is independently too short for nodes with large import graphs.

pr-af loses most often because its heavy imports widen the window between the runner's probe-release and the child's `bind()`.

## Fix (gated, regression-safe)

- **Runner** exports `AGENTFIELD_STRICT_PORT=1` next to `PORT`.
- **SDK**, *only* when that signal is present, binds the injected `PORT` **authoritatively**: if it's unavailable it logs and exits non-zero instead of silently bumping — so runner and node can never disagree. Without the signal (standalone `python -m <node>.app`, manual `PORT=…`), the existing lenient auto-bump is **unchanged** → no regression for anyone running nodes outside `af run`.
- **Readiness timeout** raised to 30s and made configurable via `AGENTFIELD_NODE_READY_TIMEOUT`.
- **PortManager** reserved-ports map is now mutex-guarded (was read/written unsynchronized).

Note: full effect requires both the updated control plane **and** the updated `agentfield` SDK in the node's venv. The timeout bump helps existing nodes immediately; the strict handshake engages once the SDK is upgraded. The lenient path is untouched, so mixed versions degrade gracefully to today's behavior.

## Verification

Patched control plane + SDK, fresh start of all four reference nodes:

| node | assigned | bound | health |
|------|----------|-------|--------|
| swe-planner | 8001 | 8001 | ✅ |
| cloudsecurity-af | 8002 | 8002 | ✅ |
| sec-af | 8003 | 8003 | ✅ |
| pr-af | 8004 | 8004 | ✅ |

pr-af — previously failing almost every `af run` — now binds its assigned port every time. `go test ./internal/infrastructure/process/...` and `./internal/core/services/...` pass; `ruff` clean.

## Follow-ups (noted, not in this PR)
- The legacy `internal/packages/runner.go` (`AgentNodeRunner`) is a dead duplicate of this allocation logic — candidate for deletion.
- `waitForAgentNode` could poll the node's *registered* `base_url` port as extra defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)