### PR TITLE
feat(desktop): one management path — agents managed via the control-plane API

### DIFF
--- a/desktop/src/main/agentfield.test.ts
+++ b/desktop/src/main/agentfield.test.ts
@@ -1,7 +1,7 @@
-import { promises as fs } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { CpClient, PackageInfo } from './cpClient'
 import {
   DEFAULT_BASE_URL,
   checkControlPlane,
@@ -20,23 +20,6 @@ import { DEFAULT_CONTROL_PLANE_PORT } from './ports'
 import { installCommand, sanitizeInstallOutput } from './installer'
 import { CATALOG, catalogEntry } from '../shared/catalog'
 
-const tmpDirs: string[] = []
-
-async function makeHome(installedYaml?: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentfield-desktop-test-'))
-  tmpDirs.push(dir)
-  if (installedYaml !== undefined) {
-    await fs.writeFile(path.join(dir, 'installed.yaml'), installedYaml, 'utf8')
-  }
-  return dir
-}
-
-afterEach(async () => {
-  await Promise.all(
-    tmpDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true }))
-  )
-})
-
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -44,32 +27,24 @@ function jsonResponse(body: unknown, status = 200): Response {
   })
 }
 
-const REGISTRY_FIXTURE = `installed:
-  pr-af:
-    name: pr-af
-    version: 0.1.0
-    description: Opens draft pull requests from a task description
-    path: /home/abir/.agentfield/packages/pr-af
-    source: local
-    source_path: ./fix-praf
-    installed_at: "2026-07-08T10:35:03-04:00"
-    status: running
-    language: python
-    runtime:
-      port: 9001
-      pid: 4242
-      started_at: "2026-07-08T10:36:00-04:00"
-      log_file: /home/abir/.agentfield/logs/pr-af.log
-  swe-af:
-    version: 0.2.1
-    description: Software engineering agent
-    status: stopped
-    runtime:
-      port: null
-      pid: null
-      started_at: null
-      log_file: /home/abir/.agentfield/logs/swe-af.log
-`
+const API_PACKAGES: PackageInfo[] = [
+  {
+    id: 'pr-af', name: 'pr-af', version: '0.1.0',
+    description: 'Opens draft pull requests from a task description',
+    status: 'running', install_path: '/home/abir/.agentfield/packages/pr-af',
+    port: 9001, process_id: 4242, configuration_required: false,
+    configuration_complete: true, author: ''
+  },
+  {
+    id: 'swe-af', name: 'swe-af', version: '0.2.1',
+    description: 'Software engineering agent', status: 'stopped', install_path: '',
+    configuration_required: false, configuration_complete: true, author: ''
+  }
+]
+
+function packagesClient(packages = API_PACKAGES): CpClient {
+  return { listPackages: vi.fn(async () => ({ packages, total: packages.length })) } as unknown as CpClient
+}
 
 describe('active base URL', () => {
   afterEach(() => setActiveControlPlanePort(DEFAULT_CONTROL_PLANE_PORT))
@@ -99,11 +74,8 @@ describe('getAgentFieldHome', () => {
 })
 
 describe('readInstalledAgents', () => {
-  // Contract: registry with running + stopped entries (including null runtime
-  // fields and a missing optional language) parses into a correct agents array.
-  it('parses running and stopped entries, null runtime fields, optional language', async () => {
-    const home = await makeHome(REGISTRY_FIXTURE)
-    const result = await readInstalledAgents(home)
+  it('maps running and stopped API packages, including absent runtime fields', async () => {
+    const result = await readInstalledAgents(packagesClient())
 
     expect(result.exists).toBe(true)
     expect(result.error).toBeUndefined()
@@ -114,7 +86,6 @@ describe('readInstalledAgents', () => {
       name: 'pr-af',
       version: '0.1.0',
       description: 'Opens draft pull requests from a task description',
-      language: 'python',
       status: 'running',
       path: '/home/abir/.agentfield/packages/pr-af',
       port: 9001,
@@ -127,7 +98,6 @@ describe('readInstalledAgents', () => {
       name: 'swe-af',
       version: '0.2.1',
       description: 'Software engineering agent',
-      language: undefined,
       status: 'stopped',
       path: null,
       port: null,
@@ -135,32 +105,17 @@ describe('readInstalledAgents', () => {
     })
   })
 
-  // Contract: missing installed.yaml (or missing ~/.agentfield entirely) is a
-  // graceful empty state, not an error.
-  it('returns { exists: false, agents: [] } when installed.yaml is missing', async () => {
-    const home = await makeHome() // dir exists, no installed.yaml
-    expect(await readInstalledAgents(home)).toEqual({ exists: false, agents: [] })
-  })
-
-  it('returns { exists: false, agents: [] } when the home dir itself is missing', async () => {
-    const home = await makeHome()
-    const missing = path.join(home, 'does-not-exist')
-    expect(await readInstalledAgents(missing)).toEqual({ exists: false, agents: [] })
-  })
-
-  // Contract: malformed YAML surfaces as an error string — never throws.
-  it('surfaces malformed YAML as an error string without throwing', async () => {
-    const home = await makeHome('installed:\n  pr-af: [unclosed\n')
-    const result = await readInstalledAgents(home)
-    expect(result.exists).toBe(true)
-    expect(result.agents).toEqual([])
-    expect(result.error).toContain('installed.yaml')
-  })
-
-  it('treats a YAML doc without an installed map as an empty registry', async () => {
-    const home = await makeHome('something_else: true\n')
-    const result = await readInstalledAgents(home)
+  it('maps an empty package list to an existing empty registry', async () => {
+    const result = await readInstalledAgents(packagesClient([]))
     expect(result).toEqual({ exists: true, agents: [] })
+  })
+
+  it('surfaces API failures without throwing', async () => {
+    const client = packagesClient()
+    vi.mocked(client.listPackages).mockRejectedValue(new Error('offline'))
+    expect(await readInstalledAgents(client)).toEqual({
+      exists: false, agents: [], error: 'offline'
+    })
   })
 })
 
@@ -522,9 +477,9 @@ describe('install catalog', () => {
 describe('installCommand', () => {
   // Contract: the renderer sends catalog *names* over IPC; only vetted
   // sources ever reach spawn, and unknown names are refused.
-  it('builds `af install <source>` for a catalog name', () => {
+  it('builds a control-plane install preview for a catalog name', () => {
     expect(installCommand(CATALOG[0].name)).toEqual({
-      command: 'af',
+      command: 'control-plane',
       args: ['install', CATALOG[0].source]
     })
   })
@@ -561,7 +516,6 @@ describe('getSnapshot', () => {
   }
 
   it('composes control plane + registry with cross-checked badges', async () => {
-    const home = await makeHome(REGISTRY_FIXTURE)
     const fetchImpl = routedFetch({
       '/health': () => jsonResponse({ status: 'healthy' }),
       // Control plane sees pr-af but not swe-af.
@@ -597,7 +551,7 @@ describe('getSnapshot', () => {
         })
     })
 
-    const snapshot = await getSnapshot({ homeDir: home, fetchImpl })
+    const snapshot = await getSnapshot({ cpClient: packagesClient(), fetchImpl })
 
     expect(snapshot.controlPlane.baseUrl).toBe('http://localhost:8080')
     expect(snapshot.controlPlane.reachable).toBe(true)
@@ -630,13 +584,12 @@ describe('getSnapshot', () => {
   })
 
   it('falls back to registry status when the nodes endpoint fails', async () => {
-    const home = await makeHome(REGISTRY_FIXTURE)
     const fetchImpl = routedFetch({
       '/health': () => jsonResponse({ status: 'healthy' }),
       '/api/v1/nodes': () => jsonResponse({ error: 'boom' }, 500)
     })
 
-    const snapshot = await getSnapshot({ homeDir: home, fetchImpl })
+    const snapshot = await getSnapshot({ cpClient: packagesClient(), fetchImpl })
     const badges = Object.fromEntries(
       snapshot.registry.agents.map((a) => [a.name, a.badge])
     )
@@ -645,7 +598,6 @@ describe('getSnapshot', () => {
   })
 
   it('does not consult the nodes view of an unrecognized service on the port', async () => {
-    const home = await makeHome(REGISTRY_FIXTURE)
     const requested: string[] = []
     const fetchImpl: FetchLike = async (input) => {
       requested.push(String(input))
@@ -653,7 +605,7 @@ describe('getSnapshot', () => {
       return jsonResponse({ status: 'alive', nodes: [] })
     }
 
-    const snapshot = await getSnapshot({ homeDir: home, fetchImpl })
+    const snapshot = await getSnapshot({ cpClient: packagesClient(), fetchImpl })
 
     expect(snapshot.controlPlane.recognized).toBe(false)
     // Badges fall back to registry statuses — the foreign 200 on /api/v1/nodes
@@ -672,15 +624,15 @@ describe('getSnapshot', () => {
   })
 
   it('reports an unreachable control plane and an absent registry gracefully', async () => {
-    const home = await makeHome()
-    const missing = path.join(home, 'nope')
     const fetchImpl: FetchLike = async () => {
       throw new TypeError('fetch failed')
     }
 
-    const snapshot = await getSnapshot({ homeDir: missing, fetchImpl })
+    const unavailable = packagesClient()
+    vi.mocked(unavailable.listPackages).mockRejectedValue(new Error('fetch failed'))
+    const snapshot = await getSnapshot({ cpClient: unavailable, fetchImpl })
     expect(snapshot.controlPlane.reachable).toBe(false)
-    expect(snapshot.registry).toEqual({ exists: false, agents: [], error: undefined })
+    expect(snapshot.registry).toEqual({ exists: false, agents: [], error: 'fetch failed' })
     expect(snapshot.usage).toBeNull()
   })
 })

--- a/desktop/src/main/agentfield.test.ts
+++ b/desktop/src/main/agentfield.test.ts
@@ -636,3 +636,30 @@ describe('getSnapshot', () => {
     expect(snapshot.usage).toBeNull()
   })
 })
+
+// Catalog rows (install_status uninstalled / other) are filtered from the
+// installed-agents listing; absent install_status keeps the row (old CP).
+it('readInstalledAgents filters catalog and uninstalled rows', async () => {
+  const pkg = (over: Record<string, unknown>) => ({
+    id: 'x', name: 'x', version: '1', status: 'not_configured', install_path: '/p',
+    configuration_required: false, configuration_complete: true,
+    description: '', author: '', ...over
+  })
+  const cpClient = {
+    listPackages: async () => ({
+      packages: [
+        pkg({ name: 'installed-one', install_status: 'installed' }),
+        pkg({ name: 'running-one', install_status: 'running' }),
+        pkg({ name: 'stopped-one', install_status: 'stopped' }),
+        pkg({ name: 'catalog-one', install_status: 'uninstalled' }),
+        pkg({ name: 'weird-one', install_status: 'not_configured' }),
+        pkg({ name: 'legacy-cp-row' })
+      ],
+      total: 6
+    })
+  } as never
+  const result = await readInstalledAgents(cpClient)
+  expect(result.agents.map((a) => a.name)).toEqual([
+    'installed-one', 'running-one', 'stopped-one', 'legacy-cp-row'
+  ])
+})

--- a/desktop/src/main/agentfield.ts
+++ b/desktop/src/main/agentfield.ts
@@ -19,7 +19,7 @@ import type {
 } from '../shared/types'
 
 import { DEFAULT_CONTROL_PLANE_PORT, baseUrlForPort } from './ports'
-import { createCpClient, type CpClient, type PackageInfo } from './cpClient'
+import { createCpClient, isInstalledPackage, type CpClient, type PackageInfo } from './cpClient'
 
 export const DEFAULT_BASE_URL = baseUrlForPort(DEFAULT_CONTROL_PLANE_PORT)
 
@@ -122,7 +122,10 @@ export async function readInstalledAgents(
 ): Promise<RegistryResult> {
   try {
     const response = await cpClient.listPackages()
-    return { exists: true, agents: response.packages.map(packageToInstalledAgent) }
+    return {
+      exists: true,
+      agents: response.packages.filter(isInstalledPackage).map(packageToInstalledAgent)
+    }
   } catch (err) {
     return { exists: false, agents: [], error: errorMessage(err) }
   }

--- a/desktop/src/main/agentfield.ts
+++ b/desktop/src/main/agentfield.ts
@@ -1,17 +1,10 @@
-// TODO(af-cli): this module currently reads ~/.agentfield/installed.yaml directly;
-// a sibling branch is adding `af list -o json` — swap readInstalledAgents() to shell
-// out to that once it lands, so the CLI stays the single source of truth for
-// registry parsing.
-//
 // This is THE single data-access module for AgentField Desktop. Everything that
 // touches the AgentField installation (~/.agentfield) or the control plane HTTP
 // API lives here and nowhere else. It deliberately does NOT import from
 // 'electron' so it stays unit-testable under plain vitest.
 
-import { promises as fs } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import yaml from 'js-yaml'
 import type {
   AgentBadge,
   AgentFieldSnapshot,
@@ -26,6 +19,7 @@ import type {
 } from '../shared/types'
 
 import { DEFAULT_CONTROL_PLANE_PORT, baseUrlForPort } from './ports'
+import { createCpClient, type CpClient, type PackageInfo } from './cpClient'
 
 export const DEFAULT_BASE_URL = baseUrlForPort(DEFAULT_CONTROL_PLANE_PORT)
 
@@ -107,57 +101,31 @@ export async function checkControlPlane(
   }
 }
 
-function toInstalledAgent(key: string, entry: unknown): InstalledAgent {
-  const record = isRecord(entry) ? entry : {}
-  const runtime = isRecord(record.runtime) ? record.runtime : {}
+export function packageToInstalledAgent(pkg: PackageInfo): InstalledAgent {
   return {
-    name: typeof record.name === 'string' && record.name !== '' ? record.name : key,
-    version: typeof record.version === 'string' ? record.version : '',
-    description: typeof record.description === 'string' ? record.description : '',
-    language: typeof record.language === 'string' ? record.language : undefined,
-    status: typeof record.status === 'string' ? record.status : 'unknown',
-    path: typeof record.path === 'string' && record.path !== '' ? record.path : null,
-    port: typeof runtime.port === 'number' ? runtime.port : null,
-    pid: typeof runtime.pid === 'number' ? runtime.pid : null
+    name: pkg.name,
+    version: pkg.version,
+    description: pkg.description,
+    status: pkg.status,
+    path: pkg.install_path || null,
+    port: pkg.port ?? null,
+    pid: pkg.process_id ?? null
   }
 }
 
 /**
- * Read <homeDir>/installed.yaml (the local agent-node registry).
- *  - Missing file or missing ~/.agentfield dir -> { exists: false, agents: [] }
- *    (graceful empty state, NOT an error).
- *  - Malformed YAML -> error surfaced as a string in the result; never throws,
- *    so nothing blows up across the IPC boundary.
+ * Read installed packages through the control-plane API. Failures are surfaced
+ * as strings so nothing throws across the IPC boundary.
  */
 export async function readInstalledAgents(
-  homeDir: string = getAgentFieldHome()
+  cpClient: CpClient = createCpClient()
 ): Promise<RegistryResult> {
-  const registryPath = path.join(homeDir, 'installed.yaml')
-  let text: string
   try {
-    text = await fs.readFile(registryPath, 'utf8')
+    const response = await cpClient.listPackages()
+    return { exists: true, agents: response.packages.map(packageToInstalledAgent) }
   } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code
-    if (code === 'ENOENT' || code === 'ENOTDIR') {
-      return { exists: false, agents: [] }
-    }
     return { exists: false, agents: [], error: errorMessage(err) }
   }
-
-  let doc: unknown
-  try {
-    doc = yaml.load(text)
-  } catch (err) {
-    return {
-      exists: true,
-      agents: [],
-      error: `Failed to parse ${registryPath}: ${errorMessage(err)}`
-    }
-  }
-
-  const installed = isRecord(doc) && isRecord(doc.installed) ? doc.installed : {}
-  const agents = Object.entries(installed).map(([key, entry]) => toInstalledAgent(key, entry))
-  return { exists: true, agents }
 }
 
 /**
@@ -361,8 +329,8 @@ export async function fetchUsageStats(
 
 export interface SnapshotOptions {
   baseUrl?: string
-  homeDir?: string
   fetchImpl?: FetchLike
+  cpClient?: CpClient
 }
 
 /**
@@ -375,7 +343,7 @@ export async function getSnapshot(options: SnapshotOptions = {}): Promise<AgentF
 
   const [controlPlane, registry] = await Promise.all([
     checkControlPlane(baseUrl, fetchImpl),
-    readInstalledAgents(options.homeDir)
+    readInstalledAgents(options.cpClient)
   ])
 
   // Only consult a recognized control plane; an unrelated service on the

--- a/desktop/src/main/agents.test.ts
+++ b/desktop/src/main/agents.test.ts
@@ -4,8 +4,11 @@ import {
   type ControlPlaneStartDeps,
   SERVER_LABEL,
   planControlPlaneLaunch,
+  runAgentAction,
+  uninstallAgent,
   startControlPlane
 } from './agents'
+import { CpApiError, type CpClient } from './cpClient'
 
 const HEALTHY: ControlPlaneStatus = {
   reachable: true,
@@ -47,6 +50,44 @@ describe('planControlPlaneLaunch', () => {
 
   it('direct-spawns for a non-default port — launchd only serves 8080', () => {
     expect(planControlPlaneLaunch('darwin', true, 9091)).toBe('spawn')
+  })
+})
+
+function managementClient(overrides: Partial<CpClient> = {}): CpClient {
+  return {
+    startAgent: vi.fn(async (agent_id) => ({ agent_id, status: 'running', pid: 1, port: 2, started_at: '', log_file: '', message: 'started', endpoints: { health: '', reasoners: '', skills: '' } })),
+    stopAgent: vi.fn(async (agent_id) => ({ agent_id, status: 'stopped', message: 'stopped' })),
+    hasInstallApi: vi.fn(async () => true),
+    uninstallPackage: vi.fn(async (package_id) => ({ package_id, status: 'uninstalled' })),
+    ...overrides
+  } as unknown as CpClient
+}
+
+describe('HTTP agent management', () => {
+  it.each(['start', 'stop'] as const)('%s returns the existing result shape', async (action) => {
+    const result = await runAgentAction(action, 'agent', { cpClient: managementClient() })
+    expect(result).toEqual({ ok: true, message: action === 'start' ? 'started' : 'stopped' })
+  })
+
+  it('restart stops then starts through the client', async () => {
+    const client = managementClient()
+    expect(await runAgentAction('restart', 'agent', { cpClient: client })).toEqual({ ok: true, message: 'started' })
+    expect(client.stopAgent).toHaveBeenCalledBefore(vi.mocked(client.startAgent))
+  })
+
+  it('maps server and unreachable errors', async () => {
+    const server = managementClient({ startAgent: vi.fn(async () => { throw new CpApiError({ status: 400, message: 'configuration missing' }) }) })
+    expect(await runAgentAction('start', 'agent', { cpClient: server })).toEqual({ ok: false, message: 'configuration missing' })
+    const offline = managementClient({ startAgent: vi.fn(async () => { throw new TypeError('fetch failed') }) })
+    expect((await runAgentAction('start', 'agent', { cpClient: offline })).message).toMatch(/start the control plane/i)
+  })
+
+  it('uninstalls without pre-stopping and detects an old control plane', async () => {
+    const client = managementClient()
+    expect(await uninstallAgent('agent', { cpClient: client })).toEqual({ ok: true, message: 'uninstalled' })
+    expect(client.stopAgent).not.toHaveBeenCalled()
+    const old = managementClient({ hasInstallApi: vi.fn(async () => false) })
+    expect((await uninstallAgent('agent', { cpClient: old })).message).toMatch(/update AgentField CLI/)
   })
 })
 

--- a/desktop/src/main/agents.ts
+++ b/desktop/src/main/agents.ts
@@ -1,127 +1,89 @@
-// Agent + control-plane lifecycle seam: shells out to the af CLI (the single
-// contract — the app never reimplements start/stop). No electron imports so
-// the module stays unit-testable.
-//
-// CLI semantics this leans on (control-plane/internal/cli):
-//   - `af run <name>` spawns the agent detached, waits for its local /health,
-//     and exits — the agent survives the CLI (and this app) exiting.
-//   - `af stop <name>` shuts down gracefully (HTTP /shutdown, then signal,
-//     then force) and flips the registry entry to stopped.
-//   - there is no `af restart` — restart here is stop-then-run.
-//   - `af server` always blocks, so the control plane is spawned detached
-//     with its output appended to ~/.agentfield/logs/control-plane.log.
+// Agent lifecycle uses the control-plane HTTP API. The only CLI path retained
+// here is the detached `af server` bootstrap.
 
 import { spawn } from 'node:child_process'
 import { closeSync, mkdirSync, openSync } from 'node:fs'
 import { join } from 'node:path'
 import type { AgentActionResult, ControlPlaneStatus } from '../shared/types'
-import { checkControlPlane, getAgentFieldHome, getBaseUrl, readInstalledAgents } from './agentfield'
+import { checkControlPlane, getAgentFieldHome } from './agentfield'
 import { getCliCommand } from './cli'
 import { childEnv } from './env'
 import { DEFAULT_CONTROL_PLANE_PORT, baseUrlForPort } from './ports'
-import { sanitizeInstallOutput } from './installer'
+import { CpApiError, createCpClient, type CpClient } from './cpClient'
 import type { RunResult } from './tray-companion'
 
 export type AgentAction = 'start' | 'stop' | 'restart'
 
-/** How long one `af run`/`af stop` may take (run waits ≤30s for readiness). */
-const CLI_TIMEOUT_MS = 90_000
-
 const MISSING_CLI_MESSAGE =
   'The AgentField CLI (af) was not found on PATH. Install it first: https://agentfield.ai/docs'
 
-/** Run one af verb to completion, capturing the last meaningful output line. */
-function runCli(args: string[], timeoutMs = CLI_TIMEOUT_MS): Promise<AgentActionResult> {
-  return new Promise((resolve) => {
-    let lastLine = ''
-    let settled = false
-    const done = (result: AgentActionResult) => {
-      if (!settled) {
-        settled = true
-        resolve(result)
-      }
-    }
+export interface AgentManagementDeps {
+  cpClient: CpClient
+}
 
-    // Point af at the control plane this app is driving. The active base URL
-    // can be a non-default port (user-configured, or auto-picked when 8080
-    // was taken) — without this, `af run` would register agents against
-    // whatever the user's own AGENTFIELD_SERVER / default 8080 resolves to,
-    // and the app would never see them.
-    const child = spawn(getCliCommand(), args, {
-      windowsHide: true,
-      env: childEnv({ AGENTFIELD_SERVER: getBaseUrl() })
-    })
-    const timer = setTimeout(() => {
-      child.kill()
-      done({ ok: false, message: `af ${args.join(' ')} timed out` })
-    }, timeoutMs)
+function defaultAgentManagementDeps(): AgentManagementDeps {
+  return { cpClient: createCpClient() }
+}
 
-    const collect = (chunk: Buffer) => {
-      const lines = sanitizeInstallOutput(chunk.toString('utf8'))
-      if (lines.length > 0) lastLine = lines[lines.length - 1]
-    }
-    child.stdout.on('data', collect)
-    child.stderr.on('data', collect)
-    child.on('error', (err: NodeJS.ErrnoException) => {
-      clearTimeout(timer)
-      done({
-        ok: false,
-        message: err.code === 'ENOENT' ? MISSING_CLI_MESSAGE : `Failed to run af: ${err.message}`
-      })
-    })
-    child.on('close', (code) => {
-      clearTimeout(timer)
-      done(
-        code === 0
-          ? { ok: true, message: lastLine }
-          : { ok: false, message: lastLine || `af ${args.join(' ')} exited with code ${code}` }
-      )
-    })
-  })
+function managementError(err: unknown): AgentActionResult {
+  if (err instanceof CpApiError) return { ok: false, message: err.message }
+  return {
+    ok: false,
+    message: 'Could not reach the control plane — start the control plane and try again'
+  }
 }
 
 /**
- * Start / stop / restart an installed agent by registry name. The name is
- * validated against ~/.agentfield/installed.yaml — the renderer only ever
- * supplies names, and unknown ones are refused rather than handed to a shell.
+ * Start / stop / restart an installed agent through the control plane.
  */
 export async function runAgentAction(
   action: AgentAction,
-  name: string
+  name: string,
+  deps: AgentManagementDeps = defaultAgentManagementDeps()
 ): Promise<AgentActionResult> {
-  const registry = await readInstalledAgents()
-  if (!registry.agents.some((agent) => agent.name === name)) {
-    return { ok: false, message: `"${name}" is not an installed agent` }
-  }
-
-  switch (action) {
-    case 'start':
-      return runCli(['run', name])
-    case 'stop':
-      return runCli(['stop', name])
-    case 'restart': {
-      // `af stop` exits cleanly when the agent is already stopped, so a
-      // restart of a wedged ("unknown") agent degrades to a plain start.
-      const stopped = await runCli(['stop', name])
-      if (!stopped.ok) return stopped
-      return runCli(['run', name])
+  try {
+    switch (action) {
+      case 'start': {
+        const result = await deps.cpClient.startAgent(name)
+        return { ok: true, message: result.message }
+      }
+      case 'stop': {
+        const result = await deps.cpClient.stopAgent(name)
+        return { ok: true, message: result.message }
+      }
+      case 'restart': {
+        await deps.cpClient.stopAgent(name)
+        const result = await deps.cpClient.startAgent(name)
+        return { ok: true, message: result.message }
+      }
     }
+  } catch (err) {
+    return managementError(err)
   }
 }
 
 /**
- * Uninstall an installed agent: graceful stop first (a stopped agent's stop
- * is a no-op), then `af uninstall --force`, which removes the package dir,
- * the registry entry, and the node-scoped secrets. Names are validated
- * against the registry like every other verb.
+ * Uninstall an installed agent. The server owns stopping a running package.
  */
-export async function uninstallAgent(name: string): Promise<AgentActionResult> {
-  const registry = await readInstalledAgents()
-  if (!registry.agents.some((agent) => agent.name === name)) {
-    return { ok: false, message: `"${name}" is not an installed agent` }
+export async function uninstallAgent(
+  name: string,
+  deps: AgentManagementDeps = defaultAgentManagementDeps()
+): Promise<AgentActionResult> {
+  try {
+    if (!(await deps.cpClient.hasInstallApi())) {
+      return {
+        ok: false,
+        message: 'Control plane update required — update AgentField CLI'
+      }
+    }
+    const result = await deps.cpClient.uninstallPackage(name)
+    return { ok: true, message: result.status }
+  } catch (err) {
+    if (err instanceof CpApiError && err.status === 404) {
+      return { ok: false, message: 'Control plane update required — update AgentField CLI' }
+    }
+    return managementError(err)
   }
-  await runCli(['stop', name])
-  return runCli(['uninstall', name, '--force'])
 }
 
 /** launchd label af-tray registers for the control-plane server agent (see af-tray shared.go). */

--- a/desktop/src/main/cpClient.test.ts
+++ b/desktop/src/main/cpClient.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from 'vitest'
+import { CpApiError, createCpClient, type FetchLike, type InstallJob } from './cpClient'
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' }
+  })
+}
+
+function mockFetch(responses: Response[]): FetchLike {
+  return vi.fn(async () => responses.shift() ?? json({})) as FetchLike
+}
+
+const job = (status: InstallJob['status'], lines: string[] = []): InstallJob => ({
+  id: 'job/1',
+  source: 'https://github.com/acme/agent',
+  kind: 'install',
+  status,
+  lines,
+  started_at: '2026-07-30T12:00:00Z'
+})
+
+describe('createCpClient', () => {
+  // Contract 1: every wrapper uses the documented method, path, body, and result.
+  it('wraps all management endpoints', async () => {
+    const payloads: unknown[] = [
+      { job_id: 'i' },
+      job('running'),
+      [job('succeeded')],
+      { package_id: 'pkg', status: 'uninstalled' },
+      { job_id: 'u' },
+      { packages: [], total: 0 },
+      { agent_id: 'agent', status: 'started', pid: 1, port: 2, started_at: 't', log_file: 'l', message: 'ok', endpoints: {} },
+      { agent_id: 'agent', status: 'stopped', message: 'ok' },
+      { agent_id: 'agent', name: 'Agent', is_running: true, status: 'running' },
+      { running_agents: [], total_count: 0 },
+      { secrets: [{ key: 'TOKEN', is_set: true, scope: 'global' }] },
+      null,
+      null,
+      { secrets: [{ key: 'TOKEN', scope: 'global' }] }
+    ]
+    const responses = payloads.map((body, index) =>
+      index === 11 || index === 12 ? new Response(null, { status: 204 }) : json(body)
+    )
+    const fetchImpl = mockFetch(responses)
+    const client = createCpClient({ baseUrl: () => 'http://cp', fetchImpl })
+
+    expect(await client.installPackage('https://github.com/acme/agent', true)).toEqual({ job_id: 'i' })
+    expect(await client.getInstallJob('job/1')).toEqual(job('running'))
+    expect(await client.listInstallJobs()).toEqual([job('succeeded')])
+    expect(await client.uninstallPackage('pkg/name')).toEqual({ package_id: 'pkg', status: 'uninstalled' })
+    expect(await client.updatePackage('pkg/name')).toEqual({ job_id: 'u' })
+    expect(await client.listPackages()).toEqual({ packages: [], total: 0 })
+    expect((await client.startAgent('agent/name', { port: 9000, detach: false })).pid).toBe(1)
+    expect((await client.stopAgent('agent/name')).status).toBe('stopped')
+    expect((await client.getAgentStatus('agent/name')).is_running).toBe(true)
+    expect(await client.listRunningAgents()).toEqual({ running_agents: [], total_count: 0 })
+    expect((await client.listAgentSecrets('agent/name')).secrets[0].key).toBe('TOKEN')
+    await client.setAgentSecret('agent/name', 'TOKEN', 'secret')
+    await client.deleteAgentSecret('agent/name', 'TOKEN', 'node')
+    expect((await client.listAllSecrets()).secrets[0].scope).toBe('global')
+
+    const calls = vi.mocked(fetchImpl).mock.calls
+    expect(calls.map(([url, init]) => [url, init?.method ?? 'GET'])).toEqual([
+      ['http://cp/api/ui/v1/agents/packages/install', 'POST'],
+      ['http://cp/api/ui/v1/agents/packages/install/jobs/job%2F1', 'GET'],
+      ['http://cp/api/ui/v1/agents/packages/install/jobs', 'GET'],
+      ['http://cp/api/ui/v1/agents/packages/pkg%2Fname/uninstall', 'POST'],
+      ['http://cp/api/ui/v1/agents/packages/pkg%2Fname/update', 'POST'],
+      ['http://cp/api/ui/v1/agents/packages', 'GET'],
+      ['http://cp/api/ui/v1/agents/agent%2Fname/start', 'POST'],
+      ['http://cp/api/ui/v1/agents/agent%2Fname/stop', 'POST'],
+      ['http://cp/api/ui/v1/agents/agent%2Fname/status', 'GET'],
+      ['http://cp/api/ui/v1/agents/running', 'GET'],
+      ['http://cp/api/ui/v1/agents/agent%2Fname/secrets', 'GET'],
+      ['http://cp/api/ui/v1/agents/agent%2Fname/secrets', 'PUT'],
+      ['http://cp/api/ui/v1/agents/agent%2Fname/secrets/TOKEN?scope=node', 'DELETE'],
+      ['http://cp/api/ui/v1/secrets', 'GET']
+    ])
+    expect(JSON.parse(String(calls[0][1]?.body))).toEqual({
+      source: 'https://github.com/acme/agent',
+      force: true
+    })
+    expect(JSON.parse(String(calls[6][1]?.body))).toEqual({ port: 9000, detach: false })
+  })
+
+  // Contracts 2 and 3: auth is conditional and late-bound providers are re-read.
+  it('late-binds base URL and API key on every call', async () => {
+    let host = 'http://one'
+    let key: string | null = null
+    const fetchImpl = mockFetch([json({ packages: [], total: 0 }), json({ packages: [], total: 0 })])
+    const client = createCpClient({ baseUrl: () => host, apiKey: () => key, fetchImpl })
+    await client.listPackages()
+    host = 'http://two/'
+    key = 'cloud-key'
+    await client.listPackages()
+
+    const calls = vi.mocked(fetchImpl).mock.calls
+    expect(calls[0][0]).toBe('http://one/api/ui/v1/agents/packages')
+    expect(new Headers(calls[0][1]?.headers).has('X-API-Key')).toBe(false)
+    expect(calls[1][0]).toBe('http://two/api/ui/v1/agents/packages')
+    expect(new Headers(calls[1][1]?.headers).get('X-API-Key')).toBe('cloud-key')
+  })
+
+  // Contract 4: HTTP errors retain status and parsed server details.
+  it.each([
+    [409, { error: 'operation busy', code: 'busy' }],
+    [400, { error: 'invalid source' }]
+  ])('throws CpApiError for status %i', async (status, body) => {
+    const client = createCpClient({ fetchImpl: mockFetch([json(body, status)]) })
+    const error = await client.installPackage('bad').catch((caught: unknown) => caught)
+    expect(error).toBeInstanceOf(CpApiError)
+    expect(error).toMatchObject({ status, message: body.error })
+  })
+
+  // Contract 4: malformed error JSON still produces a status-bearing error.
+  it('retains status for malformed error JSON', async () => {
+    const fetchImpl = mockFetch([new Response('{', { status: 500 })])
+    const error = await createCpClient({ fetchImpl }).listPackages().catch((caught: unknown) => caught)
+    expect(error).toBeInstanceOf(CpApiError)
+    expect(error).toMatchObject({ status: 500 })
+  })
+
+  // Contract 5: install API feature detection distinguishes only 404.
+  it('detects install API support and rethrows network failures', async () => {
+    expect(await createCpClient({ fetchImpl: mockFetch([json([])]) }).hasInstallApi()).toBe(true)
+    expect(await createCpClient({ fetchImpl: mockFetch([json({ error: 'missing' }, 404)]) }).hasInstallApi()).toBe(false)
+    const failure = new TypeError('offline')
+    const fetchImpl = vi.fn(async () => { throw failure }) as FetchLike
+    await expect(createCpClient({ fetchImpl }).hasInstallApi()).rejects.toBe(failure)
+  })
+
+  // Contract 6: polling emits new lines once and resolves for either terminal state.
+  it.each(['succeeded', 'failed'] as const)('watches a job through %s', async (terminal) => {
+    let clock = 0
+    const fetchImpl = mockFetch([
+      json(job('running', ['one'])),
+      json(job('running', ['one', 'two'])),
+      json(job(terminal, ['one', 'two', 'three']))
+    ])
+    const lines: string[] = []
+    const client = createCpClient({
+      fetchImpl,
+      now: () => clock,
+      sleep: async (ms) => { clock += ms }
+    })
+    const result = await client.watchInstallJob('job/1', (line) => lines.push(line), {
+      intervalMs: 10,
+      timeoutMs: 100
+    })
+    expect(result.status).toBe(terminal)
+    expect(lines).toEqual(['one', 'two', 'three'])
+  })
+
+  // Contract 6: polling rejects once its injected deadline is reached.
+  it('times out while watching a non-terminal job', async () => {
+    let clock = 0
+    const client = createCpClient({
+      fetchImpl: mockFetch([json(job('running'))]),
+      now: () => clock,
+      sleep: async (ms) => { clock += ms }
+    })
+    await expect(
+      client.watchInstallJob('job/1', () => undefined, { intervalMs: 10, timeoutMs: 10 })
+    ).rejects.toThrow('Timed out')
+  })
+
+  // Contract 7: secret scope query is encoded; absent PUT scope is omitted.
+  it('serializes optional secret scope exactly', async () => {
+    const fetchImpl = mockFetch([
+      new Response(null, { status: 204 }),
+      new Response(null, { status: 204 })
+    ])
+    const client = createCpClient({ baseUrl: () => 'http://cp', fetchImpl })
+    await client.setAgentSecret('agent', 'TOKEN', 'value')
+    await client.deleteAgentSecret('agent', 'TOKEN', 'global')
+    const calls = vi.mocked(fetchImpl).mock.calls
+    expect(JSON.parse(String(calls[0][1]?.body))).toEqual({ key: 'TOKEN', value: 'value' })
+    expect(calls[1][0]).toBe('http://cp/api/ui/v1/agents/agent/secrets/TOKEN?scope=global')
+  })
+})

--- a/desktop/src/main/cpClient.ts
+++ b/desktop/src/main/cpClient.ts
@@ -21,11 +21,30 @@ export interface InstallJob {
   finished_at?: string
 }
 
+/**
+ * True when a listing row represents a package actually present on disk.
+ * The listing also contains catalog/marketplace rows; `install_status` is the
+ * registry-backed discriminator. Older control planes omit the field — then
+ * every row is kept (no way to tell, and hiding real installs is worse).
+ */
+export function isInstalledPackage(pkg: PackageInfo): boolean {
+  if (pkg.install_status === undefined) return true
+  return ['installed', 'running', 'stopped'].includes(pkg.install_status)
+}
+
 export interface PackageInfo {
   id: string
   name: string
   version: string
   status: string
+  /**
+   * Raw registry-backed install state ("installed" | "running" | "stopped" |
+   * "uninstalled" | ...). Absent on control planes older than the sync
+   * reconciliation fix; `status` above is a derived configuration summary,
+   * not an install indicator.
+   */
+  install_status?: string
+  installed_at?: string
   install_path: string
   configuration_required: boolean
   configuration_complete: boolean

--- a/desktop/src/main/cpClient.ts
+++ b/desktop/src/main/cpClient.ts
@@ -1,0 +1,370 @@
+import { getBaseUrl, type FetchLike } from './agentfield'
+export type { FetchLike } from './agentfield'
+
+const READ_TIMEOUT_MS = 3_000
+const MUTATION_TIMEOUT_MS = 10_000
+const DEFAULT_WATCH_INTERVAL_MS = 1_000
+const DEFAULT_WATCH_TIMEOUT_MS = 15 * 60_000
+
+export type InstallJobStatus = 'pending' | 'running' | 'succeeded' | 'failed'
+export type InstallJobKind = 'install' | 'update' | 'uninstall'
+
+export interface InstallJob {
+  id: string
+  source: string
+  kind: InstallJobKind
+  status: InstallJobStatus
+  package_name?: string
+  error?: string
+  lines: string[]
+  started_at?: string
+  finished_at?: string
+}
+
+export interface PackageInfo {
+  id: string
+  name: string
+  version: string
+  status: string
+  install_path: string
+  configuration_required: boolean
+  configuration_complete: boolean
+  running_node_id?: string
+  last_started?: string
+  process_id?: number
+  port?: number
+  description: string
+  author: string
+}
+
+export interface PackageListResponse {
+  packages: PackageInfo[]
+  total: number
+}
+
+export interface AgentEndpoints {
+  health: string
+  reasoners: string
+  skills: string
+}
+
+export interface StartAgentResponse {
+  agent_id: string
+  status: string
+  pid: number
+  port: number
+  started_at: string
+  log_file: string
+  message: string
+  endpoints: AgentEndpoints
+}
+
+export interface StopAgentResponse {
+  agent_id: string
+  status: string
+  message: string
+}
+
+export interface AgentStatusResponse {
+  agent_id: string
+  name: string
+  is_running: boolean
+  status: string
+  pid?: number
+  port?: number
+  uptime?: string
+  last_seen?: string
+  configuration_required?: boolean
+  configuration_status?: string
+  endpoints?: AgentEndpoints
+  message?: string
+}
+
+export interface RunningAgent {
+  agent_id: string
+  name: string
+  status: string
+  pid: number
+  port: number
+  started_at: string
+  log_file: string
+  package?: {
+    name: string
+    version: string
+    description: string
+    author: string
+  }
+  endpoints?: AgentEndpoints
+}
+
+export interface RunningAgentsResponse {
+  running_agents: RunningAgent[]
+  total_count: number
+}
+
+export type SecretScope = 'node' | 'global'
+
+export interface AgentSecretStatus {
+  key: string
+  is_set: boolean
+  scope?: SecretScope
+}
+
+export interface SecretReference {
+  key: string
+  scope: string
+}
+
+export interface CpClientOptions {
+  baseUrl?: () => string
+  apiKey?: () => string | null
+  fetchImpl?: FetchLike
+  /** Test seam used by job polling. */
+  sleep?: (milliseconds: number) => Promise<void>
+  /** Test seam used by job polling. */
+  now?: () => number
+}
+
+export interface WatchInstallJobOptions {
+  intervalMs?: number
+  timeoutMs?: number
+}
+
+export class CpApiError extends Error {
+  readonly status: number
+  readonly code?: string | number
+
+  constructor(details: { status: number; code?: string | number; message: string }) {
+    super(details.message)
+    this.name = 'CpApiError'
+    this.status = details.status
+    this.code = details.code
+  }
+}
+
+export interface CpClient {
+  /** POST /api/ui/v1/agents/packages/install. */
+  installPackage(source: string, force?: boolean): Promise<{ job_id: string }>
+  /** GET /api/ui/v1/agents/packages/install/jobs/:jobId. */
+  getInstallJob(jobId: string): Promise<InstallJob>
+  /** GET /api/ui/v1/agents/packages/install/jobs. */
+  listInstallJobs(): Promise<InstallJob[]>
+  /** POST /api/ui/v1/agents/packages/:packageId/uninstall. */
+  uninstallPackage(packageId: string): Promise<{ package_id: string; status: string }>
+  /** POST /api/ui/v1/agents/packages/:packageId/update. */
+  updatePackage(packageId: string): Promise<{ job_id: string }>
+  /** GET /api/ui/v1/agents/packages. */
+  listPackages(): Promise<PackageListResponse>
+  /** POST /api/ui/v1/agents/:agentId/start. */
+  startAgent(
+    agentId: string,
+    options?: { port?: number; detach?: boolean }
+  ): Promise<StartAgentResponse>
+  /** POST /api/ui/v1/agents/:agentId/stop. */
+  stopAgent(agentId: string): Promise<StopAgentResponse>
+  /** GET /api/ui/v1/agents/:agentId/status. */
+  getAgentStatus(agentId: string): Promise<AgentStatusResponse>
+  /** GET /api/ui/v1/agents/running. */
+  listRunningAgents(): Promise<RunningAgentsResponse>
+  /** GET /api/ui/v1/agents/:agentId/secrets. */
+  listAgentSecrets(agentId: string): Promise<{ secrets: AgentSecretStatus[] }>
+  /** PUT /api/ui/v1/agents/:agentId/secrets. */
+  setAgentSecret(
+    agentId: string,
+    key: string,
+    value: string,
+    scope?: SecretScope
+  ): Promise<void>
+  /** DELETE /api/ui/v1/agents/:agentId/secrets/:key. */
+  deleteAgentSecret(agentId: string, key: string, scope?: SecretScope): Promise<void>
+  /** GET /api/ui/v1/secrets. */
+  listAllSecrets(): Promise<{ secrets: SecretReference[] }>
+  /** Probes GET /api/ui/v1/agents/packages/install/jobs for install-route support. */
+  hasInstallApi(): Promise<boolean>
+  /** Polls GET /api/ui/v1/agents/packages/install/jobs/:jobId until terminal. */
+  watchInstallJob(
+    jobId: string,
+    onLine: (line: string) => void,
+    options?: WatchInstallJobOptions
+  ): Promise<InstallJob>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+async function apiError(response: Response): Promise<CpApiError> {
+  let body: unknown
+  try {
+    body = await response.json()
+  } catch {
+    body = undefined
+  }
+  const record = isRecord(body) ? body : undefined
+  const serverMessage =
+    typeof record?.error === 'string'
+      ? record.error
+      : typeof record?.message === 'string'
+        ? record.message
+        : undefined
+  const code =
+    typeof record?.code === 'string' || typeof record?.code === 'number'
+      ? record.code
+      : undefined
+  return new CpApiError({
+    status: response.status,
+    code,
+    message: serverMessage ?? `Control plane request failed with status ${response.status}`
+  })
+}
+
+/**
+ * Creates a typed client for the control-plane `/api/ui/v1` management API.
+ * The base URL and API key providers are evaluated for every request.
+ */
+export function createCpClient(options: CpClientOptions = {}): CpClient {
+  const baseUrl = options.baseUrl ?? getBaseUrl
+  const apiKey = options.apiKey ?? (() => null)
+  const fetchImpl = options.fetchImpl ?? fetch
+  const sleep =
+    options.sleep ?? ((milliseconds: number) => new Promise((resolve) => setTimeout(resolve, milliseconds)))
+  const now = options.now ?? Date.now
+
+  async function request<T>(
+    path: string,
+    init: Omit<RequestInit, 'signal'> = {},
+    mutation = false,
+    noContent = false
+  ): Promise<T> {
+    const headers = new Headers(init.headers)
+    const key = apiKey()
+    if (key !== null) headers.set('X-API-Key', key)
+    if (init.body !== undefined) headers.set('Content-Type', 'application/json')
+
+    const response = await fetchImpl(`${baseUrl().replace(/\/+$/, '')}${path}`, {
+      ...init,
+      headers,
+      signal: AbortSignal.timeout(mutation ? MUTATION_TIMEOUT_MS : READ_TIMEOUT_MS)
+    })
+    if (!response.ok) throw await apiError(response)
+    if (noContent) return undefined as T
+    return (await response.json()) as T
+  }
+
+  const client: CpClient = {
+    installPackage(source, force) {
+      const body = force === undefined ? { source } : { source, force }
+      return request('/api/ui/v1/agents/packages/install', {
+        method: 'POST',
+        body: JSON.stringify(body)
+      }, true)
+    },
+    getInstallJob(jobId) {
+      return request(`/api/ui/v1/agents/packages/install/jobs/${encodeURIComponent(jobId)}`)
+    },
+    listInstallJobs() {
+      return request('/api/ui/v1/agents/packages/install/jobs')
+    },
+    uninstallPackage(packageId) {
+      return request(
+        `/api/ui/v1/agents/packages/${encodeURIComponent(packageId)}/uninstall`,
+        { method: 'POST' },
+        true
+      )
+    },
+    updatePackage(packageId) {
+      return request(
+        `/api/ui/v1/agents/packages/${encodeURIComponent(packageId)}/update`,
+        { method: 'POST' },
+        true
+      )
+    },
+    listPackages() {
+      return request('/api/ui/v1/agents/packages')
+    },
+    startAgent(agentId, startOptions) {
+      return request(
+        `/api/ui/v1/agents/${encodeURIComponent(agentId)}/start`,
+        { method: 'POST', body: JSON.stringify(startOptions ?? {}) },
+        true
+      )
+    },
+    stopAgent(agentId) {
+      return request(
+        `/api/ui/v1/agents/${encodeURIComponent(agentId)}/stop`,
+        { method: 'POST' },
+        true
+      )
+    },
+    getAgentStatus(agentId) {
+      return request(`/api/ui/v1/agents/${encodeURIComponent(agentId)}/status`)
+    },
+    listRunningAgents() {
+      return request('/api/ui/v1/agents/running')
+    },
+    listAgentSecrets(agentId) {
+      return request(`/api/ui/v1/agents/${encodeURIComponent(agentId)}/secrets`)
+    },
+    setAgentSecret(agentId, key, value, scope) {
+      const body = scope === undefined ? { key, value } : { key, value, scope }
+      return request(
+        `/api/ui/v1/agents/${encodeURIComponent(agentId)}/secrets`,
+        { method: 'PUT', body: JSON.stringify(body) },
+        true,
+        true
+      )
+    },
+    deleteAgentSecret(agentId, key, scope) {
+      const query = scope === undefined ? '' : `?scope=${encodeURIComponent(scope)}`
+      return request(
+        `/api/ui/v1/agents/${encodeURIComponent(agentId)}/secrets/${encodeURIComponent(key)}${query}`,
+        { method: 'DELETE' },
+        true,
+        true
+      )
+    },
+    listAllSecrets() {
+      return request('/api/ui/v1/secrets')
+    },
+    async hasInstallApi() {
+      try {
+        await client.listInstallJobs()
+        return true
+      } catch (error) {
+        if (error instanceof CpApiError && error.status === 404) return false
+        throw error
+      }
+    },
+    async watchInstallJob(jobId, onLine, watchOptions = {}) {
+      const intervalMs = watchOptions.intervalMs ?? DEFAULT_WATCH_INTERVAL_MS
+      const timeoutMs = watchOptions.timeoutMs ?? DEFAULT_WATCH_TIMEOUT_MS
+      const startedAt = now()
+      let emittedLineCount = 0
+
+      for (;;) {
+        if (now() - startedAt >= timeoutMs) {
+          throw new Error(`Timed out waiting for install job ${jobId}`)
+        }
+        let job: InstallJob
+        try {
+          job = await client.getInstallJob(jobId)
+        } catch (error) {
+          if (error instanceof CpApiError && error.status === 404) {
+            throw new CpApiError({
+              status: 404,
+              code: error.code,
+              message: `Install job ${jobId} disappeared`
+            })
+          }
+          throw error
+        }
+        for (const line of job.lines.slice(emittedLineCount)) onLine(line)
+        emittedLineCount = Math.max(emittedLineCount, job.lines.length)
+        if (job.status === 'succeeded' || job.status === 'failed') return job
+        await sleep(intervalMs)
+      }
+    }
+  }
+
+  return client
+}

--- a/desktop/src/main/installer.test.ts
+++ b/desktop/src/main/installer.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { CATALOG } from '../shared/catalog'
-import { installCommand, installFromSource, parseRepoSource, sanitizeInstallOutput } from './installer'
+import { CpApiError, type CpClient } from './cpClient'
+import { installAgent, installCommand, installFromSource, parseRepoSource, sanitizeInstallOutput, updateAgent } from './installer'
 
 describe('installCommand', () => {
   it('builds a plain install for a catalog entry', () => {
@@ -70,6 +71,38 @@ describe('installFromSource', () => {
     // Never spawned af install: no progress lines were forwarded.
     expect(lines).toEqual([])
     expect(result.message).toMatch(/github\.com/)
+  })
+})
+
+function installClient(overrides: Partial<CpClient> = {}): CpClient {
+  return {
+    hasInstallApi: vi.fn(async () => true),
+    installPackage: vi.fn(async () => ({ job_id: 'job' })),
+    updatePackage: vi.fn(async () => ({ job_id: 'job' })),
+    watchInstallJob: vi.fn(async (_id, onLine) => {
+      onLine('Cloning')
+      onLine('Installed')
+      return { id: 'job', source: '', kind: 'install', status: 'succeeded', lines: ['Cloning', 'Installed'] }
+    }),
+    ...overrides
+  } as unknown as CpClient
+}
+
+describe('control-plane installs', () => {
+  it('preserves progress callbacks and terminal success/failure', async () => {
+    const lines: string[] = []
+    expect(await installAgent(CATALOG[0].name, (line) => lines.push(line), false, { cpClient: installClient() })).toEqual({ ok: true, message: `${CATALOG[0].name} installed` })
+    expect(lines).toEqual(['Cloning', 'Installed'])
+    const failed = installClient({ watchInstallJob: vi.fn(async () => ({ id: 'job', source: '', kind: 'install' as const, status: 'failed' as const, error: 'clone failed', lines: [] })) })
+    expect(await installAgent(CATALOG[0].name, () => {}, false, { cpClient: failed })).toEqual({ ok: false, message: 'clone failed' })
+  })
+
+  it('surfaces conflict and old-control-plane errors without fallback', async () => {
+    const conflict = installClient({ installPackage: vi.fn(async () => { throw new CpApiError({ status: 409, message: 'another install is running' }) }) })
+    expect((await installAgent(CATALOG[0].name, () => {}, false, { cpClient: conflict })).message).toMatch(/another install/i)
+    const old = installClient({ hasInstallApi: vi.fn(async () => false) })
+    expect((await installAgent(CATALOG[0].name, () => {}, false, { cpClient: old })).message).toMatch(/update AgentField CLI/)
+    expect((await updateAgent(CATALOG[0].name, () => {}, { cpClient: old })).message).toMatch(/update AgentField CLI/)
   })
 })
 

--- a/desktop/src/main/installer.ts
+++ b/desktop/src/main/installer.ts
@@ -12,13 +12,9 @@
 // every accepted value begins with "https://github.com/" it can never be read
 // as a CLI flag when passed as one argv element to spawn (no shell).
 
-import { spawn } from 'node:child_process'
 import { catalogEntry } from '../shared/catalog'
 import type { InstallResult } from '../shared/types'
-import { readInstalledAgents } from './agentfield'
-import { runAgentAction } from './agents'
-import { getCliCommand } from './cli'
-import { childEnv } from './env'
+import { CpApiError, createCpClient, type CpClient } from './cpClient'
 
 // CSI sequences (colors, cursor movement, erase-line spinner frames) and OSC
 // sequences (terminal titles), per ECMA-48. Written with \u escapes so no
@@ -69,65 +65,57 @@ export function sanitizeInstallOutput(chunk: string): string[] {
  * `af install --force`, the CLI's reinstall-in-place (package dir and binary
  * are replaced; the registry entry and secrets are untouched).
  */
+export interface InstallerDeps {
+  cpClient: CpClient
+}
+
+/** Pure catalog lookup retained for callers/tests that need to preview an install. */
 export function installCommand(
   name: string,
   force = false
-): { command: string; args: string[] } | null {
+): { command: 'control-plane'; args: string[] } | null {
   const entry = catalogEntry(name)
   if (!entry) return null
-  // spawn() without a shell; the command is whatever CLI resolution picked
-  // (managed copy, PATH `af`, or the app's bundled binary — see main/cli.ts).
-  const args = ['install', entry.source]
-  if (force) args.push('--force')
-  return { command: getCliCommand(), args }
+  return { command: 'control-plane', args: force ? ['install', entry.source, '--force'] : ['install', entry.source] }
 }
 
-/**
- * Spawn `af <args>` (no shell), forward sanitized output lines to onLine as
- * they arrive, and resolve (never reject) with the outcome. `successMessage`
- * is produced lazily so a caller can name whatever it just installed. Shared
- * by installAgent and installFromSource so the spawn/stream/close logic lives
- * in exactly one place.
- */
-function runInstall(
-  command: string,
-  args: string[],
-  onLine: (line: string) => void,
-  successMessage: () => string
-): Promise<InstallResult> {
-  return new Promise((resolve) => {
-    let lastLine = ''
-    const forward = (chunk: Buffer) => {
-      for (const line of sanitizeInstallOutput(chunk.toString('utf8'))) {
-        // Spinner frames repeat the same text many times a second; only
-        // forward changes so the IPC channel stays quiet.
-        if (line !== lastLine) {
-          lastLine = line
-          onLine(line)
-        }
-      }
-    }
+function defaultInstallerDeps(): InstallerDeps {
+  return { cpClient: createCpClient() }
+}
 
-    const child = spawn(command, args, { windowsHide: true, env: childEnv() })
-    child.stdout.on('data', forward)
-    child.stderr.on('data', forward)
-    child.on('error', (err: NodeJS.ErrnoException) => {
-      resolve({
-        ok: false,
-        message:
-          err.code === 'ENOENT'
-            ? 'The AgentField CLI (af) was not found on PATH. Install it first: https://agentfield.ai/docs'
-            : `Failed to run af install: ${err.message}`
-      })
-    })
-    child.on('close', (code) => {
-      resolve(
-        code === 0
-          ? { ok: true, message: successMessage() }
-          : { ok: false, message: lastLine || `af install exited with code ${code}` }
-      )
-    })
-  })
+const UPDATE_REQUIRED = 'Control plane update required — update AgentField CLI'
+
+async function runInstall(
+  source: string,
+  onLine: (line: string) => void,
+  successMessage: () => string,
+  deps: InstallerDeps,
+  force?: boolean
+): Promise<InstallResult> {
+  try {
+    if (!(await deps.cpClient.hasInstallApi())) {
+      return { ok: false, message: UPDATE_REQUIRED }
+    }
+    const { job_id } = await deps.cpClient.installPackage(source, force)
+    const job = await deps.cpClient.watchInstallJob(job_id, onLine)
+    return job.status === 'succeeded'
+      ? { ok: true, message: successMessage() }
+      : { ok: false, message: job.error || job.lines.at(-1) || 'Install failed' }
+  } catch (err) {
+    if (err instanceof CpApiError && err.status === 404) {
+      return { ok: false, message: UPDATE_REQUIRED }
+    }
+    if (err instanceof CpApiError && err.status === 409) {
+      return { ok: false, message: err.message || 'Another install is already running' }
+    }
+    return {
+      ok: false,
+      message:
+        err instanceof CpApiError
+          ? err.message
+          : 'Could not reach the control plane — start the control plane and try again'
+    }
+  }
 }
 
 /**
@@ -137,13 +125,14 @@ function runInstall(
 export function installAgent(
   name: string,
   onLine: (line: string) => void,
-  force = false
+  force = false,
+  deps: InstallerDeps = defaultInstallerDeps()
 ): Promise<InstallResult> {
-  const cmd = installCommand(name, force)
-  if (!cmd) {
+  const entry = catalogEntry(name)
+  if (!entry) {
     return Promise.resolve({ ok: false, message: `"${name}" is not in the install catalog` })
   }
-  return runInstall(cmd.command, cmd.args, onLine, () => `${name} installed`)
+  return runInstall(entry.source, onLine, () => `${name} installed`, deps, force)
 }
 
 // The one host we install from. Every accepted source starts with this literal
@@ -204,7 +193,8 @@ export function parseRepoSource(input: string): string | null {
  */
 export function installFromSource(
   source: string,
-  onLine: (line: string) => void
+  onLine: (line: string) => void,
+  deps: InstallerDeps = defaultInstallerDeps()
 ): Promise<InstallResult> {
   const normalized = parseRepoSource(source)
   if (!normalized) {
@@ -213,7 +203,7 @@ export function installFromSource(
       message: 'Enter a GitHub repository URL, e.g. https://github.com/org/repo (or …/repo//subdir)'
     })
   }
-  return runInstall(getCliCommand(), ['install', normalized], onLine, () => `Installed from ${normalized}`)
+  return runInstall(normalized, onLine, () => `Installed from ${normalized}`, deps)
 }
 
 /**
@@ -226,46 +216,33 @@ export function installFromSource(
  */
 export async function updateAgent(
   name: string,
-  onLine: (line: string) => void
+  onLine: (line: string) => void,
+  deps: InstallerDeps = defaultInstallerDeps()
 ): Promise<InstallResult> {
   const entry = catalogEntry(name)
   if (!entry) {
     return { ok: false, message: `"${name}" is not in the install catalog` }
   }
-  const registry = await readInstalledAgents()
-  const installed = registry.agents.find((agent) => agent.name === name)
-  if (!installed) {
-    return { ok: false, message: `"${name}" is not installed — install it first` }
-  }
-
-  // The package binary cannot be replaced while its process runs (Windows
-  // locks running executables), so a running agent is stopped first.
-  const wasRunning = installed.status === 'running'
-  if (wasRunning) {
-    onLine(`Stopping ${name}…`)
-    const stopped = await runAgentAction('stop', name)
-    if (!stopped.ok) {
-      return { ok: false, message: `could not stop ${name}: ${stopped.message}` }
+  try {
+    if (!(await deps.cpClient.hasInstallApi())) {
+      return { ok: false, message: UPDATE_REQUIRED }
+    }
+    onLine(`Updating ${name}…`)
+    const { job_id } = await deps.cpClient.updatePackage(name)
+    const job = await deps.cpClient.watchInstallJob(job_id, onLine)
+    return job.status === 'succeeded'
+      ? { ok: true, message: `${name} updated` }
+      : { ok: false, message: job.error || job.lines.at(-1) || `Failed to update ${name}` }
+  } catch (err) {
+    if (err instanceof CpApiError && err.status === 404) {
+      return { ok: false, message: UPDATE_REQUIRED }
+    }
+    return {
+      ok: false,
+      message:
+        err instanceof CpApiError
+          ? err.message
+          : 'Could not reach the control plane — start the control plane and try again'
     }
   }
-
-  onLine(`Updating ${name}…`)
-  const result = await installAgent(name, onLine, true)
-  if (!result.ok) {
-    // Be explicit about the state we are leaving behind: the agent was
-    // stopped for an update that then failed, and nothing restarted it.
-    return wasRunning
-      ? { ok: false, message: `${result.message} — ${name} was stopped and has not been restarted` }
-      : result
-  }
-
-  if (wasRunning) {
-    onLine(`Restarting ${name}…`)
-    const started = await runAgentAction('start', name)
-    if (!started.ok) {
-      return { ok: false, message: `${name} updated but failed to restart: ${started.message}` }
-    }
-    return { ok: true, message: `${name} updated and restarted` }
-  }
-  return { ok: true, message: `${name} updated` }
 }

--- a/desktop/src/main/secrets.test.ts
+++ b/desktop/src/main/secrets.test.ts
@@ -1,5 +1,6 @@
 import yaml from 'js-yaml'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import type { CpClient, PackageInfo } from './cpClient'
 import {
   buildEnvReport,
   buildSecretsInventory,
@@ -8,6 +9,7 @@ import {
   parseUserEnvironment,
   specIsEmpty
 } from './secrets'
+import { getEnvReports, revokeAgentSecret, setAgentSecret } from './secrets'
 
 // Abridged from SWE-AF's real agentfield-package.yaml — the exact shapes
 // ParsePackageMetadata reads (control-plane/internal/packages/installer.go).
@@ -217,5 +219,43 @@ describe('buildSecretsInventory', () => {
     const refs = [{ key: 'GH_TOKEN', scope: 'other-agent' }]
     const inventory = buildSecretsInventory(refs, specs)
     expect(inventory[0]).toMatchObject({ scope: 'other-agent', usedBy: [] })
+  })
+})
+
+describe('control-plane secret management', () => {
+  const pkg: PackageInfo = {
+    id: 'agent-id', name: 'agent', version: '1', status: 'stopped',
+    install_path: '/pkg', configuration_required: true, configuration_complete: false,
+    description: '', author: ''
+  }
+
+  function client(): CpClient {
+    return {
+      listPackages: vi.fn(async () => ({ packages: [pkg], total: 1 })),
+      listAgentSecrets: vi.fn(async () => ({
+        secrets: [
+          { key: 'SET_KEY', is_set: true, scope: 'global' as const },
+          { key: 'UNSET_KEY', is_set: false }
+        ]
+      })),
+      setAgentSecret: vi.fn(async () => {}),
+      deleteAgentSecret: vi.fn(async () => {})
+    } as unknown as CpClient
+  }
+
+  it('reports declared set and unset keys from the API', async () => {
+    const reports = await getEnvReports({ cpClient: client() })
+    expect(reports[0].vars.map(({ name, status }) => ({ name, status }))).toEqual([
+      { name: 'SET_KEY', status: 'stored' },
+      { name: 'UNSET_KEY', status: 'missing' }
+    ])
+  })
+
+  it('sets and deletes without sending a scope', async () => {
+    const cpClient = client()
+    await setAgentSecret('agent-id', 'SET_KEY', 'value', { cpClient })
+    await revokeAgentSecret('agent-id', 'SET_KEY', { cpClient })
+    expect(cpClient.setAgentSecret).toHaveBeenCalledWith('agent-id', 'SET_KEY', 'value')
+    expect(cpClient.deleteAgentSecret).toHaveBeenCalledWith('agent-id', 'SET_KEY')
   })
 })

--- a/desktop/src/main/secrets.ts
+++ b/desktop/src/main/secrets.ts
@@ -6,7 +6,7 @@ import type {
   SecretsListResult,
   StoredSecret
 } from '../shared/types'
-import { CpApiError, createCpClient, type CpClient } from './cpClient'
+import { CpApiError, createCpClient, isInstalledPackage, type CpClient } from './cpClient'
 
 const GLOBAL_SCOPE = 'global'
 
@@ -195,7 +195,7 @@ export async function getEnvReports(
 ): Promise<AgentEnvReport[]> {
   try {
     const packages = await deps.cpClient.listPackages()
-    return await Promise.all(packages.packages.map(async (pkg) => {
+    return await Promise.all(packages.packages.filter(isInstalledPackage).map(async (pkg) => {
       const { secrets } = await deps.cpClient.listAgentSecrets(pkg.id)
       const vars: AgentEnvVar[] = secrets.map((secret) => ({
         name: secret.key,
@@ -243,7 +243,7 @@ export async function listStoredSecrets(
       deps.cpClient.listAllSecrets(),
       deps.cpClient.listPackages()
     ])
-    const declarations = await Promise.all(packages.packages.map(async (pkg) => ({
+    const declarations = await Promise.all(packages.packages.filter(isInstalledPackage).map(async (pkg) => ({
       id: pkg.id,
       name: pkg.name,
       keys: new Set((await deps.cpClient.listAgentSecrets(pkg.id)).secrets.map((secret) => secret.key))
@@ -278,7 +278,7 @@ export async function revokeStoredSecret(
     if (scope === GLOBAL_SCOPE) {
       const packages = await deps.cpClient.listPackages()
       agent = ''
-      for (const pkg of packages.packages) {
+      for (const pkg of packages.packages.filter(isInstalledPackage)) {
         const declared = await deps.cpClient.listAgentSecrets(pkg.id)
         if (declared.secrets.some((secret) => secret.key === key && secret.scope === GLOBAL_SCOPE)) {
           agent = pkg.id

--- a/desktop/src/main/secrets.ts
+++ b/desktop/src/main/secrets.ts
@@ -1,23 +1,3 @@
-// Agent secrets seam: reads each installed node's user_environment spec from
-// its agentfield-package.yaml and drives the af CLI's encrypted secret store
-// (`af secrets set / ls / rm`) — the exact store `af run` decrypts into the
-// agent's process environment. The app never touches the .enc files itself,
-// and secret VALUES never cross the IPC boundary: the renderer only ever
-// sees per-variable status flags, and values travel renderer → main → af's
-// stdin (never argv, which other processes could observe).
-//
-// Resolution mirrors the CLI's EnvResolver (control-plane/internal/packages/
-// env_resolver.go): process env → secret store (node scope, then global) →
-// manifest default → missing. `af run` from this app inherits our process
-// env, so checking process.env here is faithful to what the spawned agent
-// will see.
-//
-// No electron imports — unit-testable under plain vitest.
-
-import { spawn } from 'node:child_process'
-import { promises as fs } from 'node:fs'
-import path from 'node:path'
-import yaml from 'js-yaml'
 import type {
   AgentActionResult,
   AgentEnvReport,
@@ -26,14 +6,8 @@ import type {
   SecretsListResult,
   StoredSecret
 } from '../shared/types'
-import { getAgentFieldHome, readInstalledAgents } from './agentfield'
-import { getCliCommand } from './cli'
-import { childEnv } from './env'
-import { sanitizeInstallOutput } from './installer'
+import { CpApiError, createCpClient, type CpClient } from './cpClient'
 
-const SECRETS_TIMEOUT_MS = 15_000
-
-/** The store's shared scope name (control-plane/internal/packages/secrets.go). */
 const GLOBAL_SCOPE = 'global'
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -44,24 +18,17 @@ function str(value: unknown): string {
   return typeof value === 'string' ? value : ''
 }
 
-/** One variable from a manifest's user_environment section. */
 export interface EnvSpecVar {
   name: string
   description: string
-  /** type: secret — hidden input, masked display. */
   secret: boolean
-  /** Store scope `af run` reads and `af secrets set` writes: global unless scope: node. */
   scope: 'global' | 'node'
-  /** Manifest default — counts as resolved, matching the EnvResolver. */
   default: string
-  /** Optional Go/RE2 regex the value must match (validated on prompt in the CLI). */
   validation: string
 }
 
-/** Parsed user_environment block of an agentfield-package.yaml. */
 export interface EnvSpec {
   required: EnvSpecVar[]
-  /** require_one_of groups: any one resolving option satisfies the group. */
   groups: { id: string; description: string; options: EnvSpecVar[] }[]
   optional: EnvSpecVar[]
 }
@@ -79,16 +46,11 @@ function toSpecVar(raw: unknown): EnvSpecVar | null {
 }
 
 function toSpecVars(raw: unknown): EnvSpecVar[] {
-  if (!Array.isArray(raw)) return []
-  return raw.map(toSpecVar).filter((v): v is EnvSpecVar => v !== null)
+  return Array.isArray(raw)
+    ? raw.map(toSpecVar).filter((value): value is EnvSpecVar => value !== null)
+    : []
 }
 
-/**
- * Extract the user_environment section from a yaml-loaded manifest document.
- * Field shapes follow UserEnvironmentConfig in control-plane/internal/packages/
- * installer.go. Absent or malformed sections yield an empty spec — an agent
- * without declared variables simply has nothing to configure.
- */
 export function parseUserEnvironment(doc: unknown): EnvSpec {
   const env = isRecord(doc) && isRecord(doc.user_environment) ? doc.user_environment : {}
   const groups = Array.isArray(env.require_one_of)
@@ -101,100 +63,71 @@ export function parseUserEnvironment(doc: unknown): EnvSpec {
         }))
         .filter((group) => group.options.length > 0)
     : []
-  return {
-    required: toSpecVars(env.required),
-    groups,
-    optional: toSpecVars(env.optional)
-  }
+  return { required: toSpecVars(env.required), groups, optional: toSpecVars(env.optional) }
 }
 
 export function specIsEmpty(spec: EnvSpec): boolean {
   return spec.required.length === 0 && spec.groups.length === 0 && spec.optional.length === 0
 }
 
-/** Find a declared variable by name anywhere in the spec. */
 export function findSpecVar(spec: EnvSpec, name: string): EnvSpecVar | null {
-  for (const v of spec.required) if (v.name === name) return v
-  for (const group of spec.groups) for (const v of group.options) if (v.name === name) return v
-  for (const v of spec.optional) if (v.name === name) return v
+  for (const variable of spec.required) if (variable.name === name) return variable
+  for (const group of spec.groups) {
+    for (const variable of group.options) if (variable.name === name) return variable
+  }
+  for (const variable of spec.optional) if (variable.name === name) return variable
   return null
 }
 
-/** One row of `af secrets ls`: a stored key and its scope (global or a node name). */
 export interface SecretRef {
   key: string
   scope: string
 }
 
-/**
- * Parse the `af secrets ls` table (internal/ui.Table — lipgloss rounded
- * borders, no ANSI when piped). Data rows look like:
- *   │ OPENAI_API_KEY │ global │ •••••••• │
- * Everything that isn't a ≥2-cell row (borders, the header row, the empty
- * "No secrets stored" panel) is ignored.
- */
 export function parseSecretsTable(output: string): SecretRef[] {
   const refs: SecretRef[] = []
   for (const line of output.split(/\r?\n/)) {
     if (!line.includes('│')) continue
-    const cells = line
-      .split('│')
-      .map((cell) => cell.trim())
-      .filter((cell) => cell.length > 0)
-    if (cells.length < 2) continue
-    if (cells[0] === 'KEY') continue
-    refs.push({ key: cells[0], scope: cells[1] })
+    const cells = line.split('│').map((cell) => cell.trim()).filter(Boolean)
+    if (cells.length >= 2 && cells[0] !== 'KEY') refs.push({ key: cells[0], scope: cells[1] })
   }
   return refs
 }
 
-/** Store scopes relevant to this agent that currently hold the key. */
-function storedScopesFor(refs: SecretRef[], agent: string, key: string): string[] {
-  return refs
-    .filter((ref) => ref.key === key && (ref.scope === GLOBAL_SCOPE || ref.scope === agent))
-    .map((ref) => ref.scope)
-}
-
-function statusFor(
-  v: EnvSpecVar,
-  storedScopes: string[],
-  env: Record<string, string | undefined>
-): EnvVarStatus {
-  const fromEnv = env[v.name]
-  if (typeof fromEnv === 'string' && fromEnv !== '') return 'env'
-  if (storedScopes.length > 0) return 'stored'
-  if (v.default !== '') return 'default'
-  return 'missing'
-}
-
-function toReportVar(
-  v: EnvSpecVar,
+function reportVariable(
+  variable: EnvSpecVar,
   required: boolean,
-  group: { id: string; description: string } | null,
+  group: EnvSpec['groups'][number] | null,
   agent: string,
   refs: SecretRef[],
   env: Record<string, string | undefined>
 ): AgentEnvVar {
-  const storedScopes = storedScopesFor(refs, agent, v.name)
+  const storedScopes = refs
+    .filter((ref) =>
+      ref.key === variable.name && (ref.scope === GLOBAL_SCOPE || ref.scope === agent)
+    )
+    .map((ref) => ref.scope)
+  const status: EnvVarStatus =
+    env[variable.name]
+      ? 'env'
+      : storedScopes.length > 0
+        ? 'stored'
+        : variable.default
+          ? 'default'
+          : 'missing'
   return {
-    name: v.name,
-    description: v.description,
-    secret: v.secret,
-    scope: v.scope,
+    name: variable.name,
+    description: variable.description,
+    secret: variable.secret,
+    scope: variable.scope,
     required,
     group: group?.id || undefined,
     groupDescription: group?.description || undefined,
-    status: statusFor(v, storedScopes, env),
+    status,
     storedScopes
   }
 }
 
-/**
- * Assemble the renderer-facing report for one agent. `satisfied` mirrors what
- * the CLI's EnvResolver will conclude headlessly: every required variable and
- * every require_one_of group resolves from env / store / default — so `af run`
- * will not fail with "missing required environment variables".
- */
 export function buildEnvReport(
   agent: string,
   spec: EnvSpec,
@@ -202,274 +135,181 @@ export function buildEnvReport(
   env: Record<string, string | undefined> = process.env
 ): AgentEnvReport {
   const vars: AgentEnvVar[] = []
-  for (const v of spec.required) vars.push(toReportVar(v, true, null, agent, refs, env))
+  for (const variable of spec.required) vars.push(reportVariable(variable, true, null, agent, refs, env))
   for (const group of spec.groups) {
-    for (const v of group.options) vars.push(toReportVar(v, true, group, agent, refs, env))
+    for (const variable of group.options) vars.push(reportVariable(variable, true, group, agent, refs, env))
   }
-  for (const v of spec.optional) vars.push(toReportVar(v, false, null, agent, refs, env))
-
-  const requiredOk = vars.every((v) => v.group || !v.required || v.status !== 'missing')
+  for (const variable of spec.optional) vars.push(reportVariable(variable, false, null, agent, refs, env))
+  const requiredOk = vars.every((variable) =>
+    variable.group || !variable.required || variable.status !== 'missing'
+  )
   const groupsOk = spec.groups.every((group) =>
-    vars.some((v) => v.group === group.id && v.status !== 'missing')
+    vars.some((variable) => variable.group === group.id && variable.status !== 'missing')
   )
   return { agent, vars, satisfied: requiredOk && groupsOk }
 }
 
-/** Run one `af secrets …` verb, capturing all sanitized output. */
-function runSecretsCli(
-  args: string[],
-  input?: string
-): Promise<{ ok: boolean; output: string }> {
-  return new Promise((resolve) => {
-    const lines: string[] = []
-    let settled = false
-    const done = (ok: boolean) => {
-      if (!settled) {
-        settled = true
-        resolve({ ok, output: lines.join('\n') })
-      }
-    }
-
-    const child = spawn(getCliCommand(), ['secrets', ...args], {
-      windowsHide: true,
-      env: childEnv()
-    })
-    const timer = setTimeout(() => {
-      child.kill()
-      lines.push('af secrets timed out')
-      done(false)
-    }, SECRETS_TIMEOUT_MS)
-
-    const collect = (chunk: Buffer) => {
-      lines.push(...sanitizeInstallOutput(chunk.toString('utf8')))
-    }
-    child.stdout.on('data', collect)
-    child.stderr.on('data', collect)
-    child.on('error', (err: NodeJS.ErrnoException) => {
-      clearTimeout(timer)
-      lines.push(
-        err.code === 'ENOENT' ? 'The AgentField CLI (af) was not found' : String(err.message)
-      )
-      done(false)
-    })
-    child.on('close', (code) => {
-      clearTimeout(timer)
-      done(code === 0)
-    })
-    if (input !== undefined) {
-      // `af secrets set KEY` reads the value from stdin when it is not a TTY
-      // (readHiddenValue in internal/cli/secrets.go) — the value never
-      // appears in a command line.
-      child.stdin.write(`${input}\n`)
-    }
-    child.stdin.end()
-  })
-}
-
-/** Read and parse <packageDir>/agentfield-package.yaml; null when unreadable. */
-export async function readEnvSpec(packageDir: string): Promise<EnvSpec | null> {
-  try {
-    const text = await fs.readFile(path.join(packageDir, 'agentfield-package.yaml'), 'utf8')
-    return parseUserEnvironment(yaml.load(text))
-  } catch {
-    return null
-  }
-}
-
-/**
- * Build env reports for every installed agent that declares environment
- * variables. One `af secrets ls` serves all agents. A store read failure
- * degrades to "store looks empty" with the error attached — statuses from
- * process env and manifest defaults are still real.
- */
-export async function getEnvReports(
-  homeDir: string = getAgentFieldHome()
-): Promise<AgentEnvReport[]> {
-  const registry = await readInstalledAgents(homeDir)
-  if (registry.agents.length === 0) return []
-
-  const specs: { agent: string; spec: EnvSpec }[] = []
-  for (const agent of registry.agents) {
-    const dir = agent.path ?? path.join(homeDir, 'packages', agent.name)
-    const spec = await readEnvSpec(dir)
-    if (spec && !specIsEmpty(spec)) specs.push({ agent: agent.name, spec })
-  }
-  if (specs.length === 0) return []
-
-  const ls = await runSecretsCli(['ls'])
-  const refs = ls.ok ? parseSecretsTable(ls.output) : []
-  return specs.map(({ agent, spec }) => {
-    const report = buildEnvReport(agent, spec, refs)
-    if (!ls.ok) report.error = `could not read the secret store: ${ls.output}`
-    return report
-  })
-}
-
-/** Locate an agent's declared variable; refuse anything the manifest doesn't name. */
-async function resolveDeclaredVar(
-  agent: string,
-  key: string,
-  homeDir: string
-): Promise<{ spec: EnvSpecVar } | { error: string }> {
-  const registry = await readInstalledAgents(homeDir)
-  const entry = registry.agents.find((a) => a.name === agent)
-  if (!entry) return { error: `"${agent}" is not an installed agent` }
-  const spec = await readEnvSpec(entry.path ?? path.join(homeDir, 'packages', agent))
-  if (!spec) return { error: `could not read ${agent}'s manifest` }
-  const specVar = findSpecVar(spec, key)
-  if (!specVar) return { error: `${agent} does not declare ${key}` }
-  return { spec: specVar }
-}
-
-/**
- * Store a value for one of an agent's declared variables, in the scope the
- * manifest names (global by default — shared across nodes, exactly like the
- * CLI's own prompt-and-store). The renderer only ever supplies names the
- * manifest declares; anything else is refused.
- */
-export async function setAgentSecret(
-  agent: string,
-  key: string,
-  value: string,
-  homeDir: string = getAgentFieldHome()
-): Promise<AgentActionResult> {
-  const trimmed = value.trim()
-  if (trimmed === '') return { ok: false, message: 'value must not be empty' }
-
-  const resolved = await resolveDeclaredVar(agent, key, homeDir)
-  if ('error' in resolved) return { ok: false, message: resolved.error }
-
-  if (resolved.spec.validation) {
-    try {
-      if (!new RegExp(resolved.spec.validation).test(trimmed)) {
-        return {
-          ok: false,
-          message: `value does not match the required format (${resolved.spec.validation})`
-        }
-      }
-    } catch {
-      // Go RE2 pattern that JS cannot compile — let the CLI-side validation
-      // (which runs on prompt) be the judge rather than rejecting here.
-    }
-  }
-
-  const args = ['set', key]
-  if (resolved.spec.scope === 'node') args.push('--node', agent)
-  const result = await runSecretsCli(args, trimmed)
-  return result.ok
-    ? { ok: true, message: `${key} stored` }
-    : { ok: false, message: result.output || `failed to store ${key}` }
-}
-
-/** Names of installed agents whose spec declares the given variable name. */
-function agentsDeclaring(
+function declaringAgents(
   specs: { agent: string; spec: EnvSpec }[],
   key: string
 ): string[] {
   return specs.filter(({ spec }) => findSpecVar(spec, key) !== null).map(({ agent }) => agent)
 }
 
-/**
- * Join the raw store listing with the installed agents' manifests: which
- * agents can actually read each stored secret. Global secrets are readable
- * by every agent declaring the name; a node-scoped secret only by that node.
- * Ordered global-first, then node scopes, keys alphabetical within a scope.
- */
 export function buildSecretsInventory(
   refs: SecretRef[],
   specs: { agent: string; spec: EnvSpec }[]
 ): StoredSecret[] {
-  const rank = (ref: SecretRef) => (ref.scope === GLOBAL_SCOPE ? 0 : 1)
   return [...refs]
-    .sort(
-      (a, b) =>
-        rank(a) - rank(b) || a.scope.localeCompare(b.scope) || a.key.localeCompare(b.key)
+    .sort((a, b) =>
+      Number(a.scope !== GLOBAL_SCOPE) - Number(b.scope !== GLOBAL_SCOPE) ||
+      a.scope.localeCompare(b.scope) ||
+      a.key.localeCompare(b.key)
     )
     .map((ref) => ({
       key: ref.key,
       scope: ref.scope,
       usedBy:
         ref.scope === GLOBAL_SCOPE
-          ? agentsDeclaring(specs, ref.key)
-          : agentsDeclaring(
-              specs.filter(({ agent }) => agent === ref.scope),
-              ref.key
-            )
+          ? declaringAgents(specs, ref.key)
+          : declaringAgents(specs.filter(({ agent }) => agent === ref.scope), ref.key)
     }))
 }
 
-/** The whole secret store (keys and scopes only — never values). */
-export async function listStoredSecrets(
-  homeDir: string = getAgentFieldHome()
-): Promise<SecretsListResult> {
-  const ls = await runSecretsCli(['ls'])
-  if (!ls.ok) {
-    return { secrets: [], error: `could not read the secret store: ${ls.output}` }
-  }
-
-  const registry = await readInstalledAgents(homeDir)
-  const specs: { agent: string; spec: EnvSpec }[] = []
-  for (const agent of registry.agents) {
-    const dir = agent.path ?? path.join(homeDir, 'packages', agent.name)
-    const spec = await readEnvSpec(dir)
-    if (spec && !specIsEmpty(spec)) specs.push({ agent: agent.name, spec })
-  }
-  return { secrets: buildSecretsInventory(parseSecretsTable(ls.output), specs) }
+export interface SecretsDeps {
+  cpClient: CpClient
 }
 
-/**
- * Remove one stored secret from one scope. Only (key, scope) pairs that the
- * store actually lists are accepted — the renderer never gets to invent
- * arguments for `af secrets rm`.
- */
+function defaultDeps(): SecretsDeps {
+  return { cpClient: createCpClient() }
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof CpApiError
+    ? err.message
+    : 'Could not reach the control plane — start the control plane and try again'
+}
+
+export async function getEnvReports(
+  deps: SecretsDeps = defaultDeps()
+): Promise<AgentEnvReport[]> {
+  try {
+    const packages = await deps.cpClient.listPackages()
+    return await Promise.all(packages.packages.map(async (pkg) => {
+      const { secrets } = await deps.cpClient.listAgentSecrets(pkg.id)
+      const vars: AgentEnvVar[] = secrets.map((secret) => ({
+        name: secret.key,
+        description: '',
+        secret: true,
+        scope: secret.scope ?? GLOBAL_SCOPE,
+        required: true,
+        status: secret.is_set ? 'stored' : 'missing',
+        storedScopes: secret.is_set
+          ? [secret.scope === 'node' ? pkg.name : secret.scope ?? GLOBAL_SCOPE]
+          : []
+      }))
+      return {
+        agent: pkg.name,
+        vars,
+        satisfied: vars.every((variable) => variable.status !== 'missing')
+      }
+    }))
+  } catch (err) {
+    return [{ agent: '', vars: [], satisfied: false, error: errorMessage(err) }]
+  }
+}
+
+export async function setAgentSecret(
+  agent: string,
+  key: string,
+  value: string,
+  deps: SecretsDeps = defaultDeps()
+): Promise<AgentActionResult> {
+  const trimmed = value.trim()
+  if (!trimmed) return { ok: false, message: 'value must not be empty' }
+  try {
+    await deps.cpClient.setAgentSecret(agent, key, trimmed)
+    return { ok: true, message: `${key} stored` }
+  } catch (err) {
+    return { ok: false, message: errorMessage(err) }
+  }
+}
+
+export async function listStoredSecrets(
+  deps: SecretsDeps = defaultDeps()
+): Promise<SecretsListResult> {
+  try {
+    const [{ secrets }, packages] = await Promise.all([
+      deps.cpClient.listAllSecrets(),
+      deps.cpClient.listPackages()
+    ])
+    const declarations = await Promise.all(packages.packages.map(async (pkg) => ({
+      id: pkg.id,
+      name: pkg.name,
+      keys: new Set((await deps.cpClient.listAgentSecrets(pkg.id)).secrets.map((secret) => secret.key))
+    })))
+    return {
+      secrets: secrets.map((secret) => ({
+        ...secret,
+        usedBy: declarations
+          .filter(({ id, name, keys }) =>
+            keys.has(secret.key) &&
+            (secret.scope === GLOBAL_SCOPE || secret.scope === id || secret.scope === name)
+          )
+          .map(({ name }) => name)
+      }))
+    }
+  } catch (err) {
+    return { secrets: [], error: errorMessage(err) }
+  }
+}
+
 export async function revokeStoredSecret(
   key: string,
-  scope: string
+  scope: string,
+  deps: SecretsDeps = defaultDeps()
 ): Promise<AgentActionResult> {
-  const ls = await runSecretsCli(['ls'])
-  if (!ls.ok) return { ok: false, message: `could not read the secret store: ${ls.output}` }
-  const exists = parseSecretsTable(ls.output).some(
-    (ref) => ref.key === key && ref.scope === scope
-  )
-  if (!exists) return { ok: false, message: `${key} is not stored in the ${scope} scope` }
-
-  const args = ['rm', key]
-  if (scope !== GLOBAL_SCOPE) args.push('--node', scope)
-  const result = await runSecretsCli(args)
-  if (!result.ok) return { ok: false, message: result.output || `failed to remove ${key}` }
-  return {
-    ok: true,
-    message:
-      scope === GLOBAL_SCOPE ? `${key} removed for all agents` : `${key} removed for ${scope}`
+  try {
+    const { secrets } = await deps.cpClient.listAllSecrets()
+    if (!secrets.some((secret) => secret.key === key && secret.scope === scope)) {
+      return { ok: false, message: `${key} is not stored in the ${scope} scope` }
+    }
+    let agent = scope
+    if (scope === GLOBAL_SCOPE) {
+      const packages = await deps.cpClient.listPackages()
+      agent = ''
+      for (const pkg of packages.packages) {
+        const declared = await deps.cpClient.listAgentSecrets(pkg.id)
+        if (declared.secrets.some((secret) => secret.key === key && secret.scope === GLOBAL_SCOPE)) {
+          agent = pkg.id
+          break
+        }
+      }
+      if (!agent) return { ok: false, message: `no installed agent can remove ${key}` }
+    }
+    await deps.cpClient.deleteAgentSecret(agent, key)
+    return {
+      ok: true,
+      message: scope === GLOBAL_SCOPE ? `${key} removed for all agents` : `${key} removed for ${scope}`
+    }
+  } catch (err) {
+    return { ok: false, message: errorMessage(err) }
   }
 }
 
-/**
- * Remove a stored value from every scope relevant to this agent that holds
- * it (its node scope and/or global). Revoking a global key affects all
- * agents sharing it — that is the store's sharing model, and the UI labels
- * the scope so the choice is informed.
- */
 export async function revokeAgentSecret(
   agent: string,
   key: string,
-  homeDir: string = getAgentFieldHome()
+  deps: SecretsDeps = defaultDeps()
 ): Promise<AgentActionResult> {
-  const resolved = await resolveDeclaredVar(agent, key, homeDir)
-  if ('error' in resolved) return { ok: false, message: resolved.error }
-
-  const ls = await runSecretsCli(['ls'])
-  if (!ls.ok) return { ok: false, message: `could not read the secret store: ${ls.output}` }
-  const scopes = storedScopesFor(parseSecretsTable(ls.output), agent, key)
-  if (scopes.length === 0) return { ok: true, message: `${key} is not stored` }
-
-  for (const scope of scopes) {
-    const args = ['rm', key]
-    if (scope !== GLOBAL_SCOPE) args.push('--node', scope)
-    const result = await runSecretsCli(args)
-    if (!result.ok) {
-      return { ok: false, message: result.output || `failed to remove ${key}` }
+  try {
+    const { secrets } = await deps.cpClient.listAgentSecrets(agent)
+    if (!secrets.find((secret) => secret.key === key)?.is_set) {
+      return { ok: true, message: `${key} is not stored` }
     }
+    await deps.cpClient.deleteAgentSecret(agent, key)
+    return { ok: true, message: `${key} revoked` }
+  } catch (err) {
+    return { ok: false, message: errorMessage(err) }
   }
-  return { ok: true, message: `${key} revoked` }
 }


### PR DESCRIPTION
## Summary

The desktop previously managed agents two ways: shelling out to the bundled `af` CLI (install, run/stop, secrets, uninstall) while the control plane exposed overlapping HTTP APIs. Per the product decision: **one management path**. The desktop is now a pure HTTP client of the control plane for all agent management — the same code path whether the CP is local or, in the upcoming cloud mode, remote. The CLI keeps exactly three jobs: booting the local control plane, bundled-binary management, and skills install.

## Changes

- **`cpClient.ts` (new)** — typed client for the CP management API (#837): install/update/uninstall with async-job watching (incremental progress-line streaming preserving the existing IPC contract), lifecycle start/stop, secrets (no scope sent — the server owns the global-unless-`scope: node` rule now), packages listing. Late-bound base URL (port changes are picked up per call), optional `X-API-Key` for the future cloud profile, typed `CpApiError`s.
- **`agents.ts` / `installer.ts` / `secrets.ts` / `agentfield.ts`** — all CLI spawns for management replaced with client calls; `installed.yaml` parsing replaced by the packages API; desktop-side manifest scope resolution deleted. Net −187 lines.
- **Version skew**: a control plane predating the install API (< the release carrying #837) gets a "Control plane update required — update AgentField CLI" message through the existing error channels. **No CLI fallback** — deliberately, to avoid re-growing the second path.

## Behavior changes to be aware of

- **The control plane must be running for agent management** (autostart already ensures this). Previously `af install`/`af run` worked with the CP down; that capability is intentionally gone — the CP facilitates installs, secrets, and startups now.
- Env-report metadata (descriptions, optional/required grouping) is reduced to key + set-state until the secrets API returns declared metadata — follow-up noted below.

## Test plan

- [x] `npm ci`, `npm run typecheck`, `npm test` (290 tests, 15 files — all green; spawn-stubs converted to client-stubs), `npm run dist:dir` — the desktop CI's literal steps, all passing locally on Node 22
- [x] Behavior contract tests: progress-line streaming parity, 409/404/unreachable error mapping, old-CP update prompt, secrets round-trip without scope, registry-mapping table tests

## Follow-ups (separate PRs)

- Enrich `GET /agents/:id/secrets` with declared metadata (description, optional, group) to restore full keys-form fidelity; desktop consumes the fields opportunistically.
- Cloud profile (settings + remote URL + API key) — this PR makes it a config change, not a code path.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)