### PR TITLE
feat(sdk/python): model#variant reasoning-effort support across harness providers

### DIFF
--- a/docs/harness-providers.md
+++ b/docs/harness-providers.md
@@ -23,6 +23,31 @@ The extras install Python wrappers. They do not replace the runtime preflight:
 Gemini is CLI-only, and Codex or OpenCode may still require a separately
 available executable depending on the wrapper and platform.
 
+## Model selection and reasoning-effort variants
+
+Every provider accepts a `model` option on `.harness()` calls. The model string
+may carry a reasoning-effort variant after a `#` separator:
+
+```python
+result = await app.harness(
+    task,
+    provider="opencode",
+    model="openrouter/z-ai/glm-5.2#high",
+)
+```
+
+An explicit `variant="high"` keyword wins over the suffix. Per provider:
+
+| Provider | Model flag | Variant handling |
+| --- | --- | --- |
+| OpenCode | `-m <model>` | `--variant <v>` (provider-specific effort, e.g. `high`, `max`, `minimal`) |
+| Codex | `-m <model>` | `-c model_reasoning_effort=<v>` |
+| Claude Code | SDK `model` option | No effort control — variant is dropped with a debug log |
+| Gemini | `-m <model>` | No effort control — variant is dropped |
+
+The `#` separator is safe in model ids: `:` belongs to OpenRouter suffixes like
+`:free`, and `@` to Vertex-style ids, but no provider uses `#`.
+
 ## Verify
 
 Check selected providers in a container or CI job before any paid run:

--- a/sdk/go/agent/cost_tracker_test.go
+++ b/sdk/go/agent/cost_tracker_test.go
@@ -300,4 +300,21 @@ func TestRecordHarnessUsage(t *testing.T) {
 		assert.Equal(t, "openrouter/qwen/qwen3-coder", entries[0]["model"])
 		assert.Equal(t, "openrouter", entries[0]["provider"])
 	})
+
+	t.Run("model variant suffix is stripped for attribution", func(t *testing.T) {
+		a := newAgentForTest(t)
+		tracker := NewCostTracker()
+		ctx := contextWithCostTracker(context.Background(), tracker)
+
+		a.recordHarnessUsage(ctx, &harness.Result{InputTokens: 1}, harness.Options{
+			Provider: "opencode",
+			Model:    "openrouter/z-ai/glm-5.2#high",
+		})
+
+		entries := tracker.Serialize()["entries"].([]map[string]any)
+		require.Len(t, entries, 1)
+		assert.Equal(t, "openrouter/z-ai/glm-5.2", entries[0]["model"],
+			"usage must attribute to the BASE model, not the #variant-suffixed string")
+		assert.Equal(t, "openrouter", entries[0]["provider"])
+	})
 }

