### PR TITLE
feat(desktop): register af on the shell PATH on macOS/Linux too

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -143,8 +143,11 @@ bundled CLI meanwhile and Settings shows an "Update AgentField" button that
 installs the bundled copy into the managed location (never over a newer
 one; `Version: dev` builds are trusted as-is). On a machine with no CLI at
 all, first launch auto-provisions `~/.agentfield/bin` (both `agentfield`
-and the `af` alias, Windows user PATH registered) so terminals and coding
-agents get a working `af` too.
+and the `af` alias) so terminals and coding agents get a working `af` too —
+and puts that directory on the user PATH: registered in the user-scope PATH
+on Windows, appended to the shell startup file (`.bashrc`/`.bash_profile`,
+`.zshrc`, or fish's `config.fish`) on macOS/Linux, mirroring the curl
+installer's entry so whichever ran first wins and the other is a no-op.
 
 Unless switched off in Settings, the app also installs the CLI's full skill
 catalog on launch (`af skill install --non-interactive` with no name):
@@ -218,8 +221,6 @@ Packaging is unsigned for now (no notarization/signing identities configured).
 
 - Control plane URL is hard-coded to `http://localhost:8080` (not configurable yet).
 - No stop control for the control plane itself yet (the app only starts it).
-- macOS/Linux shell PATH setup stays with the curl installer — the app only
-  provisions `~/.agentfield/bin` there (absolute path always works).
 - The macOS `af-tray` companion installs its own `~/Applications/AgentField.app`
   wrapper — a second bundle named "AgentField" distinct from this desktop app in
   `/Applications`. Harmless (the tray bundle is `LSUIElement`, menu-bar only) but

--- a/desktop/src/main/cli.test.ts
+++ b/desktop/src/main/cli.test.ts
@@ -1,3 +1,6 @@
+import { promises as fs } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   type ProbedCandidate,
@@ -5,7 +8,9 @@ import {
   compareVersions,
   effectiveMinVersion,
   parseAfVersion,
+  posixPathEntry,
   probeCli,
+  registerPosixUserPath,
   selectCli
 } from './cli'
 
@@ -169,5 +174,78 @@ describe('probeCli', () => {
       responds: false,
       version: null
     })
+  })
+})
+
+describe('posixPathEntry', () => {
+  const HOME = '/home/u'
+  const BIN = '/home/u/.agentfield/bin'
+  const EXPORT = `export PATH="${BIN}:$PATH"`
+
+  it('writes ~/.zshrc for zsh with the same export line as the curl installer', () => {
+    expect(posixPathEntry('/bin/zsh', HOME, BIN, () => false)).toEqual({
+      rcFile: join(HOME, '.zshrc'),
+      line: EXPORT
+    })
+  })
+
+  it('prefers ~/.bashrc for bash, falls back to an existing ~/.bash_profile', () => {
+    const bashrc = join(HOME, '.bashrc')
+    const profile = join(HOME, '.bash_profile')
+    expect(posixPathEntry('/bin/bash', HOME, BIN, (p) => p === bashrc)?.rcFile).toBe(bashrc)
+    expect(posixPathEntry('/bin/bash', HOME, BIN, (p) => p === profile)?.rcFile).toBe(profile)
+    // Neither exists yet — .bashrc gets created, like the installer.
+    expect(posixPathEntry('/bin/bash', HOME, BIN, () => false)?.rcFile).toBe(bashrc)
+  })
+
+  it('uses fish syntax in the fish config file', () => {
+    expect(posixPathEntry('/usr/bin/fish', HOME, BIN, () => false)).toEqual({
+      rcFile: join(HOME, '.config', 'fish', 'config.fish'),
+      line: `set -gx PATH ${BIN} $PATH`
+    })
+  })
+
+  it('returns null for unknown or missing shells', () => {
+    expect(posixPathEntry('/bin/tcsh', HOME, BIN, () => false)).toBeNull()
+    expect(posixPathEntry(undefined, HOME, BIN, () => false)).toBeNull()
+  })
+})
+
+describe('registerPosixUserPath', () => {
+  const freshHome = () => fs.mkdtemp(join(tmpdir(), 'af-desktop-path-'))
+
+  it('appends a commented PATH entry to the shell startup file', async () => {
+    const home = await freshHome()
+    const bin = join(home, '.agentfield', 'bin')
+    await registerPosixUserPath(bin, '/bin/zsh', home)
+    const rc = await fs.readFile(join(home, '.zshrc'), 'utf8')
+    expect(rc).toBe(`\n# AgentField CLI\nexport PATH="${bin}:$PATH"\n`)
+  })
+
+  it('is idempotent and defers to an entry the curl installer already wrote', async () => {
+    const home = await freshHome()
+    const bin = join(home, '.agentfield', 'bin')
+    const curlEntry = `# AgentField CLI\nexport PATH="${bin}:$PATH"\n`
+    await fs.writeFile(join(home, '.zshrc'), curlEntry)
+    await registerPosixUserPath(bin, '/bin/zsh', home)
+    await registerPosixUserPath(bin, '/bin/zsh', home)
+    expect(await fs.readFile(join(home, '.zshrc'), 'utf8')).toBe(curlEntry)
+  })
+
+  it('creates the fish config directory when needed', async () => {
+    const home = await freshHome()
+    const bin = join(home, '.agentfield', 'bin')
+    await registerPosixUserPath(bin, '/usr/bin/fish', home)
+    const rc = await fs.readFile(join(home, '.config', 'fish', 'config.fish'), 'utf8')
+    expect(rc).toContain(`set -gx PATH ${bin} $PATH`)
+  })
+
+  it('never rejects for unknown shells or unwritable locations', async () => {
+    const home = await freshHome()
+    const bin = join(home, '.agentfield', 'bin')
+    await expect(registerPosixUserPath(bin, '/bin/tcsh', home)).resolves.toBeUndefined()
+    // A regular file where the rc's parent dir should be → mkdir/append fails.
+    await fs.writeFile(join(home, '.config'), 'not a directory')
+    await expect(registerPosixUserPath(bin, '/usr/bin/fish', home)).resolves.toBeUndefined()
   })
 })

