### PR TITLE
feat(control-plane): HTTP API for package install/update/uninstall + encrypted secrets

### DIFF
--- a/control-plane/internal/handlers/ui/agent_secrets.go
+++ b/control-plane/internal/handlers/ui/agent_secrets.go
@@ -1,0 +1,182 @@
+package ui
+
+import (
+	"encoding/json"
+	"net/http"
+	"regexp"
+	"sort"
+
+	"github.com/Agent-Field/agentfield/control-plane/internal/packages"
+	"github.com/Agent-Field/agentfield/control-plane/internal/storage"
+	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
+	"github.com/gin-gonic/gin"
+)
+
+const maxAgentSecretValueBytes = 32 * 1024
+
+var agentSecretKeyPattern = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+
+// AgentSecretsHandler manages the encrypted secret store used when agents start.
+type AgentSecretsHandler struct {
+	storage        storage.StorageProvider
+	agentfieldHome string
+}
+
+// NewAgentSecretsHandler creates an AgentSecretsHandler.
+func NewAgentSecretsHandler(storage storage.StorageProvider, agentfieldHome string) *AgentSecretsHandler {
+	return &AgentSecretsHandler{storage: storage, agentfieldHome: agentfieldHome}
+}
+
+type agentSecretStatus struct {
+	Key   string `json:"key"`
+	IsSet bool   `json:"is_set"`
+}
+
+type setAgentSecretRequest struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// ListAgentSecretsHandler lists secret names and whether each is set.
+func (h *AgentSecretsHandler) ListAgentSecretsHandler(c *gin.Context) {
+	agentPackage, ok := h.resolveAgentPackage(c)
+	if !ok {
+		return
+	}
+
+	store, err := packages.NewSecretStore(h.agentfieldHome)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to open secret store"})
+		return
+	}
+	storedKeys, err := store.List(agentSecretScope(agentPackage))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list secrets"})
+		return
+	}
+
+	statuses := make(map[string]bool, len(storedKeys))
+	for _, key := range declaredAgentSecretKeys(agentPackage.ConfigurationSchema) {
+		statuses[key] = false
+	}
+	for _, key := range storedKeys {
+		statuses[key] = true
+	}
+
+	keys := make([]string, 0, len(statuses))
+	for key := range statuses {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	secrets := make([]agentSecretStatus, 0, len(keys))
+	for _, key := range keys {
+		secrets = append(secrets, agentSecretStatus{Key: key, IsSet: statuses[key]})
+	}
+	c.JSON(http.StatusOK, gin.H{"secrets": secrets})
+}
+
+// SetAgentSecretHandler stores one node-scoped secret.
+func (h *AgentSecretsHandler) SetAgentSecretHandler(c *gin.Context) {
+	agentPackage, ok := h.resolveAgentPackage(c)
+	if !ok {
+		return
+	}
+
+	var req setAgentSecretRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+	if !agentSecretKeyPattern.MatchString(req.Key) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid secret key"})
+		return
+	}
+	if req.Value == "" || len([]byte(req.Value)) > maxAgentSecretValueBytes {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "secret value must be non-empty and at most 32KiB"})
+		return
+	}
+
+	store, err := packages.NewSecretStore(h.agentfieldHome)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to open secret store"})
+		return
+	}
+	if err := store.Set(agentSecretScope(agentPackage), req.Key, req.Value); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to store secret"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// DeleteAgentSecretHandler deletes one node-scoped secret.
+func (h *AgentSecretsHandler) DeleteAgentSecretHandler(c *gin.Context) {
+	agentPackage, ok := h.resolveAgentPackage(c)
+	if !ok {
+		return
+	}
+
+	store, err := packages.NewSecretStore(h.agentfieldHome)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to open secret store"})
+		return
+	}
+	if err := store.Delete(agentSecretScope(agentPackage), c.Param("key")); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete secret"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *AgentSecretsHandler) resolveAgentPackage(c *gin.Context) (*types.AgentPackage, bool) {
+	agentPackage, err := h.storage.GetAgentPackage(c.Request.Context(), c.Param("agentId"))
+	if err != nil || agentPackage == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "agent package not found"})
+		return nil, false
+	}
+	return agentPackage, true
+}
+
+func agentSecretScope(agentPackage *types.AgentPackage) string {
+	if agentPackage.Name != "" {
+		return agentPackage.Name
+	}
+	return agentPackage.ID
+}
+
+func declaredAgentSecretKeys(schema json.RawMessage) []string {
+	var manifest struct {
+		UserEnvironment struct {
+			Required []struct {
+				Name string `json:"name"`
+			} `json:"required"`
+			RequireOneOf []struct {
+				Options []struct {
+					Name string `json:"name"`
+				} `json:"options"`
+			} `json:"require_one_of"`
+		} `json:"user_environment"`
+	}
+	if json.Unmarshal(schema, &manifest) != nil {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	for _, variable := range manifest.UserEnvironment.Required {
+		if variable.Name != "" {
+			seen[variable.Name] = struct{}{}
+		}
+	}
+	for _, group := range manifest.UserEnvironment.RequireOneOf {
+		for _, variable := range group.Options {
+			if variable.Name != "" {
+				seen[variable.Name] = struct{}{}
+			}
+		}
+	}
+	keys := make([]string, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/control-plane/internal/handlers/ui/agent_secrets.go
+++ b/control-plane/internal/handlers/ui/agent_secrets.go
@@ -12,7 +12,10 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-const maxAgentSecretValueBytes = 32 * 1024
+const (
+	maxAgentSecretValueBytes = 32 * 1024
+	globalSecretScope        = "global"
+)
 
 var agentSecretKeyPattern = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
 
@@ -30,14 +33,24 @@ func NewAgentSecretsHandler(storage storage.StorageProvider, agentfieldHome stri
 type agentSecretStatus struct {
 	Key   string `json:"key"`
 	IsSet bool   `json:"is_set"`
+	// Scope reports where the stored value lives ("node" or "global");
+	// empty when the key is not set anywhere.
+	Scope string `json:"scope,omitempty"`
 }
 
 type setAgentSecretRequest struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
+	// Scope optionally forces "node" or "global". When empty the manifest's
+	// declared scope for the key wins, defaulting to global — the same rule
+	// `af secrets set` and the desktop app follow.
+	Scope string `json:"scope"`
 }
 
-// ListAgentSecretsHandler lists secret names and whether each is set.
+// ListAgentSecretsHandler lists secret names and whether each resolves for
+// this agent. Resolution mirrors the runner (EnvResolver): node scope first,
+// then global. Undeclared node-scoped keys are included because the runner
+// injects them; undeclared global keys are not injected, so they are omitted.
 func (h *AgentSecretsHandler) ListAgentSecretsHandler(c *gin.Context) {
 	agentPackage, ok := h.resolveAgentPackage(c)
 	if !ok {
@@ -49,33 +62,58 @@ func (h *AgentSecretsHandler) ListAgentSecretsHandler(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to open secret store"})
 		return
 	}
-	storedKeys, err := store.List(agentSecretScope(agentPackage))
+	nodeKeys, err := store.List(agentSecretScope(agentPackage))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list secrets"})
+		return
+	}
+	globalKeys, err := store.List(globalSecretScope)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list secrets"})
 		return
 	}
 
-	statuses := make(map[string]bool, len(storedKeys))
-	for _, key := range declaredAgentSecretKeys(agentPackage.ConfigurationSchema) {
-		statuses[key] = false
+	inNode := make(map[string]bool, len(nodeKeys))
+	for _, key := range nodeKeys {
+		inNode[key] = true
 	}
-	for _, key := range storedKeys {
-		statuses[key] = true
+	inGlobal := make(map[string]bool, len(globalKeys))
+	for _, key := range globalKeys {
+		inGlobal[key] = true
 	}
 
-	keys := make([]string, 0, len(statuses))
-	for key := range statuses {
+	listed := make(map[string]struct{})
+	for key := range declaredAgentSecrets(agentPackage.ConfigurationSchema) {
+		listed[key] = struct{}{}
+	}
+	for _, key := range nodeKeys {
+		listed[key] = struct{}{}
+	}
+
+	keys := make([]string, 0, len(listed))
+	for key := range listed {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
+
 	secrets := make([]agentSecretStatus, 0, len(keys))
 	for _, key := range keys {
-		secrets = append(secrets, agentSecretStatus{Key: key, IsSet: statuses[key]})
+		status := agentSecretStatus{Key: key}
+		switch {
+		case inNode[key]:
+			status.IsSet = true
+			status.Scope = "node"
+		case inGlobal[key]:
+			status.IsSet = true
+			status.Scope = globalSecretScope
+		}
+		secrets = append(secrets, status)
 	}
 	c.JSON(http.StatusOK, gin.H{"secrets": secrets})
 }
 
-// SetAgentSecretHandler stores one node-scoped secret.
+// SetAgentSecretHandler stores one secret in the scope selected by the
+// request, the manifest declaration, or the global default, in that order.
 func (h *AgentSecretsHandler) SetAgentSecretHandler(c *gin.Context) {
 	agentPackage, ok := h.resolveAgentPackage(c)
 	if !ok {
@@ -95,22 +133,7 @@ func (h *AgentSecretsHandler) SetAgentSecretHandler(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "secret value must be non-empty and at most 32KiB"})
 		return
 	}
-
-	store, err := packages.NewSecretStore(h.agentfieldHome)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to open secret store"})
-		return
-	}
-	if err := store.Set(agentSecretScope(agentPackage), req.Key, req.Value); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to store secret"})
-		return
-	}
-	c.Status(http.StatusNoContent)
-}
-
-// DeleteAgentSecretHandler deletes one node-scoped secret.
-func (h *AgentSecretsHandler) DeleteAgentSecretHandler(c *gin.Context) {
-	agentPackage, ok := h.resolveAgentPackage(c)
+	scope, ok := h.selectScope(c, agentPackage, req.Key, req.Scope)
 	if !ok {
 		return
 	}
@@ -120,11 +143,77 @@ func (h *AgentSecretsHandler) DeleteAgentSecretHandler(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to open secret store"})
 		return
 	}
-	if err := store.Delete(agentSecretScope(agentPackage), c.Param("key")); err != nil {
+	if err := store.Set(scope, req.Key, req.Value); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to store secret"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// DeleteAgentSecretHandler deletes one secret. The scope defaults exactly as
+// SetAgentSecretHandler's does and can be forced with ?scope=node|global.
+func (h *AgentSecretsHandler) DeleteAgentSecretHandler(c *gin.Context) {
+	agentPackage, ok := h.resolveAgentPackage(c)
+	if !ok {
+		return
+	}
+	key := c.Param("key")
+	scope, ok := h.selectScope(c, agentPackage, key, c.Query("scope"))
+	if !ok {
+		return
+	}
+
+	store, err := packages.NewSecretStore(h.agentfieldHome)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to open secret store"})
+		return
+	}
+	if err := store.Delete(scope, key); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete secret"})
 		return
 	}
 	c.Status(http.StatusNoContent)
+}
+
+// ListAllSecretsHandler lists every stored secret reference (key + scope)
+// across the global scope and all node scopes. Values are never returned.
+// This backs store-wide management UIs, mirroring `af secrets ls`.
+func (h *AgentSecretsHandler) ListAllSecretsHandler(c *gin.Context) {
+	store, err := packages.NewSecretStore(h.agentfieldHome)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to open secret store"})
+		return
+	}
+	refs, err := store.ListAll()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list secrets"})
+		return
+	}
+	secrets := make([]gin.H, 0, len(refs))
+	for _, ref := range refs {
+		secrets = append(secrets, gin.H{"key": ref.Key, "scope": ref.Scope})
+	}
+	c.JSON(http.StatusOK, gin.H{"secrets": secrets})
+}
+
+// selectScope maps a requested scope ("", "node", "global") to the concrete
+// store scope for this agent, falling back to the manifest's declaration and
+// then to global. Responds 400 and returns ok=false on anything else.
+func (h *AgentSecretsHandler) selectScope(c *gin.Context, agentPackage *types.AgentPackage, key, requested string) (string, bool) {
+	switch requested {
+	case "node":
+		return agentSecretScope(agentPackage), true
+	case globalSecretScope:
+		return globalSecretScope, true
+	case "":
+		if declaredAgentSecrets(agentPackage.ConfigurationSchema)[key] == "node" {
+			return agentSecretScope(agentPackage), true
+		}
+		return globalSecretScope, true
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"error": "scope must be \"node\" or \"global\""})
+		return "", false
+	}
 }
 
 func (h *AgentSecretsHandler) resolveAgentPackage(c *gin.Context) (*types.AgentPackage, bool) {
@@ -143,16 +232,19 @@ func agentSecretScope(agentPackage *types.AgentPackage) string {
 	return agentPackage.ID
 }
 
-func declaredAgentSecretKeys(schema json.RawMessage) []string {
+// declaredAgentSecrets returns the manifest-declared environment keys mapped
+// to their declared scope ("node" or "global"; global is the default, the
+// same rule packages.UserEnvironmentVar.SecretScope applies).
+func declaredAgentSecrets(schema json.RawMessage) map[string]string {
+	type declaredVar struct {
+		Name  string `json:"name"`
+		Scope string `json:"scope"`
+	}
 	var manifest struct {
 		UserEnvironment struct {
-			Required []struct {
-				Name string `json:"name"`
-			} `json:"required"`
+			Required     []declaredVar `json:"required"`
 			RequireOneOf []struct {
-				Options []struct {
-					Name string `json:"name"`
-				} `json:"options"`
+				Options []declaredVar `json:"options"`
 			} `json:"require_one_of"`
 		} `json:"user_environment"`
 	}
@@ -160,23 +252,24 @@ func declaredAgentSecretKeys(schema json.RawMessage) []string {
 		return nil
 	}
 
-	seen := make(map[string]struct{})
-	for _, variable := range manifest.UserEnvironment.Required {
-		if variable.Name != "" {
-			seen[variable.Name] = struct{}{}
+	declared := make(map[string]string)
+	record := func(v declaredVar) {
+		if v.Name == "" {
+			return
 		}
+		scope := globalSecretScope
+		if v.Scope == "node" {
+			scope = "node"
+		}
+		declared[v.Name] = scope
+	}
+	for _, variable := range manifest.UserEnvironment.Required {
+		record(variable)
 	}
 	for _, group := range manifest.UserEnvironment.RequireOneOf {
 		for _, variable := range group.Options {
-			if variable.Name != "" {
-				seen[variable.Name] = struct{}{}
-			}
+			record(variable)
 		}
 	}
-	keys := make([]string, 0, len(seen))
-	for key := range seen {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	return keys
+	return declared
 }

--- a/control-plane/internal/handlers/ui/agent_secrets_test.go
+++ b/control-plane/internal/handlers/ui/agent_secrets_test.go
@@ -1,0 +1,163 @@
+package ui
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Agent-Field/agentfield/control-plane/internal/packages"
+	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+const agentSecretsTestScope = "test-node"
+
+func newAgentSecretsTestRouter(t *testing.T) (*gin.Engine, string) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	agentfieldHome := t.TempDir()
+	store := setupTestStorage(t)
+	err := store.StoreAgentPackage(context.Background(), &types.AgentPackage{
+		ID:   "agent-x",
+		Name: agentSecretsTestScope,
+		ConfigurationSchema: json.RawMessage(`{
+			"user_environment": {
+				"required": [{"name": "OPENAI_API_KEY", "type": "secret"}],
+				"require_one_of": [{"options": [{"name": "ANTHROPIC_API_KEY", "type": "secret"}]}]
+			}
+		}`),
+	})
+	require.NoError(t, err)
+
+	handler := NewAgentSecretsHandler(store, agentfieldHome)
+	router := gin.New()
+	router.GET("/agents/:agentId/secrets", handler.ListAgentSecretsHandler)
+	router.PUT("/agents/:agentId/secrets", handler.SetAgentSecretHandler)
+	router.DELETE("/agents/:agentId/secrets/:key", handler.DeleteAgentSecretHandler)
+	return router, agentfieldHome
+}
+
+func agentSecretsRequest(t *testing.T, router http.Handler, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	request := httptest.NewRequest(method, path, strings.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	return response
+}
+
+// Validation contract 1: PUT writes the node scope consumed by runner-side resolution.
+func TestAgentSecretsPutResolvesForRunner(t *testing.T) {
+	router, home := newAgentSecretsTestRouter(t)
+	response := agentSecretsRequest(t, router, http.MethodPut, "/agents/agent-x/secrets",
+		`{"key":"OPENAI_API_KEY","value":"sk-test"}`)
+	require.Equal(t, http.StatusNoContent, response.Code)
+
+	store, err := packages.NewSecretStore(home)
+	require.NoError(t, err)
+	got, found, err := store.Get(agentSecretsTestScope, "OPENAI_API_KEY")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "sk-test", got)
+
+	resolved, err := (&packages.EnvResolver{
+		Store:    store,
+		NodeName: agentSecretsTestScope,
+	}).Resolve(packages.UserEnvironmentConfig{
+		Required: []packages.UserEnvironmentVar{{Name: "OPENAI_API_KEY"}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "sk-test", resolved["OPENAI_API_KEY"])
+}
+
+// Validation contract 2: GET exposes set state and declared unset keys, never values.
+func TestAgentSecretsListNamesOnly(t *testing.T) {
+	router, _ := newAgentSecretsTestRouter(t)
+	require.Equal(t, http.StatusNoContent, agentSecretsRequest(t, router, http.MethodPut,
+		"/agents/agent-x/secrets", `{"key":"OPENAI_API_KEY","value":"sk-test"}`).Code)
+
+	response := agentSecretsRequest(t, router, http.MethodGet, "/agents/agent-x/secrets", "")
+	require.Equal(t, http.StatusOK, response.Code)
+	require.NotContains(t, response.Body.String(), "sk-test")
+	require.JSONEq(t, `{"secrets":[
+		{"key":"ANTHROPIC_API_KEY","is_set":false},
+		{"key":"OPENAI_API_KEY","is_set":true}
+	]}`, response.Body.String())
+}
+
+// Validation contract 3: DELETE removes the secret and remains idempotent.
+func TestAgentSecretsDeleteIsIdempotent(t *testing.T) {
+	router, home := newAgentSecretsTestRouter(t)
+	require.Equal(t, http.StatusNoContent, agentSecretsRequest(t, router, http.MethodPut,
+		"/agents/agent-x/secrets", `{"key":"OPENAI_API_KEY","value":"sk-test"}`).Code)
+
+	for range 2 {
+		response := agentSecretsRequest(t, router, http.MethodDelete,
+			"/agents/agent-x/secrets/OPENAI_API_KEY", "")
+		require.Equal(t, http.StatusNoContent, response.Code)
+	}
+	store, err := packages.NewSecretStore(home)
+	require.NoError(t, err)
+	_, found, err := store.Get(agentSecretsTestScope, "OPENAI_API_KEY")
+	require.NoError(t, err)
+	require.False(t, found)
+}
+
+// Validation contract 4: invalid keys and empty values return 400 without writes.
+func TestAgentSecretsRejectsInvalidPut(t *testing.T) {
+	router, home := newAgentSecretsTestRouter(t)
+	for _, body := range []string{
+		`{"key":"lowercase","value":"secret"}`,
+		`{"key":"BAD-KEY","value":"secret"}`,
+		`{"key":"VALID_KEY","value":""}`,
+	} {
+		response := agentSecretsRequest(t, router, http.MethodPut, "/agents/agent-x/secrets", body)
+		require.Equal(t, http.StatusBadRequest, response.Code)
+	}
+	store, err := packages.NewSecretStore(home)
+	require.NoError(t, err)
+	keys, err := store.List(agentSecretsTestScope)
+	require.NoError(t, err)
+	require.Empty(t, keys)
+}
+
+// Validation contract 5: every operation returns 404 for an unknown agent ID.
+func TestAgentSecretsUnknownAgent(t *testing.T) {
+	router, _ := newAgentSecretsTestRouter(t)
+	tests := []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{http.MethodGet, "/agents/missing/secrets", ""},
+		{http.MethodPut, "/agents/missing/secrets", `{"key":"KEY","value":"secret"}`},
+		{http.MethodDelete, "/agents/missing/secrets/KEY", ""},
+	}
+	for _, test := range tests {
+		response := agentSecretsRequest(t, router, test.method, test.path, test.body)
+		require.Equal(t, http.StatusNotFound, response.Code)
+	}
+}
+
+// Validation contract 6: JSON-special and Unicode content round-trips exactly.
+func TestAgentSecretsComplexValueRoundTrip(t *testing.T) {
+	router, home := newAgentSecretsTestRouter(t)
+	want := "line \"one\"\n雪"
+	body, err := json.Marshal(map[string]string{"key": "COMPLEX_VALUE", "value": want})
+	require.NoError(t, err)
+	response := agentSecretsRequest(t, router, http.MethodPut, "/agents/agent-x/secrets", string(body))
+	require.Equal(t, http.StatusNoContent, response.Code)
+	require.Empty(t, response.Body.Bytes())
+
+	store, err := packages.NewSecretStore(home)
+	require.NoError(t, err)
+	got, found, err := store.Get(agentSecretsTestScope, "COMPLEX_VALUE")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.True(t, bytes.Equal([]byte(want), []byte(got)))
+}

--- a/control-plane/internal/handlers/ui/agent_secrets_test.go
+++ b/control-plane/internal/handlers/ui/agent_secrets_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -160,4 +162,92 @@ func TestAgentSecretsComplexValueRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, found)
 	require.True(t, bytes.Equal([]byte(want), []byte(got)))
+}
+
+// Exercises malformed-JSON binding and the oversized-value validation branch.
+func TestAgentSecretsRejectsMalformedAndOversizedPut(t *testing.T) {
+	router, _ := newAgentSecretsTestRouter(t)
+	for _, body := range []string{
+		`{`,
+		`{"key":"VALID_KEY","value":"` + strings.Repeat("x", maxAgentSecretValueBytes+1) + `"}`,
+	} {
+		response := agentSecretsRequest(t, router, http.MethodPut, "/agents/agent-x/secrets", body)
+		require.Equal(t, http.StatusBadRequest, response.Code)
+	}
+}
+
+// Exercises secret-store constructor failures in all three handlers.
+func TestAgentSecretsStoreOpenFailures(t *testing.T) {
+	_, home := newAgentSecretsTestRouter(t)
+	blockedHome := filepath.Join(home, "not-a-directory")
+	require.NoError(t, os.WriteFile(blockedHome, []byte("block"), 0o600))
+
+	store := setupTestStorage(t)
+	require.NoError(t, store.StoreAgentPackage(context.Background(), &types.AgentPackage{
+		ID:                  "agent-x",
+		Name:                agentSecretsTestScope,
+		ConfigurationSchema: json.RawMessage(`{"user_environment":{}}`),
+	}))
+	handler := NewAgentSecretsHandler(store, blockedHome)
+	failureRouter := gin.New()
+	failureRouter.GET("/agents/:agentId/secrets", handler.ListAgentSecretsHandler)
+	failureRouter.PUT("/agents/:agentId/secrets", handler.SetAgentSecretHandler)
+	failureRouter.DELETE("/agents/:agentId/secrets/:key", handler.DeleteAgentSecretHandler)
+
+	for _, test := range []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{"list", http.MethodGet, "/agents/agent-x/secrets", ""},
+		{"set", http.MethodPut, "/agents/agent-x/secrets", `{"key":"KEY","value":"secret"}`},
+		{"delete", http.MethodDelete, "/agents/agent-x/secrets/KEY", ""},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			response := agentSecretsRequest(t, failureRouter, test.method, test.path, test.body)
+			require.Equal(t, http.StatusInternalServerError, response.Code)
+		})
+	}
+}
+
+// Exercises List, Set, and Delete failures after a store opens successfully.
+func TestAgentSecretsCorruptStoreFailures(t *testing.T) {
+	router, home := newAgentSecretsTestRouter(t)
+	store, err := packages.NewSecretStore(home)
+	require.NoError(t, err)
+	require.NoError(t, store.Set(agentSecretsTestScope, "KEY", "value"))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(home, "secrets", agentSecretsTestScope+".enc"),
+		[]byte("not encrypted data"),
+		0o600,
+	))
+
+	for _, test := range []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{http.MethodGet, "/agents/agent-x/secrets", ""},
+		{http.MethodPut, "/agents/agent-x/secrets", `{"key":"KEY","value":"secret"}`},
+		{http.MethodDelete, "/agents/agent-x/secrets/KEY", ""},
+	} {
+		response := agentSecretsRequest(t, router, test.method, test.path, test.body)
+		require.Equal(t, http.StatusInternalServerError, response.Code)
+	}
+}
+
+// Exercises the ID fallback used when a package has no name.
+func TestAgentSecretScopeFallsBackToID(t *testing.T) {
+	require.Equal(t, "agent-x", agentSecretScope(&types.AgentPackage{ID: "agent-x"}))
+}
+
+// Exercises invalid schema and de-duplication/empty-name branches.
+func TestDeclaredAgentSecretKeysEdgeCases(t *testing.T) {
+	require.Nil(t, declaredAgentSecretKeys(json.RawMessage(`{`)))
+	schema := json.RawMessage(`{"user_environment":{
+		"required":[{"name":""},{"name":"KEY"}],
+		"require_one_of":[{"options":[{"name":""},{"name":"KEY"}]}]
+	}}`)
+	require.Equal(t, []string{"KEY"}, declaredAgentSecretKeys(schema))
 }