--- a/sdk/go/agent/harness.go
+++ b/sdk/go/agent/harness.go
@@ -13,8 +13,15 @@ type HarnessConfig struct {
 	// Provider is the default provider: "claude-code", "codex", "gemini", or "opencode".
 	Provider string
 
-	// Model is the default model identifier.
+	// Model is the default model identifier. It may carry a
+	// reasoning-effort variant after a "#" separator (e.g.
+	// "openrouter/z-ai/glm-5.2#high").
 	Model string
+
+	// Variant is the default provider-specific reasoning-effort variant
+	// (e.g. "high", "minimal"). It wins over a "#variant" suffix on Model;
+	// providers without an effort control drop it.
+	Variant string
 
 	// MaxTurns is the default max agent iterations.
 	MaxTurns int
@@ -48,6 +55,7 @@ func (a *Agent) HarnessRunner() *harness.Runner {
 			hc := a.cfg.HarnessConfig
 			opts.Provider = hc.Provider
 			opts.Model = hc.Model
+			opts.Variant = hc.Variant
 			opts.MaxTurns = hc.MaxTurns
 			opts.PermissionMode = hc.PermissionMode
 			opts.Env = hc.Env

--- a/sdk/go/agent/usage.go
+++ b/sdk/go/agent/usage.go
@@ -145,6 +145,10 @@ func (a *Agent) recordHarnessUsage(ctx context.Context, result *harness.Result, 
 	if model == "" && a.cfg.HarnessConfig != nil {
 		model = a.cfg.HarnessConfig.Model
 	}
+	// Attribute usage to the BASE model: a "#variant" reasoning-effort
+	// suffix is a harness dispatch detail, not part of the model id (the
+	// Python SDK likewise records the provider-reported base model).
+	model, _ = harness.SplitModelVariant(model)
 	if model == "" {
 		model = provider
 	}

--- a/sdk/go/harness/claudecode.go
+++ b/sdk/go/harness/claudecode.go
@@ -46,8 +46,13 @@ func (p *ClaudeCodeProvider) Execute(ctx context.Context, prompt string, options
 	// stream-json ("--output-format=stream-json requires --verbose").
 	cmd := []string{p.BinPath, "--print", "--output-format", "stream-json", "--verbose"}
 
-	if options.Model != "" {
-		cmd = append(cmd, "--model", options.Model)
+	// Strip any "#variant" reasoning-effort suffix so the CLI receives a
+	// valid model id. claude-code has no effort flag, so the variant is
+	// dropped (the Python provider logs this at debug level; this package
+	// has no provider-level logger).
+	modelValue, _ := options.resolveModelAndVariant()
+	if modelValue != "" {
+		cmd = append(cmd, "--model", modelValue)
 	}
 
 	if options.MaxTurns > 0 {

--- a/sdk/go/harness/claudecode_test.go
+++ b/sdk/go/harness/claudecode_test.go
@@ -145,3 +145,35 @@ func TestClaudeCodeProvider_ParsesStreamJSONFixture(t *testing.T) {
 		assert.Equal(t, 1, raw.Metrics.NumTurns)
 	})
 }
+
+// TestClaudeCodeProvider_StripsModelVariantSuffix mirrors the Python
+// test_execute_strips_model_variant_suffix: claude-code has no reasoning-
+// effort control, so a "#variant" suffix is stripped from --model (the CLI
+// must receive a valid model id) and the variant is dropped.
+func TestClaudeCodeProvider_StripsModelVariantSuffix(t *testing.T) {
+	p := NewClaudeCodeProvider("claude")
+
+	var gotCmd []string
+	p.runCLI = func(_ context.Context, cmd []string, _ map[string]string, _ string, _ int, _ []byte) (*CLIResult, error) {
+		gotCmd = append([]string(nil), cmd...)
+		return &CLIResult{
+			Stdout:     `{"type":"result","result":"OK","session_id":"s1","num_turns":1}`,
+			ReturnCode: 0,
+		}, nil
+	}
+
+	raw, err := p.Execute(context.Background(), "hello", Options{Model: "sonnet#high"})
+	require.NoError(t, err)
+	require.False(t, raw.IsError, "unexpected error: %s", raw.ErrorMessage)
+
+	require.Contains(t, gotCmd, "--model")
+	for i, arg := range gotCmd {
+		if arg == "--model" {
+			require.Greater(t, len(gotCmd), i+1)
+			assert.Equal(t, "sonnet", gotCmd[i+1],
+				"--model must carry the base model, not the #variant-suffixed string")
+		}
+	}
+	assert.NotContains(t, gotCmd, "sonnet#high")
+	assert.NotContains(t, gotCmd, "--variant")
+}

--- a/sdk/go/harness/codex.go
+++ b/sdk/go/harness/codex.go
@@ -65,9 +65,15 @@ func (p *CodexProvider) Execute(ctx context.Context, prompt string, options Opti
 
 	// Pass the model through with -m. SWE-AF resolves gpt-5.5 vs gpt-5.3-codex by
 	// auth mode and relies on the value reaching the CLI; the old provider
-	// ignored options.Model entirely.
-	if options.Model != "" {
-		cmd = append(cmd, "-m", options.Model)
+	// ignored options.Model entirely. Reasoning effort has no dedicated flag —
+	// it's the model_reasoning_effort config key, fed by a "#variant" suffix
+	// on the model (or an explicit Options.Variant), e.g. "gpt-5.3-codex#high".
+	modelValue, variantValue := options.resolveModelAndVariant()
+	if modelValue != "" {
+		cmd = append(cmd, "-m", modelValue)
+	}
+	if variantValue != "" {
+		cmd = append(cmd, "-c", "model_reasoning_effort="+variantValue)
 	}
 
 	// permission_mode → sandbox policy (port of codex_harness_patch.py:165-170).

--- a/sdk/go/harness/codex_test.go
+++ b/sdk/go/harness/codex_test.go
@@ -306,3 +306,61 @@ func toStringSlice(v any) []string {
 		return nil
 	}
 }
+
+// TestCodexProvider_ModelVariantReasoningEffort pins the model#variant parity
+// matrix from the Python provider tests (test_harness_provider_codex.py):
+// -m always carries the BASE model, a "#variant" suffix (or an explicit
+// Options.Variant, which wins) becomes -c model_reasoning_effort=<v>, and a
+// bare model adds no -c at all.
+func TestCodexProvider_ModelVariantReasoningEffort(t *testing.T) {
+	run := func(t *testing.T, options Options) []string {
+		t.Helper()
+		var gotCmd []string
+		p := NewCodexProvider("codex")
+		p.runCLI = func(_ context.Context, cmd []string, _ map[string]string, _ string, _ int, _ []byte) (*CLIResult, error) {
+			gotCmd = append([]string(nil), cmd...)
+			return &CLIResult{Stdout: `{"type":"turn.completed","text":"ok"}`, ReturnCode: 0}, nil
+		}
+		raw, err := p.Execute(context.Background(), "hello", options)
+		require.NoError(t, err)
+		require.False(t, raw.IsError, "unexpected error: %s", raw.ErrorMessage)
+		return gotCmd
+	}
+
+	index := func(cmd []string, flag string) int {
+		for i, arg := range cmd {
+			if arg == flag {
+				return i
+			}
+		}
+		return -1
+	}
+
+	t.Run("suffix maps to model_reasoning_effort", func(t *testing.T) {
+		cmd := run(t, Options{Model: "gpt-5.3-codex#high"})
+		mIdx := index(cmd, "-m")
+		require.GreaterOrEqual(t, mIdx, 0)
+		assert.Equal(t, "gpt-5.3-codex", cmd[mIdx+1], "-m must carry the base model, never the suffixed string")
+		cIdx := index(cmd, "-c")
+		require.GreaterOrEqual(t, cIdx, 0)
+		assert.Equal(t, "model_reasoning_effort=high", cmd[cIdx+1])
+	})
+
+	t.Run("explicit variant wins over suffix", func(t *testing.T) {
+		cmd := run(t, Options{Model: "gpt-5.5#low", Variant: "max"})
+		mIdx := index(cmd, "-m")
+		require.GreaterOrEqual(t, mIdx, 0)
+		assert.Equal(t, "gpt-5.5", cmd[mIdx+1])
+		cIdx := index(cmd, "-c")
+		require.GreaterOrEqual(t, cIdx, 0)
+		assert.Equal(t, "model_reasoning_effort=max", cmd[cIdx+1])
+	})
+
+	t.Run("bare model has no effort config", func(t *testing.T) {
+		cmd := run(t, Options{Model: "gpt-5.5"})
+		mIdx := index(cmd, "-m")
+		require.GreaterOrEqual(t, mIdx, 0)
+		assert.Equal(t, "gpt-5.5", cmd[mIdx+1])
+		assert.NotContains(t, cmd, "-c")
+	})
+}

--- a/sdk/go/harness/gemini.go
+++ b/sdk/go/harness/gemini.go
@@ -35,8 +35,11 @@ func (p *GeminiProvider) Execute(ctx context.Context, prompt string, options Opt
 		cmd = append(cmd, "--sandbox")
 	}
 
-	if options.Model != "" {
-		cmd = append(cmd, "-m", options.Model)
+	// gemini has no reasoning-effort flag; strip any "#variant" suffix so
+	// the CLI still receives a valid model id, and drop the variant.
+	modelValue, _ := options.resolveModelAndVariant()
+	if modelValue != "" {
+		cmd = append(cmd, "-m", modelValue)
 	}
 
 	// Prompt passed via -p flag.

--- a/sdk/go/harness/model.go
+++ b/sdk/go/harness/model.go
@@ -1,0 +1,38 @@
+package harness
+
+import "strings"
+
+// ModelVariantSep separates the base model id from a reasoning-effort variant
+// in the "provider/model#variant" model-string syntax. "#" is safe because
+// provider model ids never contain it (":" is taken by OpenRouter suffixes
+// like ":free", "@" by Vertex-style ids).
+const ModelVariantSep = "#"
+
+// SplitModelVariant splits a "provider/model#variant" string into its base
+// model and variant parts.
+//
+// The "#variant" suffix carries a provider-specific reasoning-effort variant
+// (e.g. "high", "minimal") through config surfaces that only hold a model
+// string. The split happens on the FIRST separator and both parts are
+// whitespace-trimmed. A bare model string passes through as (model, "");
+// an empty or blank input yields ("", ""). Mirrors the Python SDK's
+// split_model_variant (harness/_cli.py).
+func SplitModelVariant(model string) (base, variant string) {
+	if strings.TrimSpace(model) == "" {
+		return "", ""
+	}
+	base, variant, _ = strings.Cut(model, ModelVariantSep)
+	return strings.TrimSpace(base), strings.TrimSpace(variant)
+}
+
+// resolveModelAndVariant resolves the (model, variant) pair for a harness
+// invocation. An explicit Options.Variant wins over a "#variant" suffix on
+// Options.Model; the returned model never carries the suffix. Mirrors the
+// Python SDK's resolve_model_and_variant (harness/_cli.py).
+func (o Options) resolveModelAndVariant() (model, variant string) {
+	model, variant = SplitModelVariant(o.Model)
+	if explicit := strings.TrimSpace(o.Variant); explicit != "" {
+		variant = explicit
+	}
+	return model, variant
+}

--- a/sdk/go/harness/model_test.go
+++ b/sdk/go/harness/model_test.go
@@ -1,0 +1,98 @@
+package harness
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSplitModelVariant pins the Python split_model_variant matrix from
+// sdk/python/tests/test_harness_cli.py: split on the FIRST "#", trim
+// whitespace on both parts, empty parts become "".
+func TestSplitModelVariant(t *testing.T) {
+	cases := []struct {
+		name        string
+		model       string
+		wantBase    string
+		wantVariant string
+	}{
+		{"suffix parsed", "openrouter/z-ai/glm-5.2#high", "openrouter/z-ai/glm-5.2", "high"},
+		{"bare model passes through", "deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-flash", ""},
+		{"empty model", "", "", ""},
+		{"whitespace-only model", "  ", "", ""},
+		{"trailing separator drops empty variant", "model#", "model", ""},
+		{"leading separator drops empty base", "#high", "", "high"},
+		{"whitespace trimmed on both parts", " openai/gpt-5 # low ", "openai/gpt-5", "low"},
+		{"split on first separator only", "model#high#extra", "model", "high#extra"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			base, variant := SplitModelVariant(tc.model)
+			assert.Equal(t, tc.wantBase, base)
+			assert.Equal(t, tc.wantVariant, variant)
+		})
+	}
+}
+
+// TestOptionsResolveModelAndVariant pins the Python resolve_model_and_variant
+// semantics: an explicit Options.Variant wins over a "#variant" suffix, and
+// the returned model never carries the suffix.
+func TestOptionsResolveModelAndVariant(t *testing.T) {
+	t.Run("suffix used when no explicit variant", func(t *testing.T) {
+		model, variant := Options{Model: "openai/gpt-5#minimal"}.resolveModelAndVariant()
+		assert.Equal(t, "openai/gpt-5", model)
+		assert.Equal(t, "minimal", variant)
+	})
+
+	t.Run("explicit variant wins over suffix", func(t *testing.T) {
+		model, variant := Options{Model: "openai/gpt-5#low", Variant: "max"}.resolveModelAndVariant()
+		assert.Equal(t, "openai/gpt-5", model)
+		assert.Equal(t, "max", variant)
+	})
+
+	t.Run("explicit variant with bare model", func(t *testing.T) {
+		model, variant := Options{Model: "gpt-5.3-codex", Variant: "high"}.resolveModelAndVariant()
+		assert.Equal(t, "gpt-5.3-codex", model)
+		assert.Equal(t, "high", variant)
+	})
+
+	t.Run("whitespace-only explicit variant falls back to suffix", func(t *testing.T) {
+		model, variant := Options{Model: "openai/gpt-5#low", Variant: "  "}.resolveModelAndVariant()
+		assert.Equal(t, "openai/gpt-5", model)
+		assert.Equal(t, "low", variant)
+	})
+
+	t.Run("no model and no variant", func(t *testing.T) {
+		model, variant := Options{}.resolveModelAndVariant()
+		assert.Equal(t, "", model)
+		assert.Equal(t, "", variant)
+	})
+}
+
+// TestMergeOptions_Variant verifies Variant flows through the default/override
+// merge like every other option field.
+func TestMergeOptions_Variant(t *testing.T) {
+	r := NewRunner(Options{Provider: ProviderOpenCode, Variant: "high"})
+	assert.Equal(t, "high", r.mergeOptions(Options{}).Variant, "default carried through")
+	assert.Equal(t, "max", r.mergeOptions(Options{Variant: "max"}).Variant, "override wins")
+}
+
+// TestGeminiProvider_StripsModelVariantSuffix mirrors the Python
+// test_gemini_strips_model_variant_suffix: gemini has no effort control, so
+// the CLI receives the bare base model and the variant is dropped.
+func TestGeminiProvider_StripsModelVariantSuffix(t *testing.T) {
+	dir := t.TempDir()
+	script := writeTestScript(t, dir, "gemini", "#!/bin/sh\necho \"args: $@\"\n")
+
+	p := NewGeminiProvider(script)
+	raw, err := p.Execute(context.Background(), "hello", Options{Model: "gemini-2.5-pro#high"})
+	require.NoError(t, err)
+	require.False(t, raw.IsError)
+
+	assert.Contains(t, raw.Result, "-m gemini-2.5-pro")
+	assert.NotContains(t, raw.Result, "#high")
+	assert.NotContains(t, raw.Result, "--variant")
+}

--- a/sdk/go/harness/opencode.go
+++ b/sdk/go/harness/opencode.go
@@ -89,9 +89,16 @@ func (p *OpenCodeProvider) Execute(ctx context.Context, prompt string, options O
 		cmd = append(cmd, "--dir", dir)
 	}
 
-	// Pass model via -m on the run subcommand when supplied.
-	if options.Model != "" {
-		cmd = append(cmd, "-m", options.Model)
+	// Pass model via -m on the run subcommand when supplied. A "#variant"
+	// suffix on the model (or an explicit Options.Variant) maps to
+	// --variant — opencode's provider-specific reasoning effort (e.g. high,
+	// max, minimal).
+	modelValue, variantValue := options.resolveModelAndVariant()
+	if modelValue != "" {
+		cmd = append(cmd, "-m", modelValue)
+	}
+	if variantValue != "" {
+		cmd = append(cmd, "--variant", variantValue)
 	}
 
 	// opencode v1.14 does not accept --dangerously-skip-permissions on the
@@ -125,11 +132,14 @@ func (p *OpenCodeProvider) Execute(ctx context.Context, prompt string, options O
 		env[k] = v
 	}
 
-	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(options.Model)), "openrouter/") {
+	// The attribution check keys off the BASE model — a "#variant" suffix
+	// must not defeat the openrouter/ prefix match nor leak into the
+	// per-model config overlay key.
+	if strings.HasPrefix(strings.ToLower(modelValue), "openrouter/") {
 		if _, callerSet := env["OPENCODE_CONFIG_CONTENT"]; !callerSet && os.Getenv("OPENCODE_CONFIG_CONTENT") == "" {
 			attributionEnv := mergedProcessEnv(env)
 			headers := openRouterAttributionHeaders(attributionEnv)
-			modelSlug := strings.TrimPrefix(options.Model, "openrouter/")
+			modelSlug := strings.TrimPrefix(modelValue, "openrouter/")
 			if modelSlug != "" && len(headers) > 0 {
 				content := map[string]any{
 					"provider": map[string]any{

--- a/sdk/go/harness/opencode_test.go
+++ b/sdk/go/harness/opencode_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -274,5 +275,57 @@ func TestOpenCodePromptDelivery(t *testing.T) {
 				t.Fatalf("viaStdin=false: stdin should be empty, got %q", gotStdin)
 			}
 		}
+	}
+}
+
+// TestOpenCodeProvider_ModelVariantFlagWiring pins the model#variant parity
+// matrix from the Python provider tests (test_harness_provider_opencode.py):
+// a "#variant" suffix on the model maps to --variant, an explicit
+// Options.Variant wins over the suffix, and a bare model produces a
+// byte-identical argv with no --variant flag at all.
+func TestOpenCodeProvider_ModelVariantFlagWiring(t *testing.T) {
+	cases := []struct {
+		name    string
+		options Options
+		wantCmd []string
+	}{
+		{
+			name:    "suffix maps to --variant",
+			options: Options{Model: "openrouter/z-ai/glm-5.2#high"},
+			wantCmd: []string{"opencode", "run", "--format", "json", "-m", "openrouter/z-ai/glm-5.2", "--variant", "high", "hello"},
+		},
+		{
+			name:    "explicit variant wins over suffix",
+			options: Options{Model: "openai/gpt-5#low", Variant: "max"},
+			wantCmd: []string{"opencode", "run", "--format", "json", "-m", "openai/gpt-5", "--variant", "max", "hello"},
+		},
+		{
+			name:    "bare model has no variant flag",
+			options: Options{Model: "deepseek/deepseek-v4-flash"},
+			wantCmd: []string{"opencode", "run", "--format", "json", "-m", "deepseek/deepseek-v4-flash", "hello"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotCmd []string
+			p := NewOpenCodeProvider("opencode", "")
+			p.runCLI = func(_ context.Context, cmd []string, _ map[string]string, _ string, _ int, _ []byte) (*CLIResult, error) {
+				gotCmd = append([]string(nil), cmd...)
+				return &CLIResult{Stdout: "ok\n", ReturnCode: 0}, nil
+			}
+
+			raw, err := p.Execute(context.Background(), "hello", tc.options)
+			if err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+			if raw.IsError {
+				t.Fatalf("Execute IsError: %s", raw.ErrorMessage)
+			}
+
+			if !reflect.DeepEqual(gotCmd, tc.wantCmd) {
+				t.Fatalf("argv mismatch:\n got  %q\n want %q", gotCmd, tc.wantCmd)
+			}
+		})
 	}
 }

--- a/sdk/go/harness/provider.go
+++ b/sdk/go/harness/provider.go
@@ -26,8 +26,16 @@ type Options struct {
 	// Provider name: "opencode", "claude-code".
 	Provider string
 
-	// Model identifier passed to the coding agent.
+	// Model identifier passed to the coding agent. It may carry a
+	// reasoning-effort variant after a "#" separator (e.g.
+	// "openrouter/z-ai/glm-5.2#high"); providers strip the suffix and map
+	// the variant to their effort control when they have one.
 	Model string
+
+	// Variant is the provider-specific reasoning-effort variant (e.g.
+	// "high", "max", "minimal"). When set it wins over a "#variant" suffix
+	// on Model. Providers without an effort control drop it.
+	Variant string
 
 	// MaxTurns limits the number of agent iterations.
 	MaxTurns int

--- a/sdk/go/harness/runner.go
+++ b/sdk/go/harness/runner.go
@@ -190,6 +190,9 @@ func (r *Runner) mergeOptions(overrides Options) Options {
 	if overrides.Model != "" {
 		merged.Model = overrides.Model
 	}
+	if overrides.Variant != "" {
+		merged.Variant = overrides.Variant
+	}
 	if overrides.MaxTurns > 0 {
 		merged.MaxTurns = overrides.MaxTurns
 	}

--- a/sdk/go/harness/runner_test.go
+++ b/sdk/go/harness/runner_test.go
@@ -602,3 +602,30 @@ func TestRunner_BuildProvider_UsesFactory(t *testing.T) {
 		})
 	}
 }
+
+// TestOpenCodeProvider_OpenRouterOverlayUsesBaseModel ensures the OpenRouter
+// attribution overlay keys off the BASE model: a "#variant" reasoning-effort
+// suffix neither defeats the openrouter/ prefix match nor leaks into the
+// per-model config overlay key.
+func TestOpenCodeProvider_OpenRouterOverlayUsesBaseModel(t *testing.T) {
+	p := NewOpenCodeProvider("opencode", "")
+	var capturedEnv map[string]string
+	p.runCLI = func(ctx context.Context, cmd []string, env map[string]string, cwd string, timeout int, _ []byte) (*CLIResult, error) {
+		capturedEnv = env
+		return &CLIResult{Stdout: "ok\n", ReturnCode: 0}, nil
+	}
+
+	raw, err := p.Execute(context.Background(), "test prompt", Options{
+		Model: "openrouter/openai/gpt-4o#high",
+	})
+	require.NoError(t, err)
+	require.False(t, raw.IsError)
+
+	var overlay map[string]any
+	require.NoError(t, json.Unmarshal([]byte(capturedEnv["OPENCODE_CONFIG_CONTENT"]), &overlay))
+	models := overlay["provider"].(map[string]any)["openrouter"].(map[string]any)["models"].(map[string]any)
+	_, hasBase := models["openai/gpt-4o"]
+	assert.True(t, hasBase, "overlay must key the BASE model slug")
+	_, hasSuffixed := models["openai/gpt-4o#high"]
+	assert.False(t, hasSuffixed, "the #variant suffix must not leak into the overlay key")
+}

--- a/sdk/python/agentfield/harness/_cli.py
+++ b/sdk/python/agentfield/harness/_cli.py
@@ -28,6 +28,41 @@ def strip_ansi(text: str) -> str:
     return _ANSI_RE.sub("", text)
 
 
+# Separator for the ``provider/model#variant`` model-string syntax. ``#`` is
+# safe because provider model ids never contain it (``:`` is taken by
+# OpenRouter suffixes like ``:free``, ``@`` by Vertex-style ids).
+MODEL_VARIANT_SEP = "#"
+
+
+def split_model_variant(model: object) -> Tuple[Optional[str], Optional[str]]:
+    """Split a ``provider/model#variant`` string into ``(model, variant)``.
+
+    The ``#variant`` suffix carries a provider-specific reasoning-effort
+    variant (e.g. ``high``, ``minimal``) through config surfaces that only
+    hold a model string. A bare model string passes through as
+    ``(model, None)``; non-string or empty input yields ``(None, None)``.
+    """
+    if not isinstance(model, str) or not model.strip():
+        return None, None
+    base, _, variant = model.partition(MODEL_VARIANT_SEP)
+    return base.strip() or None, variant.strip() or None
+
+
+def resolve_model_and_variant(
+    options: Dict[str, object],
+) -> Tuple[Optional[str], Optional[str]]:
+    """Resolve ``(model, variant)`` from harness options.
+
+    An explicit ``options["variant"]`` wins over a ``#variant`` suffix on
+    ``options["model"]``; the returned model never carries the suffix.
+    """
+    model, variant = split_model_variant(options.get("model"))
+    explicit = options.get("variant")
+    if isinstance(explicit, str) and explicit.strip():
+        variant = explicit.strip()
+    return model, variant
+
+
 def resolve_cli_command(name: str) -> str:
     """Resolve a bare CLI name to a spawnable path on Windows.
 

--- a/sdk/python/agentfield/harness/providers/claude.py
+++ b/sdk/python/agentfield/harness/providers/claude.py
@@ -6,11 +6,15 @@ loaded when the claude-code provider is actually used.
 
 from __future__ import annotations
 
+import logging
 import time
 from typing import Any, Dict, List, Optional
 
+from agentfield.harness._cli import resolve_model_and_variant
 from agentfield.harness._result import Metrics, RawResult
 from agentfield.exceptions import HarnessProviderUnavailable
+
+logger = logging.getLogger("agentfield.harness.claude")
 
 
 def _get_claude_sdk() -> Any:
@@ -70,8 +74,16 @@ class ClaudeCodeProvider:
             ) from exc
 
         agent_options: dict[str, object] = {}
-        if options.get("model") is not None:
-            agent_options["model"] = options["model"]
+        model_value, variant_value = resolve_model_and_variant(options)
+        if model_value is not None:
+            agent_options["model"] = model_value
+        if variant_value:
+            # claude_agent_sdk has no reasoning-effort knob; drop the variant
+            # rather than passing an invalid "model#variant" model id.
+            logger.debug(
+                "Ignoring model variant %r: claude-code has no effort flag",
+                variant_value,
+            )
         # Agent root: project_dir is the canonical field, fall back to cwd
         # (agentfield#686). The SDK's cwd is both the process dir and the root
         # the agent operates in; the runner places the schema output file under

--- a/sdk/python/agentfield/harness/providers/codex.py
+++ b/sdk/python/agentfield/harness/providers/codex.py
@@ -10,6 +10,7 @@ from agentfield.harness._cli import (
     extract_final_text,
     extract_token_usage,
     parse_jsonl,
+    resolve_model_and_variant,
     run_cli,
     strip_ansi,
 )
@@ -45,6 +46,16 @@ class CodexProvider:
         elif permission_mode == "plan":
             cmd.extend(["--sandbox", "read-only"])
 
+        # Model via -m; reasoning effort has no dedicated flag — it's the
+        # model_reasoning_effort config key. The effort comes from a
+        # "#variant" suffix on the model (or an explicit options["variant"]),
+        # e.g. "gpt-5.3-codex#high".
+        model_value, variant_value = resolve_model_and_variant(options)
+        if model_value:
+            cmd.extend(["-m", model_value])
+        if variant_value:
+            cmd.extend(["-c", f"model_reasoning_effort={variant_value}"])
+
         cmd.append(prompt)
 
         env: Dict[str, str] = {}
@@ -77,7 +88,7 @@ class CodexProvider:
 
         num_turns = 0
         total_cost: Optional[float] = estimate_cli_cost(
-            model=str(options.get("model", "")),
+            model=model_value or "",
             prompt=prompt,
             result_text=result_text,
         )
@@ -127,7 +138,7 @@ class CodexProvider:
                 output_tokens=tokens["output_tokens"],
                 cache_read_tokens=tokens["cache_read_tokens"],
                 cache_creation_tokens=tokens["cache_creation_tokens"],
-                model=str(options.get("model", "")) or None,
+                model=model_value,
             ),
             is_error=is_error,
             error_message=error_message,

--- a/sdk/python/agentfield/harness/providers/gemini.py
+++ b/sdk/python/agentfield/harness/providers/gemini.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import time
 from typing import Dict, Optional
 
-from agentfield.harness._cli import estimate_cli_cost, run_cli, strip_ansi
+from agentfield.harness._cli import (
+    estimate_cli_cost,
+    resolve_model_and_variant,
+    run_cli,
+    strip_ansi,
+)
 from agentfield.harness._availability import ensure_cli_available, provider_unavailable
 from agentfield.harness._result import FailureType, Metrics, RawResult
 
@@ -30,8 +35,11 @@ class GeminiProvider:
         elif permission_mode == "plan":
             cmd.extend(["--approval-mode", "plan"])
 
-        if options.get("model"):
-            cmd.extend(["-m", str(options["model"])])
+        # gemini has no reasoning-effort flag; strip any "#variant" suffix so
+        # the CLI still receives a valid model id.
+        model_value, _variant_value = resolve_model_and_variant(options)
+        if model_value:
+            cmd.extend(["-m", model_value])
         cmd.extend(["-p", prompt])
 
         env: Dict[str, str] = {}
@@ -92,7 +100,7 @@ class GeminiProvider:
             error_message = None
 
         estimated_cost = estimate_cli_cost(
-            model=str(options.get("model", "")),
+            model=model_value or "",
             prompt=prompt,
             result_text=result_text,
         )

--- a/sdk/python/agentfield/harness/providers/opencode.py
+++ b/sdk/python/agentfield/harness/providers/opencode.py
@@ -14,6 +14,7 @@ from typing import ClassVar, Dict, Optional
 from agentfield.harness._cli import (
     estimate_cli_cost,
     extract_final_text,
+    resolve_model_and_variant,
     extract_token_usage,
     parse_jsonl,
     run_cli,
@@ -179,9 +180,14 @@ class OpenCodeProvider:
         if isinstance(dir_value, str):
             cmd.extend(["--dir", dir_value])
 
-        # Pass model via -m flag on the run subcommand
-        if options.get("model"):
-            cmd.extend(["-m", str(options["model"])])
+        # Pass model via -m. A "#variant" suffix on the model (or an explicit
+        # options["variant"]) maps to --variant — opencode's provider-specific
+        # reasoning effort (e.g. high, max, minimal).
+        model_value, variant_value = resolve_model_and_variant(options)
+        if model_value:
+            cmd.extend(["-m", model_value])
+        if variant_value:
+            cmd.extend(["--variant", variant_value])
 
         # opencode v1.14 does not accept --dangerously-skip-permissions on the
         # `run` subcommand — passing it makes yargs print the run-help screen
@@ -338,7 +344,7 @@ class OpenCodeProvider:
             estimated_cost = stream_cost
         else:
             estimated_cost = estimate_cli_cost(
-                model=str(options.get("model", "")),
+                model=model_value or "",
                 prompt=effective_prompt,
                 result_text=result_text,
             )
@@ -361,7 +367,7 @@ class OpenCodeProvider:
                 output_tokens=tokens["output_tokens"],
                 cache_read_tokens=tokens["cache_read_tokens"],
                 cache_creation_tokens=tokens["cache_creation_tokens"],
-                model=str(options.get("model", "")) or None,
+                model=model_value,
             ),
             is_error=is_error,
             error_message=error_message,

--- a/sdk/python/tests/test_harness_cli.py
+++ b/sdk/python/tests/test_harness_cli.py
@@ -11,13 +11,50 @@ from agentfield.harness._cli import (
     estimate_cli_cost,
     extract_final_text,
     parse_jsonl,
+    resolve_model_and_variant,
     run_cli,
+    split_model_variant,
     strip_ansi,
 )
 
 
 def test_strip_ansi_removes_colors():
     assert strip_ansi("\x1b[31mError\x1b[0m") == "Error"
+
+
+def test_split_model_variant_parses_suffix():
+    assert split_model_variant("openrouter/z-ai/glm-5.2#high") == (
+        "openrouter/z-ai/glm-5.2",
+        "high",
+    )
+
+
+def test_split_model_variant_passes_bare_model_through():
+    assert split_model_variant("deepseek/deepseek-v4-flash") == (
+        "deepseek/deepseek-v4-flash",
+        None,
+    )
+
+
+def test_split_model_variant_handles_missing_or_empty_model():
+    assert split_model_variant(None) == (None, None)
+    assert split_model_variant("") == (None, None)
+    assert split_model_variant("  ") == (None, None)
+    assert split_model_variant("model#") == ("model", None)
+    assert split_model_variant("#high") == (None, "high")
+
+
+def test_resolve_model_and_variant_explicit_option_wins_over_suffix():
+    assert resolve_model_and_variant(
+        {"model": "openai/gpt-5#low", "variant": "max"}
+    ) == ("openai/gpt-5", "max")
+
+
+def test_resolve_model_and_variant_uses_suffix_when_no_explicit_option():
+    assert resolve_model_and_variant({"model": "openai/gpt-5#minimal"}) == (
+        "openai/gpt-5",
+        "minimal",
+    )
 
 
 def _stream_reader(chunks: list[bytes]) -> MagicMock:

--- a/sdk/python/tests/test_harness_provider_claude.py
+++ b/sdk/python/tests/test_harness_provider_claude.py
@@ -223,3 +223,40 @@ async def test_claude_uses_project_dir_as_root_over_cwd(monkeypatch):
     )
 
     assert captured["options"].kwargs["cwd"] == "/root"
+
+
+@pytest.mark.asyncio
+async def test_execute_strips_model_variant_suffix(monkeypatch):
+    from agentfield.harness.providers.claude import ClaudeCodeProvider
+
+    captured: dict[str, Any] = {}
+
+    class FakeClaudeAgentOptions:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+    def fake_query(*, prompt: str, options: FakeClaudeAgentOptions):
+        _ = prompt
+        captured["options"] = options
+        return _AsyncStream(
+            [
+                {
+                    "type": "result",
+                    "result": "final",
+                    "session_id": "sess-1",
+                    "cost_usd": 0.01,
+                    "num_turns": 1,
+                }
+            ]
+        )
+
+    fake_sdk = ModuleType("claude_agent_sdk")
+    setattr(fake_sdk, "ClaudeAgentOptions", FakeClaudeAgentOptions)
+    setattr(fake_sdk, "query", fake_query)
+    monkeypatch.setitem(__import__("sys").modules, "claude_agent_sdk", fake_sdk)
+
+    provider = ClaudeCodeProvider()
+    raw = await provider.execute("hello", {"model": "sonnet#high"})
+
+    assert captured["options"].kwargs["model"] == "sonnet"
+    assert raw.is_error is False

--- a/sdk/python/tests/test_harness_provider_codex.py
+++ b/sdk/python/tests/test_harness_provider_codex.py
@@ -296,3 +296,48 @@ async def test_codex_project_dir_is_root_and_plan_maps_to_read_only(
     assert "--full-auto" not in cmd
     assert "--skip-git-repo-check" in cmd
     assert captured["cwd"] == "/root"
+
+
+@pytest.mark.asyncio
+async def test_codex_passes_model_and_reasoning_effort(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, Any] = {}
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        _ = (env, cwd, timeout)
+        captured["cmd"] = cmd
+        return '{"type":"turn.completed","text":"ok"}\n', "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.codex.run_cli", fake_run_cli)
+    provider = CodexProvider()
+    raw = await provider.execute("hello", {"model": "gpt-5.3-codex#high"})
+
+    cmd = captured["cmd"]
+    m_idx = cmd.index("-m")
+    assert cmd[m_idx + 1] == "gpt-5.3-codex"
+    c_idx = cmd.index("-c")
+    assert cmd[c_idx + 1] == "model_reasoning_effort=high"
+    assert cmd[-1] == "hello"
+    assert raw.metrics.model == "gpt-5.3-codex"
+
+
+@pytest.mark.asyncio
+async def test_codex_bare_model_has_no_effort_config(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, Any] = {}
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        _ = (env, cwd, timeout)
+        captured["cmd"] = cmd
+        return '{"type":"turn.completed","text":"ok"}\n', "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.codex.run_cli", fake_run_cli)
+    provider = CodexProvider()
+    await provider.execute("hello", {"model": "gpt-5.5"})
+
+    cmd = captured["cmd"]
+    m_idx = cmd.index("-m")
+    assert cmd[m_idx + 1] == "gpt-5.5"
+    assert "-c" not in cmd

--- a/sdk/python/tests/test_harness_provider_gemini.py
+++ b/sdk/python/tests/test_harness_provider_gemini.py
@@ -206,3 +206,21 @@ async def test_gemini_auto_uses_yolo_not_sandbox(monkeypatch: pytest.MonkeyPatch
 
     assert "--yolo" in captured["cmd"]
     assert "--sandbox" not in captured["cmd"]
+
+
+@pytest.mark.asyncio
+async def test_gemini_strips_model_variant_suffix(monkeypatch: pytest.MonkeyPatch):
+    captured: dict[str, Any] = {}
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        _ = (env, cwd, timeout)
+        captured["cmd"] = cmd
+        return "final text\n", "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.gemini.run_cli", fake_run_cli)
+    provider = GeminiProvider()
+    await provider.execute("hello", {"model": "gemini-2.5-pro#high"})
+
+    m_idx = captured["cmd"].index("-m")
+    assert captured["cmd"][m_idx + 1] == "gemini-2.5-pro"
+    assert "--variant" not in captured["cmd"]

--- a/sdk/python/tests/test_harness_provider_opencode.py
+++ b/sdk/python/tests/test_harness_provider_opencode.py
@@ -581,3 +581,75 @@ async def test_opencode_windows_hands_prompt_over_stdin(
     # ...and argv carries only the fixed flags, no positional prompt.
     assert captured["cmd"][:4] == ["opencode", "run", "--format", "json"]
     assert all("too large" not in part for part in captured["cmd"])
+
+
+@pytest.mark.asyncio
+async def test_opencode_model_variant_suffix_maps_to_variant_flag(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, Any] = {}
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None, input_text=None):
+        _ = (env, cwd, timeout, input_text)
+        captured["cmd"] = cmd
+        return "ok\n", "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
+
+    provider = OpenCodeProvider()
+    raw = await provider.execute("hello", {"model": "openrouter/z-ai/glm-5.2#high"})
+
+    assert captured["cmd"] == [
+        "opencode",
+        "run",
+        "--format",
+        "json",
+        "-m",
+        "openrouter/z-ai/glm-5.2",
+        "--variant",
+        "high",
+        "hello",
+    ]
+    assert raw.is_error is False
+    assert raw.metrics.model == "openrouter/z-ai/glm-5.2"
+
+
+@pytest.mark.asyncio
+async def test_opencode_explicit_variant_option_wins_over_suffix(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, Any] = {}
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None, input_text=None):
+        _ = (env, cwd, timeout, input_text)
+        captured["cmd"] = cmd
+        return "ok\n", "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
+
+    provider = OpenCodeProvider()
+    await provider.execute("hello", {"model": "openai/gpt-5#low", "variant": "max"})
+
+    m_idx = captured["cmd"].index("-m")
+    assert captured["cmd"][m_idx + 1] == "openai/gpt-5"
+    v_idx = captured["cmd"].index("--variant")
+    assert captured["cmd"][v_idx + 1] == "max"
+
+
+@pytest.mark.asyncio
+async def test_opencode_bare_model_has_no_variant_flag(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, Any] = {}
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None, input_text=None):
+        _ = (env, cwd, timeout, input_text)
+        captured["cmd"] = cmd
+        return "ok\n", "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
+
+    provider = OpenCodeProvider()
+    await provider.execute("hello", {"model": "deepseek/deepseek-v4-flash"})
+
+    assert "--variant" not in captured["cmd"]

--- a/sdk/typescript/src/agent/Agent.ts
+++ b/sdk/typescript/src/agent/Agent.ts
@@ -41,6 +41,7 @@ import { AIClient } from '../ai/AIClient.js';
 import { AgentFieldClient } from '../client/AgentFieldClient.js';
 import type { HarnessRunner } from '../harness/runner.js';
 import type { HarnessOptions, HarnessResult } from '../harness/types.js';
+import { splitModelVariant } from '../harness/modelVariant.js';
 import { MemoryClient } from '../memory/MemoryClient.js';
 import { MemoryEventClient } from '../memory/MemoryEventClient.js';
 import {
@@ -412,9 +413,13 @@ export class Agent {
 
       const providerName = options?.provider ?? this.config.harnessConfig?.provider;
       const harnessName = providerName ? String(providerName).replace(/-/g, '_') : null;
-      const modelName = String(
+      // Usage is recorded against the base model — a "#variant"
+      // reasoning-effort suffix on the configured model never reaches the
+      // provider and must not reach the tracker either.
+      const rawModelName = String(
         result.model ?? options?.model ?? this.config.harnessConfig?.model ?? providerName ?? 'harness'
       );
+      const modelName = splitModelVariant(rawModelName).model ?? rawModelName;
 
       tracker.record({
         model: modelName,

--- a/sdk/typescript/src/harness/index.ts
+++ b/sdk/typescript/src/harness/index.ts
@@ -1,5 +1,7 @@
 export type { HarnessConfig, HarnessOptions, Metrics, RawResult, HarnessResult } from './types.js';
 export { createHarnessResult, createMetrics, createRawResult } from './types.js';
+export type { ModelVariant } from './modelVariant.js';
+export { MODEL_VARIANT_SEP, splitModelVariant, resolveModelAndVariant } from './modelVariant.js';
 export type { HarnessProvider } from './providers/base.js';
 export { buildProvider, SUPPORTED_PROVIDERS } from './providers/factory.js';
 export { HarnessRunner } from './runner.js';

--- a/sdk/typescript/src/harness/modelVariant.ts
+++ b/sdk/typescript/src/harness/modelVariant.ts
@@ -1,0 +1,47 @@
+/**
+ * Separator for the `provider/model#variant` model-string syntax. `#` is
+ * safe because provider model ids never contain it (`:` is taken by
+ * OpenRouter suffixes like `:free`, `@` by Vertex-style ids).
+ */
+export const MODEL_VARIANT_SEP = '#';
+
+export interface ModelVariant {
+  model?: string;
+  variant?: string;
+}
+
+/**
+ * Split a `provider/model#variant` string into `{ model, variant }`.
+ *
+ * The `#variant` suffix carries a provider-specific reasoning-effort
+ * variant (e.g. `high`, `minimal`) through config surfaces that only
+ * hold a model string. A bare model string passes through as
+ * `{ model }`; non-string or empty input yields `{}`.
+ */
+export function splitModelVariant(model: unknown): ModelVariant {
+  if (typeof model !== 'string' || !model.trim()) {
+    return {};
+  }
+  const sepIndex = model.indexOf(MODEL_VARIANT_SEP);
+  const base = sepIndex === -1 ? model : model.slice(0, sepIndex);
+  const variant = sepIndex === -1 ? '' : model.slice(sepIndex + 1);
+  return {
+    model: base.trim() || undefined,
+    variant: variant.trim() || undefined,
+  };
+}
+
+/**
+ * Resolve `{ model, variant }` from harness options.
+ *
+ * An explicit `options.variant` wins over a `#variant` suffix on
+ * `options.model`; the returned model never carries the suffix.
+ */
+export function resolveModelAndVariant(options: Record<string, unknown>): ModelVariant {
+  const { model, variant } = splitModelVariant(options.model);
+  const explicit = options.variant;
+  if (typeof explicit === 'string' && explicit.trim()) {
+    return { model, variant: explicit.trim() };
+  }
+  return { model, variant };
+}

--- a/sdk/typescript/src/harness/providers/claude.ts
+++ b/sdk/typescript/src/harness/providers/claude.ts
@@ -1,6 +1,7 @@
 import type { HarnessProvider } from './base.js';
 import type { RawResult } from '../types.js';
 import { createMetrics, createRawResult } from '../types.js';
+import { resolveModelAndVariant } from '../modelVariant.js';
 
 type QueryInput = {
   prompt: string;
@@ -39,7 +40,10 @@ export class ClaudeCodeProvider implements HarnessProvider {
     }
 
     const agentOptions: Record<string, unknown> = {};
-    if (options.model !== undefined) agentOptions.model = options.model;
+    // claude-agent-sdk has no reasoning-effort knob; strip any "#variant"
+    // suffix so the SDK receives a valid model id, and drop the variant.
+    const { model: modelValue } = resolveModelAndVariant(options);
+    if (modelValue !== undefined) agentOptions.model = modelValue;
     if (options.cwd !== undefined) agentOptions.cwd = options.cwd;
     if (options.maxTurns !== undefined) agentOptions.max_turns = options.maxTurns;
     if (options.tools !== undefined) agentOptions.allowed_tools = options.tools;

--- a/sdk/typescript/src/harness/providers/codex.ts
+++ b/sdk/typescript/src/harness/providers/codex.ts
@@ -2,6 +2,7 @@ import type { HarnessProvider } from './base.js';
 import type { RawResult } from '../types.js';
 import { createRawResult, createMetrics } from '../types.js';
 import { runCli, parseJsonl, extractFinalText } from '../cli.js';
+import { resolveModelAndVariant } from '../modelVariant.js';
 
 export class CodexProvider implements HarnessProvider {
   private readonly bin: string;
@@ -19,6 +20,19 @@ export class CodexProvider implements HarnessProvider {
     if (options.permissionMode === 'auto') {
       cmd.push('--full-auto');
     }
+
+    // Model via -m; reasoning effort has no dedicated flag — it's the
+    // model_reasoning_effort config key. The effort comes from a "#variant"
+    // suffix on the model (or an explicit options.variant), e.g.
+    // "gpt-5.3-codex#high".
+    const { model: modelValue, variant: variantValue } = resolveModelAndVariant(options);
+    if (modelValue) {
+      cmd.push('-m', modelValue);
+    }
+    if (variantValue) {
+      cmd.push('-c', `model_reasoning_effort=${variantValue}`);
+    }
+
     cmd.push(prompt);
 
     const startApi = Date.now();
@@ -50,7 +64,7 @@ export class CodexProvider implements HarnessProvider {
       return createRawResult({
         result: resultText,
         messages: events,
-        metrics: createMetrics({ durationApiMs: Date.now() - startApi, numTurns, sessionId }),
+        metrics: createMetrics({ durationApiMs: Date.now() - startApi, numTurns, sessionId, model: modelValue }),
         isError,
         errorMessage: isError ? stderr.trim() : undefined,
       });

--- a/sdk/typescript/src/harness/providers/gemini.ts
+++ b/sdk/typescript/src/harness/providers/gemini.ts
@@ -2,6 +2,7 @@ import type { HarnessProvider } from './base.js';
 import type { RawResult } from '../types.js';
 import { createRawResult, createMetrics } from '../types.js';
 import { runCli } from '../cli.js';
+import { resolveModelAndVariant } from '../modelVariant.js';
 
 export class GeminiProvider implements HarnessProvider {
   private readonly bin: string;
@@ -19,8 +20,11 @@ export class GeminiProvider implements HarnessProvider {
     if (options.permissionMode === 'auto') {
       cmd.push('--sandbox');
     }
-    if (options.model) {
-      cmd.push('-m', String(options.model));
+    // gemini has no reasoning-effort flag; strip any "#variant" suffix so
+    // the CLI still receives a valid model id.
+    const { model: modelValue } = resolveModelAndVariant(options);
+    if (modelValue) {
+      cmd.push('-m', modelValue);
     }
     cmd.push('-p', prompt);
 

--- a/sdk/typescript/src/harness/providers/opencode.ts
+++ b/sdk/typescript/src/harness/providers/opencode.ts
@@ -2,6 +2,7 @@ import type { HarnessProvider } from './base.js';
 import type { RawResult } from '../types.js';
 import { createRawResult, createMetrics } from '../types.js';
 import { runCli } from '../cli.js';
+import { resolveModelAndVariant } from '../modelVariant.js';
 import {
   isOpenRouterRequest,
   openRouterAttributionHeaders,
@@ -31,9 +32,16 @@ export class OpenCodeProvider implements HarnessProvider {
 
     const env: Record<string, string> = { ...(options.env as Record<string, string>) };
 
-    // Pass model via -m flag on the run subcommand (not env var).
-    if (options.model) {
-      cmd.push('-m', String(options.model));
+    // Pass model via -m flag on the run subcommand (not env var). A
+    // "#variant" suffix on the model (or an explicit options.variant) maps
+    // to --variant — opencode's provider-specific reasoning effort (e.g.
+    // high, max, minimal).
+    const { model: modelValue, variant: variantValue } = resolveModelAndVariant(options);
+    if (modelValue) {
+      cmd.push('-m', modelValue);
+    }
+    if (variantValue) {
+      cmd.push('--variant', variantValue);
     }
 
     // Handle system prompt - prepend to user prompt since OpenCode
@@ -46,14 +54,15 @@ export class OpenCodeProvider implements HarnessProvider {
     // Prompt is the positional `message` arg to `opencode run`.
     cmd.push(effectivePrompt);
 
-    const explicitModel = typeof options.model === 'string' ? options.model : undefined;
+    // The attribution overlay keys off the base model — a "#variant" suffix
+    // would otherwise leak into the config's model slug.
     if (
-      explicitModel &&
-      isOpenRouterRequest({ model: explicitModel }) &&
+      modelValue &&
+      isOpenRouterRequest({ model: modelValue }) &&
       !env.OPENCODE_CONFIG_CONTENT &&
       !process.env.OPENCODE_CONFIG_CONTENT
     ) {
-      const modelSlug = explicitModel.slice('openrouter/'.length);
+      const modelSlug = modelValue.slice('openrouter/'.length);
       const headers = openRouterAttributionHeaders({ env: { ...process.env, ...env } });
       if (modelSlug && Object.keys(headers).length > 0) {
         env.OPENCODE_CONFIG_CONTENT = JSON.stringify({
@@ -82,6 +91,7 @@ export class OpenCodeProvider implements HarnessProvider {
           durationApiMs: Date.now() - startApi,
           numTurns: resultText ? 1 : 0,
           sessionId: '',
+          model: modelValue,
         }),
         isError,
         errorMessage: isError ? stderr.trim() : undefined,

--- a/sdk/typescript/src/harness/runner.ts
+++ b/sdk/typescript/src/harness/runner.ts
@@ -93,6 +93,7 @@ export class HarnessRunner {
       for (const key of [
         'provider',
         'model',
+        'variant',
         'maxTurns',
         'maxBudgetUsd',
         'maxRetries',

--- a/sdk/typescript/src/harness/types.ts
+++ b/sdk/typescript/src/harness/types.ts
@@ -1,6 +1,11 @@
 export interface HarnessConfig {
   provider: 'claude-code' | 'codex' | 'gemini' | 'opencode';
   model?: string;
+  /**
+   * Provider-specific reasoning-effort variant (e.g. `high`, `minimal`).
+   * Wins over a `#variant` suffix on `model`.
+   */
+  variant?: string;
   maxTurns?: number;
   maxBudgetUsd?: number;
   maxRetries?: number;
@@ -20,6 +25,11 @@ export interface HarnessConfig {
 export interface HarnessOptions {
   provider?: string;
   model?: string;
+  /**
+   * Provider-specific reasoning-effort variant (e.g. `high`, `minimal`).
+   * Wins over a `#variant` suffix on `model`.
+   */
+  variant?: string;
   maxTurns?: number;
   maxBudgetUsd?: number;
   maxRetries?: number;

--- a/sdk/typescript/tests/harness_model_variant.test.ts
+++ b/sdk/typescript/tests/harness_model_variant.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  MODEL_VARIANT_SEP,
+  resolveModelAndVariant,
+  splitModelVariant,
+} from '../src/harness/modelVariant.js';
+
+describe('splitModelVariant', () => {
+  it('parses a #variant suffix into model and variant', () => {
+    expect(splitModelVariant('openrouter/z-ai/glm-5.2#high')).toEqual({
+      model: 'openrouter/z-ai/glm-5.2',
+      variant: 'high',
+    });
+  });
+
+  it('passes a bare model through with no variant', () => {
+    expect(splitModelVariant('deepseek/deepseek-v4-flash')).toEqual({
+      model: 'deepseek/deepseek-v4-flash',
+      variant: undefined,
+    });
+  });
+
+  it('handles missing, empty, or non-string model', () => {
+    expect(splitModelVariant(undefined)).toEqual({});
+    expect(splitModelVariant(null)).toEqual({});
+    expect(splitModelVariant('')).toEqual({});
+    expect(splitModelVariant('  ')).toEqual({});
+    expect(splitModelVariant(42)).toEqual({});
+  });
+
+  it('treats empty halves around the separator as absent', () => {
+    expect(splitModelVariant('model#')).toEqual({ model: 'model', variant: undefined });
+    expect(splitModelVariant('#high')).toEqual({ model: undefined, variant: 'high' });
+  });
+
+  it('splits on the first separator only', () => {
+    expect(splitModelVariant('a#b#c')).toEqual({ model: 'a', variant: 'b#c' });
+  });
+
+  it('trims whitespace around both halves', () => {
+    expect(splitModelVariant(' openai/gpt-5 # high ')).toEqual({
+      model: 'openai/gpt-5',
+      variant: 'high',
+    });
+  });
+
+  it('uses # as the separator', () => {
+    expect(MODEL_VARIANT_SEP).toBe('#');
+  });
+});
+
+describe('resolveModelAndVariant', () => {
+  it('lets an explicit variant option win over the suffix', () => {
+    expect(resolveModelAndVariant({ model: 'openai/gpt-5#low', variant: 'max' })).toEqual({
+      model: 'openai/gpt-5',
+      variant: 'max',
+    });
+  });
+
+  it('uses the suffix when no explicit option is set', () => {
+    expect(resolveModelAndVariant({ model: 'openai/gpt-5#minimal' })).toEqual({
+      model: 'openai/gpt-5',
+      variant: 'minimal',
+    });
+  });
+
+  it('ignores a whitespace-only explicit variant', () => {
+    expect(resolveModelAndVariant({ model: 'openai/gpt-5#low', variant: '  ' })).toEqual({
+      model: 'openai/gpt-5',
+      variant: 'low',
+    });
+  });
+
+  it('returns nothing for empty options', () => {
+    expect(resolveModelAndVariant({})).toEqual({ model: undefined, variant: undefined });
+  });
+});

--- a/sdk/typescript/tests/harness_provider_claude.test.ts
+++ b/sdk/typescript/tests/harness_provider_claude.test.ts
@@ -57,6 +57,30 @@ describe('ClaudeCodeProvider', () => {
     expect(raw.messages).toHaveLength(2);
   });
 
+  it('strips a #variant model suffix before handing the model to the SDK', async () => {
+    const captured: { options?: Record<string, unknown> } = {};
+
+    vi.doMock(
+      '@anthropic-ai/claude-agent-sdk',
+      () => ({
+        query: ({ options }: { prompt: string; options: Record<string, unknown> }) => {
+          captured.options = options;
+          return (async function* stream() {
+            yield { type: 'result', result: 'final', session_id: 'sess-1', cost_usd: 0.01, num_turns: 1 };
+          })();
+        },
+      }),
+      { virtual: true }
+    );
+
+    const { ClaudeCodeProvider } = await import('../src/harness/providers/claude.js');
+    const provider = new ClaudeCodeProvider();
+    const raw = await provider.execute('hello', { model: 'sonnet#high' });
+
+    expect(captured.options?.model).toBe('sonnet');
+    expect(raw.isError).toBe(false);
+  });
+
   it('extracts token usage and model from the result message', async () => {
     vi.doMock(
       '@anthropic-ai/claude-agent-sdk',

--- a/sdk/typescript/tests/harness_provider_codex.test.ts
+++ b/sdk/typescript/tests/harness_provider_codex.test.ts
@@ -65,6 +65,55 @@ describe('codex provider', () => {
     expect(result.messages).toHaveLength(2);
   });
 
+  it('passes the model via -m and a #variant suffix as model_reasoning_effort', async () => {
+    vi.spyOn(cli, 'runCli').mockResolvedValue({
+      stdout: '{"type":"turn.completed","text":"ok"}\n',
+      stderr: '',
+      exitCode: 0,
+    });
+
+    const provider = new CodexProvider();
+    const result = await provider.execute('hello', { model: 'gpt-5.3-codex#high' });
+
+    expect(cli.runCli).toHaveBeenCalledWith(
+      ['codex', 'exec', '--json', '-m', 'gpt-5.3-codex', '-c', 'model_reasoning_effort=high', 'hello'],
+      { cwd: undefined, env: undefined }
+    );
+    expect(result.metrics.model).toBe('gpt-5.3-codex');
+  });
+
+  it('lets an explicit variant option win over the model suffix', async () => {
+    vi.spyOn(cli, 'runCli').mockResolvedValue({
+      stdout: '{"type":"turn.completed","text":"ok"}\n',
+      stderr: '',
+      exitCode: 0,
+    });
+
+    const provider = new CodexProvider();
+    await provider.execute('hello', { model: 'gpt-5.3-codex#low', variant: 'max' });
+
+    expect(cli.runCli).toHaveBeenCalledWith(
+      ['codex', 'exec', '--json', '-m', 'gpt-5.3-codex', '-c', 'model_reasoning_effort=max', 'hello'],
+      { cwd: undefined, env: undefined }
+    );
+  });
+
+  it('passes a bare model via -m with no effort config', async () => {
+    vi.spyOn(cli, 'runCli').mockResolvedValue({
+      stdout: '{"type":"turn.completed","text":"ok"}\n',
+      stderr: '',
+      exitCode: 0,
+    });
+
+    const provider = new CodexProvider();
+    await provider.execute('hello', { model: 'gpt-5.5' });
+
+    expect(cli.runCli).toHaveBeenCalledWith(
+      ['codex', 'exec', '--json', '-m', 'gpt-5.5', 'hello'],
+      { cwd: undefined, env: undefined }
+    );
+  });
+
   it('returns helpful message when binary is not found', async () => {
     vi.spyOn(cli, 'runCli').mockRejectedValue(new Error('spawn codex ENOENT'));
 

--- a/sdk/typescript/tests/harness_provider_gemini.test.ts
+++ b/sdk/typescript/tests/harness_provider_gemini.test.ts
@@ -75,6 +75,22 @@ describe('gemini provider', () => {
     });
     expect(result.isError).toBe(false);
   });
+
+  it('strips a #variant model suffix (gemini has no effort flag)', async () => {
+    vi.spyOn(cli, 'runCli').mockResolvedValue({
+      stdout: 'ok\n',
+      stderr: '',
+      exitCode: 0,
+    });
+
+    const provider = new GeminiProvider();
+    await provider.execute('hello', { model: 'gemini-2.5-pro#high' });
+
+    expect(cli.runCli).toHaveBeenCalledWith(['gemini', '-m', 'gemini-2.5-pro', '-p', 'hello'], {
+      cwd: undefined,
+      env: undefined,
+    });
+  });
 });
 
 describe('provider factory', () => {

--- a/sdk/typescript/tests/harness_provider_opencode.test.ts
+++ b/sdk/typescript/tests/harness_provider_opencode.test.ts
@@ -75,6 +75,75 @@ describe('opencode provider', () => {
     expect(result.isError).toBe(false);
   });
 
+  it('maps a #variant model suffix to the --variant flag', async () => {
+    vi.spyOn(cli, 'runCli').mockResolvedValue({
+      stdout: 'ok\n',
+      stderr: '',
+      exitCode: 0,
+    });
+
+    const provider = new OpenCodeProvider();
+    const result = await provider.execute('hello', { model: 'openrouter/z-ai/glm-5.2#high' });
+
+    expect(cli.runCli).toHaveBeenCalledWith(
+      ['opencode', 'run', '-m', 'openrouter/z-ai/glm-5.2', '--variant', 'high', 'hello'],
+      // OpenRouter model: env also carries the attribution overlay (asserted
+      // separately below, keyed off the base model).
+      { env: expect.objectContaining({}) },
+    );
+    expect(result.isError).toBe(false);
+    expect(result.metrics.model).toBe('openrouter/z-ai/glm-5.2');
+  });
+
+  it('lets an explicit variant option win over the model suffix', async () => {
+    vi.spyOn(cli, 'runCli').mockResolvedValue({
+      stdout: 'ok\n',
+      stderr: '',
+      exitCode: 0,
+    });
+
+    const provider = new OpenCodeProvider();
+    await provider.execute('hello', { model: 'openai/gpt-5#low', variant: 'max' });
+
+    expect(cli.runCli).toHaveBeenCalledWith(
+      ['opencode', 'run', '-m', 'openai/gpt-5', '--variant', 'max', 'hello'],
+      { env: {} },
+    );
+  });
+
+  it('passes no --variant flag for a bare model', async () => {
+    vi.spyOn(cli, 'runCli').mockResolvedValue({
+      stdout: 'ok\n',
+      stderr: '',
+      exitCode: 0,
+    });
+
+    const provider = new OpenCodeProvider();
+    await provider.execute('hello', { model: 'deepseek/deepseek-v4-flash' });
+
+    expect(cli.runCli).toHaveBeenCalledWith(
+      ['opencode', 'run', '-m', 'deepseek/deepseek-v4-flash', 'hello'],
+      { env: {} },
+    );
+  });
+
+  it('keys the OpenRouter overlay off the base model when a variant is present', async () => {
+    vi.spyOn(cli, 'runCli').mockResolvedValue({
+      stdout: 'ok\n',
+      stderr: '',
+      exitCode: 0,
+    });
+
+    const provider = new OpenCodeProvider();
+    await provider.execute('hello', { model: 'openrouter/openai/gpt-4o#high' });
+
+    const call = vi.mocked(cli.runCli).mock.calls[0];
+    const env = call[1]?.env ?? {};
+    const overlay = JSON.parse(env.OPENCODE_CONFIG_CONTENT);
+
+    expect(Object.keys(overlay.provider.openrouter.models)).toEqual(['openai/gpt-4o']);
+  });
+
   it('adds OpenCode header overlay for explicit OpenRouter model', async () => {
     vi.spyOn(cli, 'runCli').mockResolvedValue({
       stdout: 'ok\n',

--- a/sdk/typescript/tests/harness_runner.test.ts
+++ b/sdk/typescript/tests/harness_runner.test.ts
@@ -99,6 +99,30 @@ describe('harness runner', () => {
     expect(runner.isTransient('permission denied')).toBe(false);
   });
 
+  it('resolveOptions threads variant from config with per-call override winning', () => {
+    const cfg: HarnessConfig = {
+      provider: 'opencode',
+      model: 'openai/gpt-5',
+      variant: 'low',
+    };
+
+    const runner = new HarnessRunner(cfg);
+    expect(runner.resolveOptions(cfg, {}).variant).toBe('low');
+    expect(runner.resolveOptions(cfg, { variant: 'max' }).variant).toBe('max');
+  });
+
+  it('run threads variant through to the provider options', async () => {
+    const cwd = makeTempDir();
+    const provider = new MockProvider();
+    vi.spyOn(factory, 'buildProvider').mockResolvedValue(provider);
+
+    const runner = new HarnessRunner();
+    await runner.run('hello', { provider: 'opencode', model: 'openai/gpt-5#low', variant: 'max', cwd });
+
+    expect(provider.lastOptions?.model).toBe('openai/gpt-5#low');
+    expect(provider.lastOptions?.variant).toBe('max');
+  });
+
   it('run without schema returns plain HarnessResult', async () => {
     const cwd = makeTempDir();
     const provider = new MockProvider([

--- a/sdk/typescript/tests/usage_ai_capture.test.ts
+++ b/sdk/typescript/tests/usage_ai_capture.test.ts
@@ -252,6 +252,26 @@ describe('harness usage capture', () => {
     ]);
   });
 
+  it('records the base model when the configured model carries a #variant suffix', async () => {
+    const agent = new Agent({
+      nodeId: 'harness-agent',
+      harnessConfig: { provider: 'opencode', model: 'openrouter/z-ai/glm-5.2#high' } as any
+    });
+    // Provider reported cost but no model — the recorded model falls back to
+    // the configured one, minus the reasoning-effort suffix.
+    vi.spyOn(HarnessRunner.prototype, 'run').mockResolvedValue(
+      createHarnessResult({ result: 'done', costUsd: 0.5 })
+    );
+
+    const ctx = makeContext('exec-h1b', { reasonerId: 'builder' });
+    await ExecutionContext.run(ctx, () => agent.harness('do the thing'));
+
+    expect(ctx.costTracker.serialize().entries[0]).toMatchObject({
+      model: 'openrouter/z-ai/glm-5.2',
+      provider: 'openrouter'
+    });
+  });
+
   it('records cost-only runs and skips runs that reported nothing', async () => {
     const agent = makeAgent();
     const runSpy = vi.spyOn(HarnessRunner.prototype, 'run');


### PR DESCRIPTION
## Summary

Adds a runtime-agnostic way to select a **reasoning-effort variant** alongside the model for harness calls, in **all three SDKs (Python, Go, TypeScript)**: the `model` option accepts a `provider/model#variant` suffix, and an explicit `variant` option (Python kwarg / Go `Options.Variant` + `HarnessConfig.Variant` / TS `variant?: string`) wins over the suffix. This lets orchestrators (e.g. SWE-AF's model tiers) carry effort through every config surface that only holds a model string.

Per provider (identical semantics in all three SDKs):

| Provider | Model flag | Variant handling |
| --- | --- | --- |
| OpenCode | `-m <model>` | `--variant <v>` (e.g. `high`, `max`, `minimal`) |
| Codex | `-m <model>` | `-c model_reasoning_effort=<v>` |
| Claude Code | SDK `model` option | no effort control — suffix stripped, variant dropped |
| Gemini | `-m <model>` | no effort control — suffix stripped |

**Bug fixes included:** the Python and TypeScript codex providers previously passed *no model at all* to `codex exec` (`model` was only used for cost estimation), so every codex run silently used the CLI's default model. Both now pass `-m`. (The Go port had already fixed this.) In Go/TS, the OpenRouter attribution overlay and usage recording now key off the base model so a suffix can't defeat the `openrouter/` prefix match or pollute attribution.

`#` is safe as a separator: `:` belongs to OpenRouter suffixes (`:free`), `@` to Vertex-style ids; no provider uses `#` in model ids.

## Changes

**Python** (`sdk/python`): `split_model_variant`/`resolve_model_and_variant` in `harness/_cli.py`; all four providers wired; 13 new tests; `docs/harness-providers.md` section.
**Go** (`sdk/go`): `SplitModelVariant` + `Options.Variant` (`harness/model.go`, `provider.go`); providers + runner merge + `HarnessConfig.Variant` + base-model usage attribution; table-driven tests mirroring the Python matrix.
**TypeScript** (`sdk/typescript`): `modelVariant.ts` helper; `variant?: string` through `HarnessConfig`/`HarnessOptions`/runner; providers + `Agent.recordHarnessUsage` base-model fallback; test matrix mirrored across helper/provider/runner/usage suites.

## Testing

- Python: `ruff check .` clean; full suite green (`./scripts/run_pytest.sh`) on 3.12 (CI: 3.10/3.11/3.12)
- Go: `go mod tidy` (no drift), `go build`, `go vet`, `go test ./...` — all packages ok
- TypeScript: `npm ci` (lockfile in sync), `tsc --noEmit`, `vitest run` 807/807, `tsup` build
- **Live-validated per SDK** against OpenRouter through the real opencode CLI: in each of Python, Go, and TypeScript, a run with `openrouter/z-ai/glm-5.2#high` produced an opencode session record showing the assistant response served by `z-ai/glm-5.2` with `variant: high`; bare-model control runs unchanged. The real codex CLI also accepted `-m` + `-c model_reasoning_effort` and completed.

## Backward compatibility

Bare model strings produce byte-identical CLI argv in all three SDKs; the new path only activates on a `#` suffix or an explicit variant option. The codex `-m` fix (Python/TS) is an intended behavior change: a deployment that set a codex model its auth mode can't serve previously fell back to the CLI default silently — it will now error visibly.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)