--- a/desktop/src/main/cli.ts
+++ b/desktop/src/main/cli.ts
@@ -26,8 +26,9 @@
 // selection, and provisioning stay unit-testable.
 
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
-import { promises as fs } from 'node:fs'
-import { join } from 'node:path'
+import { existsSync, promises as fs } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
 import type { AgentActionResult, CliStatus } from '../shared/types'
 import { getAgentFieldHome } from './agentfield'
 import { childEnv } from './env'
@@ -267,14 +268,15 @@ export async function installBundledCli(bundledPath: string): Promise<AgentActio
   }
 
   if (process.platform === 'win32') registerWindowsUserPath(binDir)
+  else await registerPosixUserPath(binDir)
   return { ok: true, message: `AgentField CLI installed to ${binDir}` }
 }
 
 /**
  * Best-effort: put ~/.agentfield/bin on the user PATH so `af` also works in
  * terminals (and for coding agents running shell commands). User-scope only,
- * idempotent, and never blocks the caller. macOS/Linux PATH setup remains the
- * curl installer's job — editing shell profiles from a GUI app is too rude.
+ * idempotent, and never blocks the caller. macOS/Linux go through
+ * registerPosixUserPath below.
  */
 function registerWindowsUserPath(binDir: string): void {
   const script =
@@ -285,4 +287,67 @@ function registerWindowsUserPath(binDir: string): void {
     windowsHide: true,
     stdio: 'ignore'
   }).on('error', () => {})
