### PR TITLE
fix(control-plane): dashboard success rate defaults to 100% and actually covers 24h

### DIFF
--- a/control-plane/internal/handlers/ui/coverage_dashboard_additional_test.go
+++ b/control-plane/internal/handlers/ui/coverage_dashboard_additional_test.go
@@ -215,6 +215,15 @@ func TestDashboardPureHelpersCoverage(t *testing.T) {
 			{Status: string(types.ExecutionStatusSucceeded)},
 			{Status: string(types.ExecutionStatusFailed)},
 		}))
+		require.Equal(t, 100.0, (&DashboardHandler{}).calculateSuccessRate(nil))
+		require.Equal(t, 100.0, (&DashboardHandler{}).calculateSuccessRate([]*types.Execution{
+			{Status: string(types.ExecutionStatusRunning)},
+		}))
+		require.Equal(t, 50.0, (&DashboardHandler{}).calculateSuccessRate([]*types.Execution{
+			{Status: string(types.ExecutionStatusSucceeded)},
+			{Status: string(types.ExecutionStatusFailed)},
+			{Status: string(types.ExecutionStatusRunning)},
+		}))
 	})
 }
 

--- a/control-plane/internal/handlers/ui/coverage_nodes_dashboard_summary_test.go
+++ b/control-plane/internal/handlers/ui/coverage_nodes_dashboard_summary_test.go
@@ -2,10 +2,12 @@ package ui
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/Agent-Field/agentfield/control-plane/internal/core/domain"
 	"github.com/Agent-Field/agentfield/control-plane/internal/services"
@@ -23,7 +25,7 @@ func (s *dashboardOverrideStorage) QueryExecutionRecords(ctx context.Context, fi
 	if s.queryExecutionRecordsFn != nil {
 		return s.queryExecutionRecordsFn(ctx, filter)
 	}
-	return s.overrideStorage.StorageProvider.QueryExecutionRecords(ctx, filter)
+	return s.StorageProvider.QueryExecutionRecords(ctx, filter)
 }
 
 func TestNodesHandlerAdditionalCoverage(t *testing.T) {
@@ -98,6 +100,32 @@ func TestDashboardSummaryHandlerAdditionalCoverage(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.Code)
 	})
 
+	t.Run("idle system reports vacuous 100 percent success", func(t *testing.T) {
+		store := &dashboardOverrideStorage{overrideStorage: &overrideStorage{StorageProvider: setupTestStorage(t)}}
+		handler := NewDashboardHandler(store, &mockLifecycleAgentService{})
+		router := gin.New()
+		router.GET("/api/ui/v1/dashboard", handler.GetDashboardSummaryHandler)
+
+		store.queryExecutionRecordsFn = func(ctx context.Context, filter types.ExecutionFilter) ([]*types.Execution, error) {
+			return nil, nil
+		}
+		store.queryAgentPackagesFn = func(ctx context.Context, filters types.PackageFilters) ([]*types.AgentPackage, error) {
+			return nil, nil
+		}
+		store.listAgentsFn = func(ctx context.Context, filters types.AgentFilters) ([]*types.AgentNode, error) {
+			return nil, nil
+		}
+
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, httptest.NewRequest(http.MethodGet, "/api/ui/v1/dashboard", nil))
+		require.Equal(t, http.StatusOK, resp.Code)
+
+		var body DashboardSummaryResponse
+		require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+		require.Equal(t, 100.0, body.SuccessRate)
+		require.Equal(t, 0, body.Executions.Today)
+	})
+
 	t.Run("error when collector fails", func(t *testing.T) {
 		store := &dashboardOverrideStorage{overrideStorage: &overrideStorage{StorageProvider: setupTestStorage(t)}}
 		handler := NewDashboardHandler(store, &mockLifecycleAgentService{})
@@ -118,4 +146,36 @@ func TestDashboardSummaryHandlerAdditionalCoverage(t *testing.T) {
 		router.ServeHTTP(resp, httptest.NewRequest(http.MethodGet, "/api/ui/v1/dashboard", nil))
 		require.Equal(t, http.StatusInternalServerError, resp.Code)
 	})
+}
+
+func TestExecutionsSummarySuccessRateRolling24h(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	store := &dashboardOverrideStorage{overrideStorage: &overrideStorage{StorageProvider: setupTestStorage(t)}}
+	handler := NewDashboardHandler(store, &mockLifecycleAgentService{})
+
+	// 01:00 UTC: the calendar-today window is only an hour old, so most of the
+	// rolling 24h window falls in yesterday's calendar window.
+	now := time.Date(2026, 7, 17, 1, 0, 0, 0, time.UTC)
+	today := time.Date(2026, 7, 17, 0, 0, 0, 0, time.UTC)
+
+	runningToday := &types.Execution{Status: string(types.ExecutionStatusRunning), StartedAt: now.Add(-15 * time.Minute)}
+	failedWithin24h := &types.Execution{Status: string(types.ExecutionStatusFailed), StartedAt: now.Add(-23 * time.Hour)}
+	succeededWithin24h := &types.Execution{Status: string(types.ExecutionStatusSucceeded), StartedAt: now.Add(-23*time.Hour - 30*time.Minute)}
+	succeededOutside24h := &types.Execution{Status: string(types.ExecutionStatusSucceeded), StartedAt: now.Add(-24*time.Hour - 30*time.Minute)}
+
+	store.queryExecutionRecordsFn = func(ctx context.Context, filter types.ExecutionFilter) ([]*types.Execution, error) {
+		if filter.StartTime != nil && filter.StartTime.Equal(today) {
+			return []*types.Execution{runningToday}, nil
+		}
+		return []*types.Execution{failedWithin24h, succeededWithin24h, succeededOutside24h}, nil
+	}
+
+	summary, rate, err := handler.getExecutionsSummaryAndSuccessRate(context.Background(), now)
+	require.NoError(t, err)
+	require.Equal(t, 1, summary.Today)
+	require.Equal(t, 3, summary.Yesterday)
+	// Rate basis: failedWithin24h + succeededWithin24h. The in-flight run does
+	// not count against the rate and the pre-window success is excluded.
+	require.Equal(t, 50.0, rate)
 }

