### PR TITLE
fix(sdk-go): survive OpenAI's strict validator on codex --output-schema

### DIFF
--- a/sdk/go/harness/codex.go
+++ b/sdk/go/harness/codex.go
@@ -43,10 +43,39 @@ func NewCodexProvider(binPath string) *CodexProvider {
 // computation and file writing; the provider only needs the paths so it can
 // point codex's native --output-schema / --output-last-message flags at them.
 //
+// An empty schemaPath with a non-empty outputPath means "last-message only":
+// the runner determined the schema cannot be expressed in OpenAI strict mode
+// (codexSchemaStrictExpressible, schema.go), so --output-schema must not be
+// sent — the server would reject it with invalid_json_schema — but codex still
+// persists its final JSON answer to outputPath for local validation.
+//
 // This implements the schemaAware interface the runner detects (see runner.go).
 func (p *CodexProvider) SetSchema(schemaPath, outputPath string) {
 	p.schemaPath = schemaPath
 	p.outputPath = outputPath
+}
+
+// isOutputSchemaRejection reports whether CLI output carries the server-side
+// strict-schema validator's 400 for --output-schema. The error event embeds
+// `"code": "invalid_json_schema"` and `Invalid schema for response_format
+// 'codex_output_schema'` (both observed live on codex-cli 0.144.1).
+func isOutputSchemaRejection(output string) bool {
+	lower := strings.ToLower(output)
+	return strings.Contains(lower, "invalid_json_schema") ||
+		strings.Contains(lower, "invalid schema for response_format")
+}
+
+// withoutFlagValue returns cmd with one `flag value` pair removed.
+func withoutFlagValue(cmd []string, flag string) []string {
+	out := make([]string, 0, len(cmd))
+	for i := 0; i < len(cmd); i++ {
+		if cmd[i] == flag && i+1 < len(cmd) {
+			i++
+			continue
+		}
+		out = append(out, cmd[i])
+	}
+	return out
 }
 
 func (p *CodexProvider) Execute(ctx context.Context, prompt string, options Options) (*RawResult, error) {
@@ -90,14 +119,20 @@ func (p *CodexProvider) Execute(ctx context.Context, prompt string, options Opti
 	}
 
 	// Native structured output: when the runner has set a schema, point codex at
-	// the strict schema file and the last-message output file (patch lines
-	// 176-178). codex writes its final message to the last-message file, which
-	// the runner reads back.
+	// the strict schema file (patch lines 176-178). Kept independent of the
+	// last-message flag below: the runner passes an empty schemaPath when the
+	// schema is not strict-expressible (see SetSchema), and the reactive
+	// fallback after execution needs the answer file even when the server
+	// rejects the schema flag.
+	usedOutputSchema := false
 	if p.schemaPath != "" && fileExists(p.schemaPath) {
 		cmd = append(cmd, "--output-schema", p.schemaPath)
-		if p.outputPath != "" {
-			cmd = append(cmd, "--output-last-message", p.outputPath)
-		}
+		usedOutputSchema = true
+	}
+	// codex writes its final message to the last-message file, which the
+	// runner reads back.
+	if p.outputPath != "" {
+		cmd = append(cmd, "--output-last-message", p.outputPath)
 	}
 
 	env := make(map[string]string)
@@ -117,6 +152,21 @@ func (p *CodexProvider) Execute(ctx context.Context, prompt string, options Opti
 	// prompt from stdin, and delivering it there keeps large prompts off the
 	// argv and out of process listings.
 	cliResult, err := runCLI(ctx, cmd, env, cwd, options.timeout(), []byte(prompt))
+
+	// Reactive fallback: if the server's strict-schema validator refused the
+	// schema we sent (invalid_json_schema 400 — the validator's rules can
+	// tighten upstream at any time), rerun once WITHOUT --output-schema. The
+	// prompt suffix still pins the JSON contract and --output-last-message
+	// still captures the final answer, so the runner's local validation takes
+	// over exactly as in the not-strict-expressible path.
+	if err == nil && usedOutputSchema && cliResult.ReturnCode != 0 &&
+		isOutputSchemaRejection(cliResult.Stdout+cliResult.Stderr) {
+		retryCmd := withoutFlagValue(cmd, "--output-schema")
+		if retryResult, retryErr := runCLI(ctx, retryCmd, env, cwd, options.timeout(), []byte(prompt)); retryErr == nil {
+			cliResult = retryResult
+		}
+	}
+
 	apiMS := int(time.Since(startAPI).Milliseconds())
 
 	if err != nil {

--- a/sdk/go/harness/codex_test.go
+++ b/sdk/go/harness/codex_test.go
@@ -364,3 +364,260 @@ func TestCodexProvider_ModelVariantReasoningEffort(t *testing.T) {
 		assert.NotContains(t, cmd, "-c")
 	})
 }
+
+// codexSchemaRejectionEvent is the real error event codex exec --json emits
+// when the server's strict validator refuses --output-schema (captured live on
+// codex-cli 0.144.1, issue: invalid_json_schema for codex_output_schema).
+const codexSchemaRejectionEvent = `{"type":"error","message":"{\n  \"type\": \"error\",\n  \"error\": {\n    \"type\": \"invalid_request_error\",\n    \"code\": \"invalid_json_schema\",\n    \"message\": \"Invalid schema for response_format 'codex_output_schema'. Please ensure it is a valid JSON Schema.\",\n    \"param\": \"text.format.schema\"\n  },\n  \"status\": 400\n}"}`
+
+// TestCodexSchemaStrictExpressible pins the live-probed strict-validator rules:
+// which schema shapes may be sent through --output-schema and which must fall
+// back to last-message + local validation.
+func TestCodexSchemaStrictExpressible(t *testing.T) {
+	strictObject := func(props map[string]any) map[string]any {
+		return codexStrictJSONSchema(map[string]any{
+			"type":       "object",
+			"properties": props,
+		})
+	}
+
+	cases := []struct {
+		name   string
+		schema map[string]any
+		want   bool
+	}{
+		{
+			name:   "flat strict object",
+			schema: strictObject(map[string]any{"status": map[string]any{"type": "string"}}),
+			want:   true,
+		},
+		{
+			name:   "empty properties object",
+			schema: strictObject(map[string]any{}),
+			want:   true,
+		},
+		{
+			name: "free-form map property",
+			schema: strictObject(map[string]any{
+				"meta": map[string]any{"type": "object"},
+			}),
+			want: false,
+		},
+		{
+			name: "typed map property",
+			schema: strictObject(map[string]any{
+				"meta": map[string]any{
+					"type":                 "object",
+					"additionalProperties": map[string]any{"type": "string"},
+				},
+			}),
+			want: false,
+		},
+		{
+			name: "bare Any node",
+			schema: strictObject(map[string]any{
+				"value": map[string]any{},
+			}),
+			want: false,
+		},
+		{
+			name: "anyOf with null",
+			schema: strictObject(map[string]any{
+				"note": map[string]any{"anyOf": []any{
+					map[string]any{"type": "string"},
+					map[string]any{"type": "null"},
+				}},
+			}),
+			want: true,
+		},
+		{
+			name: "array of strict objects via $defs ref",
+			schema: codexStrictJSONSchema(map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"items": map[string]any{
+						"type":  "array",
+						"items": map[string]any{"$ref": "#/$defs/Sub"},
+					},
+				},
+				"$defs": map[string]any{
+					"Sub": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"x": map[string]any{"type": "string"},
+						},
+					},
+				},
+			}),
+			want: true,
+		},
+		{
+			name: "inexpressible $defs entry poisons the schema",
+			schema: codexStrictJSONSchema(map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"sub": map[string]any{"$ref": "#/$defs/Sub"},
+				},
+				"$defs": map[string]any{
+					"Sub": map[string]any{"type": "object"},
+				},
+			}),
+			want: false,
+		},
+		{
+			name: "array without items",
+			schema: strictObject(map[string]any{
+				"xs": map[string]any{"type": "array"},
+			}),
+			want: false,
+		},
+		{
+			name: "type list of primitives",
+			schema: strictObject(map[string]any{
+				"a": map[string]any{"type": []any{"string", "null"}},
+			}),
+			want: true,
+		},
+		{
+			name: "type list containing object",
+			schema: strictObject(map[string]any{
+				"a": map[string]any{"type": []any{"object", "null"}},
+			}),
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, codexSchemaStrictExpressible(tc.schema))
+		})
+	}
+}
+
+// TestCodexProvider_LastMessageOnlyArgv verifies the not-strict-expressible
+// contract: an empty schemaPath with a non-empty outputPath yields
+// --output-last-message but NO --output-schema.
+func TestCodexProvider_LastMessageOnlyArgv(t *testing.T) {
+	dir := t.TempDir()
+	outputPath := OutputPath(dir)
+
+	var gotCmd []string
+	p := NewCodexProvider("codex")
+	p.SetSchema("", outputPath)
+	p.runCLI = func(_ context.Context, cmd []string, _ map[string]string, _ string, _ int, _ []byte) (*CLIResult, error) {
+		gotCmd = cmd
+		return &CLIResult{Stdout: `{"type":"result","result":"{}"}`, ReturnCode: 0}, nil
+	}
+
+	_, err := p.Execute(context.Background(), "prompt", Options{})
+	require.NoError(t, err)
+	assert.NotContains(t, gotCmd, "--output-schema")
+	assert.Contains(t, strings.Join(gotCmd, " "), "--output-last-message "+outputPath)
+}
+
+// TestCodexProvider_OutputSchemaRejectionFallback verifies the reactive
+// fallback: a run whose --output-schema is refused server-side
+// (invalid_json_schema) is rerun exactly once without the flag, keeping
+// --output-last-message, and the retry's result is returned.
+func TestCodexProvider_OutputSchemaRejectionFallback(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := SchemaPath(dir)
+	outputPath := OutputPath(dir)
+	require.NoError(t, os.WriteFile(schemaPath, []byte(`{"type":"object","properties":{},"required":[],"additionalProperties":false}`), 0o600))
+
+	var calls [][]string
+	p := NewCodexProvider("codex")
+	p.SetSchema(schemaPath, outputPath)
+	p.runCLI = func(_ context.Context, cmd []string, _ map[string]string, _ string, _ int, _ []byte) (*CLIResult, error) {
+		calls = append(calls, cmd)
+		if len(calls) == 1 {
+			return &CLIResult{Stdout: codexSchemaRejectionEvent, ReturnCode: 1}, nil
+		}
+		return &CLIResult{
+			Stdout:     `{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"{\"ok\":true}"}}`,
+			ReturnCode: 0,
+		}, nil
+	}
+
+	raw, err := p.Execute(context.Background(), "prompt", Options{})
+	require.NoError(t, err)
+	require.Len(t, calls, 2)
+
+	first := strings.Join(calls[0], " ")
+	assert.Contains(t, first, "--output-schema "+schemaPath)
+	second := strings.Join(calls[1], " ")
+	assert.NotContains(t, calls[1], "--output-schema")
+	assert.Contains(t, second, "--output-last-message "+outputPath)
+
+	assert.False(t, raw.IsError)
+	assert.Equal(t, `{"ok":true}`, raw.Result)
+}
+
+// TestCodexProvider_NonSchemaFailureNoFallbackRetry verifies an ordinary
+// failure (no invalid_json_schema marker) is NOT rerun.
+func TestCodexProvider_NonSchemaFailureNoFallbackRetry(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := SchemaPath(dir)
+	outputPath := OutputPath(dir)
+	require.NoError(t, os.WriteFile(schemaPath, []byte(`{"type":"object","properties":{},"required":[],"additionalProperties":false}`), 0o600))
+
+	callCount := 0
+	p := NewCodexProvider("codex")
+	p.SetSchema(schemaPath, outputPath)
+	p.runCLI = func(_ context.Context, _ []string, _ map[string]string, _ string, _ int, _ []byte) (*CLIResult, error) {
+		callCount++
+		return &CLIResult{Stderr: "stream error: something unrelated", ReturnCode: 1}, nil
+	}
+
+	raw, err := p.Execute(context.Background(), "prompt", Options{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, callCount)
+	assert.True(t, raw.IsError)
+}
+
+// TestRunner_Run_CodexInexpressibleSchemaSkipsFlag drives the runner end-to-end
+// with a schema containing a free-form map field: the codex argv must carry
+// --output-last-message but not --output-schema, and the answer written to the
+// last-message file must still parse and validate locally.
+func TestRunner_Run_CodexInexpressibleSchemaSkipsFlag(t *testing.T) {
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "captured-args.txt")
+
+	script := writeTestScript(t, dir, "codex",
+		"#!/bin/sh\n"+
+			"cat > /dev/null\n"+
+			"printf '%s\\n' \"$@\" > \""+argsFile+"\"\n"+
+			"out=\"\"\n"+
+			"prev=\"\"\n"+
+			"for a in \"$@\"; do\n"+
+			"  if [ \"$prev\" = \"--output-last-message\" ]; then out=\"$a\"; fi\n"+
+			"  prev=\"$a\"\n"+
+			"done\n"+
+			"if [ -n \"$out\" ]; then printf '%s' '{\"status\":\"ok\",\"meta\":{\"k\":\"v\"}}' > \"$out\"; fi\n"+
+			"printf '%s\\n' '{\"type\":\"result\",\"result\":\"\"}'\n")
+
+	runner := NewRunner(Options{Provider: ProviderCodex, BinPath: script})
+
+	var dest struct {
+		Status string         `json:"status"`
+		Meta   map[string]any `json:"meta"`
+	}
+	result, err := runner.Run(context.Background(), "do the work", map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"status": map[string]any{"type": "string"},
+			"meta":   map[string]any{"type": "object"},
+		},
+	}, &dest, Options{ProjectDir: dir})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.IsError, "expected success, got: %s", result.ErrorMessage)
+	assert.Equal(t, "ok", dest.Status)
+	assert.Equal(t, map[string]any{"k": "v"}, dest.Meta)
+
+	captured, err := os.ReadFile(argsFile)
+	require.NoError(t, err)
+	args := string(captured)
+	assert.NotContains(t, args, "--output-schema")
+	assert.Contains(t, args, "--output-last-message")
+}