--- a/control-plane/internal/handlers/ui/agent_secrets_test.go
+++ b/control-plane/internal/handlers/ui/agent_secrets_test.go
@@ -29,7 +29,10 @@ func newAgentSecretsTestRouter(t *testing.T) (*gin.Engine, string) {
 		Name: agentSecretsTestScope,
 		ConfigurationSchema: json.RawMessage(`{
 			"user_environment": {
-				"required": [{"name": "OPENAI_API_KEY", "type": "secret"}],
+				"required": [
+					{"name": "OPENAI_API_KEY", "type": "secret"},
+					{"name": "NODE_SCOPED_KEY", "type": "secret", "scope": "node"}
+				],
 				"require_one_of": [{"options": [{"name": "ANTHROPIC_API_KEY", "type": "secret"}]}]
 			}
 		}`),
@@ -41,6 +44,7 @@ func newAgentSecretsTestRouter(t *testing.T) (*gin.Engine, string) {
 	router.GET("/agents/:agentId/secrets", handler.ListAgentSecretsHandler)
 	router.PUT("/agents/:agentId/secrets", handler.SetAgentSecretHandler)
 	router.DELETE("/agents/:agentId/secrets/:key", handler.DeleteAgentSecretHandler)
+	router.GET("/secrets", handler.ListAllSecretsHandler)
 	return router, agentfieldHome
 }
 
@@ -88,7 +92,8 @@ func TestAgentSecretsListNamesOnly(t *testing.T) {
 	require.NotContains(t, response.Body.String(), "sk-test")
 	require.JSONEq(t, `{"secrets":[
 		{"key":"ANTHROPIC_API_KEY","is_set":false},
-		{"key":"OPENAI_API_KEY","is_set":true}
+		{"key":"NODE_SCOPED_KEY","is_set":false},
+		{"key":"OPENAI_API_KEY","is_set":true,"scope":"global"}
 	]}`, response.Body.String())
 }
 
@@ -193,6 +198,7 @@ func TestAgentSecretsStoreOpenFailures(t *testing.T) {
 	failureRouter.GET("/agents/:agentId/secrets", handler.ListAgentSecretsHandler)
 	failureRouter.PUT("/agents/:agentId/secrets", handler.SetAgentSecretHandler)
 	failureRouter.DELETE("/agents/:agentId/secrets/:key", handler.DeleteAgentSecretHandler)
+	failureRouter.GET("/secrets", handler.ListAllSecretsHandler)
 
 	for _, test := range []struct {
 		name   string
@@ -203,6 +209,7 @@ func TestAgentSecretsStoreOpenFailures(t *testing.T) {
 		{"list", http.MethodGet, "/agents/agent-x/secrets", ""},
 		{"set", http.MethodPut, "/agents/agent-x/secrets", `{"key":"KEY","value":"secret"}`},
 		{"delete", http.MethodDelete, "/agents/agent-x/secrets/KEY", ""},
+		{"list-all", http.MethodGet, "/secrets", ""},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			response := agentSecretsRequest(t, failureRouter, test.method, test.path, test.body)
@@ -229,8 +236,9 @@ func TestAgentSecretsCorruptStoreFailures(t *testing.T) {
 		body   string
 	}{
 		{http.MethodGet, "/agents/agent-x/secrets", ""},
-		{http.MethodPut, "/agents/agent-x/secrets", `{"key":"KEY","value":"secret"}`},
-		{http.MethodDelete, "/agents/agent-x/secrets/KEY", ""},
+		{http.MethodPut, "/agents/agent-x/secrets", `{"key":"KEY","value":"secret","scope":"node"}`},
+		{http.MethodDelete, "/agents/agent-x/secrets/KEY?scope=node", ""},
+		{http.MethodGet, "/secrets", ""},
 	} {
 		response := agentSecretsRequest(t, router, test.method, test.path, test.body)
 		require.Equal(t, http.StatusInternalServerError, response.Code)
@@ -242,12 +250,139 @@ func TestAgentSecretScopeFallsBackToID(t *testing.T) {
 	require.Equal(t, "agent-x", agentSecretScope(&types.AgentPackage{ID: "agent-x"}))
 }
 
-// Exercises invalid schema and de-duplication/empty-name branches.
-func TestDeclaredAgentSecretKeysEdgeCases(t *testing.T) {
-	require.Nil(t, declaredAgentSecretKeys(json.RawMessage(`{`)))
+// Exercises invalid schema, de-duplication/empty-name branches, and the
+// global-unless-node scope defaulting rule.
+func TestDeclaredAgentSecretsEdgeCases(t *testing.T) {
+	require.Nil(t, declaredAgentSecrets(json.RawMessage(`{`)))
 	schema := json.RawMessage(`{"user_environment":{
-		"required":[{"name":""},{"name":"KEY"}],
-		"require_one_of":[{"options":[{"name":""},{"name":"KEY"}]}]
+		"required":[{"name":""},{"name":"KEY"},{"name":"NODE_KEY","scope":"node"}],
+		"require_one_of":[{"options":[{"name":""},{"name":"KEY"},{"name":"WEIRD","scope":"bogus"}]}]
 	}}`)
-	require.Equal(t, []string{"KEY"}, declaredAgentSecretKeys(schema))
+	require.Equal(t, map[string]string{
+		"KEY":      "global",
+		"NODE_KEY": "node",
+		"WEIRD":    "global",
+	}, declaredAgentSecrets(schema))
+}
+
+// Scope contract 1+2: undeclared keys default to the global scope; keys the
+// manifest declares scope:node land in the node scope — mirroring af secrets.
+func TestAgentSecretsScopeDefaults(t *testing.T) {
+	router, home := newAgentSecretsTestRouter(t)
+	require.Equal(t, http.StatusNoContent, agentSecretsRequest(t, router, http.MethodPut,
+		"/agents/agent-x/secrets", `{"key":"UNDECLARED_KEY","value":"v1"}`).Code)
+	require.Equal(t, http.StatusNoContent, agentSecretsRequest(t, router, http.MethodPut,
+		"/agents/agent-x/secrets", `{"key":"NODE_SCOPED_KEY","value":"v2"}`).Code)
+
+	store, err := packages.NewSecretStore(home)
+	require.NoError(t, err)
+	globalKeys, err := store.List("global")
+	require.NoError(t, err)
+	require.Equal(t, []string{"UNDECLARED_KEY"}, globalKeys)
+	nodeKeys, err := store.List(agentSecretsTestScope)
+	require.NoError(t, err)
+	require.Equal(t, []string{"NODE_SCOPED_KEY"}, nodeKeys)
+}
+
+// Scope contract 3: explicit scope overrides the manifest default; anything
+// other than node/global is rejected on both PUT and DELETE.
+func TestAgentSecretsScopeOverrides(t *testing.T) {
+	router, home := newAgentSecretsTestRouter(t)
+	require.Equal(t, http.StatusNoContent, agentSecretsRequest(t, router, http.MethodPut,
+		"/agents/agent-x/secrets", `{"key":"NODE_SCOPED_KEY","value":"v","scope":"global"}`).Code)
+	require.Equal(t, http.StatusNoContent, agentSecretsRequest(t, router, http.MethodPut,
+		"/agents/agent-x/secrets", `{"key":"UNDECLARED_KEY","value":"v","scope":"node"}`).Code)
+	require.Equal(t, http.StatusBadRequest, agentSecretsRequest(t, router, http.MethodPut,
+		"/agents/agent-x/secrets", `{"key":"UNDECLARED_KEY","value":"v","scope":"bogus"}`).Code)
+	require.Equal(t, http.StatusBadRequest, agentSecretsRequest(t, router, http.MethodDelete,
+		"/agents/agent-x/secrets/UNDECLARED_KEY?scope=bogus", "").Code)
+
+	store, err := packages.NewSecretStore(home)
+	require.NoError(t, err)
+	globalKeys, err := store.List("global")
+	require.NoError(t, err)
+	require.Equal(t, []string{"NODE_SCOPED_KEY"}, globalKeys)
+	nodeKeys, err := store.List(agentSecretsTestScope)
+	require.NoError(t, err)
+	require.Equal(t, []string{"UNDECLARED_KEY"}, nodeKeys)
+}
+
+// Scope contract 4+5: the listing reports effective resolution — node scope
+// shadows global — and includes undeclared node-scoped keys (the runner
+// injects them) while omitting undeclared global keys (it does not).
+func TestAgentSecretsListEffectiveResolution(t *testing.T) {
+	router, home := newAgentSecretsTestRouter(t)
+	store, err := packages.NewSecretStore(home)
+	require.NoError(t, err)
+	require.NoError(t, store.Set("global", "OPENAI_API_KEY", "global-v"))
+	require.NoError(t, store.Set(agentSecretsTestScope, "OPENAI_API_KEY", "node-v"))
+	require.NoError(t, store.Set(agentSecretsTestScope, "UNDECLARED_NODE", "v"))
+	require.NoError(t, store.Set("global", "UNDECLARED_GLOBAL", "v"))
+
+	response := agentSecretsRequest(t, router, http.MethodGet, "/agents/agent-x/secrets", "")
+	require.Equal(t, http.StatusOK, response.Code)
+	require.JSONEq(t, `{"secrets":[
+		{"key":"ANTHROPIC_API_KEY","is_set":false},
+		{"key":"NODE_SCOPED_KEY","is_set":false},
+		{"key":"OPENAI_API_KEY","is_set":true,"scope":"node"},
+		{"key":"UNDECLARED_NODE","is_set":true,"scope":"node"}
+	]}`, response.Body.String())
+}
+
+// Scope contract 6: DELETE uses the same defaulting rule as PUT and honors an
+// explicit ?scope= override without touching the other scope's copy.
+func TestAgentSecretsDeleteScopes(t *testing.T) {
+	router, home := newAgentSecretsTestRouter(t)
+	store, err := packages.NewSecretStore(home)
+	require.NoError(t, err)
+	require.NoError(t, store.Set("global", "OPENAI_API_KEY", "global-v"))
+	require.NoError(t, store.Set(agentSecretsTestScope, "OPENAI_API_KEY", "node-v"))
+
+	// Default for a global-declared key deletes the global copy only.
+	require.Equal(t, http.StatusNoContent, agentSecretsRequest(t, router, http.MethodDelete,
+		"/agents/agent-x/secrets/OPENAI_API_KEY", "").Code)
+	nodeKeys, err := store.List(agentSecretsTestScope)
+	require.NoError(t, err)
+	require.Equal(t, []string{"OPENAI_API_KEY"}, nodeKeys)
+	globalKeys, err := store.List("global")
+	require.NoError(t, err)
+	require.Empty(t, globalKeys)
+
+	// Explicit node override removes the remaining node copy.
+	require.Equal(t, http.StatusNoContent, agentSecretsRequest(t, router, http.MethodDelete,
+		"/agents/agent-x/secrets/OPENAI_API_KEY?scope=node", "").Code)
+	nodeKeys, err = store.List(agentSecretsTestScope)
+	require.NoError(t, err)
+	require.Empty(t, nodeKeys)
+}
+
+// Scope contract 7: the store-wide listing returns key+scope rows across all
+// scopes and never values.
+func TestListAllSecrets(t *testing.T) {
+	router, home := newAgentSecretsTestRouter(t)
+	store, err := packages.NewSecretStore(home)
+	require.NoError(t, err)
+	require.NoError(t, store.Set("global", "SHARED_KEY", "shh-1"))
+	require.NoError(t, store.Set(agentSecretsTestScope, "NODE_KEY", "shh-2"))
+
+	response := agentSecretsRequest(t, router, http.MethodGet, "/secrets", "")
+	require.Equal(t, http.StatusOK, response.Code)
+	require.NotContains(t, response.Body.String(), "shh-")
+	require.JSONEq(t, `{"secrets":[
+		{"key":"SHARED_KEY","scope":"global"},
+		{"key":"NODE_KEY","scope":"test-node"}
+	]}`, response.Body.String())
+}
+
+// Exercises the global-scope List failure branch after node List succeeds.
+func TestAgentSecretsListGlobalScopeFailure(t *testing.T) {
+	router, home := newAgentSecretsTestRouter(t)
+	store, err := packages.NewSecretStore(home)
+	require.NoError(t, err)
+	require.NoError(t, store.Set(agentSecretsTestScope, "KEY", "value"))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(home, "secrets", "global.enc"), []byte("not encrypted"), 0o600))
+
+	response := agentSecretsRequest(t, router, http.MethodGet, "/agents/agent-x/secrets", "")
+	require.Equal(t, http.StatusInternalServerError, response.Code)
 }

--- a/control-plane/internal/handlers/ui/packages_install.go
+++ b/control-plane/internal/handlers/ui/packages_install.go
@@ -1,0 +1,97 @@
+package ui
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/Agent-Field/agentfield/control-plane/internal/services/packagejobs"
+	"github.com/gin-gonic/gin"
+)
+
+type PackageInstallHandler struct {
+	manager packageJobManager
+}
+
+type packageJobManager interface {
+	StartInstall(source string, force bool) (*packagejobs.Job, error)
+	StartUpdate(packageName string) (*packagejobs.Job, error)
+	Uninstall(packageName string) error
+	GetJob(id string) (*packagejobs.Job, bool)
+	ListJobs() []*packagejobs.Job
+}
+
+func NewPackageInstallHandler(manager packageJobManager) *PackageInstallHandler {
+	return &PackageInstallHandler{manager: manager}
+}
+
+type installPackageRequest struct {
+	Source string `json:"source" binding:"required"`
+	Force  bool   `json:"force"`
+}
+
+func (h *PackageInstallHandler) InstallPackageHandler(c *gin.Context) {
+	var req installPackageRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		RespondBadRequest(c, "source is required")
+		return
+	}
+	job, err := h.manager.StartInstall(req.Source, req.Force)
+	if err != nil {
+		h.respondOperationError(c, err)
+		return
+	}
+	c.JSON(http.StatusAccepted, gin.H{"job_id": job.ID})
+}
+
+func (h *PackageInstallHandler) GetInstallJobHandler(c *gin.Context) {
+	job, ok := h.manager.GetJob(c.Param("jobId"))
+	if !ok {
+		RespondNotFound(c, "install job not found")
+		return
+	}
+	c.JSON(http.StatusOK, job)
+}
+
+func (h *PackageInstallHandler) ListInstallJobsHandler(c *gin.Context) {
+	c.JSON(http.StatusOK, h.manager.ListJobs())
+}
+
+func (h *PackageInstallHandler) UninstallPackageHandler(c *gin.Context) {
+	packageID := c.Param("packageId")
+	if packageID == "" {
+		RespondBadRequest(c, "packageId is required")
+		return
+	}
+	if err := h.manager.Uninstall(packageID); err != nil {
+		h.respondOperationError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"package_id": packageID, "status": "uninstalled"})
+}
+
+func (h *PackageInstallHandler) UpdatePackageHandler(c *gin.Context) {
+	packageID := c.Param("packageId")
+	if packageID == "" {
+		RespondBadRequest(c, "packageId is required")
+		return
+	}
+	job, err := h.manager.StartUpdate(packageID)
+	if err != nil {
+		h.respondOperationError(c, err)
+		return
+	}
+	c.JSON(http.StatusAccepted, gin.H{"job_id": job.ID})
+}
+
+func (h *PackageInstallHandler) respondOperationError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, packagejobs.ErrInvalidSource):
+		RespondBadRequest(c, err.Error())
+	case errors.Is(err, packagejobs.ErrBusy):
+		RespondError(c, http.StatusConflict, err.Error())
+	case errors.Is(err, packagejobs.ErrNotFound):
+		RespondNotFound(c, err.Error())
+	default:
+		RespondInternalError(c, err.Error())
+	}
+}

