### PR TITLE
feat(deploy): cloud control-plane image that can install and run agents in-container

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,11 +38,42 @@ jobs:
       - name: Smoke test control plane image
         run: docker run --rm agentfield-control-plane:test --help
 
+  control-plane-cloud-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build control plane cloud image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: deployments/docker/Dockerfile.control-plane-cloud
+          load: true
+          tags: agentfield-control-plane-cloud:test
+
+      - name: Smoke test cloud image toolchains
+        run: |
+          docker run --rm --entrypoint sh agentfield-control-plane-cloud:test -c '
+            set -e
+            af --help > /dev/null
+            git --version
+            python3 --version
+            python3 -m pip --version
+            python3 -m venv --help > /dev/null
+            node --version
+            npm --version
+            go version
+          '
+
   # Summary job that depends on all critical checks
   required-checks:
     name: All Required Checks Passed
     runs-on: ubuntu-latest
-    needs: [control-plane-image]
+    needs: [control-plane-image, control-plane-cloud-image]
     if: always()
     steps:
       - name: Check all jobs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -472,9 +472,11 @@ jobs:
           if [ "${ENVIRONMENT}" = "staging" ]; then
             # Staging: use staging-X.Y.Z-rc.N prefix
             echo "tags=${image}:staging-${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "cloud_tags=${image}-cloud:staging-${VERSION}" >> "$GITHUB_OUTPUT"
           else
             # Production: version tag + latest
             echo "tags=${image}:${TAG_NAME},${image}:latest" >> "$GITHUB_OUTPUT"
+            echo "cloud_tags=${image}-cloud:${TAG_NAME},${image}-cloud:latest" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set up Docker Buildx
@@ -497,6 +499,18 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.docker_meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push control plane cloud image
+        if: needs.prepare.outputs.publish_docker == 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: deployments/docker/Dockerfile.control-plane-cloud
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.docker_meta.outputs.cloud_tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/deployments/docker/Dockerfile.control-plane-cloud
+++ b/deployments/docker/Dockerfile.control-plane-cloud
@@ -1,0 +1,88 @@
+# Cloud variant of the control-plane image: includes the toolchains the
+# HTTP install API needs to install and run agent nodes inside the same
+# container (git clone, python venv + pip, node/npm, go build), plus the
+# full `af` CLI for interactive administration (e.g. `railway ssh`).
+#
+# The default Dockerfile.control-plane stays distroless for deployments
+# where agents run elsewhere; this image trades size for a box that can
+# host the control plane AND its agents — the single-container topology
+# used by cloud deploys (Railway template, VM installs).
+#
+# Runs as root: cloud platforms (Railway) mount volumes root-owned, and
+# agent installs write venvs/binaries under $AGENTFIELD_HOME=/data.
+
+FROM --platform=$BUILDPLATFORM node:20-alpine AS ui-builder
+WORKDIR /app/web
+
+COPY control-plane/web/client/package*.json ./
+RUN npm ci
+COPY control-plane/web/client/ .
+# See Dockerfile.control-plane for why vite runs without the tsc precheck.
+RUN npx vite build
+
+FROM --platform=$BUILDPLATFORM golang:1.25-bookworm AS go-builder
+WORKDIR /app
+
+ARG TARGETOS
+ARG TARGETARCH
+ENV CGO_ENABLED=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    pkg-config \
+    gcc-aarch64-linux-gnu \
+    libc6-dev-arm64-cross \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY control-plane/go.mod control-plane/go.sum ./control-plane/
+COPY control-plane/third_party/ ./control-plane/third_party/
+RUN cd control-plane && go mod download
+
+COPY control-plane/ ./control-plane/
+COPY --from=ui-builder /app/web/dist ./control-plane/web/client/dist
+
+# Build the unified `af` binary (CLI + server in one, embedded UI). The
+# container entrypoint runs `af server`; `railway ssh` users get the full
+# CLI (af list / secrets / logs) against the same $AGENTFIELD_HOME.
+RUN cd control-plane && \
+    if [ "${TARGETARCH}" = "arm64" ]; then export CC=aarch64-linux-gnu-gcc; else export CC=gcc; fi && \
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -tags "embedded sqlite_fts5" -o /app/bin/af ./cmd/af
+
+# Toolchain donors — same arch as the runtime stage (no --platform pin).
+FROM node:22-bookworm-slim AS node-dist
+FROM golang:1.25-bookworm AS go-dist
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    python3 \
+    python3-pip \
+    python3-venv \
+    tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node runtime for TypeScript/JavaScript agent nodes.
+COPY --from=node-dist /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-dist /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
+    ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
+# Go toolchain for Go agent nodes (built at install time).
+COPY --from=go-dist /usr/local/go /usr/local/go
+ENV PATH=/usr/local/go/bin:$PATH
+
+COPY --from=go-builder /app/bin/af /usr/local/bin/af
+COPY --from=go-builder /app/control-plane/config /etc/agentfield/config
+
+# Everything stateful (SQLite, BoltDB, installed.yaml, secrets keyring,
+# agent package dirs) lives under one mount point.
+ENV AGENTFIELD_HOME=/data
+RUN mkdir -p /data
+
+EXPOSE 8080
+
+# tini reaps the agent child processes the control plane spawns.
+ENTRYPOINT ["tini", "--", "af", "server"]


### PR DESCRIPTION
## Summary

The published control-plane image is distroless: no git, python, node, or go — so the HTTP install API (#837) physically cannot install agent nodes inside it. This adds a **cloud variant** built for the single-container topology (control plane + agents on one box) used by cloud deploys (Railway template, VM installs). The distroless image remains the default and is unchanged.

## Changes

- **`deployments/docker/Dockerfile.control-plane-cloud`** — debian-slim runtime with git, python3 (+venv/pip), node 22 (copied from the official image, no curl|bash), the Go toolchain (Go agents build at install time), and the full `af` binary (`railway ssh` users get the whole CLI). `AGENTFIELD_HOME=/data` puts SQLite, BoltDB, `installed.yaml`, the secrets keyring, and agent package dirs on one volume mount. `tini` is PID 1 so agent child processes are reaped. Runs as root because cloud platforms (Railway) mount volumes root-owned. 631MB.
- **`docker.yml`** — build + smoke-test job for the cloud image (asserts every toolchain is present and `af` runs); added to required checks.
- **`release.yml`** — publishes `agentfield/control-plane-cloud` (same staging/latest tag scheme) alongside the base image on the existing release flow.

## Verified end-to-end locally

Booted the image and drove it exactly as the desktop will drive a cloud box, from outside over HTTP:

1. `POST /api/ui/v1/agents/packages/install` with `Agent-Field/pr-af//go` → git clone + `go build` **inside the container** → job `succeeded`.
2. Start without required keys → correctly refused with the actionable missing-env error.
3. Secrets set via the API → agent started, registered over loopback (`localhost:8001`), `/health` green, state under `/data`.
4. `docker exec af list` shows the installed node — in-container CLI administration works.

## Notes

- Image size 631MB vs ~4GB/100GB platform caps — fine. The Go toolchain is the biggest contributor; dropping it would break Go-based agents (pr-af//go, swe-af//go), so it stays.
- Follow-up (separate): point the Railway template at this image with a volume + `${{secret(32)}}` API key.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)