### PR TITLE
feat(desktop): sign and notarize macOS release builds

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -68,3 +68,50 @@ jobs:
       - name: Package (unsigned, unpacked)
         working-directory: desktop
         run: npm run dist:dir
+
+  # Manual-dispatch-only: prove the macOS signing/notarization secrets work
+  # without cutting a release. Imports the Developer ID cert into a keychain
+  # (the same thing electron-builder does with CSC_LINK) and authenticates
+  # against Apple's notary service. Run it after rotating the cert or the
+  # app-specific password.
+  verify-signing-secrets:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: macos-14
+    steps:
+      - name: Import Developer ID cert into a temporary keychain
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ -z "$CSC_LINK" ] || [ -z "$CSC_KEY_PASSWORD" ]; then
+            echo "CSC_LINK / CSC_KEY_PASSWORD secrets not set" >&2
+            exit 1
+          fi
+          printf '%s' "$CSC_LINK" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security create-keychain -p ci-temp verify.keychain
+          security unlock-keychain -p ci-temp verify.keychain
+          security import "$RUNNER_TEMP/cert.p12" -k verify.keychain \
+            -P "$CSC_KEY_PASSWORD" -T /usr/bin/codesign
+          # -v lists only identities whose full chain verifies; an import that
+          # yields zero valid identities would also break electron-builder.
+          security find-identity -v -p codesigning verify.keychain | tee identities.txt
+          grep -q "Developer ID Application" identities.txt
+
+      - name: Authenticate against the Apple notary service
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "$APPLE_ID" ] || [ -z "$APPLE_APP_SPECIFIC_PASSWORD" ] || [ -z "$APPLE_TEAM_ID" ]; then
+            echo "APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD / APPLE_TEAM_ID secrets not set" >&2
+            exit 1
+          fi
+          # history performs a real authenticated API call; bad credentials
+          # fail with HTTP 401 and a non-zero exit.
+          xcrun notarytool history \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -508,13 +508,16 @@ jobs:
             sdk/python/dist/*.whl
             sdk/python/dist/*.tar.gz
 
-  # Desktop installers — unsigned for now (signing/notarization is a known
-  # follow-up): DMG + zip on macOS (Apple Silicon), NSIS .exe on Windows
-  # (x64), attached to the same release as the CLI binaries so users download
-  # whichever they want. Runs for staging (RC prereleases) and production
-  # alike. The bundled af CLI is built from the release commit with the
-  # embedded web UI + sqlite FTS (parity with build-single-binary.sh), so the
-  # installed app is fully self-contained on a fresh machine.
+  # Desktop installers — DMG + zip on macOS (Apple Silicon), NSIS .exe on
+  # Windows (x64), attached to the same release as the CLI binaries so users
+  # download whichever they want. Runs for staging (RC prereleases) and
+  # production alike. The bundled af CLI is built from the release commit with
+  # the embedded web UI + sqlite FTS (parity with build-single-binary.sh), so
+  # the installed app is fully self-contained on a fresh machine.
+  #
+  # macOS builds are Developer ID signed + notarized via the CSC_LINK /
+  # CSC_KEY_PASSWORD / APPLE_* secrets. Windows builds are still unsigned
+  # (Authenticode is a separate follow-up).
   desktop-installers:
     needs:
       - prepare
@@ -531,7 +534,8 @@ jobs:
     permissions:
       contents: write
     env:
-      # No signing identities in CI yet; package unsigned.
+      # Never auto-discover identities from the runner keychain; macOS signing
+      # uses the explicit CSC_LINK cert, Windows stays unsigned.
       CSC_IDENTITY_AUTO_DISCOVERY: 'false'
     steps:
       - name: Checkout release commit
@@ -584,9 +588,78 @@ jobs:
           AF_CLI_VERSION: ${{ needs.prepare.outputs.tag_name }}
         run: npm run bundle-cli -- full
 
-      - name: Build installers
+      # electron-builder signs every Mach-O in the bundle (including the
+      # bundled af/af-tray) with the Developer ID cert + hardened runtime,
+      # then notarizes and staples the .app before packing DMG/zip from it.
+      # Missing secrets degrade the artifact instead of blocking the release:
+      # no CSC_LINK → unsigned (ad-hoc) build, no APPLE_APP_SPECIFIC_PASSWORD
+      # → signed but un-notarized build, each with a workflow warning.
+      - name: Build installers (macOS, signed + notarized)
+        if: runner.os == 'macOS'
+        working-directory: desktop
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          if [ -z "$CSC_LINK" ] || [ -z "$APPLE_APP_SPECIFIC_PASSWORD" ]; then
+            echo "::warning::signing/notarization secrets incomplete; electron-builder will skip what it lacks credentials for"
+            # Partial APPLE_* env makes electron-builder hard-fail, and an
+            # unsigned app can never notarize; drop the set entirely so it
+            # degrades to a skip-with-warning instead.
+            unset APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID
+          fi
+          npm run dist
+
+      - name: Build installers (Windows)
+        if: runner.os == 'Windows'
         working-directory: desktop
         run: npm run dist
+
+      # The .app inside the DMG is already notarized + stapled; notarizing and
+      # stapling the DMG container as well makes the download pass Gatekeeper
+      # even offline. Then hard-verify what is about to ship: a signing or
+      # notarization regression must fail the release here, not on users'
+      # machines.
+      - name: Notarize DMG + verify Gatekeeper acceptance (macOS)
+        if: runner.os == 'macOS'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+        run: |
+          set -euo pipefail
+          if [ -z "$CSC_LINK" ] || [ -z "$APPLE_APP_SPECIFIC_PASSWORD" ]; then
+            echo "::warning::signing/notarization secrets incomplete; skipping DMG notarization and Gatekeeper verification"
+            exit 0
+          fi
+          shopt -s nullglob
+          dmgs=(desktop/release/*.dmg)
+          if [ ${#dmgs[@]} -eq 0 ]; then
+            echo "no dmg found under desktop/release" >&2
+            exit 1
+          fi
+          for dmg in "${dmgs[@]}"; do
+            xcrun notarytool submit "$dmg" \
+              --apple-id "$APPLE_ID" \
+              --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+              --team-id "$APPLE_TEAM_ID" \
+              --wait
+            xcrun stapler staple "$dmg"
+            xcrun stapler validate "$dmg"
+          done
+          apps=(desktop/release/mac*/*.app)
+          if [ ${#apps[@]} -eq 0 ]; then
+            echo "no packed .app found under desktop/release" >&2
+            exit 1
+          fi
+          for app in "${apps[@]}"; do
+            xcrun stapler validate "$app"
+            spctl --assess --type execute -vv "$app"
+          done
 
       - name: Attach installers to the release
         shell: bash

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -52,7 +52,10 @@
         "dmg",
         "zip"
       ],
-      "darkModeSupport": true
+      "darkModeSupport": true,
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "notarize": true
     },
     "win": {
       "target": [


### PR DESCRIPTION
## Summary

The `desktop-installers` release job shipped ad-hoc-signed DMGs, so Gatekeeper blocked every macOS download ("Apple could not verify…"; on macOS 15 the only way through is Privacy & Security → Open Anyway). This wires Developer ID signing + Apple notarization into the release pipeline so the uploaded DMG is accepted cleanly.

## Changes

- **`desktop/package.json`**: `hardenedRuntime` + `notarize` on the mac config. electron-builder signs every Mach-O in the bundle (including the bundled `af`/`af-tray` Go binaries — verified `@electron/osx-sign` walks the whole bundle), notarizes and staples the `.app`, then packs the DMG/zip from the stapled app. Default electron-builder entitlements (JIT etc.) apply.
- **`release.yml`**: the macOS leg gets `CSC_LINK`/`CSC_KEY_PASSWORD` (Developer ID cert) and `APPLE_ID`/`APPLE_APP_SPECIFIC_PASSWORD`/`APPLE_TEAM_ID` (notarization). Steps are split per OS because `CSC_LINK` means an Authenticode cert on the Windows leg. If secrets are incomplete the build degrades to the previous unsigned behavior with a workflow warning instead of failing the release.
- **New post-build step (macOS)**: notarizes + staples the DMG container itself (Gatekeeper acceptance even offline) and hard-verifies the artifacts (`stapler validate`, `spctl --assess`) so a signing regression fails the release run, not on users' machines.

PR CI (`desktop.yml`) stays secret-less and unsigned — the new config is inert without credentials and the existing ad-hoc afterPack hook still covers those builds. Windows Authenticode signing is a separate follow-up.

## Validation contract

- Release build with all five secrets → DMG whose app is Developer ID signed, notarized, stapled; `spctl --assess` accepts it; users get no Gatekeeper wall.
- Release build with missing/partial secrets → build still succeeds, warning emitted, artifact equivalent to today's.
- PR CI without secrets → unchanged (unsigned + ad-hoc signature, packaging still validated).
- Windows leg → byte-for-byte same behavior as before.

## Test plan

- [x] `desktop`: `npm run typecheck` + `npm test` (265 passing) — config-only change, no code paths touched
- [x] Workflow YAML parse-validated; electron-builder credential/skip semantics verified against the vendored `app-builder-lib`/`@electron/osx-sign`/`@electron/notarize` sources
- [ ] Real proof requires a release run (next RC): check the mac leg logs for "notarization successful" + the new verify step, then download the DMG on a Mac and confirm no Gatekeeper prompt

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)