--- a/control-plane/internal/handlers/ui/packages_install_test.go
+++ b/control-plane/internal/handlers/ui/packages_install_test.go
@@ -138,3 +138,75 @@ func TestUpdatePackageHandlerMappings(t *testing.T) {
 		})
 	}
 }
+
+// Exercises the malformed-JSON bind-error branch before the manager is called.
+func TestInstallPackageHandlerRejectsMalformedJSON(t *testing.T) {
+	manager := &stubPackageJobManager{
+		startInstall: func(string, bool) (*packagejobs.Job, error) {
+			t.Fatal("manager should not be called")
+			return nil, nil
+		},
+	}
+	ctx, response := testContext(http.MethodPost, "/", []byte(`{`))
+	NewPackageInstallHandler(manager).InstallPackageHandler(ctx)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+// Exercises the successful get and list handler branches.
+func TestPackageInstallJobReadHandlers(t *testing.T) {
+	job := &packagejobs.Job{ID: "job-1"}
+	manager := &stubPackageJobManager{jobs: map[string]*packagejobs.Job{"job-1": job}}
+	handler := NewPackageInstallHandler(manager)
+
+	ctx, response := testContext(http.MethodGet, "/", nil, gin.Param{Key: "jobId", Value: "job-1"})
+	handler.GetInstallJobHandler(ctx)
+	if response.Code != http.StatusOK {
+		t.Fatalf("get status=%d body=%s", response.Code, response.Body.String())
+	}
+
+	ctx, response = testContext(http.MethodGet, "/", nil)
+	handler.ListInstallJobsHandler(ctx)
+	if response.Code != http.StatusOK {
+		t.Fatalf("list status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+// Exercises missing route-parameter branches for uninstall and update.
+func TestPackageOperationHandlersRequirePackageID(t *testing.T) {
+	manager := &stubPackageJobManager{}
+	handler := NewPackageInstallHandler(manager)
+	for _, invoke := range []func(*gin.Context){
+		handler.UninstallPackageHandler,
+		handler.UpdatePackageHandler,
+	} {
+		ctx, response := testContext(http.MethodPost, "/", nil)
+		invoke(ctx)
+		if response.Code != http.StatusBadRequest {
+			t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+		}
+	}
+}
+
+// Exercises successful uninstall and the default internal-error mapping.
+func TestUninstallPackageHandlerSuccessAndInternalError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "success", want: http.StatusOK},
+		{name: "internal", err: errors.New("plain failure"), want: http.StatusInternalServerError},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manager := &stubPackageJobManager{uninstall: func(string) error { return test.err }}
+			ctx, response := testContext(http.MethodDelete, "/", nil, gin.Param{Key: "packageId", Value: "demo"})
+			NewPackageInstallHandler(manager).UninstallPackageHandler(ctx)
+			if response.Code != test.want {
+				t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+			}
+		})
+	}
+}