--- a/sdk/go/harness/runner.go
+++ b/sdk/go/harness/runner.go
@@ -100,10 +100,21 @@ func (r *Runner) Run(ctx context.Context, prompt string, schema map[string]any, 
 			}
 			nativeSchemaPath = SchemaPath(absDir)
 			nativeOutputPath = OutputPath(absDir)
-			if strictJSON, mErr := json.MarshalIndent(codexStrictJSONSchema(schema), "", "  "); mErr == nil {
+			strictSchema := codexStrictJSONSchema(schema)
+			if strictJSON, mErr := json.MarshalIndent(strictSchema, "", "  "); mErr == nil {
 				if mkErr := os.MkdirAll(filepath.Dir(nativeSchemaPath), 0o700); mkErr == nil {
 					if wErr := os.WriteFile(nativeSchemaPath, strictJSON, 0o600); wErr == nil {
-						sa.SetSchema(nativeSchemaPath, nativeOutputPath)
+						if codexSchemaStrictExpressible(strictSchema) {
+							sa.SetSchema(nativeSchemaPath, nativeOutputPath)
+						} else {
+							// OpenAI's strict validator would 400 this schema
+							// (free-form map / Any nodes — invalid_json_schema),
+							// so skip --output-schema: the schema file stays on
+							// disk for the model to read via the prompt suffix,
+							// --output-last-message still captures the answer,
+							// and schema enforcement falls to local validation.
+							sa.SetSchema("", nativeOutputPath)
+						}
 						useNativeSchema = true
 						// Clean up unconditionally: CleanupTempFiles no-ops when
 						// outputDir is "." so the strict schema / native output

--- a/sdk/go/harness/schema.go
+++ b/sdk/go/harness/schema.go
@@ -117,6 +117,94 @@ func codexStrictJSONSchema(schema map[string]any) map[string]any {
 	return strict
 }
 
+// codexSchemaStrictExpressible reports whether a strict-rewritten schema can be
+// enforced server-side via codex's --output-schema. OpenAI's strict-mode
+// validator (probed live against codex-cli 0.144.1) requires, on EVERY node:
+//
+//   - a "type" key, unless the node is a $ref or an anyOf/oneOf/allOf
+//     combinator — so bare {} nodes (Go `any` / Python `Any` fields) are out;
+//   - for objects: "additionalProperties" supplied and false, plus "required"
+//     listing every property key. Free-form maps (map[string]any /
+//     dict[str, Any] — an object node with no "properties") cannot satisfy
+//     this without forcing the model to emit an empty object, so they are out;
+//   - typed maps (additionalProperties as a subschema) are rejected outright.
+//
+// format / minItems / default / anyOf-with-null / $defs+$ref all pass the
+// validator and stay expressible. When this returns false the runner keeps the
+// codex-native prompt + --output-last-message but drops --output-schema,
+// leaving enforcement to local validation — the server would 400 the request
+// with invalid_json_schema otherwise.
+func codexSchemaStrictExpressible(schema map[string]any) bool {
+	// $ref targets live in $defs/definitions; every definition must itself be
+	// expressible for any reference to it to be.
+	for _, defKey := range []string{"$defs", "definitions"} {
+		if defs, ok := schema[defKey].(map[string]any); ok {
+			for _, value := range defs {
+				m, ok := value.(map[string]any)
+				if !ok || !codexSchemaStrictExpressible(m) {
+					return false
+				}
+			}
+		}
+	}
+
+	if _, ok := schema["$ref"].(string); ok {
+		return true // target checked via the $defs walk above
+	}
+
+	for _, key := range []string{"anyOf", "oneOf", "allOf"} {
+		if branch, ok := schema[key].([]any); ok {
+			for _, item := range branch {
+				m, ok := item.(map[string]any)
+				if !ok || !codexSchemaStrictExpressible(m) {
+					return false
+				}
+			}
+			return true
+		}
+	}
+
+	switch typeValue := schema["type"].(type) {
+	case string:
+		switch typeValue {
+		case "object":
+			props, ok := schema["properties"].(map[string]any)
+			if !ok {
+				return false // free-form map — strict mode would force {}
+			}
+			if ap, ok := schema["additionalProperties"].(bool); !ok || ap {
+				return false
+			}
+			for _, value := range props {
+				m, ok := value.(map[string]any)
+				if !ok || !codexSchemaStrictExpressible(m) {
+					return false
+				}
+			}
+			return true
+		case "array":
+			items, ok := schema["items"].(map[string]any)
+			if !ok {
+				return false // tuple/itemless arrays — not expressible
+			}
+			return codexSchemaStrictExpressible(items)
+		default:
+			return true // primitive leaf
+		}
+	case []any:
+		// e.g. ["string","null"]; only primitive members are safely strict.
+		for _, tv := range typeValue {
+			s, ok := tv.(string)
+			if !ok || s == "object" || s == "array" {
+				return false
+			}
+		}
+		return len(typeValue) > 0
+	default:
+		return false // no type, no $ref, no combinator — e.g. {} for Any
+	}
+}
+
 // BuildCodexNativeSuffix constructs the prompt suffix for codex's native
 // structured output. Unlike BuildPromptSuffix (which asks the model to Write a
 // file), this tells the model to emit its final JSON answer directly — the


### PR DESCRIPTION
## Summary

The server behind `codex exec` now validates `--output-schema` against OpenAI strict-mode rules, rejecting non-strict schemas with `invalid_json_schema` (400). Since the Go harness passes every role schema through that flag, this killed all schema-enforced codex roles in Agent-Field/SWE-AF#106 — sessions died in seconds before any agent output.

Live probing against the validator (codex-cli 0.144.1, ChatGPT-account auth) established the actual rules:

- every object node needs `additionalProperties: false` **supplied** and a `required` array listing **every** property key
- every node needs a `type` key (or `$ref` / `anyOf`-style combinator) — bare `{}` nodes are rejected with "schema must have a 'type' key"
- free-form maps (`map[string]any` → `{"type":"object"}` with no `properties`), typed maps (`additionalProperties: {schema}`), and **boolean subschemas** (invopop emits `true` for `any`-typed fields, producing the generic "Please ensure it is a valid JSON Schema" 400) cannot be expressed at all
- `format`, `minItems`, `default`, `anyOf`-with-null, `$defs`/`$ref`, and root `$schema` all pass

## Changes Made

- **`schema.go`**: new `codexSchemaStrictExpressible` classifies a strict-rewritten schema against those rules, so the runner knows in advance when the server would refuse `--output-schema` (free-form map / `any` fields can't be made strict without forcing an empty object on the model).
- **`runner.go`**: for inexpressible schemas the runner still writes the schema file (the model reads it via the codex-native prompt suffix) but hands the provider an empty `schemaPath` — codex runs with `--output-last-message` only, and the existing local validation enforces the schema.
- **`codex.go`**: `--output-last-message` is decoupled from `--output-schema`; and if the server rejects a schema anyway (`invalid_json_schema` in the CLI output — the validator can tighten upstream at any time), the provider reruns once without the flag so the call degrades to local validation instead of failing the role.

## Testing

- New unit tests: expressibility table (11 shapes), last-message-only argv, rejection→retry flow (asserts the retry drops `--output-schema` and keeps `--output-last-message`), no-retry on unrelated failures, and a runner end-to-end test with an inexpressible schema.
- Full `sdk/go` suite green via `./scripts/coverage-surface.sh sdk-go` (harness coverage 92.1%); `go mod tidy` clean.
- **Live-verified against the real validator**: the strict rewrites of SWE-AF's actual `GitInitResult` and `Architecture` role schemas are ACCEPTED; the real `PRD` schema (boolean subschema via `AskUserFormField.default_value`) is correctly gated to the fallback path.

Pairs with the SWE-AF-side Python fix for Agent-Field/SWE-AF#106; SWE-AF's Go node picks this up via its next SDK re-pin (`go.mod` pseudo-version + `AGENTFIELD_SDK_REF` in ci.yml/Dockerfile).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)