### PR TITLE
fix(install): replace binaries atomically to avoid macOS SIGKILL on upgrade

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -417,9 +417,14 @@ install_binary() {
   # Create install directory
   mkdir -p "$install_dir"
 
-  # Copy binary
-  cp "$binary_path" "$install_dir/agentfield"
-  chmod +x "$install_dir/agentfield"
+  # Stage to a temp file and rename into place. Overwriting an existing binary
+  # in place (cp onto the same inode) poisons the macOS kernel's cached
+  # code-signature state for that vnode, and every subsequent exec is killed
+  # with SIGKILL even though codesign --verify passes. mv gives upgrades a
+  # fresh inode and is atomic.
+  cp "$binary_path" "$install_dir/agentfield.tmp.$$"
+  chmod +x "$install_dir/agentfield.tmp.$$"
+  mv -f "$install_dir/agentfield.tmp.$$" "$install_dir/agentfield"
 
   # Create symlink for convenience (best effort)
   local symlink_created=0
@@ -652,9 +657,13 @@ install_tray() {
     fi
   fi
 
-  cp "$tray_path" "$INSTALL_DIR/af-tray"
-  chmod +x "$INSTALL_DIR/af-tray"
-  xattr -d com.apple.quarantine "$INSTALL_DIR/af-tray" 2>/dev/null || true
+  # Stage + rename for the same reason as install_binary: cp onto an existing
+  # inode makes the macOS kernel SIGKILL the binary on every exec after an
+  # upgrade.
+  cp "$tray_path" "$INSTALL_DIR/af-tray.tmp.$$"
+  chmod +x "$INSTALL_DIR/af-tray.tmp.$$"
+  xattr -d com.apple.quarantine "$INSTALL_DIR/af-tray.tmp.$$" 2>/dev/null || true
+  mv -f "$INSTALL_DIR/af-tray.tmp.$$" "$INSTALL_DIR/af-tray"
 
   # Delegate .app-bundle + launchd setup to the tray binary itself, so all of
   # that logic lives in one place (Go) and stays testable — mirroring how the


### PR DESCRIPTION
## Problem

Re-running the install script over an existing installation left `af` unrunnable on macOS — every invocation died with `zsh: killed af` (SIGKILL), including the script's own `--version` verification step. Confusingly, `codesign --verify` on the installed binary passed.

Root cause: `install_binary` used `cp` to overwrite the existing binary **in place**, reusing the same inode. When the old binary has a live process at overwrite time (e.g. `af server` running during a `curl | bash` upgrade — the common case), the macOS kernel's cached per-vnode code-signing state is invalidated, and the path becomes permanently poisoned: every subsequent exec is either SIGKILLed or hangs in uninterruptible wait (`U` state, immune to `kill -9`), even though the on-disk signature verifies clean.

## Verified locally (Darwin 24.6.0, arm64)

- `cp` over an *idle* binary (same or different content): fine — no poisoning.
- `cp` over a binary **while a process was executing it**: reproduced — subsequent execs hang in uninterruptible kernel wait; the poisoning persists after the old process dies.
- Applying this PR's stage+`mv` replacement to the poisoned path: **fixed** — next exec runs normally (fresh inode clears the kernel's cached state).
- Fresh installs and upgrades via the new stage+`mv` path: run correctly.

## Fix

Stage the binary to a temp file in the install dir and `mv` it into place. Rename gives upgrades a fresh inode and is atomic, so there is no window where the binary is missing and no in-place write to a mapped file. Applied to both copy sites:

- `install_binary` — the `agentfield` CLI binary
- `install_tray` — the `af-tray` binary (same latent bug; the tray force-restarts on update, so an upgrade over a running tray would hit it)

## Workaround for already-broken installs

`codesign -f -s - ~/.agentfield/bin/agentfield` (re-sign in place), or delete the file and reinstall with the fixed script. Processes already hung in `U` state clear on reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)