--- a/control-plane/internal/handlers/ui/packages_install_test.go
+++ b/control-plane/internal/handlers/ui/packages_install_test.go
@@ -1,0 +1,140 @@
+package ui
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Agent-Field/agentfield/control-plane/internal/services/packagejobs"
+	"github.com/gin-gonic/gin"
+)
+
+type stubPackageJobManager struct {
+	startInstall func(string, bool) (*packagejobs.Job, error)
+	startUpdate  func(string) (*packagejobs.Job, error)
+	uninstall    func(string) error
+	jobs         map[string]*packagejobs.Job
+}
+
+func (s *stubPackageJobManager) StartInstall(source string, force bool) (*packagejobs.Job, error) {
+	return s.startInstall(source, force)
+}
+func (s *stubPackageJobManager) StartUpdate(name string) (*packagejobs.Job, error) {
+	return s.startUpdate(name)
+}
+func (s *stubPackageJobManager) Uninstall(name string) error { return s.uninstall(name) }
+func (s *stubPackageJobManager) GetJob(id string) (*packagejobs.Job, bool) {
+	job, ok := s.jobs[id]
+	return job, ok
+}
+func (s *stubPackageJobManager) ListJobs() []*packagejobs.Job {
+	result := make([]*packagejobs.Job, 0, len(s.jobs))
+	for _, job := range s.jobs {
+		result = append(result, job)
+	}
+	return result
+}
+
+func testContext(method, path string, body []byte, params ...gin.Param) (*gin.Context, *httptest.ResponseRecorder) {
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(method, path, bytes.NewReader(body))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+	ctx.Params = params
+	return ctx, recorder
+}
+
+// Contract 1: POST install returns 202 and a job ID.
+func TestInstallPackageHandlerAccepted(t *testing.T) {
+	manager := &stubPackageJobManager{
+		startInstall: func(source string, force bool) (*packagejobs.Job, error) {
+			if source != "https://github.com/owner/repo" || force {
+				t.Fatalf("request source=%q force=%v", source, force)
+			}
+			return &packagejobs.Job{ID: "job-1"}, nil
+		},
+	}
+	ctx, response := testContext(http.MethodPost, "/", []byte(`{"source":"https://github.com/owner/repo"}`))
+	NewPackageInstallHandler(manager).InstallPackageHandler(ctx)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	var body map[string]string
+	_ = json.Unmarshal(response.Body.Bytes(), &body)
+	if body["job_id"] != "job-1" {
+		t.Fatalf("body=%v", body)
+	}
+}
+
+// Contracts 2 and 3: validation maps to 400 and busy maps to 409.
+func TestInstallPackageHandlerErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"invalid", packagejobs.ErrInvalidSource, http.StatusBadRequest},
+		{"busy", packagejobs.ErrBusy, http.StatusConflict},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manager := &stubPackageJobManager{
+				startInstall: func(string, bool) (*packagejobs.Job, error) { return nil, test.err },
+			}
+			ctx, response := testContext(http.MethodPost, "/", []byte(`{"source":"bad"}`))
+			NewPackageInstallHandler(manager).InstallPackageHandler(ctx)
+			if response.Code != test.want {
+				t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+			}
+		})
+	}
+}
+
+// Contract 5: GET of an unknown job returns 404.
+func TestGetInstallJobHandlerUnknown(t *testing.T) {
+	manager := &stubPackageJobManager{jobs: map[string]*packagejobs.Job{}}
+	ctx, response := testContext(http.MethodGet, "/", nil, gin.Param{Key: "jobId", Value: "missing"})
+	NewPackageInstallHandler(manager).GetInstallJobHandler(ctx)
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("status=%d", response.Code)
+	}
+}
+
+// Contract 7: unknown uninstall targets map to 404.
+func TestUninstallPackageHandlerUnknown(t *testing.T) {
+	manager := &stubPackageJobManager{uninstall: func(string) error { return packagejobs.ErrNotFound }}
+	ctx, response := testContext(http.MethodDelete, "/", nil, gin.Param{Key: "packageId", Value: "missing"})
+	NewPackageInstallHandler(manager).UninstallPackageHandler(ctx)
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("status=%d", response.Code)
+	}
+}
+
+func TestUpdatePackageHandlerMappings(t *testing.T) {
+	tests := []struct {
+		name string
+		job  *packagejobs.Job
+		err  error
+		want int
+	}{
+		{"accepted", &packagejobs.Job{ID: "update-1"}, nil, http.StatusAccepted},
+		{"missing", nil, packagejobs.ErrNotFound, http.StatusNotFound},
+		{"busy", nil, packagejobs.ErrBusy, http.StatusConflict},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manager := &stubPackageJobManager{
+				startUpdate: func(string) (*packagejobs.Job, error) { return test.job, test.err },
+				uninstall:   func(string) error { return errors.New("unused") },
+			}
+			ctx, response := testContext(http.MethodPost, "/", nil, gin.Param{Key: "packageId", Value: "demo"})
+			NewPackageInstallHandler(manager).UpdatePackageHandler(ctx)
+			if response.Code != test.want {
+				t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+			}
+		})
+	}
+}

