### PR TITLE
feat: node-declared reasoner descriptions + entry points in discovery and af ls

### DIFF
--- a/control-plane/internal/cli/ls_reasoners.go
+++ b/control-plane/internal/cli/ls_reasoners.go
@@ -17,6 +17,7 @@ type lsOptions struct {
 	all          bool
 	node         string
 	live         bool
+	entrypoints  bool
 	outputFormat string
 	stdout       io.Writer
 	stdoutTTY    bool
@@ -29,10 +30,12 @@ type reasonerListResponse struct {
 }
 
 type reasonerListItem struct {
-	Node      string  `json:"node"`
-	Reasoner  string  `json:"reasoner"`
-	LastRunAt *string `json:"last_run_at,omitempty"`
-	Status    string  `json:"status"`
+	Node        string   `json:"node"`
+	Reasoner    string   `json:"reasoner"`
+	Description string   `json:"description,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	LastRunAt   *string  `json:"last_run_at,omitempty"`
+	Status      string   `json:"status"`
 }
 
 func NewReasonerListCommand() *cobra.Command {
@@ -57,6 +60,7 @@ func NewReasonerListCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.all, "all", false, "Show every reasoner")
 	cmd.Flags().StringVar(&opts.node, "node", "", "Filter to a single node")
 	cmd.Flags().BoolVar(&opts.live, "live", false, "Only show reasoners whose node is live")
+	cmd.Flags().BoolVarP(&opts.entrypoints, "entrypoints", "e", false, "Only show reasoners tagged as entry points")
 	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "", "Output format: pretty, json, yaml")
 	return cmd
 }
@@ -81,6 +85,9 @@ func runReasonerList(ctx context.Context, query string, opts *lsOptions) error {
 	}
 	if opts.live {
 		values.Set("live", "true")
+	}
+	if opts.entrypoints {
+		values.Set("entrypoints", "true")
 	}
 	resp, err := makeRequest(ctx, http.MethodGet, appendQuery("/api/v1/reasoners", values), nil, "application/json")
 	if err != nil {
@@ -107,10 +114,36 @@ func renderReasonerList(out io.Writer, resp reasonerListResponse, recentHeader b
 	}
 	for _, item := range resp.Reasoners {
 		name := item.Node + "." + item.Reasoner
-		fmt.Fprintf(out, "%-28s %-12s %s\n", name, relativeTime(item.LastRunAt), item.Status)
+		fmt.Fprintf(out, "%-28s %-12s %-6s %s\n", name, relativeTime(item.LastRunAt), item.Status, describeReasoner(item))
 	}
 	if resp.Total > resp.Shown {
 		fmt.Fprintf(out, "\n%d more recent  -  %d total  -  use `af ls --all`\n", resp.Total-resp.Shown, resp.Total)
+	}
+}
+
+// describeReasoner renders the trailing description column: entry points are
+// labeled so callers can spot a node's intended surface, and long descriptions
+// are truncated to keep rows on one line.
+func describeReasoner(item reasonerListItem) string {
+	const maxLen = 80
+	desc := strings.Join(strings.Fields(item.Description), " ")
+	if len(desc) > maxLen {
+		desc = desc[:maxLen-1] + "…"
+	}
+	entry := false
+	for _, tag := range item.Tags {
+		if strings.EqualFold(strings.TrimSpace(tag), "entrypoint") {
+			entry = true
+			break
+		}
+	}
+	switch {
+	case entry && desc != "":
+		return "[entrypoint] " + desc
+	case entry:
+		return "[entrypoint]"
+	default:
+		return desc
 	}
 }
 

--- a/control-plane/internal/handlers/discovery.go
+++ b/control-plane/internal/handlers/discovery.go
@@ -517,7 +517,7 @@ func buildDiscoveryResponse(agents []*types.AgentNode, filters DiscoveryFilters)
 				reasonerCap.OutputSchema = decodeSchema(reasoner.OutputSchema)
 			}
 			if filters.IncludeDescriptions {
-				reasonerCap.Description = extractDescription(agent.Metadata, reasoner.ID)
+				reasonerCap.Description = reasonerDescription(agent.Metadata, reasoner)
 			}
 			if filters.IncludeExamples {
 				reasonerCap.Examples = extractExamples(agent.Metadata, reasoner.ID)
@@ -544,7 +544,11 @@ func buildDiscoveryResponse(agents []*types.AgentNode, filters DiscoveryFilters)
 				skillCap.InputSchema = decodeSchema(skill.InputSchema)
 			}
 			if filters.IncludeDescriptions {
-				skillCap.Description = extractDescription(agent.Metadata, skill.ID)
+				if desc := strings.TrimSpace(skill.Description); desc != "" {
+					skillCap.Description = &desc
+				} else {
+					skillCap.Description = extractDescription(agent.Metadata, skill.ID)
+				}
 			}
 
 			capability.Skills = append(capability.Skills, skillCap)
@@ -593,6 +597,16 @@ func decodeSchema(raw json.RawMessage) map[string]interface{} {
 		return nil
 	}
 	return schema
+}
+
+// reasonerDescription resolves a reasoner's description: the field the SDK
+// registered on the reasoner record wins; the legacy agent-level
+// metadata.Custom["descriptions"] map remains as a fallback for older SDKs.
+func reasonerDescription(metadata types.AgentMetadata, reasoner types.ReasonerDefinition) *string {
+	if desc := strings.TrimSpace(reasoner.Description); desc != "" {
+		return &desc
+	}
+	return extractDescription(metadata, reasoner.ID)
 }
 
 func extractDescription(metadata types.AgentMetadata, id string) *string {

--- a/control-plane/internal/handlers/discovery_test.go
+++ b/control-plane/internal/handlers/discovery_test.go
@@ -96,6 +96,45 @@ func TestDiscoveryCapabilities_WithFiltersAndSchemas(t *testing.T) {
 	assert.Empty(t, resp.Capabilities[0].Skills)
 }
 
+// Validation contract: a description registered on the reasoner/skill record
+// itself (new SDKs) must win over the legacy agent-level metadata map, and
+// records without one must still fall back to that map (old SDKs).
+func TestDiscoveryCapabilities_RecordLevelDescriptions(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	InvalidateDiscoveryCache()
+
+	agents := buildDiscoveryAgents()
+	// agent-alpha's reasoner+skill gain record-level descriptions that differ
+	// from the metadata map entries; agent-beta stays metadata-map-only.
+	agents[0].Reasoners[0].Description = "Record-level reasoner description"
+	agents[0].Skills[0].Description = "Record-level skill description"
+
+	lister := &stubAgentLister{agents: agents}
+	router := gin.New()
+	router.GET("/api/v1/discovery/capabilities", DiscoveryCapabilitiesHandler(lister))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/discovery/capabilities", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp DiscoveryResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Capabilities, 2)
+
+	alpha := resp.Capabilities[0]
+	require.Equal(t, "agent-alpha", alpha.AgentID)
+	require.NotNil(t, alpha.Reasoners[0].Description)
+	assert.Equal(t, "Record-level reasoner description", *alpha.Reasoners[0].Description)
+	require.NotNil(t, alpha.Skills[0].Description)
+	assert.Equal(t, "Record-level skill description", *alpha.Skills[0].Description)
+
+	beta := resp.Capabilities[1]
+	require.Equal(t, "agent-beta", beta.AgentID)
+	require.NotNil(t, beta.Reasoners[0].Description)
+	assert.Equal(t, "Performs comprehensive research", *beta.Reasoners[0].Description)
+}
+
 func TestDiscoveryCapabilities_Formats(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	InvalidateDiscoveryCache()

--- a/control-plane/internal/handlers/nodes_register.go
+++ b/control-plane/internal/handlers/nodes_register.go
@@ -930,6 +930,7 @@ func RegisterServerlessAgentHandler(storageProvider storage.StorageProvider, uiS
 			outputSchemaBytes, _ := json.Marshal(r.OutputSchema)
 			reasoners[i] = types.ReasonerDefinition{
 				ID:           r.ID,
+				Description:  r.Description,
 				InputSchema:  json.RawMessage(inputSchemaBytes),
 				OutputSchema: json.RawMessage(outputSchemaBytes),
 				Tags:         r.Tags,
@@ -946,6 +947,7 @@ func RegisterServerlessAgentHandler(storageProvider storage.StorageProvider, uiS
 			inputSchemaBytes, _ := json.Marshal(s.InputSchema)
 			skills[i] = types.SkillDefinition{
 				ID:          s.ID,
+				Description: s.Description,
 				InputSchema: json.RawMessage(inputSchemaBytes),
 				Tags:        s.Tags,
 			}

--- a/control-plane/internal/handlers/reasoner_catalog.go
+++ b/control-plane/internal/handlers/reasoner_catalog.go
@@ -22,10 +22,12 @@ type ReasonerCatalogStore interface {
 }
 
 type ReasonerCatalogRow struct {
-	Node      string  `json:"node"`
-	Reasoner  string  `json:"reasoner"`
-	LastRunAt *string `json:"last_run_at,omitempty"`
-	Status    string  `json:"status"`
+	Node        string   `json:"node"`
+	Reasoner    string   `json:"reasoner"`
+	Description string   `json:"description,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	LastRunAt   *string  `json:"last_run_at,omitempty"`
+	Status      string   `json:"status"`
 }
 
 type ReasonerCatalogResponse struct {
@@ -70,6 +72,7 @@ func ListReasonersHandler(store ReasonerCatalogStore) gin.HandlerFunc {
 		nodeFilter := strings.TrimSpace(c.Query("node"))
 		liveOnly := parseQueryBool(c.Query("live"))
 		showAll := parseQueryBool(c.Query("all"))
+		entrypointsOnly := parseQueryBool(c.Query("entrypoints"))
 
 		rows := make([]ReasonerCatalogRow, 0)
 		for _, agent := range agents {
@@ -84,6 +87,9 @@ func ListReasonersHandler(store ReasonerCatalogStore) gin.HandlerFunc {
 				continue
 			}
 			for _, reasoner := range agent.Reasoners {
+				if entrypointsOnly && !hasTag(reasoner.Tags, types.TagEntrypoint) {
+					continue
+				}
 				fullName := agent.ID + "." + reasoner.ID
 				if query != "" && !fuzzyReasonerMatch(fullName, query) {
 					continue
@@ -93,11 +99,19 @@ func ListReasonersHandler(store ReasonerCatalogStore) gin.HandlerFunc {
 					formatted := ts.Format(time.RFC3339)
 					lastRun = &formatted
 				}
+				description := strings.TrimSpace(reasoner.Description)
+				if description == "" {
+					if fromMeta := extractDescription(agent.Metadata, reasoner.ID); fromMeta != nil {
+						description = strings.TrimSpace(*fromMeta)
+					}
+				}
 				rows = append(rows, ReasonerCatalogRow{
-					Node:      agent.ID,
-					Reasoner:  reasoner.ID,
-					LastRunAt: lastRun,
-					Status:    status,
+					Node:        agent.ID,
+					Reasoner:    reasoner.ID,
+					Description: description,
+					Tags:        reasoner.Tags,
+					LastRunAt:   lastRun,
+					Status:      status,
 				})
 			}
 		}
@@ -110,6 +124,13 @@ func ListReasonersHandler(store ReasonerCatalogStore) gin.HandlerFunc {
 			}
 			if leftOK && !left.Equal(right) {
 				return left.After(right)
+			}
+			// Among never-run (or same-timestamp) rows, surface declared entry
+			// points first so a fresh registry lists callable surfaces on top.
+			leftEntry := hasTag(rows[i].Tags, types.TagEntrypoint)
+			rightEntry := hasTag(rows[j].Tags, types.TagEntrypoint)
+			if leftEntry != rightEntry {
+				return leftEntry
 			}
 			return rows[i].Node+"."+rows[i].Reasoner < rows[j].Node+"."+rows[j].Reasoner
 		})
@@ -254,6 +275,15 @@ func reasonerNodeStatus(agent *types.AgentNode) string {
 	default:
 		return "stale"
 	}
+}
+
+func hasTag(tags []string, want string) bool {
+	for _, tag := range tags {
+		if strings.EqualFold(strings.TrimSpace(tag), want) {
+			return true
+		}
+	}
+	return false
 }
 
 func fuzzyReasonerMatch(value, query string) bool {

--- a/control-plane/internal/handlers/reasoner_catalog_test.go
+++ b/control-plane/internal/handlers/reasoner_catalog_test.go
@@ -78,6 +78,64 @@ func TestListReasonersHandlerRecencyAndFilters(t *testing.T) {
 	require.NotNil(t, body.Reasoners[0].LastRunAt)
 }
 
+// Validation contract: rows carry the reasoner's description (record field
+// first, legacy metadata map as fallback) and tags; entrypoints=true filters
+// to entrypoint-tagged reasoners; among never-run rows, entry points list
+// first so a fresh registry shows callable surfaces on top.
+func TestListReasonersHandlerDescriptionsAndEntrypoints(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := &reasonerCatalogStoreStub{
+		agents: []*types.AgentNode{
+			{
+				ID:           "swe-planner",
+				HealthStatus: types.HealthStatusActive,
+				Reasoners: []types.ReasonerDefinition{
+					{ID: "run_coder", Description: "Internal coding role"},
+					{
+						ID:          "implement_issue",
+						Description: "Implement one scoped issue on a branch",
+						Tags:        []string{"swe-issue", types.TagEntrypoint},
+					},
+					{ID: "legacy_only"},
+				},
+				Metadata: types.AgentMetadata{
+					Custom: map[string]interface{}{
+						"descriptions": map[string]interface{}{
+							"legacy_only": "From the metadata map",
+						},
+					},
+				},
+			},
+		},
+	}
+	router := gin.New()
+	router.GET("/api/v1/reasoners", ListReasonersHandler(store))
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/reasoners", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body ReasonerCatalogResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, 3, body.Total)
+	// No rows have runs -> the entrypoint-tagged reasoner sorts first.
+	require.Equal(t, "implement_issue", body.Reasoners[0].Reasoner)
+	require.Equal(t, "Implement one scoped issue on a branch", body.Reasoners[0].Description)
+	require.Contains(t, body.Reasoners[0].Tags, "entrypoint")
+	byName := map[string]ReasonerCatalogRow{}
+	for _, row := range body.Reasoners {
+		byName[row.Reasoner] = row
+	}
+	require.Equal(t, "From the metadata map", byName["legacy_only"].Description)
+
+	rec = httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/reasoners?entrypoints=true", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	body = ReasonerCatalogResponse{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, 1, body.Total)
+	require.Equal(t, "implement_issue", body.Reasoners[0].Reasoner)
+}
+
 func TestListReasonersHandlerErrorsAndTruncation(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/control-plane/pkg/types/types.go
+++ b/control-plane/pkg/types/types.go
@@ -216,9 +216,16 @@ type CallbackTestResult struct {
 	LatencyMS int64  `json:"latency_ms,omitempty"`
 }
 
+// TagEntrypoint marks a reasoner as an intended external entry point of its
+// node (as opposed to internal plumbing other reasoners call). Discovery
+// surfaces and `af ls` can filter on it, so callers browsing a node see the
+// reasoners they are meant to invoke first.
+const TagEntrypoint = "entrypoint"
+
 // ReasonerDefinition defines a reasoner provided by an agent node.
 type ReasonerDefinition struct {
 	ID             string           `json:"id"`
+	Description    string           `json:"description,omitempty"`
 	InputSchema    json.RawMessage  `json:"input_schema"`
 	OutputSchema   json.RawMessage  `json:"output_schema"`
 	MemoryConfig   MemoryConfig     `json:"memory_config"`
@@ -232,6 +239,7 @@ type ReasonerDefinition struct {
 // SkillDefinition defines a skill provided by an agent node.
 type SkillDefinition struct {
 	ID           string          `json:"id"`
+	Description  string          `json:"description,omitempty"`
 	InputSchema  json.RawMessage `json:"input_schema"`
 	Tags         []string        `json:"tags"`
 	ProposedTags []string        `json:"proposed_tags,omitempty"`

--- a/sdk/go/agent/agent.go
+++ b/sdk/go/agent/agent.go
@@ -100,7 +100,10 @@ func WithCLIFormatter(formatter func(context.Context, any, error)) ReasonerOptio
 	}
 }
 
-// WithDescription adds a human-readable description for help/list commands.
+// WithDescription adds a caller-facing summary for the reasoner. It is shown
+// by local help/list commands AND registered with the control plane, where
+// discovery (`GET /api/v1/discovery/capabilities`) and `af ls` surface it —
+// say what the reasoner does and when a caller should pick it.
 func WithDescription(desc string) ReasonerOption {
 	return func(r *Reasoner) {
 		r.Description = desc

--- a/sdk/go/agent/agent_lifecycle.go
+++ b/sdk/go/agent/agent_lifecycle.go
@@ -134,6 +134,7 @@ func (a *Agent) registerNode(ctx context.Context) error {
 	for _, reasoner := range a.reasoners {
 		reasoners = append(reasoners, types.ReasonerDefinition{
 			ID:             reasoner.Name,
+			Description:    reasoner.Description,
 			InputSchema:    reasoner.InputSchema,
 			OutputSchema:   reasoner.OutputSchema,
 			Tags:           reasoner.Tags,

--- a/sdk/go/agent/agent_lifecycle_test.go
+++ b/sdk/go/agent/agent_lifecycle_test.go
@@ -50,6 +50,48 @@ func TestInitialize_WrapsRegisterNodeError(t *testing.T) {
 	assert.Contains(t, err.Error(), "register node:")
 }
 
+// Validation contract: a reasoner registered with WithDescription must carry
+// that description in the node-registration payload sent to the control plane
+// (it was previously local-only, used for CLI help).
+func TestRegisterNode_TransmitsReasonerDescription(t *testing.T) {
+	var payload types.NodeRegistrationRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"registered"}`))
+	}))
+	defer server.Close()
+
+	a, err := New(Config{
+		NodeID:        "node-desc",
+		Version:       "1.0.0",
+		AgentFieldURL: server.URL,
+		Logger:        log.New(io.Discard, "", 0),
+	})
+	require.NoError(t, err)
+	a.RegisterReasoner("implement_issue",
+		func(context.Context, map[string]any) (any, error) { return nil, nil },
+		WithDescription("Implement one scoped issue on a branch"),
+		WithReasonerTags("entrypoint"),
+	)
+	a.RegisterReasoner("run_coder",
+		func(context.Context, map[string]any) (any, error) { return nil, nil },
+	)
+
+	require.NoError(t, a.registerNode(context.Background()))
+
+	byID := map[string]types.ReasonerDefinition{}
+	for _, r := range payload.Reasoners {
+		byID[r.ID] = r
+	}
+	require.Len(t, byID, 2)
+	assert.Equal(t, "Implement one scoped issue on a branch", byID["implement_issue"].Description)
+	assert.Contains(t, byID["implement_issue"].Tags, "entrypoint")
+	assert.Empty(t, byID["run_coder"].Description)
+}
+
 func TestInitialize_ContinuesWhenDIDOrReadyUpdatesFail(t *testing.T) {
 	agentDID, _ := testDIDCredentials(t)
 	var statusCalls int

--- a/sdk/go/types/types.go
+++ b/sdk/go/types/types.go
@@ -8,6 +8,7 @@ import (
 // ReasonerDefinition mirrors the AgentField server registration contract.
 type ReasonerDefinition struct {
 	ID             string           `json:"id"`
+	Description    string           `json:"description,omitempty"`
 	InputSchema    json.RawMessage  `json:"input_schema"`
 	OutputSchema   json.RawMessage  `json:"output_schema"`
 	Tags           []string         `json:"tags,omitempty"`

--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -128,6 +128,9 @@ class ReasonerEntry:
     input_types: Dict[str, tuple]  # (type, default) tuples - not Pydantic model
     output_type: type
     tags: List[str] = field(default_factory=list)
+    # Human/agent-facing summary sent to the control plane and surfaced by
+    # discovery + `af ls`. Defaults to the function docstring's first paragraph.
+    description: str = ""
     vc_enabled: Optional[bool] = None
     # Trigger bindings declared via @reasoner(triggers=[...]) or sugar
     # decorators @on_event / @on_schedule. The control plane upserts a
@@ -147,7 +150,21 @@ class SkillEntry:
     input_types: Dict[str, tuple]  # (type, default) tuples
     output_type: type
     tags: List[str] = field(default_factory=list)
+    # Same contract as ReasonerEntry.description.
+    description: str = ""
     vc_enabled: Optional[bool] = None
+
+
+def _docstring_summary(func: Callable) -> str:
+    """First paragraph of the function docstring, whitespace-collapsed.
+
+    Used as the default reasoner/skill description sent to the control plane —
+    a one-to-few-line summary reads well in discovery listings, while the rest
+    of the docstring (Args/Returns) stays local.
+    """
+    doc = inspect.getdoc(func) or ""
+    first_paragraph = doc.split("\n\n", 1)[0]
+    return " ".join(first_paragraph.split())
 
 
 # Import aiohttp for fire-and-forget HTTP calls
@@ -1034,6 +1051,9 @@ class Agent(FastAPI):
             if entry.vc_enabled is not None
             else self._agent_vc_enabled,
         }
+        description = getattr(entry, "description", "")
+        if description:
+            metadata["description"] = description
         triggers = getattr(entry, "triggers", None)
         accepts_webhook = getattr(entry, "accepts_webhook", "warn")
         if kind == "reasoner":
@@ -1940,6 +1960,7 @@ class Agent(FastAPI):
         name: Optional[str] = None,
         tags: Optional[List[str]] = None,
         *,
+        description: Optional[str] = None,
         vc_enabled: Optional[bool] = None,
         require_realtime_validation: bool = False,
         triggers: Optional[List[Any]] = None,
@@ -1953,6 +1974,7 @@ class Agent(FastAPI):
         name: Optional[str] = None,
         tags: Optional[List[str]] = None,
         *,
+        description: Optional[str] = None,
         vc_enabled: Optional[bool] = None,
         require_realtime_validation: bool = False,
         triggers: Optional[List[Any]] = None,
@@ -1965,6 +1987,7 @@ class Agent(FastAPI):
         name: Optional[str] = None,
         tags: Optional[List[str]] = None,
         *,
+        description: Optional[str] = None,
         vc_enabled: Optional[bool] = None,
         require_realtime_validation: bool = False,
         triggers: Optional[List[Any]] = None,
@@ -1980,6 +2003,11 @@ class Agent(FastAPI):
             path (str, optional): The API endpoint path for this reasoner. Defaults to /reasoners/{function_name}.
             name (str, optional): Explicit AgentField registration ID. Defaults to the function name.
             tags (List[str] | None, optional): Organizational tags that travel with the reasoner metadata.
+                The "entrypoint" tag marks a reasoner as an intended external entry point; discovery
+                and `af ls` surface those first.
+            description (str, optional): Caller-facing summary registered with the control plane and
+                shown by discovery / `af ls` — say what the reasoner does and when to call it.
+                Defaults to the first paragraph of the function docstring.
             vc_enabled (bool | None, optional): Override VC generation for this reasoner. True forces VC creation,
                 False disables it, and None inherits the agent-level policy.
             triggers (list, optional): EventTrigger / ScheduleTrigger declarations. Same shape as the
@@ -1990,6 +2018,7 @@ class Agent(FastAPI):
         direct_registration, decorator_path = split_direct_registration_arg(path)
         decorator_name = name
         decorator_tags = tags
+        decorator_description = description
         kwarg_triggers = list(triggers) if triggers else None
         kwarg_accepts_webhook = accepts_webhook
 
@@ -2230,6 +2259,8 @@ class Agent(FastAPI):
                 input_types=input_fields,  # Store (type, default) tuples, not Pydantic model
                 output_type=return_type,
                 tags=resolved_tags,
+                description=(decorator_description or "").strip()
+                or _docstring_summary(func),
                 vc_enabled=vc_setting,
                 triggers=list(merged_triggers or []),
                 accepts_webhook=resolved_accepts_webhook,
@@ -2892,6 +2923,7 @@ class Agent(FastAPI):
         path: Optional[str] = None,
         name: Optional[str] = None,
         *,
+        description: Optional[str] = None,
         vc_enabled: Optional[bool] = None,
         require_realtime_validation: bool = False,
     ) -> Callable[P, T]: ...
@@ -2903,6 +2935,7 @@ class Agent(FastAPI):
         path: Optional[str] = None,
         name: Optional[str] = None,
         *,
+        description: Optional[str] = None,
         vc_enabled: Optional[bool] = None,
         require_realtime_validation: bool = False,
     ) -> Callable[[Callable[P, T]], Callable[P, T]]: ...
@@ -2913,6 +2946,7 @@ class Agent(FastAPI):
         path: Optional[str] = None,
         name: Optional[str] = None,
         *,
+        description: Optional[str] = None,
         vc_enabled: Optional[bool] = None,
         require_realtime_validation: bool = False,
     ):
@@ -2936,6 +2970,8 @@ class Agent(FastAPI):
             path (str, optional): Custom API endpoint path for this skill.
                                 Defaults to "/skills/{function_name}".
             name (str, optional): Explicit AgentField registration ID. Defaults to the function name.
+            description (str, optional): Caller-facing summary registered with the control plane and
+                shown by discovery. Defaults to the first paragraph of the function docstring.
             vc_enabled (bool | None, optional): Override VC generation for this skill. True forces VC creation,
                 False disables it, and None inherits the agent-level policy.
 
@@ -3015,6 +3051,7 @@ class Agent(FastAPI):
         direct_registration, decorator_tags = split_direct_registration_arg(tags)
         decorator_path = path
         decorator_name = name
+        decorator_description = description
 
         def decorator(func: Callable) -> Callable:
             # Extract function metadata
@@ -3274,6 +3311,8 @@ class Agent(FastAPI):
                 input_types=input_fields,  # Store (type, default) tuples, not Pydantic model
                 output_type=return_type,
                 tags=resolved_tags,
+                description=(decorator_description or "").strip()
+                or _docstring_summary(func),
                 vc_enabled=vc_setting,
             )
             # NOTE: Legacy self.skills.append() removed - skills property generates list on-demand

--- a/sdk/python/tests/test_reasoner_descriptions.py
+++ b/sdk/python/tests/test_reasoner_descriptions.py
@@ -1,0 +1,99 @@
+"""Per-reasoner/skill descriptions in registration metadata.
+
+Validation contract:
+  - C1: @app.reasoner(description=...) puts that text in the reasoner's
+    registration metadata dict (the payload the control plane stores and
+    discovery/`af ls` surface).
+  - C2: without an explicit description, the first paragraph of the function
+    docstring (whitespace-collapsed) is used; no docstring -> no description
+    key at all (older control planes see an unchanged payload).
+  - C3: @router.reasoner(description=...) reaches the agent metadata through
+    include_router unchanged.
+  - C4: skills follow the same contract as reasoners.
+"""
+
+import pytest
+from agentfield import Agent
+from agentfield.router import AgentRouter
+
+
+def _metadata_by_id(entries):
+    return {entry["id"]: entry for entry in entries}
+
+
+@pytest.mark.unit
+def test_reasoner_explicit_description_wins_over_docstring():
+    app = Agent(node_id="test_agent", auto_register=False)
+
+    @app.reasoner(description="Implement one scoped issue on a branch")
+    async def implement_issue(issue: dict) -> dict:
+        """Docstring that should NOT be used."""
+        return {}
+
+    meta = _metadata_by_id(app.reasoners)["implement_issue"]
+    assert meta["description"] == "Implement one scoped issue on a branch"
+
+
+@pytest.mark.unit
+def test_reasoner_description_defaults_to_docstring_first_paragraph():
+    app = Agent(node_id="test_agent", auto_register=False)
+
+    @app.reasoner()
+    async def build(goal: str) -> dict:
+        """End-to-end: plan, execute, verify
+        across multiple lines.
+
+        Args:
+            goal: everything after the blank line stays local.
+        """
+        return {}
+
+    meta = _metadata_by_id(app.reasoners)["build"]
+    assert meta["description"] == "End-to-end: plan, execute, verify across multiple lines."
+
+
+@pytest.mark.unit
+def test_reasoner_without_docstring_omits_description_key():
+    app = Agent(node_id="test_agent", auto_register=False)
+
+    @app.reasoner()
+    async def bare(x: str) -> dict:
+        return {"x": x}
+
+    meta = _metadata_by_id(app.reasoners)["bare"]
+    assert "description" not in meta
+
+
+@pytest.mark.unit
+def test_router_reasoner_description_passes_through_include_router():
+    app = Agent(node_id="test_agent", auto_register=False)
+    router = AgentRouter(tags=["swe-issue"])
+
+    @router.reasoner(description="Sub-harness entry point", tags=["entrypoint"])
+    async def implement_issue(issue: dict) -> dict:
+        return {}
+
+    app.include_router(router)
+
+    meta = _metadata_by_id(app.reasoners)["implement_issue"]
+    assert meta["description"] == "Sub-harness entry point"
+    assert "entrypoint" in meta["tags"]
+
+
+@pytest.mark.unit
+def test_skill_description_explicit_and_docstring_default():
+    app = Agent(node_id="test_agent", auto_register=False)
+
+    @app.skill(description="Deterministic helper")
+    def helper(x: int) -> int:
+        """Docstring that should NOT be used."""
+        return x
+
+    @app.skill()
+    def documented(x: int) -> int:
+        """Adds one to x."""
+        return x + 1
+
+    skills = _metadata_by_id(app.skills)
+    assert skills["helper"]["description"] == "Deterministic helper"
+    assert skills["documented"]["description"] == "Adds one to x."


### PR DESCRIPTION
## Summary

Nodes can now **self-describe their callable surface**: each reasoner/skill carries a caller-facing description registered with the control plane, and an `entrypoint` tag convention marks the reasoners external callers are meant to invoke. Discovery (`GET /api/v1/discovery/capabilities`) and `af ls` surface both — so a harness browsing any AgentField control plane can pick the right entry point (e.g. SWE-AF's `implement_issue` vs `build`) without hardcoded knowledge of the node.

Before: discovery returned `{id, tags, invocation_target}` per reasoner — `implement_issue` was indistinguishable from internal plumbing like `run_coder`, and the only per-reasoner description path was an agent-level `metadata.custom["descriptions"]` map that **no SDK ever wrote**.

## Changes (one commit per concern)

- **control-plane** — `ReasonerDefinition`/`SkillDefinition` gain `description` (rides in the reasoners JSON blob, no migration). Discovery prefers the record-level description, falling back to the legacy metadata map (older SDKs unaffected). The serverless ingest path stops dropping the `description` it already parsed. The `af ls` catalog returns description+tags, accepts `entrypoints=true`, and sorts entrypoint-tagged rows first among never-run rows. Adds `types.TagEntrypoint`.
- **cli** — `af ls` renders a description column (`[entrypoint]`-labeled, one-line truncated) and gains `-e/--entrypoints`.
- **sdk-go** — `WithDescription` (previously local-only CLI help) is now transmitted at registration.
- **sdk-python** — `@app.reasoner(description=...)` / `@app.skill(description=...)`; defaults to the docstring's first paragraph (whitespace-collapsed); flows through `AgentRouter.include_router` unchanged. Reasoners without any docstring/description send a byte-identical payload to before.

Compatibility is two-way: old control plane + new SDK silently ignores the extra field; new control plane + old SDK falls back to the metadata map. TypeScript SDK is a follow-up.

## Test plan

- [x] `internal/handlers`: record-level description wins over metadata map, fallback preserved (reasoners + skills); catalog returns description/tags, `entrypoints=true` filters, entrypoint-first ordering among never-run rows
- [x] `sdk/go`: registration payload carries `WithDescription` text + tags (httptest capture)
- [x] `sdk/python`: 5 new tests — explicit kwarg wins, docstring-first-paragraph default, no-docstring omits the key, router passthrough, skills parity
- [x] Full local gates: control-plane `go build`/`go vet`/`go test ./...` (one pre-existing env-dependent failure in `internal/server` `TestStartAndStopCoverAdditionalBranches`, reproduces on clean main under WSL2 — unrelated); `sdk/go` tidy/build/test clean; `sdk/python` `ruff check` + full pytest clean on 3.12

## Follow-up

Agent-Field/SWE-AF will register routing descriptions + `entrypoint` tags for `build`/`implement_issue` on all four nodes (PR ready, gated on this releasing).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)