### PR TITLE
fix(sdk): Windows harness reliability — opencode prompts over stdin, idle watchdog 120s→300s

### DIFF
--- a/sdk/go/harness/cli.go
+++ b/sdk/go/harness/cli.go
@@ -16,7 +16,14 @@ import (
 
 // defaultIdleSeconds is the no-progress watchdog window used when the env var
 // AGENTFIELD_HARNESS_IDLE_SECONDS is unset or invalid. A value <= 0 disables it.
-const defaultIdleSeconds = 120
+//
+// 300 rather than 120: provider CLIs in JSON mode (e.g. `opencode run
+// --format json`) emit events only at completion boundaries — never
+// token-by-token — so one long reasoning completion over a large context is
+// minutes of legitimate stdout silence. At 120s the watchdog routinely killed
+// healthy runs on slower models; 300s tolerates a long single completion while
+// still catching genuine hangs.
+const defaultIdleSeconds = 300
 
 // resolveIdleSeconds reads the idle watchdog window from the environment,
 // falling back to defaultIdleSeconds. A value <= 0 disables the watchdog.

--- a/sdk/go/harness/opencode.go
+++ b/sdk/go/harness/opencode.go
@@ -6,11 +6,24 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 )
+
+// openCodePromptViaStdin reports whether to hand the prompt to opencode over
+// stdin instead of argv. On Windows the CLI on PATH is usually an npm .cmd
+// shim that runs via cmd.exe, whose ~8k command-line cap real prompts blow
+// straight through ("The command line is too long.") — pr-af style prompts
+// that embed diff context die there, and schema retries (which append more
+// text) can never recover. opencode reads the prompt from stdin when the
+// positional arg is absent, so feed it that way there. POSIX keeps the
+// battle-tested positional-arg path. Mirrors the Python SDK's
+// _prompt_via_stdin (harness/providers/opencode.py). Package var so tests can
+// exercise both paths on any OS.
+var openCodePromptViaStdin = runtime.GOOS == "windows"
 
 var (
 	openCodeSemaphore chan struct{}
@@ -23,7 +36,7 @@ const defaultMaxConcurrent = 4
 type OpenCodeProvider struct {
 	BinPath   string
 	ServerURL string
-	runCLI    func(ctx context.Context, cmd []string, env map[string]string, cwd string, timeout int) (*CLIResult, error)
+	runCLI    func(ctx context.Context, cmd []string, env map[string]string, cwd string, timeout int, stdin []byte) (*CLIResult, error)
 }
 
 func getSemaphore() chan struct{} {
@@ -48,7 +61,7 @@ func NewOpenCodeProvider(binPath, serverURL string) *OpenCodeProvider {
 	if serverURL == "" {
 		serverURL = os.Getenv("OPENCODE_SERVER")
 	}
-	return &OpenCodeProvider{BinPath: binPath, ServerURL: serverURL, runCLI: RunCLI}
+	return &OpenCodeProvider{BinPath: binPath, ServerURL: serverURL, runCLI: RunCLIWithStdin}
 }
 
 func (p *OpenCodeProvider) Execute(ctx context.Context, prompt string, options Options) (*RawResult, error) {
@@ -97,8 +110,14 @@ func (p *OpenCodeProvider) Execute(ctx context.Context, prompt string, options O
 		)
 	}
 
-	// Prompt is positional on `opencode run` (replaces deprecated -p).
-	cmd = append(cmd, effectivePrompt)
+	// Prompt is positional on `opencode run` (replaces deprecated -p) on
+	// POSIX; on Windows it goes over stdin instead (see openCodePromptViaStdin).
+	var stdinPrompt []byte
+	if openCodePromptViaStdin {
+		stdinPrompt = []byte(effectivePrompt)
+	} else {
+		cmd = append(cmd, effectivePrompt)
+	}
 
 	// Build environment
 	env := make(map[string]string)
@@ -146,7 +165,7 @@ func (p *OpenCodeProvider) Execute(ctx context.Context, prompt string, options O
 
 	startAPI := time.Now()
 
-	cliResult, err := p.runCLI(ctx, cmd, env, options.Cwd, options.timeout())
+	cliResult, err := p.runCLI(ctx, cmd, env, options.Cwd, options.timeout(), stdinPrompt)
 	apiMS := int(time.Since(startAPI).Milliseconds())
 
 	if err != nil {

--- a/sdk/go/harness/opencode_json_test.go
+++ b/sdk/go/harness/opencode_json_test.go
@@ -13,7 +13,7 @@ import (
 // runCLI that yields the given stdout/stderr/returncode and captures the argv.
 func fakeOpenCode(stdout, stderr string, code int, gotCmd *[]string) *OpenCodeProvider {
 	p := NewOpenCodeProvider("opencode", "")
-	p.runCLI = func(_ context.Context, cmd []string, _ map[string]string, _ string, _ int) (*CLIResult, error) {
+	p.runCLI = func(_ context.Context, cmd []string, _ map[string]string, _ string, _ int, _ []byte) (*CLIResult, error) {
 		if gotCmd != nil {
 			*gotCmd = cmd
 		}

--- a/sdk/go/harness/opencode_test.go
+++ b/sdk/go/harness/opencode_test.go
@@ -24,7 +24,7 @@ func TestOpenCodeConcurrencyLimit(t *testing.T) {
 	var wg sync.WaitGroup
 
 	p := NewOpenCodeProvider("", "")
-	p.runCLI = func(ctx context.Context, cmd []string, env map[string]string, cwd string, timeout int) (*CLIResult, error) {
+	p.runCLI = func(ctx context.Context, cmd []string, env map[string]string, cwd string, timeout int, stdin []byte) (*CLIResult, error) {
 		c := atomic.AddInt64(&current, 1)
 
 		// track max concurrency
@@ -73,7 +73,7 @@ func TestOpenCodeContextCancellation(t *testing.T) {
 
 	p := NewOpenCodeProvider("", "")
 
-	p.runCLI = func(ctx context.Context, cmd []string, env map[string]string, cwd string, timeout int) (*CLIResult, error) {
+	p.runCLI = func(ctx context.Context, cmd []string, env map[string]string, cwd string, timeout int, stdin []byte) (*CLIResult, error) {
 		<-block
 		return &CLIResult{}, nil
 	}
@@ -220,6 +220,59 @@ func TestOpenCodeSemaphore_ReleasedOnSubprocessFailure(t *testing.T) {
 		}
 		if !raw.IsError {
 			t.Fatalf("call %d expected IsError for non-zero exit", i)
+		}
+	}
+}
+
+// TestOpenCodePromptDelivery pins how the prompt reaches opencode: over stdin
+// when openCodePromptViaStdin is set (Windows — npm .cmd shims run via
+// cmd.exe, whose ~8k argv cap real prompts exceed), positional argv otherwise
+// (POSIX). Regression test for the silent review degradation where every
+// long-prompt call died with "The command line is too long." and schema
+// validation reported "The output file was NOT created."
+func TestOpenCodePromptDelivery(t *testing.T) {
+	orig := openCodePromptViaStdin
+	defer func() { openCodePromptViaStdin = orig }()
+
+	const prompt = "review this very long diff"
+
+	for _, viaStdin := range []bool{true, false} {
+		openCodePromptViaStdin = viaStdin
+
+		var gotCmd []string
+		var gotStdin []byte
+		p := NewOpenCodeProvider("opencode", "")
+		p.runCLI = func(_ context.Context, cmd []string, _ map[string]string, _ string, _ int, stdin []byte) (*CLIResult, error) {
+			gotCmd = append([]string(nil), cmd...)
+			gotStdin = append([]byte(nil), stdin...)
+			return &CLIResult{Stdout: "done"}, nil
+		}
+
+		if _, err := p.Execute(context.Background(), prompt, Options{}); err != nil {
+			t.Fatalf("viaStdin=%v: Execute error: %v", viaStdin, err)
+		}
+
+		inArgv := false
+		for _, arg := range gotCmd {
+			if arg == prompt {
+				inArgv = true
+			}
+		}
+
+		if viaStdin {
+			if inArgv {
+				t.Fatalf("viaStdin=true: prompt must not be in argv: %q", gotCmd)
+			}
+			if string(gotStdin) != prompt {
+				t.Fatalf("viaStdin=true: stdin = %q, want the prompt", gotStdin)
+			}
+		} else {
+			if !inArgv {
+				t.Fatalf("viaStdin=false: prompt missing from argv: %q", gotCmd)
+			}
+			if len(gotStdin) != 0 {
+				t.Fatalf("viaStdin=false: stdin should be empty, got %q", gotStdin)
+			}
 		}
 	}
 }

--- a/sdk/go/harness/runner_test.go
+++ b/sdk/go/harness/runner_test.go
@@ -396,7 +396,7 @@ func TestOpenCodeProvider_WithOptions(t *testing.T) {
 func TestOpenCodeProvider_OpenRouterConfigOverlay(t *testing.T) {
 	p := NewOpenCodeProvider("opencode", "")
 	var capturedEnv map[string]string
-	p.runCLI = func(ctx context.Context, cmd []string, env map[string]string, cwd string, timeout int) (*CLIResult, error) {
+	p.runCLI = func(ctx context.Context, cmd []string, env map[string]string, cwd string, timeout int, _ []byte) (*CLIResult, error) {
 		capturedEnv = env
 		return &CLIResult{Stdout: "ok\n", ReturnCode: 0}, nil
 	}

--- a/sdk/python/agentfield/harness/_cli.py
+++ b/sdk/python/agentfield/harness/_cli.py
@@ -13,7 +13,13 @@ from agentfield.openrouter_attribution import apply_subprocess_env
 
 _ANSI_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 
-_DEFAULT_IDLE_SECONDS = 120.0
+# 300 rather than 120: provider CLIs in JSON mode (e.g. `opencode run
+# --format json`) emit events only at completion boundaries - never
+# token-by-token - so one long reasoning completion over a large context is
+# minutes of legitimate stdout silence. At 120s the watchdog routinely
+# killed healthy runs on slower models; 300s tolerates a long single
+# completion while still catching genuine hangs.
+_DEFAULT_IDLE_SECONDS = 300.0
 
 
 def strip_ansi(text: str) -> str:
@@ -24,7 +30,7 @@ def _resolve_idle_seconds(idle_seconds: Optional[float]) -> Optional[float]:
     """Resolve the no-progress watchdog window.
 
     Precedence: explicit ``idle_seconds`` arg, then env
-    ``AGENTFIELD_HARNESS_IDLE_SECONDS``, then ``_DEFAULT_IDLE_SECONDS`` (120s).
+    ``AGENTFIELD_HARNESS_IDLE_SECONDS``, then ``_DEFAULT_IDLE_SECONDS`` (300s).
     A value <= 0 disables the watchdog.
     """
     if idle_seconds is None:


### PR DESCRIPTION
## What

Two harness reliability fixes for Windows (and one cross-platform default), split out of #752 so they can merge and ship independently — they unblock every Go-SDK agent that uses CLI harness providers on Windows.

1. **opencode prompts go over stdin on Windows** (`sdk/go/harness`). The CLI on PATH is an npm `.cmd` shim that runs via cmd.exe, whose ~8k command-line cap real prompts blow straight through ("The command line is too long."). Passing the prompt as a positional argv meant every prompt embedding diff context died at spawn — and schema retries (which append more text) could never recover. **The observable failure was silent and severe**: pr-af-go on Windows "completed" reviews with zero dimensions planned and a confident "Safe to merge — 0 findings" verdict manufactured from mechanical parsing (every failed call downgraded to "0 findings for this dimension"). opencode reads the prompt from stdin when the positional arg is absent; this mirrors the Python SDK's `_prompt_via_stdin` fix that already shipped. POSIX keeps the positional-arg path.

2. **Idle-watchdog default 120s → 300s, both SDKs** (`sdk/go/harness`, `sdk/python/agentfield/harness`). Provider CLIs in JSON mode emit events only at completion boundaries (opencode writes a `text` event only when a part has `time.end` — never token-by-token), so one long reasoning completion over a big context is minutes of legitimate stdout silence. At 120s the watchdog routinely killed healthy runs on slower models — observed live: reviews on deepseek-v4-pro died with "no progress for 120s" 8–19 minutes into otherwise-progressing pipelines, while chatty tool-calling models (kimi) sailed through because every tool_use reset the window. `AGENTFIELD_HARNESS_IDLE_SECONDS` still overrides; `<= 0` still disables.

## Verification

- Runtime-verified on Windows 11: pre-fix, a pr-af-go review of a 335-line PR produced a false-clean (`plan.dimensions: null`, empty LLM fields); post-fix the identical review ran 5 real dimensions and produced 8 verified findings, with the prompt visible on stdin (argv ends at the model flag).
- `TestOpenCodePromptDelivery` pins both prompt-delivery paths; runs green.
- Full Go + Python harness suites show **zero new failures** vs the pre-existing native-Windows baseline (sh-script fixture tests that are green on Linux CI).

## Follow-ups (not in this PR)

- pr-af (both ports) should bump its pinned Go SDK once this lands, or fresh Windows installs keep the broken behavior.
- gemini/codex providers also pass prompts via argv through npm shims on Windows; same treatment applies if/when they're exercised there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)