--- a/control-plane/internal/packages/git.go
+++ b/control-plane/internal/packages/git.go
@@ -274,23 +274,17 @@ func (gi *GitInstaller) cloneRepository(info *GitPackageInfo) (string, error) {
 		return "", fmt.Errorf("failed to create temp directory: %w", err)
 	}
 
-	// Build git clone command with optimizations
-	args := []string{"clone"}
-
-	// Shallow clone for efficiency (only latest commit)
-	args = append(args, "--depth", "1")
-
-	// Clone specific branch/tag if specified
+	// Fixed-shape invocations: the user-influenced values (ref, clone URL)
+	// only ever occupy option-value or post-"--" positional slots, so git can
+	// never parse them as flags. validateCloneArgs above additionally rejects
+	// dash-prefixed values. Shallow clone (--depth 1) for efficiency.
+	var cmd *exec.Cmd
 	if info.Ref != "" {
-		args = append(args, "--branch", info.Ref)
+		cmd = exec.Command("git", "clone", "--depth", "1", "--branch", info.Ref, "--", info.CloneURL, tempDir)
+	} else {
+		cmd = exec.Command("git", "clone", "--depth", "1", "--", info.CloneURL, tempDir)
 	}
-
-	// "--" ends option parsing so the URL and target directory can never be
-	// interpreted as git flags, even if validation is bypassed upstream.
-	args = append(args, "--", info.CloneURL, tempDir)
-
-	// Execute git clone
-	cmd := exec.Command("git", args...)
+	args := cmd.Args[1:]
 
 	// Capture both stdout and stderr for better error messages
 	var stdout, stderr bytes.Buffer

--- a/control-plane/internal/packages/git.go
+++ b/control-plane/internal/packages/git.go
@@ -248,8 +248,26 @@ func (gi *GitInstaller) InstallFromGit(gitURL string, force bool) error {
 	return nil
 }
 
