### PR TITLE
fix(security): bump brace-expansion for CVE-2026-14257 (#352, #353)

### DIFF
--- a/control-plane/web/client/package-lock.json
+++ b/control-plane/web/client/package-lock.json
@@ -4036,9 +4036,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+            "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4595,9 +4595,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+            "version": "1.1.17",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+            "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9668,9 +9668,9 @@
             }
         },
         "node_modules/sucrase/node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+            "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"

--- a/control-plane/web/client/package.json
+++ b/control-plane/web/client/package.json
@@ -88,8 +88,8 @@
         "js-yaml": "4.3.0",
         "esbuild": "0.28.1",
         "ws": "8.21.0",
-        "brace-expansion@1": "1.1.16",
-        "brace-expansion@2": "2.1.2",
+        "brace-expansion@1": "1.1.17",
+        "brace-expansion@2": "2.1.3",
         "postcss": "$postcss"
     },
     "pnpm": {
@@ -97,8 +97,8 @@
             "js-yaml": "4.3.0",
             "esbuild": "0.28.1",
             "ws": "8.21.0",
-            "brace-expansion@1": "1.1.16",
-            "brace-expansion@2": "2.1.2",
+            "brace-expansion@1": "1.1.17",
+            "brace-expansion@2": "2.1.3",
             "postcss": "8.5.18"
         }
     }

--- a/control-plane/web/client/pnpm-lock.yaml
+++ b/control-plane/web/client/pnpm-lock.yaml
@@ -8,8 +8,8 @@ overrides:
   js-yaml: 4.3.0
   esbuild: 0.28.1
   ws: 8.21.0
-  brace-expansion@1: 1.1.16
-  brace-expansion@2: 2.1.2
+  brace-expansion@1: 1.1.17
+  brace-expansion@2: 2.1.3
   postcss: 8.5.18
 
 importers:
@@ -1801,11 +1801,11 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.17:
+    resolution: {integrity: sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.3:
+    resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5286,12 +5286,12 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.17:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.3:
     dependencies:
       balanced-match: 1.0.2
 
@@ -6485,11 +6485,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.17
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.3
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes Dependabot alerts **#352** (`package-lock.json`) and **#353** (`pnpm-lock.yaml`) for [CVE-2026-14257](https://github.com/juliangruber/brace-expansion/security/advisories/GHSA-mh99-v99m-4gvg) — DoS via unbounded brace expansion length causing an OOM process crash.

Bump npm/pnpm overrides in `control-plane/web/client` and regenerate both lockfiles:

| Range | Before (vulnerable) | After (patched) |
|---|---|---|
| `brace-expansion@1` | `1.1.16` | `1.1.17` |
| `brace-expansion@2` | `2.1.2` | `2.1.3` |

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] Tests only
- [x] CI / tooling
- [ ] Breaking change

## Test plan

- [x] Confirm lockfiles resolve only `brace-expansion@1.1.17` and `2.1.3`
- [x] `cd control-plane/web/client && npm ci && npm ls brace-expansion`
- [x] `cd control-plane/web/client && npm run build`
- [x] `cd control-plane/web/client && npm test` (131 files / 683 tests passed)
- [x] CI green (coverage, functional tests, control-plane, CodeQL)

## Test coverage

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR (no bare additions). *(dependency-only bump; no application code changes)*
- [x] If I removed code, I updated `coverage-baseline.json` in this PR *only if* the removal caused a legitimate regression and I called it out in the summary above. *(N/A)*
- [x] The coverage gate check is green in CI before requesting review.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) (if present) and [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
- [x] Commits are signed and follow conventional-commits style.
- [x] I have linked any related issues (Fixes #123 / Closes #456).

## Related issues / PRs

- Dependabot alert #352 (`control-plane/web/client/package-lock.json`)
- Dependabot alert #353 (`control-plane/web/client/pnpm-lock.yaml`)
- GHSA-mh99-v99m-4gvg / CVE-2026-14257
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fab799d6-d8de-4379-9ee4-0847e09c4a9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fab799d6-d8de-4379-9ee4-0847e09c4a9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

