### PR TITLE
ci(sdk-python): pin ruff to 0.15.22 (0.16.0 turns the lint gate red repo-wide)

### DIFF
--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -35,7 +35,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .[dev]
-          pip install ruff
+          # Pinned: ruff 0.16.0 flags ~2700 pre-existing violations (I001,
+          # BLE001, C408, ...) repo-wide; bump deliberately alongside the fixes.
+          pip install "ruff==0.15.22"
 
       - name: Lint
         working-directory: sdk/python


### PR DESCRIPTION
## Summary

The sdk-python workflow installs unpinned ruff (`pip install ruff`). ruff 0.16.0 just released, and under it **current main fails `ruff check .` with 2721 errors** (I001, BLE001, C408, …) while passing 0.15.22 clean — so every sdk-python PR's Lint job is now red regardless of its content. First hit: #783's lint-and-test jobs.

## Changes Made

- Pin `pip install "ruff==0.15.22"` in `.github/workflows/sdk-python.yml` — the newest version main is actually clean under.

## Test Plan

- [x] `ruff check .` on main with 0.15.22 → clean; with 0.16.0 → 2721 errors (verified locally on both)
- [ ] Lint job green on this PR

Follow-up: bump the pin deliberately in its own PR alongside the new-rule fixes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)