### PR TITLE
test: harden the install/uninstall/sync workflows behind the desktop convergence

### DIFF
--- a/control-plane/internal/cli/commands/commands_test.go
+++ b/control-plane/internal/cli/commands/commands_test.go
@@ -160,6 +160,14 @@ func TestInstallCommand_MetadataAndExecute(t *testing.T) {
 			wantInstallRun: 1,
 		},
 		{
+			name:           "success with subdirectory path",
+			args:           []string{"pkg-monorepo", "--path", "go", "--force"},
+			wantSource:     "pkg-monorepo",
+			wantOptions:    domain.InstallOptions{Force: true, Verbose: false, Path: "go"},
+			wantListCalls:  0,
+			wantInstallRun: 1,
+		},
+		{
 			name:           "verbose continues when listing packages fails",
 			args:           []string{"pkg-c", "--verbose"},
 			wantSource:     "pkg-c",

--- a/control-plane/internal/cli/uninstall.go
+++ b/control-plane/internal/cli/uninstall.go
@@ -7,12 +7,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	uninstallForce bool
-)
-
 // NewUninstallCommand creates the uninstall command
 func NewUninstallCommand() *cobra.Command {
+	var uninstallForce bool
+
 	cmd := &cobra.Command{
 		Use:   "uninstall <package-name>",
 		Short: "Uninstall an agent node package",
@@ -28,7 +26,9 @@ Examples:
   agentfield uninstall my-agent
   agentfield uninstall sentiment-analyzer --force`,
 		Args: cobra.ExactArgs(1),
-		RunE: runUninstallCommand,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runUninstallCommand(args[0], uninstallForce)
+		},
 	}
 
 	cmd.Flags().BoolVarP(&uninstallForce, "force", "f", false, "Force uninstall even if agent node is running")
@@ -36,13 +36,11 @@ Examples:
 	return cmd
 }
 
-func runUninstallCommand(cmd *cobra.Command, args []string) error {
-	packageName := args[0]
-
+func runUninstallCommand(packageName string, force bool) error {
 	// Create uninstaller
 	uninstaller := &packages.PackageUninstaller{
 		AgentFieldHome: getAgentFieldHomeDir(),
-		Force:          uninstallForce,
+		Force:          force,
 	}
 
 	// Uninstall package

--- a/control-plane/internal/cli/uninstall_test.go
+++ b/control-plane/internal/cli/uninstall_test.go
@@ -1,0 +1,204 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/Agent-Field/agentfield/control-plane/internal/packages"
+	"gopkg.in/yaml.v3"
+)
+
+func seedUninstallPackage(t *testing.T, home, name, status string, pid *int) string {
+	t.Helper()
+
+	packageDir := filepath.Join(home, "packages", name)
+	if err := os.MkdirAll(packageDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", packageDir, err)
+	}
+	manifest := []byte("name: " + name + "\nversion: 1.0.0\nentrypoint:\n  start: echo ready\n")
+	if err := os.WriteFile(filepath.Join(packageDir, "agentfield-package.yaml"), manifest, 0o644); err != nil {
+		t.Fatalf("WriteFile(manifest): %v", err)
+	}
+
+	registry := packages.InstallationRegistry{
+		Installed: map[string]packages.InstalledPackage{
+			name: {
+				Name:   name,
+				Path:   packageDir,
+				Status: status,
+				Runtime: packages.RuntimeInfo{
+					PID: pid,
+				},
+			},
+		},
+	}
+	data, err := yaml.Marshal(registry)
+	if err != nil {
+		t.Fatalf("yaml.Marshal(registry): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "installed.yaml"), data, 0o644); err != nil {
+		t.Fatalf("WriteFile(installed.yaml): %v", err)
+	}
+	return packageDir
+}
+
+func readUninstallRegistry(t *testing.T, home string) packages.InstallationRegistry {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(home, "installed.yaml"))
+	if err != nil {
+		t.Fatalf("ReadFile(installed.yaml): %v", err)
+	}
+	var registry packages.InstallationRegistry
+	if err := yaml.Unmarshal(data, &registry); err != nil {
+		t.Fatalf("yaml.Unmarshal(installed.yaml): %v", err)
+	}
+	return registry
+}
+
+func executeUninstall(t *testing.T, args ...string) error {
+	t.Helper()
+
+	cmd := NewUninstallCommand()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+func startUninstallChild(t *testing.T) (*exec.Cmd, <-chan struct{}) {
+	t.Helper()
+
+	child := exec.Command("sleep", "300")
+	if err := child.Start(); err != nil {
+		t.Fatalf("start sleep child: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		_ = child.Wait()
+		close(done)
+	}()
+	t.Cleanup(func() {
+		_ = child.Process.Kill()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Errorf("timed out reaping sleep child PID %d", child.Process.Pid)
+		}
+	})
+	return child, done
+}
+
+func assertProcessAlive(t *testing.T, pid int) {
+	t.Helper()
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Fatalf("process %d is not alive: %v", pid, err)
+	}
+}
+
+func assertPackagePresent(t *testing.T, home, name, packageDir string) {
+	t.Helper()
+	if _, ok := readUninstallRegistry(t, home).Installed[name]; !ok {
+		t.Fatalf("registry entry %q was removed", name)
+	}
+	if _, err := os.Stat(packageDir); err != nil {
+		t.Fatalf("package directory %q is not present: %v", packageDir, err)
+	}
+}
+
+func TestUninstallHappyPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENTFIELD_HOME", home)
+	packageDir := seedUninstallPackage(t, home, "demo", "stopped", nil)
+
+	if err := executeUninstall(t, "demo"); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	if _, ok := readUninstallRegistry(t, home).Installed["demo"]; ok {
+		t.Fatal("registry entry demo still exists")
+	}
+	if _, err := os.Stat(packageDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("package directory still exists or stat failed unexpectedly: %v", err)
+	}
+}
+
+func TestUninstallRunningPackageRefusesWithoutForce(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENTFIELD_HOME", home)
+	child, _ := startUninstallChild(t)
+	pid := child.Process.Pid
+	packageDir := seedUninstallPackage(t, home, "running-demo", "running", &pid)
+
+	err := executeUninstall(t, "running-demo")
+	if err == nil {
+		t.Fatal("uninstall succeeded without --force")
+	}
+	message := strings.ToLower(err.Error())
+	if !strings.Contains(message, "running") || !strings.Contains(message, "force") {
+		t.Fatalf("uninstall error = %q, want running and force", err)
+	}
+	assertProcessAlive(t, pid)
+	assertPackagePresent(t, home, "running-demo", packageDir)
+}
+
+func TestUninstallForceKillsRunningPackage(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENTFIELD_HOME", home)
+	child, done := startUninstallChild(t)
+	pid := child.Process.Pid
+	packageDir := seedUninstallPackage(t, home, "running-demo", "running", &pid)
+
+	if err := executeUninstall(t, "running-demo", "--force"); err != nil {
+		t.Fatalf("forced uninstall: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("process %d was not killed", pid)
+	}
+	if _, ok := readUninstallRegistry(t, home).Installed["running-demo"]; ok {
+		t.Fatal("registry entry running-demo still exists")
+	}
+	if _, err := os.Stat(packageDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("package directory still exists or stat failed unexpectedly: %v", err)
+	}
+}
+
+func TestUninstallUnknownPackage(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENTFIELD_HOME", home)
+
+	err := executeUninstall(t, "missing")
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "not installed") {
+		t.Fatalf("uninstall error = %v, want not installed error", err)
+	}
+}
+
+func TestUninstallForceFlagDoesNotLeakBetweenCommands(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENTFIELD_HOME", home)
+	seedUninstallPackage(t, home, "stopped-demo", "stopped", nil)
+	if err := executeUninstall(t, "stopped-demo", "--force"); err != nil {
+		t.Fatalf("first forced uninstall: %v", err)
+	}
+
+	child, _ := startUninstallChild(t)
+	pid := child.Process.Pid
+	packageDir := seedUninstallPackage(t, home, "running-demo", "running", &pid)
+	err := executeUninstall(t, "running-demo")
+	if err == nil {
+		t.Fatal("fresh command inherited --force")
+	}
+	message := strings.ToLower(err.Error())
+	if !strings.Contains(message, "running") || !strings.Contains(message, "force") {
+		t.Fatalf("uninstall error = %q, want running and force", err)
+	}
+	assertProcessAlive(t, pid)
+	assertPackagePresent(t, home, "running-demo", packageDir)
+}

--- a/control-plane/internal/handlers/ui/packages_install_test.go
+++ b/control-plane/internal/handlers/ui/packages_install_test.go
@@ -69,6 +69,22 @@ func TestInstallPackageHandlerAccepted(t *testing.T) {
 	}
 }
 
+func TestInstallPackageHandlerPassesForce(t *testing.T) {
+	manager := &stubPackageJobManager{
+		startInstall: func(source string, force bool) (*packagejobs.Job, error) {
+			if source != "https://github.com/owner/repo" || !force {
+				t.Fatalf("request source=%q force=%v", source, force)
+			}
+			return &packagejobs.Job{ID: "job-force"}, nil
+		},
+	}
+	ctx, response := testContext(http.MethodPost, "/", []byte(`{"source":"https://github.com/owner/repo","force":true}`))
+	NewPackageInstallHandler(manager).InstallPackageHandler(ctx)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
 // Contracts 2 and 3: validation maps to 400 and busy maps to 409.
 func TestInstallPackageHandlerErrors(t *testing.T) {
 	tests := []struct {
@@ -106,7 +122,7 @@ func TestGetInstallJobHandlerUnknown(t *testing.T) {
 // Contract 7: unknown uninstall targets map to 404.
 func TestUninstallPackageHandlerUnknown(t *testing.T) {
 	manager := &stubPackageJobManager{uninstall: func(string) error { return packagejobs.ErrNotFound }}
-	ctx, response := testContext(http.MethodDelete, "/", nil, gin.Param{Key: "packageId", Value: "missing"})
+	ctx, response := testContext(http.MethodPost, "/", nil, gin.Param{Key: "packageId", Value: "missing"})
 	NewPackageInstallHandler(manager).UninstallPackageHandler(ctx)
 	if response.Code != http.StatusNotFound {
 		t.Fatalf("status=%d", response.Code)
@@ -156,7 +172,13 @@ func TestInstallPackageHandlerRejectsMalformedJSON(t *testing.T) {
 
 // Exercises the successful get and list handler branches.
 func TestPackageInstallJobReadHandlers(t *testing.T) {
-	job := &packagejobs.Job{ID: "job-1"}
+	job := &packagejobs.Job{
+		ID:          "job-1",
+		Status:      packagejobs.StatusFailed,
+		Lines:       []string{"installing", "failed"},
+		Error:       "installation failed",
+		PackageName: "demo-package",
+	}
 	manager := &stubPackageJobManager{jobs: map[string]*packagejobs.Job{"job-1": job}}
 	handler := NewPackageInstallHandler(manager)
 
@@ -164,6 +186,22 @@ func TestPackageInstallJobReadHandlers(t *testing.T) {
 	handler.GetInstallJobHandler(ctx)
 	if response.Code != http.StatusOK {
 		t.Fatalf("get status=%d body=%s", response.Code, response.Body.String())
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode job response: %v", err)
+	}
+	if body["status"] != string(packagejobs.StatusFailed) {
+		t.Fatalf("status field=%v", body["status"])
+	}
+	if lines, ok := body["lines"].([]interface{}); !ok || len(lines) != 2 {
+		t.Fatalf("lines field=%v", body["lines"])
+	}
+	if body["error"] != "installation failed" {
+		t.Fatalf("error field=%v", body["error"])
+	}
+	if body["package_name"] != "demo-package" {
+		t.Fatalf("package_name field=%v", body["package_name"])
 	}
 
 	ctx, response = testContext(http.MethodGet, "/", nil)
@@ -202,7 +240,7 @@ func TestUninstallPackageHandlerSuccessAndInternalError(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			manager := &stubPackageJobManager{uninstall: func(string) error { return test.err }}
-			ctx, response := testContext(http.MethodDelete, "/", nil, gin.Param{Key: "packageId", Value: "demo"})
+			ctx, response := testContext(http.MethodPost, "/", nil, gin.Param{Key: "packageId", Value: "demo"})
 			NewPackageInstallHandler(manager).UninstallPackageHandler(ctx)
 			if response.Code != test.want {
 				t.Fatalf("status=%d body=%s", response.Code, response.Body.String())

--- a/control-plane/internal/handlers/ui/packages_test.go
+++ b/control-plane/internal/handlers/ui/packages_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
 
@@ -127,6 +128,52 @@ func TestListPackagesHandler(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "failed to list packages", response.Error)
 
+		mockStorage.AssertExpectations(t)
+	})
+
+	t.Run("preserves install status and installed timestamp wire fields", func(t *testing.T) {
+		installedAt := time.Date(2026, time.July, 29, 23, 45, 12, 0, time.FixedZone("test", -4*60*60))
+		statuses := []types.PackageStatus{
+			types.PackageStatusInstalled,
+			types.PackageStatusRunning,
+			types.PackageStatusStopped,
+			types.PackageStatusUninstalled,
+			types.PackageStatus("catalog"),
+		}
+		rows := make([]*types.AgentPackage, 0, len(statuses)+1)
+		for i, status := range statuses {
+			rows = append(rows, &types.AgentPackage{
+				ID:          "package-" + string(rune('a'+i)),
+				Name:        string(status),
+				Status:      status,
+				InstalledAt: installedAt,
+			})
+		}
+		rows = append(rows, &types.AgentPackage{
+			ID:     "package-zero-time",
+			Name:   "zero time",
+			Status: types.PackageStatusInstalled,
+		})
+
+		router, mockStorage, _ := setupRouterAndServices()
+		mockStorage.On("QueryAgentPackages", mock.AnythingOfType("context.Context"), mock.AnythingOfType("types.PackageFilters")).Return(rows, nil).Once()
+
+		req, _ := http.NewRequest(http.MethodGet, "/api/ui/v1/agents/packages", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var response struct {
+			Packages []map[string]interface{} `json:"packages"`
+		}
+		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		assert.Len(t, response.Packages, len(rows))
+		for i, status := range statuses {
+			assert.Equal(t, string(status), response.Packages[i]["install_status"])
+			assert.Equal(t, "2026-07-30T03:45:12Z", response.Packages[i]["installed_at"])
+		}
+		assert.Equal(t, string(types.PackageStatusInstalled), response.Packages[len(statuses)]["install_status"])
+		assert.NotContains(t, response.Packages[len(statuses)], "installed_at")
 		mockStorage.AssertExpectations(t)
 	})
 }

--- a/control-plane/internal/server/package_routes_test.go
+++ b/control-plane/internal/server/package_routes_test.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/Agent-Field/agentfield/control-plane/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackageRoutesRegistered(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	srv := &AgentFieldServer{
+		Router:            gin.New(),
+		storage:           newStubStorage(),
+		payloadStore:      &stubPayloadStore{},
+		webhookDispatcher: &stubWebhookDispatcher{},
+		config: &config.Config{
+			UI: config.UIConfig{Enabled: true},
+		},
+	}
+
+	srv.registerUIAPI()
+
+	routes := make(map[string]struct{})
+	for _, route := range srv.Router.Routes() {
+		routes[route.Method+" "+route.Path] = struct{}{}
+	}
+	for _, want := range []string{
+		"GET /api/ui/v1/agents/packages",
+		"POST /api/ui/v1/agents/packages/install",
+		"GET /api/ui/v1/agents/packages/install/jobs",
+		"GET /api/ui/v1/agents/packages/install/jobs/:jobId",
+		"POST /api/ui/v1/agents/packages/:packageId/uninstall",
+		"POST /api/ui/v1/agents/packages/:packageId/update",
+	} {
+		_, ok := routes[want]
+		require.Truef(t, ok, "route %q is not registered; routes=%v", want, srv.Router.Routes())
+	}
+}

--- a/control-plane/internal/server/package_sync.go
+++ b/control-plane/internal/server/package_sync.go
@@ -87,6 +87,10 @@ func SyncPackagesFromRegistry(agentfieldHome string, storageProvider packageStor
 		// Convert schema to JSON for storage
 		schemaJson, _ := json.Marshal(packageYaml)
 		now := time.Now()
+		installedAt := now
+		if parsed, err := time.Parse(time.RFC3339, pkg.InstalledAt); err == nil && !parsed.IsZero() {
+			installedAt = parsed
+		}
 		agentPkg := &types.AgentPackage{
 			ID:                  pkgName,
 			Name:                pkg.Name,
@@ -96,7 +100,7 @@ func SyncPackagesFromRegistry(agentfieldHome string, storageProvider packageStor
 			ConfigurationSchema: schemaJson,
 			Status:              types.PackageStatusInstalled,
 			ConfigurationStatus: types.ConfigurationStatusDraft,
-			InstalledAt:         now,
+			InstalledAt:         installedAt,
 			UpdatedAt:           now,
 		}
 		if existing != nil {

--- a/control-plane/internal/server/package_sync_test.go
+++ b/control-plane/internal/server/package_sync_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -135,4 +137,133 @@ func TestSyncAbsentRegistryStillDowngrades(t *testing.T) {
 	}
 	require.NoError(t, SyncPackagesFromRegistry(t.TempDir(), storage))
 	require.Equal(t, types.PackageStatusUninstalled, storage.packages["stale-agent"].Status)
+}
+
+func TestSyncPackagesFromRegistryInstalledAtContracts(t *testing.T) {
+	t.Parallel()
+
+	knownInstalledAt := time.Date(2026, 7, 30, 21, 48, 53, 0, time.UTC)
+	tests := []struct {
+		name        string
+		installedAt string
+		assert      func(*testing.T, time.Time)
+	}{
+		{
+			name:        "uses registry timestamp",
+			installedAt: knownInstalledAt.Format(time.RFC3339),
+			assert: func(t *testing.T, got time.Time) {
+				require.Equal(t, knownInstalledAt, got)
+			},
+		},
+		{
+			name: "falls back to current time when absent",
+			assert: func(t *testing.T, got time.Time) {
+				require.False(t, got.IsZero())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			agentfieldHome := t.TempDir()
+			pkgDir := filepath.Join(agentfieldHome, "timestamp-agent")
+			require.NoError(t, os.MkdirAll(pkgDir, 0o755))
+			installed := `installed:
+  timestamp-agent:
+    name: Timestamp Agent
+    version: 1.0.0
+    path: ` + pkgDir + `
+`
+			if tt.installedAt != "" {
+				installed += `    installed_at: "` + tt.installedAt + `"
+`
+			}
+			require.NoError(t, os.WriteFile(filepath.Join(agentfieldHome, "installed.yaml"), []byte(installed), 0o644))
+			require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "agentfield-package.yaml"),
+				[]byte("name: Timestamp Agent\nversion: 1.0.0\n"), 0o644))
+
+			storage := newStubPackageStorage()
+			require.NoError(t, SyncPackagesFromRegistry(agentfieldHome, storage))
+			tt.assert(t, storage.packages["timestamp-agent"].InstalledAt)
+		})
+	}
+}
+
+func TestSyncPackagesFromRegistryPreservesExistingFields(t *testing.T) {
+	t.Parallel()
+
+	agentfieldHome := t.TempDir()
+	pkgDir := filepath.Join(agentfieldHome, "configured-agent")
+	require.NoError(t, os.MkdirAll(pkgDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(agentfieldHome, "installed.yaml"), []byte(`installed:
+  configured-agent:
+    name: Configured Agent
+    version: 2.0.0
+    path: `+pkgDir+`
+    installed_at: "2026-07-30T17:48:53-04:00"
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "agentfield-package.yaml"),
+		[]byte("name: Configured Agent\nversion: 2.0.0\n"), 0o644))
+
+	priorInstalledAt := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	storage := newStubPackageStorage()
+	storage.packages["configured-agent"] = &types.AgentPackage{
+		ID:                  "configured-agent",
+		Name:                "Configured Agent",
+		Version:             "1.0.0",
+		Status:              types.PackageStatusUninstalled,
+		ConfigurationStatus: types.ConfigurationStatus("configured"),
+		InstalledAt:         priorInstalledAt,
+	}
+
+	require.NoError(t, SyncPackagesFromRegistry(agentfieldHome, storage))
+	got := storage.packages["configured-agent"]
+	require.Equal(t, types.PackageStatusInstalled, got.Status)
+	require.Equal(t, priorInstalledAt, got.InstalledAt)
+	require.Equal(t, types.ConfigurationStatus("configured"), got.ConfigurationStatus)
+}
+
+func TestSyncPackagesFromRegistryIsIdempotentForInstalledAt(t *testing.T) {
+	t.Parallel()
+
+	agentfieldHome := t.TempDir()
+	pkgDir := filepath.Join(agentfieldHome, "idempotent-agent")
+	require.NoError(t, os.MkdirAll(pkgDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(agentfieldHome, "installed.yaml"), []byte(`installed:
+  idempotent-agent:
+    name: Idempotent Agent
+    version: 1.0.0
+    path: `+pkgDir+`
+    installed_at: "2026-07-30T17:48:53-04:00"
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "agentfield-package.yaml"),
+		[]byte("name: Idempotent Agent\nversion: 1.0.0\n"), 0o644))
+
+	storage := newStubPackageStorage()
+	require.NoError(t, SyncPackagesFromRegistry(agentfieldHome, storage))
+	first := storage.packages["idempotent-agent"].InstalledAt
+	require.NoError(t, SyncPackagesFromRegistry(agentfieldHome, storage))
+	require.Equal(t, first, storage.packages["idempotent-agent"].InstalledAt)
+}
+
+type listingErrorPackageStorage struct {
+	*stubPackageStorage
+	err error
+}
+
+func (s *listingErrorPackageStorage) QueryAgentPackages(context.Context, types.PackageFilters) ([]*types.AgentPackage, error) {
+	return nil, s.err
+}
+
+func TestSyncPackagesFromRegistryIgnoresStorageListingFailure(t *testing.T) {
+	t.Parallel()
+
+	storage := &listingErrorPackageStorage{
+		stubPackageStorage: newStubPackageStorage(),
+		err:                errors.New("storage unavailable"),
+	}
+	require.NoError(t, SyncPackagesFromRegistry(t.TempDir(), storage))
 }

--- a/control-plane/internal/server/package_sync_wiring_test.go
+++ b/control-plane/internal/server/package_sync_wiring_test.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	infrastorage "github.com/Agent-Field/agentfield/control-plane/internal/infrastructure/storage"
+	"github.com/Agent-Field/agentfield/control-plane/internal/services/packagejobs"
+	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackageJobsUninstallReconcilesRegistryToStorage(t *testing.T) {
+	t.Parallel()
+
+	agentfieldHome := t.TempDir()
+	pkgDir := filepath.Join(agentfieldHome, "wiring-agent")
+	require.NoError(t, os.MkdirAll(pkgDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "agentfield-package.yaml"),
+		[]byte("name: Wiring Agent\nversion: 1.0.0\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(agentfieldHome, "installed.yaml"), []byte(`installed:
+  wiring-agent:
+    name: Wiring Agent
+    version: 1.0.0
+    path: `+pkgDir+`
+    installed_at: "2026-07-30T17:48:53-04:00"
+    status: stopped
+`), 0o644))
+
+	storage := newStubPackageStorage()
+	storage.packages["wiring-agent"] = &types.AgentPackage{
+		ID:          "wiring-agent",
+		Name:        "Wiring Agent",
+		Version:     "1.0.0",
+		InstallPath: pkgDir,
+		Status:      types.PackageStatusInstalled,
+		InstalledAt: time.Date(2026, 7, 30, 21, 48, 53, 0, time.UTC),
+	}
+
+	fileSystem := infrastorage.NewFileSystemAdapter()
+	registryStorage := infrastorage.NewLocalRegistryStorage(
+		fileSystem,
+		filepath.Join(agentfieldHome, "installed.json"),
+	)
+	manager := packagejobs.NewManager(registryStorage, agentfieldHome, nil)
+	hookCalls := 0
+	manager.SetOnRegistryChange(func() {
+		hookCalls++
+		_ = SyncPackagesFromRegistry(agentfieldHome, storage)
+	})
+
+	require.NoError(t, manager.Uninstall("wiring-agent"))
+	require.Equal(t, 1, hookCalls)
+	require.Equal(t, types.PackageStatusUninstalled, storage.packages["wiring-agent"].Status)
+}

--- a/control-plane/internal/services/packagejobs/manager.go
+++ b/control-plane/internal/services/packagejobs/manager.go
@@ -282,6 +282,19 @@ func (m *Manager) isRunning(name string) (bool, error) {
 }
 
 func (m *Manager) Uninstall(packageName string) error {
+	m.mu.Lock()
+	if m.active {
+		m.mu.Unlock()
+		return ErrBusy
+	}
+	m.active = true
+	m.mu.Unlock()
+	defer func() {
+		m.mu.Lock()
+		m.active = false
+		m.mu.Unlock()
+	}()
+
 	if _, err := m.installer.GetPackageInfo(packageName); err != nil {
 		return ErrNotFound
 	}

--- a/control-plane/internal/services/packagejobs/manager_test.go
+++ b/control-plane/internal/services/packagejobs/manager_test.go
@@ -406,3 +406,129 @@ func TestRegistryChangeHook(t *testing.T) {
 		t.Fatalf("after uninstall calls = %d, want 2", calls)
 	}
 }
+
+func TestRegistryChangeHookRunsBeforeJobSucceeds(t *testing.T) {
+	release := make(chan struct{})
+	inst := &stubInstaller{
+		block:        release,
+		afterInstall: []domain.InstalledPackage{{Name: "demo"}},
+	}
+	manager := newManager(inst, &stubAgentService{}, t.TempDir())
+	var jobID string
+	var status JobStatus
+	manager.SetOnRegistryChange(func() {
+		job, ok := manager.GetJob(jobID)
+		if !ok {
+			t.Errorf("job %q not found in hook", jobID)
+			return
+		}
+		status = job.Status
+	})
+
+	job, err := manager.StartInstall("https://github.com/o/r", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jobID = job.ID
+	close(release)
+	if got := waitForJob(t, manager, job.ID); got.Status != StatusSucceeded {
+		t.Fatalf("status = %s", got.Status)
+	}
+	if status != StatusRunning {
+		t.Fatalf("status observed by hook = %s, want %s", status, StatusRunning)
+	}
+}
+
+func TestUpdateRegistryChangeHook(t *testing.T) {
+	tests := []struct {
+		name       string
+		installErr error
+		wantCalls  int
+	}{
+		{name: "success", wantCalls: 1},
+		{name: "failure", installErr: errors.New("boom"), wantCalls: 0},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			if err := os.WriteFile(filepath.Join(home, "installed.yaml"), []byte("installed:\n  demo:\n    source_path: owner/repo@main\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			inst := &stubInstaller{
+				installed:  []domain.InstalledPackage{{Name: "demo"}},
+				installErr: test.installErr,
+			}
+			manager := newManager(inst, &stubAgentService{}, home)
+			calls := 0
+			manager.SetOnRegistryChange(func() { calls++ })
+
+			job, err := manager.StartUpdate("demo")
+			if err != nil {
+				t.Fatal(err)
+			}
+			waitForJob(t, manager, job.ID)
+			if calls != test.wantCalls {
+				t.Fatalf("hook calls = %d, want %d", calls, test.wantCalls)
+			}
+		})
+	}
+}
+
+func TestSourceFromRegistry(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  string
+		want    string
+		wantErr error
+	}{
+		{name: "resolved ref", source: "owner/repo@sha", want: "https://github.com/owner/repo"},
+		{name: "bare repository", source: "owner/repo", want: "https://github.com/owner/repo"},
+		{name: "subdirectory ref", source: "owner/repo//subdir@ref", want: "https://github.com/owner/repo//subdir"},
+		{name: "at before final subdirectory segment", source: "owner/repo//sub@dir/agent", wantErr: ErrInvalidSource},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := sourceFromRegistry(test.source)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("err = %v, want %v", err, test.wantErr)
+			}
+			if got != test.want {
+				t.Fatalf("source = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestUninstallIsBusyDuringInstallAndSucceedsAfterward(t *testing.T) {
+	release := make(chan struct{})
+	var calls []string
+	inst := &stubInstaller{
+		block:        release,
+		installed:    []domain.InstalledPackage{{Name: "demo"}},
+		afterInstall: []domain.InstalledPackage{{Name: "demo"}},
+		calls:        &calls,
+	}
+	manager := newManager(inst, &stubAgentService{}, t.TempDir())
+	job, err := manager.StartInstall("https://github.com/o/r", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := manager.Uninstall("demo"); !errors.Is(err, ErrBusy) {
+		t.Fatalf("uninstall during install err = %v, want %v", err, ErrBusy)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("calls during install = %v, want none", calls)
+	}
+
+	close(release)
+	if got := waitForJob(t, manager, job.ID); got.Status != StatusSucceeded {
+		t.Fatalf("install status = %s", got.Status)
+	}
+	if err := manager.Uninstall("demo"); err != nil {
+		t.Fatalf("uninstall after install: %v", err)
+	}
+	if got := strings.Join(calls, ","); got != "install,remove:demo" {
+		t.Fatalf("calls = %s", got)
+	}
+}

--- a/desktop/src/main/agents.test.ts
+++ b/desktop/src/main/agents.test.ts
@@ -75,6 +75,20 @@ describe('HTTP agent management', () => {
     expect(client.stopAgent).toHaveBeenCalledBefore(vi.mocked(client.startAgent))
   })
 
+  it('restart does not start when stopping fails', async () => {
+    const client = managementClient({
+      stopAgent: vi.fn(async () => {
+        throw new CpApiError({ status: 500, message: 'could not stop' })
+      })
+    })
+
+    expect(await runAgentAction('restart', 'agent', { cpClient: client })).toEqual({
+      ok: false,
+      message: 'could not stop'
+    })
+    expect(client.startAgent).not.toHaveBeenCalled()
+  })
+
   it('maps server and unreachable errors', async () => {
     const server = managementClient({ startAgent: vi.fn(async () => { throw new CpApiError({ status: 400, message: 'configuration missing' }) }) })
     expect(await runAgentAction('start', 'agent', { cpClient: server })).toEqual({ ok: false, message: 'configuration missing' })
@@ -88,6 +102,32 @@ describe('HTTP agent management', () => {
     expect(client.stopAgent).not.toHaveBeenCalled()
     const old = managementClient({ hasInstallApi: vi.fn(async () => false) })
     expect((await uninstallAgent('agent', { cpClient: old })).message).toMatch(/update AgentField CLI/)
+  })
+
+  it('maps a mid-flight uninstall 404 to the old-control-plane message', async () => {
+    const client = managementClient({
+      uninstallPackage: vi.fn(async () => {
+        throw new CpApiError({ status: 404, message: 'route not found' })
+      })
+    })
+
+    expect(await uninstallAgent('agent', { cpClient: client })).toEqual({
+      ok: false,
+      message: 'Control plane update required — update AgentField CLI'
+    })
+  })
+
+  it('maps an offline uninstall to the management fallback message', async () => {
+    const client = managementClient({
+      uninstallPackage: vi.fn(async () => {
+        throw new TypeError('fetch failed')
+      })
+    })
+
+    expect(await uninstallAgent('agent', { cpClient: client })).toEqual({
+      ok: false,
+      message: 'Could not reach the control plane — start the control plane and try again'
+    })
   })
 })
 

--- a/desktop/src/main/cpClient.test.ts
+++ b/desktop/src/main/cpClient.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
-import { CpApiError, createCpClient, type FetchLike, type InstallJob } from './cpClient'
+import {
+  CpApiError,
+  createCpClient,
+  isInstalledPackage,
+  type FetchLike,
+  type InstallJob,
+  type PackageInfo
+} from './cpClient'
 
 function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -153,6 +160,61 @@ describe('createCpClient', () => {
     expect(lines).toEqual(['one', 'two', 'three'])
   })
 
+  it('reports when a job disappears while it is being watched', async () => {
+    let clock = 0
+    const client = createCpClient({
+      fetchImpl: mockFetch([
+        json(job('running', ['one'])),
+        json({ error: 'not found' }, 404)
+      ]),
+      now: () => clock,
+      sleep: async (ms) => { clock += ms }
+    })
+
+    await expect(
+      client.watchInstallJob('job/1', () => undefined, { intervalMs: 10, timeoutMs: 100 })
+    ).rejects.toThrow('disappeared')
+  })
+
+  it('rethrows non-404 API errors while watching a job', async () => {
+    let clock = 0
+    const failure = new CpApiError({ status: 500, message: 'server failed' })
+    const getInstallJob = vi
+      .fn()
+      .mockResolvedValueOnce(job('running'))
+      .mockRejectedValueOnce(failure)
+    const client = createCpClient({
+      now: () => clock,
+      sleep: async (ms) => { clock += ms }
+    })
+    client.getInstallJob = getInstallJob
+
+    await expect(
+      client.watchInstallJob('job/1', () => undefined, { intervalMs: 10, timeoutMs: 100 })
+    ).rejects.toBe(failure)
+  })
+
+  it('does not replay lines when the retained job log shrinks', async () => {
+    let clock = 0
+    const firstLines = Array.from({ length: 10 }, (_, index) => `line ${index + 1}`)
+    const retainedLines = firstLines.slice(4)
+    const lines: string[] = []
+    const client = createCpClient({
+      fetchImpl: mockFetch([
+        json(job('running', firstLines)),
+        json(job('succeeded', retainedLines))
+      ]),
+      now: () => clock,
+      sleep: async (ms) => { clock += ms }
+    })
+
+    await client.watchInstallJob('job/1', (line) => lines.push(line), {
+      intervalMs: 10,
+      timeoutMs: 100
+    })
+    expect(lines).toEqual(firstLines)
+  })
+
   // Contract 6: polling rejects once its injected deadline is reached.
   it('times out while watching a non-terminal job', async () => {
     let clock = 0
@@ -178,5 +240,44 @@ describe('createCpClient', () => {
     const calls = vi.mocked(fetchImpl).mock.calls
     expect(JSON.parse(String(calls[0][1]?.body))).toEqual({ key: 'TOKEN', value: 'value' })
     expect(calls[1][0]).toBe('http://cp/api/ui/v1/agents/agent/secrets/TOKEN?scope=global')
+  })
+
+  it('omits force from install requests when it is undefined', async () => {
+    const fetchImpl = mockFetch([json({ job_id: 'job' })])
+    const client = createCpClient({ fetchImpl })
+    await client.installPackage('https://github.com/acme/agent')
+
+    expect(JSON.parse(String(vi.mocked(fetchImpl).mock.calls[0][1]?.body))).toEqual({
+      source: 'https://github.com/acme/agent'
+    })
+  })
+})
+
+describe('isInstalledPackage', () => {
+  const pkg = (install_status?: string): PackageInfo =>
+    ({
+      id: 'pkg',
+      name: 'Package',
+      version: '1.0.0',
+      status: 'configured',
+      install_status,
+      install_path: '/tmp/pkg',
+      configuration_required: false,
+      configuration_complete: true,
+      description: '',
+      author: ''
+    })
+
+  it.each([
+    [undefined, true],
+    ['installed', true],
+    ['running', true],
+    ['stopped', true],
+    ['uninstalled', false],
+    ['not_configured', false],
+    ['catalog', false],
+    ['', false]
+  ])('maps install_status %s to %s', (installStatus, expected) => {
+    expect(isInstalledPackage(pkg(installStatus))).toBe(expected)
   })
 })

--- a/desktop/src/main/installer.test.ts
+++ b/desktop/src/main/installer.test.ts
@@ -72,6 +72,24 @@ describe('installFromSource', () => {
     expect(lines).toEqual([])
     expect(result.message).toMatch(/github\.com/)
   })
+
+  it('installs a normalized GitHub source without force', async () => {
+    const client = installClient()
+    const result = await installFromSource(
+      '  https://github.com/Agent-Field/pr-af/  ',
+      () => {},
+      { cpClient: client }
+    )
+
+    expect(client.installPackage).toHaveBeenCalledWith(
+      'https://github.com/Agent-Field/pr-af',
+      undefined
+    )
+    expect(result).toEqual({
+      ok: true,
+      message: 'Installed from https://github.com/Agent-Field/pr-af'
+    })
+  })
 })
 
 function installClient(overrides: Partial<CpClient> = {}): CpClient {
@@ -97,12 +115,88 @@ describe('control-plane installs', () => {
     expect(await installAgent(CATALOG[0].name, () => {}, false, { cpClient: failed })).toEqual({ ok: false, message: 'clone failed' })
   })
 
+  it('forwards force for reinstall-in-place updates', async () => {
+    const client = installClient()
+    await installAgent(CATALOG[0].name, () => {}, true, { cpClient: client })
+    expect(client.installPackage).toHaveBeenCalledWith(CATALOG[0].source, true)
+  })
+
   it('surfaces conflict and old-control-plane errors without fallback', async () => {
     const conflict = installClient({ installPackage: vi.fn(async () => { throw new CpApiError({ status: 409, message: 'another install is running' }) }) })
     expect((await installAgent(CATALOG[0].name, () => {}, false, { cpClient: conflict })).message).toMatch(/another install/i)
     const old = installClient({ hasInstallApi: vi.fn(async () => false) })
     expect((await installAgent(CATALOG[0].name, () => {}, false, { cpClient: old })).message).toMatch(/update AgentField CLI/)
     expect((await updateAgent(CATALOG[0].name, () => {}, { cpClient: old })).message).toMatch(/update AgentField CLI/)
+  })
+
+  it('maps mid-request 404s to the update-required result', async () => {
+    const missing = new CpApiError({ status: 404, message: 'not found' })
+    const install = installClient({
+      installPackage: vi.fn(async () => { throw missing })
+    })
+    expect(await installAgent(CATALOG[0].name, () => {}, false, { cpClient: install })).toEqual({
+      ok: false,
+      message: 'Control plane update required — update AgentField CLI'
+    })
+
+    const update = installClient({
+      updatePackage: vi.fn(async () => { throw missing })
+    })
+    expect(await updateAgent(CATALOG[0].name, () => {}, { cpClient: update })).toEqual({
+      ok: false,
+      message: 'Control plane update required — update AgentField CLI'
+    })
+  })
+
+  it('reports network failures during install', async () => {
+    const client = installClient({
+      installPackage: vi.fn(async () => { throw new TypeError('offline') })
+    })
+    expect(await installAgent(CATALOG[0].name, () => {}, false, { cpClient: client })).toEqual({
+      ok: false,
+      message: 'Could not reach the control plane — start the control plane and try again'
+    })
+  })
+
+  it('falls back from a failed job error to its last line and then a default', async () => {
+    const failedWithLine = installClient({
+      watchInstallJob: vi.fn(async () => ({
+        id: 'job',
+        source: '',
+        kind: 'install' as const,
+        status: 'failed' as const,
+        lines: ['clone failed']
+      }))
+    })
+    expect(await installAgent(CATALOG[0].name, () => {}, false, { cpClient: failedWithLine })).toEqual({
+      ok: false,
+      message: 'clone failed'
+    })
+
+    const failedEmpty = installClient({
+      watchInstallJob: vi.fn(async () => ({
+        id: 'job',
+        source: '',
+        kind: 'install' as const,
+        status: 'failed' as const,
+        lines: []
+      }))
+    })
+    expect(await installAgent(CATALOG[0].name, () => {}, false, { cpClient: failedEmpty })).toEqual({
+      ok: false,
+      message: 'Install failed'
+    })
+  })
+
+  it('rejects unknown catalog names at the async function boundary', async () => {
+    await expect(installAgent('not-in-catalog', () => {})).resolves.toEqual({
+      ok: false,
+      message: '"not-in-catalog" is not in the install catalog'
+    })
+    await expect(updateAgent('not-in-catalog', () => {})).resolves.toEqual({
+      ok: false,
+      message: '"not-in-catalog" is not in the install catalog'
+    })
   })
 })
 

--- a/desktop/src/main/secrets.test.ts
+++ b/desktop/src/main/secrets.test.ts
@@ -5,8 +5,10 @@ import {
   buildEnvReport,
   buildSecretsInventory,
   findSpecVar,
+  listStoredSecrets,
   parseSecretsTable,
   parseUserEnvironment,
+  revokeStoredSecret,
   specIsEmpty
 } from './secrets'
 import { getEnvReports, revokeAgentSecret, setAgentSecret } from './secrets'
@@ -257,5 +259,172 @@ describe('control-plane secret management', () => {
     await revokeAgentSecret('agent-id', 'SET_KEY', { cpClient })
     expect(cpClient.setAgentSecret).toHaveBeenCalledWith('agent-id', 'SET_KEY', 'value')
     expect(cpClient.deleteAgentSecret).toHaveBeenCalledWith('agent-id', 'SET_KEY')
+  })
+
+  it.each(['', '   \t\n'])('rejects an empty secret value without issuing a PUT', async (value) => {
+    const cpClient = client()
+    expect(await setAgentSecret('agent-id', 'SET_KEY', value, { cpClient })).toEqual({
+      ok: false,
+      message: 'value must not be empty'
+    })
+    expect(cpClient.setAgentSecret).not.toHaveBeenCalled()
+  })
+
+  it('short-circuits deletion for a declared but unset key', async () => {
+    const cpClient = client()
+    expect(await revokeAgentSecret('agent-id', 'UNSET_KEY', { cpClient })).toEqual({
+      ok: true,
+      message: 'UNSET_KEY is not stored'
+    })
+    expect(cpClient.deleteAgentSecret).not.toHaveBeenCalled()
+  })
+
+  it('excludes catalog rows from environment reports', async () => {
+    const catalog = { ...pkg, id: 'catalog-id', name: 'catalog', install_status: 'uninstalled' }
+    const cpClient = client()
+    vi.mocked(cpClient.listPackages).mockResolvedValue({
+      packages: [{ ...pkg, install_status: 'installed' }, catalog],
+      total: 2
+    })
+
+    const reports = await getEnvReports({ cpClient })
+
+    expect(reports.map(({ agent }) => agent)).toEqual(['agent'])
+    expect(cpClient.listAgentSecrets).toHaveBeenCalledTimes(1)
+    expect(cpClient.listAgentSecrets).not.toHaveBeenCalledWith('catalog-id')
+  })
+
+  it('returns the error sentinel when package listing fails', async () => {
+    const cpClient = client()
+    vi.mocked(cpClient.listPackages).mockRejectedValue(
+      new TypeError('fetch failed')
+    )
+
+    expect(await getEnvReports({ cpClient })).toEqual([{
+      agent: '',
+      vars: [],
+      satisfied: false,
+      error: 'Could not reach the control plane — start the control plane and try again'
+    }])
+  })
+})
+
+describe('stored secret inventory', () => {
+  const basePackage: PackageInfo = {
+    id: 'base', name: 'base', version: '1', status: 'stopped',
+    install_path: '/pkg', configuration_required: true, configuration_complete: false,
+    description: '', author: ''
+  }
+
+  function inventoryClient(): CpClient {
+    const packages: PackageInfo[] = [
+      { ...basePackage, id: 'alpha-id', name: 'alpha', install_status: 'installed' },
+      { ...basePackage, id: 'beta-id', name: 'beta', install_status: 'running' },
+      { ...basePackage, id: 'gamma-id', name: 'gamma' },
+      { ...basePackage, id: 'catalog-id', name: 'catalog', install_status: 'uninstalled' }
+    ]
+    return {
+      listPackages: vi.fn(async () => ({ packages, total: packages.length })),
+      listAllSecrets: vi.fn(async () => ({
+        secrets: [
+          { key: 'GLOBAL_KEY', scope: 'global' },
+          { key: 'ID_KEY', scope: 'beta-id' },
+          { key: 'NAME_KEY', scope: 'gamma' }
+        ]
+      })),
+      listAgentSecrets: vi.fn(async (agent: string) => ({
+        secrets: agent === 'alpha-id'
+          ? [{ key: 'GLOBAL_KEY', is_set: true, scope: 'global' as const }]
+          : agent === 'beta-id'
+            ? [{ key: 'ID_KEY', is_set: true, scope: 'node' as const }]
+            : [{ key: 'NAME_KEY', is_set: true, scope: 'node' as const }]
+      })),
+      deleteAgentSecret: vi.fn(async () => {})
+    } as unknown as CpClient
+  }
+
+  it('lists only installed declarations and joins global, package-id, and package-name scopes', async () => {
+    const cpClient = inventoryClient()
+
+    expect(await listStoredSecrets({ cpClient })).toEqual({
+      secrets: [
+        { key: 'GLOBAL_KEY', scope: 'global', usedBy: ['alpha'] },
+        { key: 'ID_KEY', scope: 'beta-id', usedBy: ['beta'] },
+        { key: 'NAME_KEY', scope: 'gamma', usedBy: ['gamma'] }
+      ]
+    })
+    expect(cpClient.listAgentSecrets).toHaveBeenCalledTimes(3)
+    expect(cpClient.listAgentSecrets).not.toHaveBeenCalledWith('catalog-id')
+  })
+
+  it('returns an empty inventory and error when one declaration lookup fails', async () => {
+    const cpClient = inventoryClient()
+    vi.mocked(cpClient.listAgentSecrets).mockImplementation(async (agent) => {
+      if (agent === 'beta-id') throw new TypeError('fetch failed')
+      return { secrets: [] }
+    })
+
+    expect(await listStoredSecrets({ cpClient })).toEqual({
+      secrets: [],
+      error: 'Could not reach the control plane — start the control plane and try again'
+    })
+  })
+
+  it('reports a missing scoped secret without deleting', async () => {
+    const cpClient = inventoryClient()
+    vi.mocked(cpClient.listAllSecrets).mockResolvedValue({ secrets: [] })
+
+    expect(await revokeStoredSecret('MISSING', 'alpha', { cpClient })).toEqual({
+      ok: false,
+      message: 'MISSING is not stored in the alpha scope'
+    })
+    expect(cpClient.deleteAgentSecret).not.toHaveBeenCalled()
+  })
+
+  it('deletes a node-scoped secret through its declaring agent', async () => {
+    const cpClient = inventoryClient()
+    vi.mocked(cpClient.listAllSecrets).mockResolvedValue({
+      secrets: [{ key: 'NODE_KEY', scope: 'alpha-id' }]
+    })
+
+    expect(await revokeStoredSecret('NODE_KEY', 'alpha-id', { cpClient })).toEqual({
+      ok: true,
+      message: 'NODE_KEY removed for alpha-id'
+    })
+    expect(cpClient.deleteAgentSecret).toHaveBeenCalledWith('alpha-id', 'NODE_KEY')
+  })
+
+  it('scans installed agents and deletes a global secret through a capable one', async () => {
+    const cpClient = inventoryClient()
+    vi.mocked(cpClient.listAllSecrets).mockResolvedValue({
+      secrets: [{ key: 'GLOBAL_KEY', scope: 'global' }]
+    })
+    vi.mocked(cpClient.listAgentSecrets).mockImplementation(async (agent) => ({
+      secrets: agent === 'beta-id'
+        ? [{ key: 'GLOBAL_KEY', is_set: true, scope: 'global' as const }]
+        : []
+    }))
+
+    expect(await revokeStoredSecret('GLOBAL_KEY', 'global', { cpClient })).toEqual({
+      ok: true,
+      message: 'GLOBAL_KEY removed for all agents'
+    })
+    expect(cpClient.deleteAgentSecret).toHaveBeenCalledWith('beta-id', 'GLOBAL_KEY')
+    expect(cpClient.listAgentSecrets).not.toHaveBeenCalledWith('catalog-id')
+  })
+
+  it('explains when no installed agent can remove a global secret', async () => {
+    const cpClient = inventoryClient()
+    vi.mocked(cpClient.listAllSecrets).mockResolvedValue({
+      secrets: [{ key: 'ORPHANED', scope: 'global' }]
+    })
+    vi.mocked(cpClient.listAgentSecrets).mockResolvedValue({ secrets: [] })
+
+    expect(await revokeStoredSecret('ORPHANED', 'global', { cpClient })).toEqual({
+      ok: false,
+      message: 'no installed agent can remove ORPHANED'
+    })
+    expect(cpClient.deleteAgentSecret).not.toHaveBeenCalled()
+    expect(cpClient.listAgentSecrets).not.toHaveBeenCalledWith('catalog-id')
   })
 })


### PR DESCRIPTION
## Summary

Test-hardening pass over the package install/uninstall/sync surfaces that #837/#841/#842/#843 built, in preparation for the desktop cloud-mode UI work. Closes the behavior-level gaps a coverage audit found: cross-repo wire contracts, reconcile preservation semantics, and previously-untested CLI/desktop paths. Includes three small fixes the new tests forced out.

## Fixes (all surfaced by writing the missing tests)

- **Registry sync kept the wrong install time**: net-new DB rows created by `SyncPackagesFromRegistry` were stamped with the sync time instead of the registry entry's `installed_at`.
- **Uninstall could race an in-flight install job**: `Manager.Uninstall` now takes the active-job slot and returns `ErrBusy` (mapped to 409) instead of interleaving.
- **`af uninstall --force` leaked across invocations**: the flag was a package-level global; now scoped per command construction.

## New test coverage

- **Wire contract, producer side**: `install_status` vocabulary and `installed_at` (RFC3339 UTC, omitted when zero) asserted on the packages listing — the fields the desktop's install filter consumes. Exact method+path registration tests for all six package-management routes, and the uninstall handler test now uses POST like the real route.
- **Reconcile semantics**: timestamp fidelity, `InstalledAt`/`ConfigurationStatus` preservation across re-syncs, idempotence, storage-failure tolerance, and a wiring test proving a job-manager uninstall reaches the packages DB through the registry-change hook.
- **Job manager**: hook-before-`succeeded` ordering (the read-your-writes guarantee), update-path hook, `sourceFromRegistry` ref stripping, uninstall-vs-install race. Package stays at 100% coverage.
- **CLI**: first behavioral tests for `af uninstall` (removal, running-package refusal, force-kill, flag isolation) and `af install --path` threading.
- **Desktop** (+32 tests, 291 → 323): `watchInstallJob` job-eviction and log-cap shrink guard, mid-flight 404 version skew in install/update/uninstall, `isInstalledPackage` fail-open for old CPs, `listStoredSecrets`/`revokeStoredSecret` (previously zero coverage), and the catalog-row filter at all three secrets call sites.

## Validation

- Full control-plane suite green locally (`-tags sqlite_fts5`); the one failure, `TestStartAndStopCoverAdditionalBranches`, fails identically on pristine main on this machine (local-environment artifact, green in CI).
- Patch coverage: every touched production function at 100%.
- Desktop: `typecheck`, 323/323 tests, `dist:dir` all green on Node 22.
- Zero lint findings in touched files.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)