### PR TITLE
chore(web-client): override ws to 8.21.0

### DIFF
--- a/control-plane/web/client/package.json
+++ b/control-plane/web/client/package.json
@@ -87,12 +87,14 @@
     },
     "overrides": {
         "js-yaml": "4.2.0",
-        "esbuild": "0.28.1"
+        "esbuild": "0.28.1",
+        "ws": "8.21.0"
     },
     "pnpm": {
         "overrides": {
             "js-yaml": "4.2.0",
-            "esbuild": "0.28.1"
+            "esbuild": "0.28.1",
+            "ws": "8.21.0"
         }
     }
 }

--- a/control-plane/web/client/pnpm-lock.yaml
+++ b/control-plane/web/client/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   js-yaml: 4.2.0
   esbuild: 0.28.1
+  ws: 8.21.0
 
 importers:
 
@@ -3727,8 +3728,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -6035,7 +6036,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.20.0
+      ws: 8.21.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -7477,7 +7478,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.20.0: {}
+  ws@8.21.0: {}
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
## What
- pins transitive `ws` to `8.21.0` in `control-plane/web/client`
- updates `pnpm-lock.yaml` so the web client no longer resolves `ws@8.20.0`

## Why
GitHub Dependabot is flagging `ws@8.20.0` in the web client lockfile (`GHSA-96hv-2xvq-fx4p` / `CVE-2026-48779`).

## Validation
- `cd control-plane/web/client && pnpm install`
- `cd control-plane/web/client && pnpm test`

`pnpm test` is currently failing for an existing repo issue unrelated to this override:
- `src/components/workflow/AgentHealthHeatmap.tsx` and `src/components/workflow/ExecutionScatterPlot.tsx` import `date-fns`, but `date-fns` is not present in the package manifest, so Vitest fails during module resolution on the current branch.

Keeping this as draft until CI runs and we decide whether to fix or separately track that pre-existing test failure.
