### PR TITLE
Link to applications directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,8 @@ Full walkthrough — authoring, installing, and configuring nodes: [Installing a
 
 [See all examples →](https://www.agentfield.ai/examples?utm_source=github-readme&utm_campaign=github-readme&utm_id=github-readme-see-all-examples)
 
+[Explore every application in the AgentField organization →](https://github.com/Agent-Field#applications-built-on-agentfield)
+
 Built something with AgentField? [Submit your project to be featured on the examples page](https://github.com/Agent-Field/agentfield/issues/new?template=community-project.md).
 
 ## Architecture


### PR DESCRIPTION
## What changed
- Adds a compact link from the core AgentField README to the organization application directory.

## Why
- Keeps the deeper core README showcase while directing visitors to the organization-level catalogue as the source of truth.

## Validation
- Verified the destination heading and profile directory link.
- Staged and committed only README.md; unrelated untracked worktree files were left untouched.