+}
+
+export interface PosixPathEntry {
+  rcFile: string
+  line: string
+}
+
+/**
+ * Which startup file the user's shell reads and how a PATH entry is phrased
+ * there. Must stay in lockstep with the curl installer's configure_path
+ * (scripts/install.sh): both write the same entry into the same file, and
+ * each skips when the file already mentions binDir — so whichever installer
+ * runs first wins and the other becomes a no-op. Unknown shells get null
+ * (best effort, same as the installer).
+ */
+export function posixPathEntry(
+  shell: string | undefined,
+  home: string,
+  binDir: string,
+  fileExists: (path: string) => boolean = existsSync
+): PosixPathEntry | null {
+  const exportLine = `export PATH="${binDir}:$PATH"`
+  switch (shell?.split('/').pop()) {
+    case 'bash': {
+      const bashrc = join(home, '.bashrc')
+      const profile = join(home, '.bash_profile')
+      const rcFile = fileExists(bashrc) || !fileExists(profile) ? bashrc : profile
+      return { rcFile, line: exportLine }
+    }
+    case 'zsh':
+      return { rcFile: join(home, '.zshrc'), line: exportLine }
+    case 'fish':
+      return {
+        rcFile: join(home, '.config', 'fish', 'config.fish'),
+        line: `set -gx PATH ${binDir} $PATH`
+      }
+    default:
+      return null
+  }
+}
+
+/**
+ * macOS/Linux counterpart of registerWindowsUserPath: append a PATH entry
+ * for ~/.agentfield/bin to the user's shell startup file. Same contract —
+ * best-effort (a failure never fails the CLI install), idempotent (skipped
+ * when the file already mentions binDir, e.g. the curl installer configured
+ * it), and never rejects.
+ */
+export async function registerPosixUserPath(
+  binDir: string,
+  shell: string | undefined = process.env.SHELL,
+  home: string = homedir()
+): Promise<void> {
+  try {
+    const entry = posixPathEntry(shell, home, binDir)
+    if (!entry) return
+    const current = await fs.readFile(entry.rcFile, 'utf8').catch(() => '')
+    if (current.includes(binDir)) return
+    await fs.mkdir(dirname(entry.rcFile), { recursive: true })
+    await fs.appendFile(entry.rcFile, `\n# AgentField CLI\n${entry.line}\n`)
+  } catch {
+    // best effort — the managed copy still works by absolute path
+  }
 }


### PR DESCRIPTION
## Summary

A desktop-only install already provisions the bundled `af` CLI into `~/.agentfield/bin` and registers that directory on the user PATH on Windows — but on macOS/Linux, PATH setup was left to the curl installer (a documented limitation), so terminals never got a working `af` command unless the curl installer had also run.

This adds the POSIX counterpart: `registerPosixUserPath` appends a PATH entry to the user's shell startup file when the app installs the managed CLI, phrased identically to the curl installer's `configure_path` (`scripts/install.sh`) so the two installers converge — whichever runs first wins and the other becomes a no-op.

## Behavior (validation contract)

- When the app provisions `~/.agentfield/bin` on macOS/Linux, the user's shell startup file gains a PATH entry for it: bash → `.bashrc` (falling back to an existing `.bash_profile`), zsh → `.zshrc`, fish → `~/.config/fish/config.fish` with fish syntax (`set -gx PATH … $PATH`), each guarded by the same `# AgentField CLI` comment the curl installer writes.
- Idempotent: if the startup file already mentions the bin dir (e.g. the curl installer configured it), nothing is appended; repeated provisioning appends exactly once.
- Best-effort: an unknown shell or an unwritable profile never fails the CLI install — the managed copy still works by absolute path.
- Windows behavior is unchanged (`registerWindowsUserPath`).
- Runs only when the app actually installs the managed copy, not on every launch.

## Changes

- `desktop/src/main/cli.ts` — new `posixPathEntry` (pure shell→rc-file/line mapping, injectable existence check) and `registerPosixUserPath`; called from `installBundledCli` on non-Windows.
- `desktop/src/main/cli.test.ts` — 8 new vitest cases covering the contract above (rc-file selection, installer line parity, idempotency/convergence, fish dir creation, never-rejects).
- `desktop/README.md` — bundled-CLI section updated; the "macOS/Linux shell PATH setup stays with the curl installer" limitation removed.

## Test plan

- [x] `npm ci && npm run typecheck && npm test` in `desktop/` on Node 22 (matching Desktop CI): 273 tests passing.
- [ ] Desktop CI (macos-14 + windows-latest) green, including the packaging smoke.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)