+// validateCloneArgs rejects ref/URL values that git would parse as options
+// rather than positional arguments. The clone URL and ref can originate from
+// user input (CLI args or the HTTP install API), so a value starting with "-"
+// could otherwise smuggle flags like --upload-pack into the git invocation.
+func validateCloneArgs(info *GitPackageInfo) error {
+	if strings.HasPrefix(info.Ref, "-") {
+		return fmt.Errorf("invalid git ref %q: must not start with '-'", info.Ref)
+	}
+	if strings.HasPrefix(info.CloneURL, "-") {
+		return fmt.Errorf("invalid clone URL %q: must not start with '-'", info.CloneURL)
+	}
+	return nil
+}
+
 // cloneRepository clones the Git repository with optimizations
 func (gi *GitInstaller) cloneRepository(info *GitPackageInfo) (string, error) {
+	if err := validateCloneArgs(info); err != nil {
+		return "", err
+	}
+
 	// Create temporary directory
 	tempDir, err := os.MkdirTemp("", "agentfield-git-install-")
 	if err != nil {
@@ -267,8 +285,9 @@ func (gi *GitInstaller) cloneRepository(info *GitPackageInfo) (string, error) {
 		args = append(args, "--branch", info.Ref)
 	}
 
-	// Add URLs
-	args = append(args, info.CloneURL, tempDir)
+	// "--" ends option parsing so the URL and target directory can never be
+	// interpreted as git flags, even if validation is bypassed upstream.
+	args = append(args, "--", info.CloneURL, tempDir)
 
 	// Execute git clone
 	cmd := exec.Command("git", args...)

--- a/control-plane/internal/packages/git.go
+++ b/control-plane/internal/packages/git.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -248,13 +249,18 @@ func (gi *GitInstaller) InstallFromGit(gitURL string, force bool) error {
 	return nil
 }
 
+// safeGitRefPattern matches refs (branches, tags, commits) that cannot be
+// mistaken for git options: they must start with an alphanumeric character.
+// Ref values can originate from user input (CLI args or the HTTP install
+// API), so anything option-like could otherwise smuggle flags such as
+// --upload-pack into the git invocation.
+var safeGitRefPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._/-]*$`)
+
 // validateCloneArgs rejects ref/URL values that git would parse as options
-// rather than positional arguments. The clone URL and ref can originate from
-// user input (CLI args or the HTTP install API), so a value starting with "-"
-// could otherwise smuggle flags like --upload-pack into the git invocation.
+// rather than positional arguments.
 func validateCloneArgs(info *GitPackageInfo) error {
-	if strings.HasPrefix(info.Ref, "-") {
-		return fmt.Errorf("invalid git ref %q: must not start with '-'", info.Ref)
+	if info.Ref != "" && !safeGitRefPattern.MatchString(info.Ref) {
+		return fmt.Errorf("invalid git ref %q: must start with an alphanumeric character and contain only [A-Za-z0-9._/-]", info.Ref)
 	}
 	if strings.HasPrefix(info.CloneURL, "-") {
 		return fmt.Errorf("invalid clone URL %q: must not start with '-'", info.CloneURL)
@@ -276,11 +282,11 @@ func (gi *GitInstaller) cloneRepository(info *GitPackageInfo) (string, error) {
 
 	// Fixed-shape invocations: the user-influenced values (ref, clone URL)
 	// only ever occupy option-value or post-"--" positional slots, so git can
-	// never parse them as flags. validateCloneArgs above additionally rejects
-	// dash-prefixed values. Shallow clone (--depth 1) for efficiency.
+	// never parse them as flags. The ref is re-validated inline against the
+	// anchored safeGitRefPattern immediately before use.
 	var cmd *exec.Cmd
-	if info.Ref != "" {
-		cmd = exec.Command("git", "clone", "--depth", "1", "--branch", info.Ref, "--", info.CloneURL, tempDir)
+	if ref := info.Ref; ref != "" && safeGitRefPattern.MatchString(ref) {
+		cmd = exec.Command("git", "clone", "--depth", "1", "--branch", ref, "--", info.CloneURL, tempDir)
 	} else {
 		cmd = exec.Command("git", "clone", "--depth", "1", "--", info.CloneURL, tempDir)
 	}

--- a/control-plane/internal/packages/git_test.go
+++ b/control-plane/internal/packages/git_test.go
@@ -128,3 +128,28 @@ func TestGitInstallerErrorsWithoutGit(t *testing.T) {
 		t.Fatalf("expected cloneRepository failure, got %v", err)
 	}
 }
+
+func TestValidateCloneArgsRejectsOptionLikeValues(t *testing.T) {
+	cases := []struct {
+		name    string
+		info    GitPackageInfo
+		wantErr bool
+	}{
+		{"clean https url", GitPackageInfo{CloneURL: "https://github.com/o/r"}, false},
+		{"clean url with ref", GitPackageInfo{CloneURL: "https://github.com/o/r", Ref: "v1.2.3"}, false},
+		{"flag-like url", GitPackageInfo{CloneURL: "--upload-pack=touch /tmp/pwned"}, true},
+		{"flag-like ref", GitPackageInfo{CloneURL: "https://github.com/o/r", Ref: "--upload-pack=evil"}, true},
+		{"dash ref", GitPackageInfo{CloneURL: "https://github.com/o/r", Ref: "-b"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateCloneArgs(&tc.info)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/control-plane/internal/server/routes_ui.go
+++ b/control-plane/internal/server/routes_ui.go
@@ -90,6 +90,9 @@ func (s *AgentFieldServer) registerUIAPI() {
 			agents.GET("/:agentId/secrets", secretsHandler.ListAgentSecretsHandler)
 			agents.PUT("/:agentId/secrets", secretsHandler.SetAgentSecretHandler)
 			agents.DELETE("/:agentId/secrets/:key", secretsHandler.DeleteAgentSecretHandler)
+			// Store-wide secret references (key + scope, never values),
+			// mirroring `af secrets ls` for management UIs.
+			uiAPI.GET("/secrets", secretsHandler.ListAllSecretsHandler)
 
 			// Environment file endpoints
 			envHandler := ui.NewEnvHandler(s.storage, s.agentService, s.agentfieldHome)

--- a/control-plane/internal/server/routes_ui.go
+++ b/control-plane/internal/server/routes_ui.go
@@ -57,6 +57,14 @@ func (s *AgentFieldServer) registerUIAPI() {
 			agents.GET("/packages", packagesHandler.ListPackagesHandler)
 			agents.GET("/packages/:packageId/details", packagesHandler.GetPackageDetailsHandler)
 
+			// Package install/update/uninstall endpoints (async jobs)
+			installHandler := ui.NewPackageInstallHandler(s.packageJobs)
+			agents.POST("/packages/install", installHandler.InstallPackageHandler)
+			agents.GET("/packages/install/jobs", installHandler.ListInstallJobsHandler)
+			agents.GET("/packages/install/jobs/:jobId", installHandler.GetInstallJobHandler)
+			agents.POST("/packages/:packageId/uninstall", installHandler.UninstallPackageHandler)
+			agents.POST("/packages/:packageId/update", installHandler.UpdatePackageHandler)
+
 			// Agent lifecycle management endpoints
 			lifecycleHandler := ui.NewLifecycleHandler(s.storage, s.agentService)
 			agents.GET("/running", lifecycleHandler.ListRunningAgentsHandler)
@@ -76,6 +84,12 @@ func (s *AgentFieldServer) registerUIAPI() {
 			agents.GET("/:agentId/config/schema", configHandler.GetConfigSchemaHandler)
 			agents.GET("/:agentId/config", configHandler.GetConfigHandler)
 			agents.POST("/:agentId/config", configHandler.SetConfigHandler)
+
+			// Encrypted secret store endpoints (the store RunAgent injects from)
+			secretsHandler := ui.NewAgentSecretsHandler(s.storage, s.agentfieldHome)
+			agents.GET("/:agentId/secrets", secretsHandler.ListAgentSecretsHandler)
+			agents.PUT("/:agentId/secrets", secretsHandler.SetAgentSecretHandler)
+			agents.DELETE("/:agentId/secrets/:key", secretsHandler.DeleteAgentSecretHandler)
 
 			// Environment file endpoints
 			envHandler := ui.NewEnvHandler(s.storage, s.agentService, s.agentfieldHome)

--- a/control-plane/internal/server/server.go
+++ b/control-plane/internal/server/server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Agent-Field/agentfield/control-plane/internal/server/knowledgebase"
 	"github.com/Agent-Field/agentfield/control-plane/internal/server/middleware"
 	"github.com/Agent-Field/agentfield/control-plane/internal/services"
+	"github.com/Agent-Field/agentfield/control-plane/internal/services/packagejobs"
 	_ "github.com/Agent-Field/agentfield/control-plane/internal/sources/all" // register first-party trigger Sources
 	"github.com/Agent-Field/agentfield/control-plane/internal/storage"
 	"github.com/Agent-Field/agentfield/control-plane/internal/utils"
@@ -56,6 +57,7 @@ type AgentFieldServer struct {
 	statusManager         *services.StatusManager // Add StatusManager for unified status management
 	agentService          interfaces.AgentService // Add AgentService for lifecycle management
 	agentClient           interfaces.AgentClient  // Add AgentClient for agent communication
+	packageJobs           *packagejobs.Manager    // Async package install/update jobs
 	config                *config.Config
 	storageHealthOverride func(context.Context) gin.H
 	cacheHealthOverride   func(context.Context) gin.H
@@ -153,6 +155,9 @@ func NewAgentFieldServer(cfg *config.Config) (*AgentFieldServer, error) {
 
 	// Create AgentService
 	agentService := coreservices.NewAgentService(processManager, portManager, registryStorage, agentClient, agentfieldHome)
+
+	// Async package install/update job manager (HTTP install API)
+	packageJobs := packagejobs.NewManager(registryStorage, agentfieldHome, agentService)
 
 	// Initialize StatusManager for unified status management
 	statusManagerConfig := services.StatusManagerConfig{
@@ -508,6 +513,7 @@ func NewAgentFieldServer(cfg *config.Config) (*AgentFieldServer, error) {
 		statusManager:          statusManager,
 		agentService:           agentService,
 		agentClient:            agentClient,
+		packageJobs:            packageJobs,
 		config:                 cfg,
 		keystoreService:        keystoreService,
 		didService:             didService,

--- a/control-plane/internal/services/packagejobs/manager.go
+++ b/control-plane/internal/services/packagejobs/manager.go
@@ -1,0 +1,373 @@
+package packagejobs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Agent-Field/agentfield/control-plane/internal/core/domain"
+	"github.com/Agent-Field/agentfield/control-plane/internal/core/interfaces"
+	coreservices "github.com/Agent-Field/agentfield/control-plane/internal/core/services"
+	infrastorage "github.com/Agent-Field/agentfield/control-plane/internal/infrastructure/storage"
+	"github.com/Agent-Field/agentfield/control-plane/internal/logger"
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	maxJobLines = 500
+	maxJobs     = 50
+)
+
+var (
+	ErrBusy          = errors.New("a package operation is already running")
+	ErrInvalidSource = errors.New("invalid package source")
+	ErrNotFound      = errors.New("package not found")
+
+	repoPartRE   = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
+	subdirPartRE = regexp.MustCompile(`^[A-Za-z0-9_./-]+$`)
+	ansiRE       = regexp.MustCompile(`\x1b\[[0-?]*[ -/]*[@-~]`)
+)
+
+type JobKind string
+
+const (
+	JobInstall   JobKind = "install"
+	JobUpdate    JobKind = "update"
+	JobUninstall JobKind = "uninstall"
+)
+
+type JobStatus string
+
+const (
+	StatusPending   JobStatus = "pending"
+	StatusRunning   JobStatus = "running"
+	StatusSucceeded JobStatus = "succeeded"
+	StatusFailed    JobStatus = "failed"
+)
+
+type Job struct {
+	ID          string     `json:"id"`
+	Source      string     `json:"source"`
+	Kind        JobKind    `json:"kind"`
+	Status      JobStatus  `json:"status"`
+	PackageName string     `json:"package_name,omitempty"`
+	Error       string     `json:"error,omitempty"`
+	Lines       []string   `json:"lines"`
+	StartedAt   *time.Time `json:"started_at,omitempty"`
+	FinishedAt  *time.Time `json:"finished_at,omitempty"`
+}
+
+type installer interface {
+	InstallPackage(source string, options domain.InstallOptions) error
+	UninstallPackage(name string) error
+	ListInstalledPackages() ([]domain.InstalledPackage, error)
+	GetPackageInfo(name string) (*domain.InstalledPackage, error)
+}
+
+type Manager struct {
+	mu             sync.RWMutex
+	installer      installer
+	agentService   interfaces.AgentService
+	agentfieldHome string
+	jobs           map[string]*Job
+	order          []string
+	active         bool
+}
+
+// NewManager constructs the package service exactly as the CLI container does.
+func NewManager(registryStorage interfaces.RegistryStorage, agentfieldHome string, agentService interfaces.AgentService) *Manager {
+	fileSystem := infrastorage.NewFileSystemAdapter()
+	return newManager(coreservices.NewPackageService(registryStorage, fileSystem, agentfieldHome), agentService, agentfieldHome)
+}
+
+func newManager(inst installer, agentService interfaces.AgentService, agentfieldHome string) *Manager {
+	return &Manager{
+		installer:      inst,
+		agentService:   agentService,
+		agentfieldHome: agentfieldHome,
+		jobs:           make(map[string]*Job),
+	}
+}
+
+func ValidateSource(source string) (string, error) {
+	source = strings.TrimSpace(source)
+	const prefix = "https://github.com/"
+	if !strings.HasPrefix(source, prefix) || strings.ContainsAny(source, " \t\r\n?#") {
+		return "", ErrInvalidSource
+	}
+	rest := strings.TrimPrefix(source, prefix)
+	repoRaw, subdir, hasSubdir := rest, "", false
+	if i := strings.Index(rest, "//"); i >= 0 {
+		repoRaw, subdir, hasSubdir = rest[:i], rest[i+2:], true
+	}
+	repoRaw = strings.TrimSuffix(repoRaw, "/")
+	parts := strings.Split(repoRaw, "/")
+	if len(parts) != 2 || !repoPartRE.MatchString(parts[0]) || !repoPartRE.MatchString(parts[1]) ||
+		parts[0] == "." || parts[0] == ".." || parts[1] == "." || parts[1] == ".." {
+		return "", ErrInvalidSource
+	}
+	normalized := prefix + strings.Join(parts, "/")
+	if !hasSubdir {
+		return normalized, nil
+	}
+	subdir = strings.TrimSuffix(subdir, "/")
+	if subdir == "" || strings.Contains(subdir, "..") || strings.HasPrefix(subdir, "/") || !subdirPartRE.MatchString(subdir) {
+		return "", ErrInvalidSource
+	}
+	return normalized + "//" + subdir, nil
+}
+
+func (m *Manager) StartInstall(source string, force bool) (*Job, error) {
+	normalized, err := ValidateSource(source)
+	if err != nil {
+		return nil, err
+	}
+	return m.startJob(JobInstall, normalized, "", force)
+}
+
+func (m *Manager) StartUpdate(packageName string) (*Job, error) {
+	entry, err := m.registryEntry(packageName)
+	if err != nil {
+		return nil, err
+	}
+	source, err := sourceFromRegistry(entry.SourcePath)
+	if err != nil {
+		return nil, err
+	}
+	return m.startJob(JobUpdate, source, packageName, true)
+}
+
+func (m *Manager) startJob(kind JobKind, source, packageName string, force bool) (*Job, error) {
+	m.mu.Lock()
+	if m.active {
+		m.mu.Unlock()
+		return nil, ErrBusy
+	}
+	job := &Job{
+		ID:          uuid.NewString(),
+		Source:      source,
+		Kind:        kind,
+		Status:      StatusPending,
+		PackageName: packageName,
+		Lines:       []string{"validating source"},
+	}
+	m.active = true
+	m.jobs[job.ID] = job
+	m.order = append(m.order, job.ID)
+	m.evictLocked()
+	result := cloneJob(job)
+	m.mu.Unlock()
+
+	go m.run(job.ID, force)
+	return result, nil
+}
+
+func (m *Manager) run(jobID string, force bool) {
+	started := time.Now().UTC()
+	m.mu.Lock()
+	job := m.jobs[jobID]
+	job.Status = StatusRunning
+	job.StartedAt = &started
+	source, kind, packageName := job.Source, job.Kind, job.PackageName
+	m.mu.Unlock()
+
+	m.appendLine(jobID, fmt.Sprintf("installing %s", source))
+	var err error
+	var wasRunning bool
+	if kind == JobUpdate {
+		wasRunning, err = m.isRunning(packageName)
+		if err == nil && wasRunning {
+			m.appendLine(jobID, fmt.Sprintf("stopping %s", packageName))
+			err = m.agentService.StopAgent(packageName)
+		}
+	}
+
+	before := m.installedNames()
+	if err == nil {
+		installSource, options := splitSubdir(source, force)
+		err = m.installer.InstallPackage(installSource, options)
+	}
+	if err == nil && packageName == "" {
+		packageName = m.discoverPackageName(before)
+	}
+	if err == nil && kind == JobUpdate && wasRunning {
+		m.appendLine(jobID, fmt.Sprintf("restarting %s", packageName))
+		_, err = m.agentService.RunAgent(packageName, domain.RunOptions{Detach: true})
+	}
+	if err == nil {
+		m.appendLine(jobID, fmt.Sprintf("install completed: %s", packageName))
+	}
+	m.finish(jobID, packageName, err)
+}
+
+func splitSubdir(source string, force bool) (string, domain.InstallOptions) {
+	options := domain.InstallOptions{Force: force}
+	const prefix = "https://github.com/"
+	rest := strings.TrimPrefix(source, prefix)
+	if i := strings.Index(rest, "//"); i >= 0 {
+		options.Path = rest[i+2:]
+		source = prefix + rest[:i]
+	}
+	return source, options
+}
+
+func (m *Manager) installedNames() map[string]bool {
+	names := make(map[string]bool)
+	pkgs, err := m.installer.ListInstalledPackages()
+	if err != nil {
+		return names
+	}
+	for _, pkg := range pkgs {
+		names[pkg.Name] = true
+	}
+	return names
+}
+
+func (m *Manager) discoverPackageName(before map[string]bool) string {
+	pkgs, err := m.installer.ListInstalledPackages()
+	if err != nil {
+		return ""
+	}
+	for _, pkg := range pkgs {
+		if !before[pkg.Name] {
+			return pkg.Name
+		}
+	}
+	return ""
+}
+
+func (m *Manager) isRunning(name string) (bool, error) {
+	if m.agentService == nil {
+		return false, nil
+	}
+	status, err := m.agentService.GetAgentStatus(name)
+	if err != nil {
+		return false, err
+	}
+	return status.IsRunning, nil
+}
+
+func (m *Manager) Uninstall(packageName string) error {
+	if _, err := m.installer.GetPackageInfo(packageName); err != nil {
+		return ErrNotFound
+	}
+	running, err := m.isRunning(packageName)
+	if err != nil {
+		return err
+	}
+	if running {
+		if err := m.agentService.StopAgent(packageName); err != nil {
+			return err
+		}
+	}
+	if err := m.installer.UninstallPackage(packageName); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Manager) GetJob(id string) (*Job, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	job, ok := m.jobs[id]
+	if !ok {
+		return nil, false
+	}
+	return cloneJob(job), true
+}
+
+func (m *Manager) ListJobs() []*Job {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make([]*Job, 0, len(m.order))
+	for i := len(m.order) - 1; i >= 0; i-- {
+		result = append(result, cloneJob(m.jobs[m.order[i]]))
+	}
+	return result
+}
+
+func (m *Manager) appendLine(id, line string) {
+	line = ansiRE.ReplaceAllString(line, "")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	job, ok := m.jobs[id]
+	if !ok {
+		return
+	}
+	job.Lines = append(job.Lines, line)
+	if len(job.Lines) > maxJobLines {
+		job.Lines = append([]string(nil), job.Lines[len(job.Lines)-maxJobLines:]...)
+	}
+}
+
+func (m *Manager) finish(id, packageName string, runErr error) {
+	finished := time.Now().UTC()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	job := m.jobs[id]
+	job.PackageName = packageName
+	job.FinishedAt = &finished
+	if runErr != nil {
+		job.Status = StatusFailed
+		job.Error = runErr.Error()
+		logger.Logger.Error().Err(runErr).Str("job_id", id).Msg("package job failed")
+	} else {
+		job.Status = StatusSucceeded
+	}
+	m.active = false
+}
+
+func (m *Manager) evictLocked() {
+	for len(m.order) > maxJobs {
+		delete(m.jobs, m.order[0])
+		m.order = m.order[1:]
+	}
+}
+
+func cloneJob(job *Job) *Job {
+	copy := *job
+	copy.Lines = append([]string(nil), job.Lines...)
+	return &copy
+}
+
+type registryPackage struct {
+	SourcePath string `yaml:"source_path"`
+}
+
+func (m *Manager) registryEntry(name string) (*registryPackage, error) {
+	data, err := os.ReadFile(filepath.Join(m.agentfieldHome, "installed.yaml"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	var registry struct {
+		Installed map[string]registryPackage `yaml:"installed"`
+	}
+	if err := yaml.Unmarshal(data, &registry); err != nil {
+		return nil, err
+	}
+	entry, ok := registry.Installed[name]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return &entry, nil
+}
+
+func sourceFromRegistry(source string) (string, error) {
+	if !strings.HasPrefix(source, "https://github.com/") {
+		source = "https://github.com/" + source
+	}
+	// Registries retain the resolved ref as @branch; update intentionally tracks latest.
+	if at := strings.LastIndex(source, "@"); at > strings.LastIndex(source, "/") {
+		source = source[:at]
+	}
+	return ValidateSource(source)
+}

--- a/control-plane/internal/services/packagejobs/manager.go
+++ b/control-plane/internal/services/packagejobs/manager.go
@@ -109,7 +109,8 @@ func ValidateSource(source string) (string, error) {
 	repoRaw = strings.TrimSuffix(repoRaw, "/")
 	parts := strings.Split(repoRaw, "/")
 	if len(parts) != 2 || !repoPartRE.MatchString(parts[0]) || !repoPartRE.MatchString(parts[1]) ||
-		parts[0] == "." || parts[0] == ".." || parts[1] == "." || parts[1] == ".." {
+		parts[0] == "." || parts[0] == ".." || parts[1] == "." || parts[1] == ".." ||
+		strings.HasPrefix(parts[0], "-") || strings.HasPrefix(parts[1], "-") {
 		return "", ErrInvalidSource
 	}
 	normalized := prefix + strings.Join(parts, "/")
@@ -119,6 +120,11 @@ func ValidateSource(source string) (string, error) {
 	subdir = strings.TrimSuffix(subdir, "/")
 	if subdir == "" || strings.Contains(subdir, "..") || strings.HasPrefix(subdir, "/") || !subdirPartRE.MatchString(subdir) {
 		return "", ErrInvalidSource
+	}
+	for _, segment := range strings.Split(subdir, "/") {
+		if segment == "" || strings.HasPrefix(segment, "-") {
+			return "", ErrInvalidSource
+		}
 	}
 	return normalized + "//" + subdir, nil
 }

--- a/control-plane/internal/services/packagejobs/manager_test.go
+++ b/control-plane/internal/services/packagejobs/manager_test.go
@@ -1,0 +1,226 @@
+package packagejobs
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Agent-Field/agentfield/control-plane/internal/core/domain"
+)
+
+type stubInstaller struct {
+	mu           sync.Mutex
+	installErr   error
+	block        <-chan struct{}
+	installed    []domain.InstalledPackage
+	afterInstall []domain.InstalledPackage
+	calls        *[]string
+	lastOptions  domain.InstallOptions
+}
+
+func (s *stubInstaller) InstallPackage(_ string, options domain.InstallOptions) error {
+	if s.block != nil {
+		<-s.block
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastOptions = options
+	if s.calls != nil {
+		*s.calls = append(*s.calls, "install")
+	}
+	if s.installErr == nil && s.afterInstall != nil {
+		s.installed = append([]domain.InstalledPackage(nil), s.afterInstall...)
+	}
+	return s.installErr
+}
+func (s *stubInstaller) UninstallPackage(name string) error {
+	if s.calls != nil {
+		*s.calls = append(*s.calls, "remove:"+name)
+	}
+	return nil
+}
+func (s *stubInstaller) ListInstalledPackages() ([]domain.InstalledPackage, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]domain.InstalledPackage(nil), s.installed...), nil
+}
+func (s *stubInstaller) GetPackageInfo(name string) (*domain.InstalledPackage, error) {
+	for _, pkg := range s.installed {
+		if pkg.Name == name {
+			copy := pkg
+			return &copy, nil
+		}
+	}
+	return nil, os.ErrNotExist
+}
+
+type stubAgentService struct {
+	running bool
+	calls   *[]string
+}
+
+func (s *stubAgentService) RunAgent(name string, _ domain.RunOptions) (*domain.RunningAgent, error) {
+	if s.calls != nil {
+		*s.calls = append(*s.calls, "start:"+name)
+	}
+	return &domain.RunningAgent{Name: name}, nil
+}
+func (s *stubAgentService) StopAgent(name string) error {
+	if s.calls != nil {
+		*s.calls = append(*s.calls, "stop:"+name)
+	}
+	s.running = false
+	return nil
+}
+func (s *stubAgentService) GetAgentStatus(name string) (*domain.AgentStatus, error) {
+	return &domain.AgentStatus{Name: name, IsRunning: s.running}, nil
+}
+func (s *stubAgentService) ListRunningAgents() ([]domain.RunningAgent, error) { return nil, nil }
+
+func waitForJob(t *testing.T, manager *Manager, id string) *Job {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		job, ok := manager.GetJob(id)
+		if ok && (job.Status == StatusSucceeded || job.Status == StatusFailed) {
+			return job
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("job did not finish")
+	return nil
+}
+
+// Contract 1: a valid GitHub install succeeds and records its package name.
+func TestInstallSucceedsAndDiscoversPackageName(t *testing.T) {
+	inst := &stubInstaller{afterInstall: []domain.InstalledPackage{{Name: "demo"}}}
+	manager := newManager(inst, &stubAgentService{}, t.TempDir())
+	job, err := manager.StartInstall("https://github.com/owner/repo", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := waitForJob(t, manager, job.ID)
+	if got.Status != StatusSucceeded || got.PackageName != "demo" {
+		t.Fatalf("job = %#v", got)
+	}
+}
+
+// Contract 2: unsafe sources are rejected before a job is created.
+func TestInvalidSourcesCreateNoJobs(t *testing.T) {
+	manager := newManager(&stubInstaller{}, &stubAgentService{}, t.TempDir())
+	for _, source := range []string{"../local", "git@github.com:o/r.git", "https://gitlab.com/o/r"} {
+		if _, err := manager.StartInstall(source, false); !errors.Is(err, ErrInvalidSource) {
+			t.Errorf("source %q: err = %v", source, err)
+		}
+	}
+	if got := len(manager.ListJobs()); got != 0 {
+		t.Fatalf("created %d jobs", got)
+	}
+}
+
+// Contract 3: only one package job can be active.
+func TestSecondInstallIsBusy(t *testing.T) {
+	release := make(chan struct{})
+	manager := newManager(&stubInstaller{block: release}, &stubAgentService{}, t.TempDir())
+	first, err := manager.StartInstall("https://github.com/o/one", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.StartInstall("https://github.com/o/two", false); !errors.Is(err, ErrBusy) {
+		t.Fatalf("err = %v", err)
+	}
+	close(release)
+	if got := waitForJob(t, manager, first.ID); got.Status != StatusSucceeded {
+		t.Fatalf("first status = %s", got.Status)
+	}
+}
+
+// Contract 4: failures release the active-job lock.
+func TestFailedInstallAllowsNextInstall(t *testing.T) {
+	inst := &stubInstaller{installErr: errors.New("boom")}
+	manager := newManager(inst, &stubAgentService{}, t.TempDir())
+	first, _ := manager.StartInstall("https://github.com/o/one", false)
+	got := waitForJob(t, manager, first.ID)
+	if got.Status != StatusFailed || got.Error != "boom" {
+		t.Fatalf("job = %#v", got)
+	}
+	inst.installErr = nil
+	second, err := manager.StartInstall("https://github.com/o/two", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForJob(t, manager, second.ID)
+}
+
+// Contract 6: recorded progress is free of terminal ANSI escapes.
+func TestJobLinesContainNoANSI(t *testing.T) {
+	manager := newManager(&stubInstaller{afterInstall: []domain.InstalledPackage{{Name: "demo"}}}, &stubAgentService{}, t.TempDir())
+	job, _ := manager.StartInstall("https://github.com/o/repo", false)
+	manager.appendLine(job.ID, "\x1b[31mred\x1b[0m")
+	got := waitForJob(t, manager, job.ID)
+	for _, line := range got.Lines {
+		if strings.Contains(line, "\x1b") {
+			t.Fatalf("ANSI line: %q", line)
+		}
+	}
+}
+
+// Contract 7: uninstall stops a running package before removing it.
+func TestUninstallStopsThenRemoves(t *testing.T) {
+	var calls []string
+	inst := &stubInstaller{installed: []domain.InstalledPackage{{Name: "demo"}}, calls: &calls}
+	manager := newManager(inst, &stubAgentService{running: true, calls: &calls}, t.TempDir())
+	if err := manager.Uninstall("demo"); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(calls, ",") != "stop:demo,remove:demo" {
+		t.Fatalf("calls = %v", calls)
+	}
+	if err := manager.Uninstall("missing"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("missing err = %v", err)
+	}
+}
+
+// Contract 8: update restores the prior running state and forces installation.
+func TestUpdateStopsForceInstallsAndRestarts(t *testing.T) {
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, "installed.yaml"), []byte("installed:\n  demo:\n    source_path: https://github.com/o/repo@main\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	var calls []string
+	inst := &stubInstaller{installed: []domain.InstalledPackage{{Name: "demo"}}, calls: &calls}
+	manager := newManager(inst, &stubAgentService{running: true, calls: &calls}, home)
+	job, err := manager.StartUpdate("demo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := waitForJob(t, manager, job.ID); got.Status != StatusSucceeded {
+		t.Fatalf("job = %#v", got)
+	}
+	if strings.Join(calls, ",") != "stop:demo,install,start:demo" {
+		t.Fatalf("calls = %v", calls)
+	}
+	if !inst.lastOptions.Force {
+		t.Fatal("update was not forced")
+	}
+}
+
+// Contract 9: progress retains only the most recent 500 lines.
+func TestJobLinesAreCapped(t *testing.T) {
+	release := make(chan struct{})
+	manager := newManager(&stubInstaller{block: release}, &stubAgentService{}, t.TempDir())
+	job, _ := manager.StartInstall("https://github.com/o/repo", false)
+	for i := 0; i < maxJobLines+50; i++ {
+		manager.appendLine(job.ID, "line")
+	}
+	got, _ := manager.GetJob(job.ID)
+	if len(got.Lines) != maxJobLines {
+		t.Fatalf("lines = %d", len(got.Lines))
+	}
+	close(release)
+	waitForJob(t, manager, job.ID)
+}

--- a/control-plane/internal/services/packagejobs/manager_test.go
+++ b/control-plane/internal/services/packagejobs/manager_test.go
@@ -2,6 +2,7 @@ package packagejobs
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Agent-Field/agentfield/control-plane/internal/core/domain"
+	infrastorage "github.com/Agent-Field/agentfield/control-plane/internal/infrastructure/storage"
 )
 
 type stubInstaller struct {
@@ -20,6 +22,9 @@ type stubInstaller struct {
 	afterInstall []domain.InstalledPackage
 	calls        *[]string
 	lastOptions  domain.InstallOptions
+	listErr      error
+	infoErr      error
+	uninstallErr error
 }
 
 func (s *stubInstaller) InstallPackage(_ string, options domain.InstallOptions) error {
@@ -41,14 +46,17 @@ func (s *stubInstaller) UninstallPackage(name string) error {
 	if s.calls != nil {
 		*s.calls = append(*s.calls, "remove:"+name)
 	}
-	return nil
+	return s.uninstallErr
 }
 func (s *stubInstaller) ListInstalledPackages() ([]domain.InstalledPackage, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return append([]domain.InstalledPackage(nil), s.installed...), nil
+	return append([]domain.InstalledPackage(nil), s.installed...), s.listErr
 }
 func (s *stubInstaller) GetPackageInfo(name string) (*domain.InstalledPackage, error) {
+	if s.infoErr != nil {
+		return nil, s.infoErr
+	}
 	for _, pkg := range s.installed {
 		if pkg.Name == name {
 			copy := pkg
@@ -59,25 +67,28 @@ func (s *stubInstaller) GetPackageInfo(name string) (*domain.InstalledPackage, e
 }
 
 type stubAgentService struct {
-	running bool
-	calls   *[]string
+	running   bool
+	calls     *[]string
+	statusErr error
+	stopErr   error
+	runErr    error
 }
 
 func (s *stubAgentService) RunAgent(name string, _ domain.RunOptions) (*domain.RunningAgent, error) {
 	if s.calls != nil {
 		*s.calls = append(*s.calls, "start:"+name)
 	}
-	return &domain.RunningAgent{Name: name}, nil
+	return &domain.RunningAgent{Name: name}, s.runErr
 }
 func (s *stubAgentService) StopAgent(name string) error {
 	if s.calls != nil {
 		*s.calls = append(*s.calls, "stop:"+name)
 	}
 	s.running = false
-	return nil
+	return s.stopErr
 }
 func (s *stubAgentService) GetAgentStatus(name string) (*domain.AgentStatus, error) {
-	return &domain.AgentStatus{Name: name, IsRunning: s.running}, nil
+	return &domain.AgentStatus{Name: name, IsRunning: s.running}, s.statusErr
 }
 func (s *stubAgentService) ListRunningAgents() ([]domain.RunningAgent, error) { return nil, nil }
 
@@ -223,4 +234,141 @@ func TestJobLinesAreCapped(t *testing.T) {
 	}
 	close(release)
 	waitForJob(t, manager, job.ID)
+}
+
+// Exercises the real NewManager constructor without starting an installation.
+func TestNewManagerRejectsInvalidSource(t *testing.T) {
+	home := t.TempDir()
+	registry := infrastorage.NewLocalRegistryStorage(
+		infrastorage.NewFileSystemAdapter(),
+		filepath.Join(home, "installed.json"),
+	)
+	manager := NewManager(registry, home, &stubAgentService{})
+	if _, err := manager.StartInstall("not-a-github-url", false); !errors.Is(err, ErrInvalidSource) {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// Exercises validation branches for malformed repository and subdirectory components.
+func TestValidateSourceEdgeCases(t *testing.T) {
+	invalid := []string{
+		"https://github.com/owner",
+		"https://github.com/./repo",
+		"https://github.com/-owner/repo",
+		"https://github.com/owner/-repo",
+		"https://github.com/owner/repo//",
+		"https://github.com/owner/repo//../bad",
+		"https://github.com/owner/repo///bad",
+		"https://github.com/owner/repo//bad?query",
+		"https://github.com/owner/repo//-bad",
+		"https://github.com/owner/repo//bad//part",
+	}
+	for _, source := range invalid {
+		if _, err := ValidateSource(source); !errors.Is(err, ErrInvalidSource) {
+			t.Errorf("source %q: err = %v", source, err)
+		}
+	}
+	if got, err := ValidateSource(" https://github.com/owner/repo/ "); err != nil || got != "https://github.com/owner/repo" {
+		t.Fatalf("got %q, err = %v", got, err)
+	}
+}
+
+// Exercises update registry not-found, read, YAML, entry, and invalid-source failures.
+func TestStartUpdateRegistryFailures(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		setup   func(string)
+		want    error
+	}{
+		{name: "missing", want: ErrNotFound},
+		{name: "read", setup: func(home string) {
+			requireDir := filepath.Join(home, "installed.yaml")
+			if err := os.Mkdir(requireDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "yaml", content: "installed: ["},
+		{name: "entry", content: "installed: {}\n", want: ErrNotFound},
+		{name: "source", content: "installed:\n  demo:\n    source_path: invalid\n", want: ErrInvalidSource},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			if test.setup != nil {
+				test.setup(home)
+			} else if test.content != "" {
+				if err := os.WriteFile(filepath.Join(home, "installed.yaml"), []byte(test.content), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			manager := newManager(&stubInstaller{}, &stubAgentService{}, home)
+			_, err := manager.StartUpdate("demo")
+			if err == nil || (test.want != nil && !errors.Is(err, test.want)) {
+				t.Fatalf("err = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+// Exercises uninstall status, stop, and installer failure propagation.
+func TestUninstallPropagatesOperationFailures(t *testing.T) {
+	boom := errors.New("boom")
+	tests := []struct {
+		name  string
+		inst  *stubInstaller
+		agent *stubAgentService
+	}{
+		{"status", &stubInstaller{installed: []domain.InstalledPackage{{Name: "demo"}}}, &stubAgentService{statusErr: boom}},
+		{"stop", &stubInstaller{installed: []domain.InstalledPackage{{Name: "demo"}}}, &stubAgentService{running: true, stopErr: boom}},
+		{"remove", &stubInstaller{installed: []domain.InstalledPackage{{Name: "demo"}}, uninstallErr: boom}, &stubAgentService{}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := newManager(test.inst, test.agent, t.TempDir()).Uninstall("demo"); !errors.Is(err, boom) {
+				t.Fatalf("err = %v", err)
+			}
+		})
+	}
+}
+
+// Exercises nil agent service, list failures, absent append targets, and job eviction.
+func TestManagerHelperEdgeCases(t *testing.T) {
+	manager := newManager(&stubInstaller{listErr: errors.New("list")}, nil, t.TempDir())
+	if got, err := ValidateSource("https://github.com/owner/repo//agents/demo/"); err != nil ||
+		got != "https://github.com/owner/repo//agents/demo" {
+		t.Fatalf("source=%q err=%v", got, err)
+	}
+	source, options := splitSubdir("https://github.com/owner/repo//agents/demo", true)
+	if source != "https://github.com/owner/repo" || options.Path != "agents/demo" || !options.Force {
+		t.Fatalf("source=%q options=%+v", source, options)
+	}
+	if running, err := manager.isRunning("demo"); err != nil || running {
+		t.Fatalf("running=%v err=%v", running, err)
+	}
+	if got := manager.installedNames(); len(got) != 0 {
+		t.Fatalf("names=%v", got)
+	}
+	if got := manager.discoverPackageName(nil); got != "" {
+		t.Fatalf("name=%q", got)
+	}
+	manager.appendLine("missing", "ignored")
+	if job, ok := manager.GetJob("missing"); ok || job != nil {
+		t.Fatalf("job=%v ok=%v", job, ok)
+	}
+
+	manager.mu.Lock()
+	for i := 0; i <= maxJobs; i++ {
+		id := fmt.Sprintf("job-%d", i)
+		manager.jobs[id] = &Job{ID: id}
+		manager.order = append(manager.order, id)
+	}
+	manager.evictLocked()
+	manager.mu.Unlock()
+	if len(manager.order) != maxJobs {
+		t.Fatalf("jobs=%d", len(manager.order))
+	}
+	if got := manager.ListJobs(); len(got) != maxJobs {
+		t.Fatalf("listed jobs=%d", len(got))
+	}
 }


### PR DESCRIPTION
## Summary

Agent package **install** and **secrets** are CLI-only today (`af install`, `af secrets set`), while start/stop are already REST-exposed. This PR closes that gap so a remote client (AgentField Desktop in the upcoming cloud mode, the web UI, or any API consumer) can manage packages on the box the control plane runs on — the foundation for running the control plane + agents on a cloud instance with the desktop as a pure remote client.

## Changes

- **`internal/services/packagejobs`** — async job manager wrapping the existing `PackageService`: one active job at a time, in-memory job registry (last 50 jobs, 500 ANSI-free progress lines each), and update jobs that remember/restore the package's running state.
- **Install handlers** — `POST /api/ui/v1/agents/packages/install` → `202 {job_id}`; job polling via `GET .../install/jobs/:jobId`; `POST .../packages/:packageId/uninstall|update`. Source validation is strict: `https://github.com/<owner>/<repo>[//<subdir>]` only (safe charset, no `..`, no query/fragment) — no local paths, no arbitrary hosts.
- **Secrets handlers** — `GET/PUT/DELETE /api/ui/v1/agents/:agentId/secrets[/:key]` writing the **encrypted store that `RunAgent` actually injects from**. Scope follows the CLI/desktop rule: global by default, node when the manifest declares `scope: node`, explicit override on PUT/DELETE. The listing reports effective resolution (node shadows global), and `GET /api/ui/v1/secrets` lists store-wide key+scope refs like `af secrets ls`. The existing `/env` endpoints write a plaintext `.env` that nothing reads at spawn time — set-key-then-start over HTTP silently produced agents without their API keys. Listing returns key names + manifest-declared unset keys (`is_set: false`) so clients can render a keys form; values are never returned or logged.
- **Wiring** — manager constructed in `server.go` from the existing `registryStorage`/`agentService`; routes registered in the `agents` UI group.

## Validation contract → tests

Each behavior was specified before implementation; every test maps to a contract item (see comments in the test files): async job lifecycle & 409-while-busy, source whitelist rejections, failed-install mutex release, ANSI-free progress, uninstall-stops-running-agent ordering, update force+run-state restore, line caps; secrets round-trip through the store the runner reads, names-only listing, idempotent delete, key/value validation, unknown-agent 404s, unicode round-trip.

## Test plan

- [x] `go build ./...` and `CGO_ENABLED=0 GOOS=linux go build ./cmd/agentfield-server`
- [x] `go test -tags sqlite_fts5 ./internal/services/packagejobs/ ./internal/handlers/ui/ ./internal/server/` — all green (includes route-registration coverage)
- [x] `golangci-lint run` — zero issues in changed files (the 94 pre-existing repo issues are untouched; that CI step is continue-on-error)
- [x] Full `go test -tags sqlite_fts5 ./...` run locally: only failure is `TestDevServiceRunDev`, which fails identically on an untouched `main` checkout in this WSL environment (python3-subprocess port-scan test; pre-existing, unrelated)

## Notes / follow-ups

- Endpoints sit at the same auth level as the existing start/stop lifecycle endpoints. Scoped/per-device tokens for process-spawning surfaces are a planned follow-up as part of the cloud-mode security work, tracked separately.
- The published container image is distroless (no git/python/npm), so in-container installs need the upcoming cloud image variant — separate PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