--- a/control-plane/internal/handlers/ui/dashboard.go
+++ b/control-plane/internal/handlers/ui/dashboard.go
@@ -36,10 +36,12 @@ func NewDashboardHandler(storage storage.StorageProvider, agentService interface
 
 // DashboardSummaryResponse represents the dashboard summary response
 type DashboardSummaryResponse struct {
-	Agents      AgentsSummary     `json:"agents"`
-	Executions  ExecutionsSummary `json:"executions"`
-	SuccessRate float64           `json:"success_rate"`
-	Packages    PackagesSummary   `json:"packages"`
+	Agents     AgentsSummary     `json:"agents"`
+	Executions ExecutionsSummary `json:"executions"`
+	// SuccessRate is the percentage (0-100) of terminal executions started in
+	// the last 24 hours that succeeded; 100 when none have finished.
+	SuccessRate float64         `json:"success_rate"`
+	Packages    PackagesSummary `json:"packages"`
 }
 
 // AgentsSummary represents agent statistics

--- a/control-plane/internal/handlers/ui/dashboard_aggregate.go
+++ b/control-plane/internal/handlers/ui/dashboard_aggregate.go
@@ -779,8 +779,21 @@ func (h *DashboardHandler) getExecutionsSummaryAndSuccessRate(ctx context.Contex
 		return ExecutionsSummary{}, 0, err
 	}
 
-	// Calculate success rate from today's executions
-	successRate := h.calculateSuccessRate(todayExecutions)
+	// Success rate covers the rolling last-24h window, which spans the tail of
+	// yesterday's calendar window plus all of today's.
+	cutoff := now.Add(-24 * time.Hour)
+	last24h := make([]*types.Execution, 0, len(todayExecutions)+len(yesterdayExecutions))
+	for _, exec := range todayExecutions {
+		if !exec.StartedAt.Before(cutoff) {
+			last24h = append(last24h, exec)
+		}
+	}
+	for _, exec := range yesterdayExecutions {
+		if !exec.StartedAt.Before(cutoff) {
+			last24h = append(last24h, exec)
+		}
+	}
+	successRate := h.calculateSuccessRate(last24h)
 
 	return ExecutionsSummary{
 		Today:     len(todayExecutions),
@@ -788,20 +801,26 @@ func (h *DashboardHandler) getExecutionsSummaryAndSuccessRate(ctx context.Contex
 	}, successRate, nil
 }
 
-// calculateSuccessRate calculates the success rate from executions
+// calculateSuccessRate returns the percentage of terminal executions that
+// succeeded. In-flight executions don't count against the rate, and with no
+// terminal executions at all there is nothing failing, so it reports 100.
 func (h *DashboardHandler) calculateSuccessRate(executions []*types.Execution) float64 {
-	if len(executions) == 0 {
-		return 0.0
-	}
-
 	successCount := 0
+	terminalCount := 0
 	for _, exec := range executions {
+		if !types.IsTerminalExecutionStatus(exec.Status) {
+			continue
+		}
+		terminalCount++
 		if types.NormalizeExecutionStatus(exec.Status) == types.ExecutionStatusSucceeded {
 			successCount++
 		}
 	}
+	if terminalCount == 0 {
+		return 100.0
+	}
 
-	return float64(successCount) / float64(len(executions)) * 100.0
+	return float64(successCount) / float64(terminalCount) * 100.0
 }
 
 // getPackagesSummary collects package statistics

--- a/control-plane/web/client/src/pages/NewDashboardPage.test.tsx
+++ b/control-plane/web/client/src/pages/NewDashboardPage.test.tsx
@@ -130,7 +130,7 @@ describe("NewDashboardPage", () => {
     });
     vi.mocked(getDashboardSummary).mockResolvedValue({
       executions: { today: 10 },
-      success_rate: 0.9,
+      success_rate: 90,
       agents: { running: 1 },
     });
   });
