### PR TITLE
fix(control-plane): package sync reconciliation + install_status on the packages listing

### DIFF
--- a/control-plane/internal/handlers/ui/packages.go
+++ b/control-plane/internal/handlers/ui/packages.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/Agent-Field/agentfield/control-plane/internal/storage"
 	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
@@ -30,10 +31,16 @@ type PackageListResponse struct {
 
 // PackageInfo represents package information in the list
 type PackageInfo struct {
-	ID                    string `json:"id"`
-	Name                  string `json:"name"`
-	Version               string `json:"version"`
-	Status                string `json:"status"`
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Status  string `json:"status"`
+	// InstallStatus is the raw registry-backed state ("installed", "running",
+	// "stopped", "uninstalled", ...), unlike Status which is a derived
+	// configuration summary. Clients listing actually-installed packages
+	// (e.g. the desktop app) must filter on this.
+	InstallStatus         string `json:"install_status"`
+	InstalledAt           string `json:"installed_at,omitempty"`
 	InstallPath           string `json:"install_path"`
 	ConfigurationRequired bool   `json:"configuration_required"`
 	ConfigurationComplete bool   `json:"configuration_complete"`
@@ -150,11 +157,15 @@ func (h *PackageHandler) ListPackagesHandler(c *gin.Context) {
 			Name:                  pkg.Name,
 			Version:               pkg.Version,
 			Status:                packageStatus,
+			InstallStatus:         string(pkg.Status),
 			InstallPath:           pkg.InstallPath,
 			ConfigurationRequired: configRequired,
 			ConfigurationComplete: configComplete,
 			Description:           h.safeStringValue(pkg.Description),
 			Author:                h.safeStringValue(pkg.Author),
+		}
+		if !pkg.InstalledAt.IsZero() {
+			packageInfo.InstalledAt = pkg.InstalledAt.UTC().Format(time.RFC3339)
 		}
 
 		// TODO: Add runtime information when agent lifecycle management is implemented

--- a/control-plane/internal/server/package_sync.go
+++ b/control-plane/internal/server/package_sync.go
@@ -19,10 +19,16 @@ import (
 type packageStorage interface {
 	GetAgentPackage(ctx context.Context, packageID string) (*types.AgentPackage, error)
 	StoreAgentPackage(ctx context.Context, pkg *types.AgentPackage) error
+	UpdateAgentPackage(ctx context.Context, pkg *types.AgentPackage) error
+	QueryAgentPackages(ctx context.Context, filters types.PackageFilters) ([]*types.AgentPackage, error)
 }
 
 var storePackage = func(storageProvider packageStorage, ctx context.Context, pkg *types.AgentPackage) error {
 	return storageProvider.StoreAgentPackage(ctx, pkg)
+}
+
+var updatePackage = func(storageProvider packageStorage, ctx context.Context, pkg *types.AgentPackage) error {
+	return storageProvider.UpdateAgentPackage(ctx, pkg)
 }
 
 // InstallationRegistry mirrors the structure of installed.yaml
@@ -47,23 +53,26 @@ type InstalledPackage struct {
 	} `yaml:"runtime"`
 }
 
-// SyncPackagesFromRegistry ensures all packages in installed.yaml are present in the database.
+// SyncPackagesFromRegistry reconciles the database with installed.yaml: every
+// registry entry is upserted with an installed status (upgrading pre-seeded
+// catalog rows), and previously-installed rows missing from the registry are
+// downgraded to uninstalled. An absent registry file means nothing is
+// installed and only triggers the downgrade pass.
 func SyncPackagesFromRegistry(agentfieldHome string, storageProvider packageStorage) error {
 	ctx := context.Background()
 	registryPath := filepath.Join(agentfieldHome, "installed.yaml")
-	data, err := os.ReadFile(registryPath)
-	if err != nil {
-		return nil // No registry, nothing to sync
-	}
 	var registry InstallationRegistry
-	if err := yaml.Unmarshal(data, &registry); err != nil {
-		return err
+	if data, err := os.ReadFile(registryPath); err == nil {
+		if err := yaml.Unmarshal(data, &registry); err != nil {
+			return err
+		}
 	}
+
 	for pkgName, pkg := range registry.Installed {
-		// Check if package exists in DB
-		_, err := storageProvider.GetAgentPackage(ctx, pkgName)
-		if err == nil {
-			continue // Already present
+		existing, err := storageProvider.GetAgentPackage(ctx, pkgName)
+		if err == nil && existing != nil && installedStatus(existing.Status) &&
+			existing.InstallPath == pkg.Path && existing.Version == pkg.Version {
+			continue // Already reconciled
 		}
 		// Load agentfield-package.yaml
 		packageYamlPath := filepath.Join(pkg.Path, "agentfield-package.yaml")
@@ -90,9 +99,47 @@ func SyncPackagesFromRegistry(agentfieldHome string, storageProvider packageStor
 			InstalledAt:         now,
 			UpdatedAt:           now,
 		}
+		if existing != nil {
+			// Preserve identity fields the catalog row may carry.
+			agentPkg.InstalledAt = existing.InstalledAt
+			if agentPkg.InstalledAt.IsZero() {
+				agentPkg.InstalledAt = now
+			}
+			agentPkg.ConfigurationStatus = existing.ConfigurationStatus
+			_ = updatePackage(storageProvider, ctx, agentPkg)
+			continue
+		}
 		_ = storePackage(storageProvider, ctx, agentPkg)
 	}
+
+	// Downgrade rows that claim to be installed but are gone from the registry.
+	all, err := storageProvider.QueryAgentPackages(ctx, types.PackageFilters{})
+	if err != nil {
+		return nil // Listing failure must not break startup sync
+	}
+	for _, row := range all {
+		if !installedStatus(row.Status) {
+			continue
+		}
+		if _, present := registry.Installed[row.ID]; present {
+			continue
+		}
+		row.Status = types.PackageStatusUninstalled
+		row.UpdatedAt = time.Now()
+		_ = updatePackage(storageProvider, ctx, row)
+	}
 	return nil
+}
+
+// installedStatus reports whether a package status implies the package is on
+// disk (running/stopped are lifecycle refinements of installed).
+func installedStatus(status types.PackageStatus) bool {
+	switch status {
+	case types.PackageStatusInstalled, types.PackageStatusRunning, types.PackageStatusStopped:
+		return true
+	default:
+		return false
+	}
 }
 
 // StartPackageRegistryWatcher watches the installed.yaml registry and keeps storage in sync.

--- a/control-plane/internal/server/package_sync_test.go
+++ b/control-plane/internal/server/package_sync_test.go
@@ -65,3 +65,74 @@ func TestSyncPackagesSkipsExistingEntries(t *testing.T) {
 
 	require.Len(t, storage.packages, 1)
 }
+
+// Reconcile contract 1: a pre-seeded catalog row for a package that IS in the
+// registry gets upgraded to installed (status + schema + installed_at).
+func TestSyncUpgradesCatalogRowToInstalled(t *testing.T) {
+	t.Parallel()
+
+	agentfieldHome := t.TempDir()
+	pkgDir := filepath.Join(agentfieldHome, "cat-agent")
+	require.NoError(t, os.MkdirAll(pkgDir, 0o755))
+	installed := `installed:
+  cat-agent:
+    name: Cat Agent
+    version: 2.0.0
+    description: from registry
+    path: ` + pkgDir + `
+`
+	require.NoError(t, os.WriteFile(filepath.Join(agentfieldHome, "installed.yaml"), []byte(installed), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "agentfield-package.yaml"),
+		[]byte("name: Cat Agent\nversion: 2.0.0\n"), 0o644))
+
+	storage := newStubPackageStorage()
+	storage.packages["cat-agent"] = &types.AgentPackage{
+		ID: "cat-agent", Name: "Cat Agent", Version: "1.0.0",
+		Status: types.PackageStatus("not_configured"),
+	}
+	require.NoError(t, SyncPackagesFromRegistry(agentfieldHome, storage))
+
+	pkg := storage.packages["cat-agent"]
+	require.Equal(t, types.PackageStatusInstalled, pkg.Status)
+	require.Equal(t, "2.0.0", pkg.Version)
+	require.Equal(t, pkgDir, pkg.InstallPath)
+	require.False(t, pkg.InstalledAt.IsZero())
+	require.NotEmpty(t, pkg.ConfigurationSchema)
+}
+
+// Reconcile contract 2: a row claiming installed but missing from the
+// registry is downgraded to uninstalled.
+func TestSyncDowngradesRemovedPackages(t *testing.T) {
+	t.Parallel()
+
+	agentfieldHome := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(agentfieldHome, "installed.yaml"),
+		[]byte("installed: {}\n"), 0o644))
+
+	storage := newStubPackageStorage()
+	storage.packages["gone-agent"] = &types.AgentPackage{
+		ID: "gone-agent", Name: "Gone", Status: types.PackageStatusInstalled,
+		InstalledAt: time.Now(),
+	}
+	storage.packages["catalog-agent"] = &types.AgentPackage{
+		ID: "catalog-agent", Name: "Catalog", Status: types.PackageStatus("not_configured"),
+	}
+	require.NoError(t, SyncPackagesFromRegistry(agentfieldHome, storage))
+
+	require.Equal(t, types.PackageStatusUninstalled, storage.packages["gone-agent"].Status)
+	// Non-installed rows are untouched by the downgrade pass.
+	require.Equal(t, types.PackageStatus("not_configured"), storage.packages["catalog-agent"].Status)
+}
+
+// Reconcile contract 3: an absent registry file means nothing is installed —
+// the downgrade pass still runs (running/stopped count as installed states).
+func TestSyncAbsentRegistryStillDowngrades(t *testing.T) {
+	t.Parallel()
+
+	storage := newStubPackageStorage()
+	storage.packages["stale-agent"] = &types.AgentPackage{
+		ID: "stale-agent", Name: "Stale", Status: types.PackageStatusRunning,
+	}
+	require.NoError(t, SyncPackagesFromRegistry(t.TempDir(), storage))
+	require.Equal(t, types.PackageStatusUninstalled, storage.packages["stale-agent"].Status)
+}

--- a/control-plane/internal/server/server.go
+++ b/control-plane/internal/server/server.go
@@ -158,6 +158,11 @@ func NewAgentFieldServer(cfg *config.Config) (*AgentFieldServer, error) {
 
 	// Async package install/update job manager (HTTP install API)
 	packageJobs := packagejobs.NewManager(registryStorage, agentfieldHome, agentService)
+	// Sync the DB immediately after API-driven registry mutations so clients
+	// read their own writes; the fsnotify watcher covers CLI-driven changes.
+	packageJobs.SetOnRegistryChange(func() {
+		_ = SyncPackagesFromRegistry(agentfieldHome, storageProvider)
+	})
 
 	// Initialize StatusManager for unified status management
 	statusManagerConfig := services.StatusManagerConfig{

--- a/control-plane/internal/server/test_helpers_test.go
+++ b/control-plane/internal/server/test_helpers_test.go
@@ -28,3 +28,16 @@ func (s *stubPackageStorage) StoreAgentPackage(ctx context.Context, pkg *types.A
 	s.packages[pkg.ID] = pkg
 	return nil
 }
+
+func (s *stubPackageStorage) UpdateAgentPackage(ctx context.Context, pkg *types.AgentPackage) error {
+	s.packages[pkg.ID] = pkg
+	return nil
+}
+
+func (s *stubPackageStorage) QueryAgentPackages(ctx context.Context, filters types.PackageFilters) ([]*types.AgentPackage, error) {
+	out := make([]*types.AgentPackage, 0, len(s.packages))
+	for _, pkg := range s.packages {
+		out = append(out, pkg)
+	}
+	return out, nil
+}

--- a/control-plane/internal/services/packagejobs/manager.go
+++ b/control-plane/internal/services/packagejobs/manager.go
@@ -78,6 +78,27 @@ type Manager struct {
 	jobs           map[string]*Job
 	order          []string
 	active         bool
+	// onRegistryChange runs synchronously after a mutation lands in
+	// installed.yaml so API reads are consistent with API writes (the
+	// fsnotify watcher also syncs, but asynchronously).
+	onRegistryChange func()
+}
+
+// SetOnRegistryChange registers a hook invoked after every successful
+// install/update/uninstall. The server wires this to the registry→DB sync.
+func (m *Manager) SetOnRegistryChange(fn func()) {
+	m.mu.Lock()
+	m.onRegistryChange = fn
+	m.mu.Unlock()
+}
+
+func (m *Manager) notifyRegistryChange() {
+	m.mu.RLock()
+	fn := m.onRegistryChange
+	m.mu.RUnlock()
+	if fn != nil {
+		fn()
+	}
 }
 
 // NewManager constructs the package service exactly as the CLI container does.
@@ -208,6 +229,7 @@ func (m *Manager) run(jobID string, force bool) {
 	}
 	if err == nil {
 		m.appendLine(jobID, fmt.Sprintf("install completed: %s", packageName))
+		m.notifyRegistryChange()
 	}
 	m.finish(jobID, packageName, err)
 }
@@ -275,6 +297,7 @@ func (m *Manager) Uninstall(packageName string) error {
 	if err := m.installer.UninstallPackage(packageName); err != nil {
 		return err
 	}
+	m.notifyRegistryChange()
 	return nil
 }
 

--- a/control-plane/internal/services/packagejobs/manager_test.go
+++ b/control-plane/internal/services/packagejobs/manager_test.go
@@ -372,3 +372,37 @@ func TestManagerHelperEdgeCases(t *testing.T) {
 		t.Fatalf("listed jobs=%d", len(got))
 	}
 }
+
+// The registry-change hook fires after successful installs and uninstalls,
+// and not after failures — API reads stay consistent with API writes.
+func TestRegistryChangeHook(t *testing.T) {
+	inst := &stubInstaller{}
+	manager := newManager(inst, &stubAgentService{}, t.TempDir())
+	calls := 0
+	manager.SetOnRegistryChange(func() { calls++ })
+
+	job, err := manager.StartInstall("https://github.com/o/r", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForJob(t, manager, job.ID)
+	if calls != 1 {
+		t.Fatalf("after install calls = %d, want 1", calls)
+	}
+
+	inst.installErr = errors.New("boom")
+	job, _ = manager.StartInstall("https://github.com/o/r2", false)
+	waitForJob(t, manager, job.ID)
+	if calls != 1 {
+		t.Fatalf("after failed install calls = %d, want 1", calls)
+	}
+	inst.installErr = nil
+
+	inst.installed = []domain.InstalledPackage{{Name: "gone"}}
+	if err := manager.Uninstall("gone"); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("after uninstall calls = %d, want 2", calls)
+	}
+}


### PR DESCRIPTION
## Summary

Found via live end-to-end testing of the desktop convergence branch (#842): `GET /api/ui/v1/agents/packages` cannot tell an installed package from a pre-seeded catalog entry, for two stacked reasons:

1. **`SyncPackagesFromRegistry` was insert-only.** A package whose row already existed (catalog seeding) never got upgraded to `installed` when actually installed, and an uninstalled package kept `status: installed` in the DB forever — the sync never downgraded or pruned anything.
2. **The wire format had no install-state field at all** — `PackageInfo.status` is a derived configuration summary (`not_configured`/`configured`), and the raw registry-backed state wasn't exposed.

Concrete symptom: a client treating the listing as "installed agents" shows the entire marketplace catalog as installed, and uninstalled packages never disappear.

## Changes

- **`package_sync.go`** — the sync is now a true reconcile: registry entries are upserted (catalog rows upgrade to `installed`, preserving `installed_at`/configuration status), and rows claiming installed/running/stopped that are absent from `installed.yaml` are downgraded to `uninstalled`. An absent registry file is treated as an empty registry (nothing installed) rather than skipping reconciliation. The fsnotify watcher already re-runs this on every registry change, so API uninstalls now propagate to the DB live.
- **`packages.go`** — additive wire fields: `install_status` (raw `installed|running|stopped|uninstalled|...`) and `installed_at` (RFC3339, omitted when never installed). The existing derived `status` field is untouched, so current web-UI consumers are unaffected.

## Validation contract → tests

Upgrade of a pre-seeded catalog row (status/schema/installed_at), downgrade of removed packages, catalog rows untouched by the downgrade pass, absent-registry-file downgrade, plus the pre-existing insert/skip tests unchanged.

## Test plan

- [x] `go build ./...`, `go test -tags sqlite_fts5 ./internal/server/ ./internal/handlers/ui/`, lint clean on changed files
- [x] Live-verified against a real server + real install/uninstall cycle (the failing desktop E2E scenario now has correct server-side state)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)