@@ -279,7 +279,7 @@ describe("NewDashboardPage", () => {
     });
     vi.mocked(getDashboardSummary).mockResolvedValue({
         executions: { today: 123 },
-        success_rate: 0.88,
+        success_rate: 88,
         agents: { running: 5 },
     });
     

--- a/control-plane/web/client/src/pages/NewDashboardPage.tsx
+++ b/control-plane/web/client/src/pages/NewDashboardPage.tsx
@@ -782,7 +782,7 @@ export function NewDashboardPage() {
           <Separator orientation="vertical" className="hidden h-6 sm:block" />
           <div className="flex items-center gap-1.5">
             <span className="text-2xl font-semibold tabular-nums">
-              {successRate != null ? `${(successRate * 100).toFixed(0)}%` : "—"}
+              {successRate != null ? `${successRate.toFixed(0)}%` : "—"}
             </span>
             <span className="text-muted-foreground">success</span>
           </div>

--- a/control-plane/web/client/src/test/pages/NewDashboardPage.test.tsx
+++ b/control-plane/web/client/src/test/pages/NewDashboardPage.test.tsx
@@ -10,7 +10,7 @@ const pageState = vi.hoisted(() => ({
   useQueryResult: {
     data: {
       executions: { today: 12 },
-      success_rate: 0.91,
+      success_rate: 91,
       agents: { running: 3 },
     },
     isLoading: false,
@@ -147,7 +147,7 @@ describe("NewDashboardPage", () => {
     pageState.useQueryResult = {
       data: {
         executions: { today: 12 },
-        success_rate: 0.91,
+        success_rate: 91,
         agents: { running: 3 },
       },
       isLoading: false,

--- a/control-plane/web/client/src/test/services/dashboardService.test.ts
+++ b/control-plane/web/client/src/test/services/dashboardService.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 const SUMMARY_FIXTURE = {
   agents: { running: 3, total: 5 },
   executions: { today: 42, yesterday: 38 },
-  success_rate: 0.95,
+  success_rate: 95,
   packages: { available: 10, installed: 7 },
 };
 
@@ -98,7 +98,7 @@ describe('getDashboardSummary', () => {
     expect(result.agents.running).toBe(3);
     expect(result.agents.total).toBe(5);
     expect(result.executions.today).toBe(42);
-    expect(result.success_rate).toBe(0.95);
+    expect(result.success_rate).toBe(95);
     expect(result.packages.installed).toBe(7);
   });
 


### PR DESCRIPTION
## Summary

The dashboard "Success rate" stat (desktop app tile labeled *last 24 hours*, web dashboard *success* stat) had three compounding bugs:

- **Idle looked like an outage.** With no executions, `/api/ui/v1/dashboard/summary` returned `success_rate: 0`, so an idle system showed a red **0%** as if everything had failed. Nothing failing should read healthy: it now returns **100**.
- **"Last 24 hours" was actually calendar-today UTC.** The rate was computed from executions started since midnight UTC — at 01:00 UTC that's a one-hour sample. It now covers a rolling `[now-24h, now]` window (derived from the already-fetched today+yesterday query results, no extra storage round-trip).
- **In-flight runs counted as failures.** Running/waiting executions sat in the denominator. The denominator is now terminal executions only, so kicking off a workflow no longer drags the rate down before it finishes.

While fixing the consumer side, the web dashboard turned out to double-scale the value (`successRate * 100` on an already-0–100 percentage) — its test fixtures mirrored the same wrong 0–1 scale, so tests passed while a real server response would have rendered **9100%**. Fixture scales are aligned with the actual API contract.

The desktop app needs no change: its "last 24 hours" label is now truthful and it renders the server value as-is.

## Validation contract

- Zero executions in the window → `success_rate` is 100 (idle reads healthy, not failed)
- Only terminal executions count: a running/waiting execution affects neither numerator nor denominator
- The window is rolling 24h: an execution started 23h ago (yesterday, UTC) counts; one started 24.5h ago does not
- `executions.today` / `executions.yesterday` remain calendar-day counts (unchanged)
- Web dashboard renders `91` from the API as "91%", not "9100%"

Each new test maps to one of the items above (`TestExecutionsSummarySuccessRateRolling24h`, the `calculateSuccessRate` edge cases, the idle-summary endpoint test, and the corrected web fixtures).

## Test plan

- [x] `go test ./...` — 49 packages pass; the one failure (`internal/server: TestStartAndStopCoverAdditionalBranches`) reproduces identically on clean `origin/main` in the same environment (WSL-specific, green in CI)
- [x] `golangci-lint run` — no findings in touched files
- [x] Web UI: `npm ci && npm run build` and `npm run test:coverage` — 683/683 tests pass

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)