### PR TITLE
feat(desktop): cloud mode — connect the desktop to a remote control plane

### DIFF
--- a/desktop/src/main/agentfield.test.ts
+++ b/desktop/src/main/agentfield.test.ts
@@ -290,6 +290,11 @@ describe('fetchControlPlaneNodes', () => {
     )
   })
 
+  it('treats a null nodes slice as an empty control-plane view', async () => {
+    const fetchImpl: FetchLike = async () => jsonResponse({ nodes: null, count: 0 })
+    expect(await fetchControlPlaneNodes('http://localhost:8080', fetchImpl)).toEqual(new Map())
+  })
+
   it('returns null on a non-200 response', async () => {
     const fetchImpl: FetchLike = async () => jsonResponse({ error: 'nope' }, 500)
     expect(await fetchControlPlaneNodes('http://localhost:8080', fetchImpl)).toBeNull()
@@ -356,6 +361,15 @@ describe('fetchExecutions', () => {
       durationMs: 45,
       terminal: true,
       errorMessage: null
+    })
+  })
+
+  it('treats a null runs slice as empty activity', async () => {
+    const fetchImpl: FetchLike = async () =>
+      jsonResponse({ runs: null, total_count: 0 })
+    await expect(fetchExecutions('http://localhost:8080', fetchImpl)).resolves.toEqual({
+      running: [],
+      recent: []
     })
   })
 

--- a/desktop/src/main/agentfield.test.ts
+++ b/desktop/src/main/agentfield.test.ts
@@ -7,6 +7,7 @@ import {
   checkControlPlane,
   deriveAgentBadge,
   fetchControlPlaneNodes,
+  fetchDashboardMetrics,
   fetchExecutions,
   fetchUsageStats,
   getAgentFieldHome,
@@ -19,6 +20,7 @@ import {
 import { DEFAULT_CONTROL_PLANE_PORT } from './ports'
 import { installCommand, sanitizeInstallOutput } from './installer'
 import { CATALOG, catalogEntry } from '../shared/catalog'
+import { setCloudConnection } from './connection'
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -64,6 +66,51 @@ describe('active base URL', () => {
     }
     await checkControlPlane(undefined, fetchImpl)
     expect(seen).toEqual(['http://localhost:9091/health'])
+  })
+})
+
+describe('raw control-plane fetch authentication', () => {
+  afterEach(() => setActiveControlPlanePort(DEFAULT_CONTROL_PLANE_PORT))
+
+  async function callRawReaders(fetchImpl: FetchLike): Promise<void> {
+    await checkControlPlane(undefined, fetchImpl)
+    await fetchControlPlaneNodes(undefined, fetchImpl)
+    await fetchExecutions(undefined, fetchImpl)
+    await fetchDashboardMetrics(undefined, fetchImpl)
+    await fetchUsageStats(undefined, fetchImpl)
+  }
+
+  it('adds X-API-Key to every raw reader in cloud mode', async () => {
+    setCloudConnection('https://cp.example', 'cloud-key')
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/health')) return jsonResponse({ status: 'healthy' })
+      if (url.includes('/nodes')) return jsonResponse({ nodes: [] })
+      if (url.includes('/workflow-runs')) return jsonResponse({ runs: [] })
+      if (url.includes('/dashboard/summary')) return jsonResponse({})
+      return jsonResponse({ totals: {} })
+    }) as FetchLike
+    await callRawReaders(fetchImpl)
+    expect(vi.mocked(fetchImpl).mock.calls).toHaveLength(5)
+    for (const [, init] of vi.mocked(fetchImpl).mock.calls) {
+      expect(new Headers(init?.headers).get('X-API-Key')).toBe('cloud-key')
+    }
+  })
+
+  it('omits X-API-Key from every raw reader in local mode', async () => {
+    setActiveControlPlanePort(8080)
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/health')) return jsonResponse({ status: 'healthy' })
+      if (url.includes('/nodes')) return jsonResponse({ nodes: [] })
+      if (url.includes('/workflow-runs')) return jsonResponse({ runs: [] })
+      if (url.includes('/dashboard/summary')) return jsonResponse({})
+      return jsonResponse({ totals: {} })
+    }) as FetchLike
+    await callRawReaders(fetchImpl)
+    for (const [, init] of vi.mocked(fetchImpl).mock.calls) {
+      expect(new Headers(init?.headers).has('X-API-Key')).toBe(false)
+    }
   })
 })
 

--- a/desktop/src/main/agentfield.ts
+++ b/desktop/src/main/agentfield.ts
@@ -160,9 +160,11 @@ export async function fetchControlPlaneNodes(
     })
     if (!res.ok) return null
     const body: unknown = await res.json()
-    if (!isRecord(body) || !Array.isArray(body.nodes)) return null
+    if (!isRecord(body) || !('nodes' in body)) return null
+    const nodes = body.nodes ?? []
+    if (!Array.isArray(nodes)) return null
     const health = new Map<string, string>()
-    for (const node of body.nodes) {
+    for (const node of nodes) {
       if (!isRecord(node) || typeof node.id !== 'string' || node.id === '') continue
       health.set(node.id, typeof node.health_status === 'string' ? node.health_status : 'unknown')
     }
@@ -249,8 +251,10 @@ export async function fetchExecutions(
     )
     if (!res.ok) return null
     const body: unknown = await res.json()
-    if (!isRecord(body) || !Array.isArray(body.runs)) return null
-    const summaries = body.runs
+    if (!isRecord(body) || !('runs' in body)) return null
+    const runs = body.runs ?? []
+    if (!Array.isArray(runs)) return null
+    const summaries = runs
       .filter(isRecord)
       .map(toExecutionSummary)
       .filter((s): s is ExecutionSummary => s !== null)

--- a/desktop/src/main/agentfield.ts
+++ b/desktop/src/main/agentfield.ts
@@ -20,6 +20,7 @@ import type {
 
 import { DEFAULT_CONTROL_PLANE_PORT, baseUrlForPort } from './ports'
 import { createCpClient, isInstalledPackage, type CpClient, type PackageInfo } from './cpClient'
+import * as connection from './connection'
 
 export const DEFAULT_BASE_URL = baseUrlForPort(DEFAULT_CONTROL_PLANE_PORT)
 
@@ -30,14 +31,12 @@ export const DEFAULT_BASE_URL = baseUrlForPort(DEFAULT_CONTROL_PLANE_PORT)
 // the tray, open-web-ui, AGENTFIELD_SERVER for spawned `af` — reads it via
 // getBaseUrl() so nothing in the app hard-codes 8080.
 
-let activeBaseUrl = DEFAULT_BASE_URL
-
 export function getBaseUrl(): string {
-  return activeBaseUrl
+  return connection.getBaseUrl()
 }
 
 export function setActiveControlPlanePort(port: number): void {
-  activeBaseUrl = baseUrlForPort(port)
+  connection.setLocalPort(port)
 }
 
 const HTTP_TIMEOUT_MS = 3000
@@ -59,6 +58,13 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
 
+function authHeaders(): Headers {
+  const headers = new Headers()
+  const apiKey = connection.getApiKey()
+  if (apiKey !== null) headers.set('X-API-Key', apiKey)
+  return headers
+}
+
 /**
  * Probe GET {baseUrl}/health.
  *  - 200 {"status":"healthy",...}   -> { reachable: true, recognized: true,  healthy: true }
@@ -76,6 +82,7 @@ export async function checkControlPlane(
 ): Promise<ControlPlaneStatus> {
   try {
     const res = await fetchImpl(`${baseUrl}/health`, {
+      headers: authHeaders(),
       signal: AbortSignal.timeout(HTTP_TIMEOUT_MS)
     })
     let raw: unknown
@@ -148,6 +155,7 @@ export async function fetchControlPlaneNodes(
 ): Promise<Map<string, string> | null> {
   try {
     const res = await fetchImpl(`${baseUrl}/api/v1/nodes?show_all=true`, {
+      headers: authHeaders(),
       signal: AbortSignal.timeout(HTTP_TIMEOUT_MS)
     })
     if (!res.ok) return null
@@ -237,7 +245,7 @@ export async function fetchExecutions(
   try {
     const res = await fetchImpl(
       `${baseUrl}/api/ui/v2/workflow-runs?page=1&page_size=25&sort_by=updated_at&sort_order=desc`,
-      { signal: AbortSignal.timeout(HTTP_TIMEOUT_MS) }
+      { headers: authHeaders(), signal: AbortSignal.timeout(HTTP_TIMEOUT_MS) }
     )
     if (!res.ok) return null
     const body: unknown = await res.json()
@@ -265,6 +273,7 @@ export async function fetchDashboardMetrics(
 ): Promise<DashboardMetrics | null> {
   try {
     const res = await fetchImpl(`${baseUrl}/api/ui/v1/dashboard/summary`, {
+      headers: authHeaders(),
       signal: AbortSignal.timeout(HTTP_TIMEOUT_MS)
     })
     if (!res.ok) return null
@@ -306,11 +315,12 @@ function parseUsageGroups(value: unknown): UsageGroup[] {
  * the whole Home. Never throws across IPC.
  */
 export async function fetchUsageStats(
-  baseUrl: string = DEFAULT_BASE_URL,
+  baseUrl: string = getBaseUrl(),
   fetchImpl: FetchLike = fetch
 ): Promise<UsageStats | null> {
   try {
     const res = await fetchImpl(`${baseUrl}/api/ui/v1/usage/stats?window=24h`, {
+      headers: authHeaders(),
       signal: AbortSignal.timeout(HTTP_TIMEOUT_MS)
     })
     if (res.status === 404 || res.status === 401 || res.status === 403) return null

--- a/desktop/src/main/autostart.test.ts
+++ b/desktop/src/main/autostart.test.ts
@@ -4,6 +4,7 @@ import {
   autostartAgentPlan,
   controlPlanePortCandidates,
   planControlPlaneBoot,
+  runAutostart,
   type PortProbe
 } from './autostart'
 
@@ -20,8 +21,39 @@ function agent(name: string, badge: SnapshotAgent['badge']): SnapshotAgent {
   }
 }
 
+describe('runAutostart cloud mode', () => {
+  it('only checks and reports the active remote control plane', async () => {
+    let checks = 0
+    let persisted = 0
+    const logs: string[] = []
+    await runAutostart(
+      settings({
+        cloud: { enabled: true, serverUrl: 'https://cloud.example', apiKey: 'secret' },
+        autostartAgents: ['must-not-start']
+      }),
+      (line) => logs.push(line),
+      async () => {
+        persisted++
+      },
+      {
+        getBaseUrl: () => 'https://cloud.example',
+        checkControlPlane: async () => {
+          checks++
+          return { reachable: true, recognized: true, healthy: true }
+        }
+      }
+    )
+    expect(checks).toBe(1)
+    expect(persisted).toBe(0)
+    expect(logs).toEqual([
+      'autostart: remote control plane reachable at https://cloud.example'
+    ])
+  })
+})
+
 function settings(overrides: Partial<DesktopSettings>): DesktopSettings {
   return {
+    cloud: { enabled: false, serverUrl: '', apiKey: '' },
     openAtLogin: false,
     appearance: 'system',
     autostartControlPlane: true,

--- a/desktop/src/main/autostart.ts
+++ b/desktop/src/main/autostart.ts
@@ -20,7 +20,7 @@ import type {
   DesktopSettings,
   SnapshotAgent
 } from '../shared/types'
-import { checkControlPlane, getSnapshot, setActiveControlPlanePort } from './agentfield'
+import { checkControlPlane, getBaseUrl, getSnapshot, setActiveControlPlanePort } from './agentfield'
 import { runAgentAction, startControlPlane } from './agents'
 import { DEFAULT_CONTROL_PLANE_PORT, baseUrlForPort, pickFreePort } from './ports'
 
@@ -128,8 +128,20 @@ export function planControlPlaneBoot(
 export async function runAutostart(
   settings: DesktopSettings,
   log: (message: string) => void,
-  persistPort: (port: number) => Promise<void> = async () => {}
+  persistPort: (port: number) => Promise<void> = async () => {},
+  deps: { checkControlPlane?: typeof checkControlPlane; getBaseUrl?: typeof getBaseUrl } = {}
 ): Promise<void> {
+  if (settings.cloud.enabled) {
+    const baseUrl = (deps.getBaseUrl ?? getBaseUrl)()
+    const status = await (deps.checkControlPlane ?? checkControlPlane)()
+    log(
+      status.reachable
+        ? `autostart: remote control plane reachable at ${baseUrl}`
+        : `autostart: remote control plane unreachable at ${baseUrl}`
+    )
+    return
+  }
+
   const probes: PortProbe[] = []
   for (const port of controlPlanePortCandidates(settings)) {
     probes.push({ port, status: await checkControlPlane(baseUrlForPort(port)) })

--- a/desktop/src/main/cloud.test.ts
+++ b/desktop/src/main/cloud.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getApiKey, getBaseUrl, setLocalPort } from './connection'
+import { applyConnectionProfile, normalizeServerUrl, testCloudConnection } from './cloud'
+import { DEFAULT_SETTINGS } from './settings'
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  })
+}
+
+function fakeFetch(responses: Array<Response | Error>): typeof fetch {
+  return vi.fn(async () => {
+    const next = responses.shift()
+    if (next instanceof Error) throw next
+    if (!next) throw new Error('unexpected fetch')
+    return next
+  }) as unknown as typeof fetch
+}
+
+afterEach(() => setLocalPort(8080))
+
+describe('normalizeServerUrl', () => {
+  it('normalizes host input and removes paths, queries, and trailing slashes', () => {
+    expect(normalizeServerUrl(' cp.example/path/?x=1 ')).toBe('https://cp.example')
+    expect(normalizeServerUrl('https://cp.example:8443///')).toBe('https://cp.example:8443')
+  })
+
+  it('allows insecure HTTP only on local and private hosts', () => {
+    expect(normalizeServerUrl('http://localhost:8080/ui')).toBe('http://localhost:8080')
+    expect(normalizeServerUrl('http://127.0.0.1:8080')).toBe('http://127.0.0.1:8080')
+    expect(normalizeServerUrl('http://10.2.3.4')).toBe('http://10.2.3.4')
+    expect(normalizeServerUrl('http://172.16.1.2')).toBe('http://172.16.1.2')
+    expect(normalizeServerUrl('http://192.168.1.2')).toBe('http://192.168.1.2')
+    expect(normalizeServerUrl('http://cp.example')).toBeNull()
+  })
+
+  it('rejects empty and malformed input', () => {
+    expect(normalizeServerUrl('')).toBeNull()
+    expect(normalizeServerUrl(':// bad')).toBeNull()
+    expect(normalizeServerUrl('ftp://cp.example')).toBeNull()
+  })
+})
+
+describe('testCloudConnection', () => {
+  it('reports healthy authenticated servers, install support, and health version', async () => {
+    const fetchImpl = fakeFetch([
+      json({ status: 'healthy', version: '1.2.3' }),
+      json({ packages: [] }),
+      json([])
+    ])
+    await expect(
+      testCloudConnection('cp.example/', 'secret', { fetchImpl })
+    ).resolves.toEqual({
+      ok: true,
+      healthy: true,
+      authOk: true,
+      installApi: true,
+      version: '1.2.3',
+      message: 'Connection successful'
+    })
+    for (const [, init] of vi.mocked(fetchImpl).mock.calls) {
+      expect(new Headers(init?.headers).get('X-API-Key')).toBe('secret')
+      expect(init?.signal).toBeInstanceOf(AbortSignal)
+    }
+  })
+
+  it('distinguishes a rejected API key', async () => {
+    const fetchImpl = fakeFetch([json({ status: 'healthy' }), json({}, 401)])
+    await expect(testCloudConnection('https://cp.example', 'bad', { fetchImpl })).resolves.toEqual({
+      ok: false,
+      healthy: true,
+      authOk: false,
+      installApi: false,
+      message: 'API key rejected'
+    })
+  })
+
+  it('distinguishes an unreachable server', async () => {
+    const fetchImpl = fakeFetch([new Error('offline')])
+    await expect(testCloudConnection('https://cp.example/', 'key', { fetchImpl })).resolves.toEqual({
+      ok: false,
+      healthy: false,
+      authOk: false,
+      installApi: false,
+      message: 'Could not reach https://cp.example'
+    })
+  })
+
+  it('reports an older control plane without install API and discovers version separately', async () => {
+    const fetchImpl = fakeFetch([
+      json({ status: 'healthy' }),
+      json({ packages: [] }),
+      json({}, 404),
+      json({ server_version: '0.9.0' })
+    ])
+    await expect(
+      testCloudConnection('https://cp.example', 'key', { fetchImpl })
+    ).resolves.toEqual({
+      ok: true,
+      healthy: true,
+      authOk: true,
+      installApi: false,
+      version: '0.9.0',
+      message: 'Connected; install API unavailable'
+    })
+  })
+
+  it('omits an unknown version', async () => {
+    const fetchImpl = fakeFetch([
+      json({ status: 'healthy' }),
+      json({ packages: [] }),
+      json([]),
+      json({}, 404)
+    ])
+    const result = await testCloudConnection('https://cp.example', 'key', { fetchImpl })
+    expect(result.ok).toBe(true)
+    expect(result).not.toHaveProperty('version')
+  })
+})
+
+describe('applyConnectionProfile', () => {
+  it('applies an enabled normalized profile and clears it when disabled', () => {
+    setLocalPort(9091)
+    applyConnectionProfile({
+      ...DEFAULT_SETTINGS,
+      cloud: { enabled: true, serverUrl: ' cp.example/path ', apiKey: 'secret' }
+    })
+    expect(getBaseUrl()).toBe('https://cp.example')
+    expect(getApiKey()).toBe('secret')
+    applyConnectionProfile(DEFAULT_SETTINGS)
+    expect(getBaseUrl()).toBe('http://localhost:9091')
+    expect(getApiKey()).toBeNull()
+  })
+})

--- a/desktop/src/main/cloud.ts
+++ b/desktop/src/main/cloud.ts
@@ -1,0 +1,184 @@
+import type { CloudTestResult, DesktopSettings } from '../shared/types'
+import { clearCloudConnection, setCloudConnection } from './connection'
+
+export type { CloudTestResult } from '../shared/types'
+
+function isPrivateHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '')
+  if (host === 'localhost' || host === '::1') return true
+  const parts = host.split('.').map(Number)
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+    return false
+  }
+  return (
+    parts[0] === 10 ||
+    parts[0] === 127 ||
+    (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
+    (parts[0] === 192 && parts[1] === 168)
+  )
+}
+
+export function normalizeServerUrl(input: string): string | null {
+  const trimmed = input.trim()
+  if (!trimmed) return null
+  const candidate = /^[a-z][a-z\d+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`
+  try {
+    const parsed = new URL(candidate)
+    if (!parsed.hostname || parsed.username || parsed.password) return null
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return null
+    if (parsed.protocol === 'http:' && !isPrivateHost(parsed.hostname)) return null
+    return parsed.origin
+  } catch {
+    return null
+  }
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function versionFrom(value: unknown): string | undefined {
+  const body = record(value)
+  if (!body) return undefined
+  for (const key of ['version', 'server_version', 'build_version']) {
+    if (typeof body[key] === 'string' && body[key] !== '') return body[key] as string
+  }
+  const build = record(body.build)
+  return build && typeof build.version === 'string' && build.version !== ''
+    ? build.version
+    : undefined
+}
+
+async function jsonBestEffort(response: Response): Promise<unknown> {
+  try {
+    return await response.json()
+  } catch {
+    return undefined
+  }
+}
+
+export async function testCloudConnection(
+  url: string,
+  apiKey: string,
+  deps: { fetchImpl?: typeof fetch } = {}
+): Promise<CloudTestResult> {
+  const normalized = normalizeServerUrl(url)
+  if (!normalized) {
+    return {
+      ok: false,
+      healthy: false,
+      authOk: false,
+      installApi: false,
+      message: 'Enter a valid server URL'
+    }
+  }
+  const fetchImpl = deps.fetchImpl ?? globalThis.fetch
+  const headers = { 'X-API-Key': apiKey }
+
+  let health: Response
+  try {
+    health = await fetchImpl(`${normalized}/health`, {
+      method: 'GET',
+      headers,
+      signal: AbortSignal.timeout(5000)
+    })
+  } catch {
+    return {
+      ok: false,
+      healthy: false,
+      authOk: false,
+      installApi: false,
+      message: `Could not reach ${normalized}`
+    }
+  }
+
+  const healthBody = await jsonBestEffort(health)
+  const healthy = health.ok
+  let version = versionFrom(healthBody)
+  if (!healthy) {
+    return {
+      ok: false,
+      healthy: false,
+      authOk: false,
+      installApi: false,
+      ...(version ? { version } : {}),
+      message: `Control plane at ${normalized} is not healthy`
+    }
+  }
+
+  let authResponse: Response
+  try {
+    authResponse = await fetchImpl(`${normalized}/api/ui/v1/agents/packages`, {
+      method: 'GET',
+      headers,
+      signal: AbortSignal.timeout(5000)
+    })
+  } catch {
+    return {
+      ok: false,
+      healthy: true,
+      authOk: false,
+      installApi: false,
+      ...(version ? { version } : {}),
+      message: 'Could not verify API access'
+    }
+  }
+  const authOk = authResponse.ok
+  if (!authOk) {
+    return {
+      ok: false,
+      healthy: true,
+      authOk: false,
+      installApi: false,
+      ...(version ? { version } : {}),
+      message:
+        authResponse.status === 401 || authResponse.status === 403
+          ? 'API key rejected'
+          : `API request failed with status ${authResponse.status}`
+    }
+  }
+
+  let installApi = false
+  try {
+    const installResponse = await fetchImpl(
+      `${normalized}/api/ui/v1/agents/packages/install/jobs`,
+      { method: 'GET', headers, signal: AbortSignal.timeout(5000) }
+    )
+    installApi = installResponse.status !== 404
+  } catch {
+    installApi = false
+  }
+
+  if (!version) {
+    try {
+      const versionResponse = await fetchImpl(`${normalized}/api/v1/version`, {
+        method: 'GET',
+        headers,
+        signal: AbortSignal.timeout(5000)
+      })
+      if (versionResponse.ok) version = versionFrom(await jsonBestEffort(versionResponse))
+    } catch {
+      // Version discovery is best-effort.
+    }
+  }
+
+  return {
+    ok: true,
+    healthy: true,
+    authOk: true,
+    installApi,
+    ...(version ? { version } : {}),
+    message: installApi ? 'Connection successful' : 'Connected; install API unavailable'
+  }
+}
+
+export function applyConnectionProfile(settings: DesktopSettings): void {
+  const normalized = normalizeServerUrl(settings.cloud?.serverUrl ?? '')
+  if (settings.cloud?.enabled && normalized) {
+    setCloudConnection(normalized, settings.cloud.apiKey || null)
+  } else {
+    clearCloudConnection()
+  }
+}

--- a/desktop/src/main/connection.test.ts
+++ b/desktop/src/main/connection.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  clearCloudConnection,
+  getApiKey,
+  getBaseUrl,
+  isCloudActive,
+  setCloudConnection,
+  setLocalPort
+} from './connection'
+
+afterEach(() => setLocalPort(8080))
+
+describe('connection state', () => {
+  it('switches to cloud and restores the last local port', () => {
+    setLocalPort(9091)
+    setCloudConnection('https://cp.example', 'secret')
+    expect(getBaseUrl()).toBe('https://cp.example')
+    expect(getApiKey()).toBe('secret')
+    expect(isCloudActive()).toBe(true)
+    clearCloudConnection()
+    expect(getBaseUrl()).toBe('http://localhost:9091')
+    expect(getApiKey()).toBeNull()
+    expect(isCloudActive()).toBe(false)
+  })
+
+  it('setting a local port clears cloud state', () => {
+    setCloudConnection('https://cp.example', 'secret')
+    setLocalPort(8082)
+    expect(getBaseUrl()).toBe('http://localhost:8082')
+    expect(getApiKey()).toBeNull()
+    expect(isCloudActive()).toBe(false)
+  })
+})

--- a/desktop/src/main/connection.ts
+++ b/desktop/src/main/connection.ts
@@ -1,0 +1,37 @@
+const DEFAULT_LOCAL_URL = 'http://localhost:8080'
+
+let localUrl = DEFAULT_LOCAL_URL
+let baseUrl = localUrl
+let apiKey: string | null = null
+let cloudActive = false
+
+export function getBaseUrl(): string {
+  return baseUrl
+}
+
+export function setLocalPort(port: number): void {
+  localUrl = `http://localhost:${port}`
+  baseUrl = localUrl
+  apiKey = null
+  cloudActive = false
+}
+
+export function setCloudConnection(url: string, key: string | null): void {
+  baseUrl = url
+  apiKey = key
+  cloudActive = true
+}
+
+export function clearCloudConnection(): void {
+  baseUrl = localUrl
+  apiKey = null
+  cloudActive = false
+}
+
+export function getApiKey(): string | null {
+  return apiKey
+}
+
+export function isCloudActive(): boolean {
+  return cloudActive
+}

--- a/desktop/src/main/cpClient.test.ts
+++ b/desktop/src/main/cpClient.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { setCloudConnection, setLocalPort } from './connection'
 import {
   CpApiError,
   createCpClient,
@@ -29,6 +30,7 @@ const job = (status: InstallJob['status'], lines: string[] = []): InstallJob => 
 })
 
 describe('createCpClient', () => {
+  afterEach(() => setLocalPort(8080))
   // Contract 1: every wrapper uses the documented method, path, body, and result.
   it('wraps all management endpoints', async () => {
     const payloads: unknown[] = [
@@ -108,6 +110,15 @@ describe('createCpClient', () => {
     expect(new Headers(calls[0][1]?.headers).has('X-API-Key')).toBe(false)
     expect(calls[1][0]).toBe('http://two/api/ui/v1/agents/packages')
     expect(new Headers(calls[1][1]?.headers).get('X-API-Key')).toBe('cloud-key')
+  })
+
+  it('uses the default connection-state API key provider', async () => {
+    const fetchImpl = mockFetch([json({ packages: [], total: 0 })])
+    setCloudConnection('https://cp.example', 'state-key')
+    await createCpClient({ fetchImpl }).listPackages()
+    const [url, init] = vi.mocked(fetchImpl).mock.calls[0]
+    expect(url).toBe('https://cp.example/api/ui/v1/agents/packages')
+    expect(new Headers(init?.headers).get('X-API-Key')).toBe('state-key')
   })
 
   // Contract 4: HTTP errors retain status and parsed server details.

--- a/desktop/src/main/cpClient.test.ts
+++ b/desktop/src/main/cpClient.test.ts
@@ -8,6 +8,7 @@ import {
   type InstallJob,
   type PackageInfo
 } from './cpClient'
+import { readInstalledAgents } from './agentfield'
 
 function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -94,6 +95,34 @@ describe('createCpClient', () => {
     expect(JSON.parse(String(calls[6][1]?.body))).toEqual({ port: 9000, detach: false })
   })
 
+  it('normalizes Go nil slices in list responses', async () => {
+    const fetchImpl = mockFetch([
+      json({ packages: null, total: 0 }),
+      json(null),
+      json({ running_agents: null, total_count: 0 }),
+      json({ secrets: null }),
+      json({ secrets: null })
+    ])
+    const client = createCpClient({ fetchImpl })
+
+    await expect(client.listPackages()).resolves.toEqual({ packages: [], total: 0 })
+    await expect(client.listInstallJobs()).resolves.toEqual([])
+    await expect(client.listRunningAgents()).resolves.toEqual({
+      running_agents: [],
+      total_count: 0
+    })
+    await expect(client.listAgentSecrets('agent')).resolves.toEqual({ secrets: [] })
+    await expect(client.listAllSecrets()).resolves.toEqual({ secrets: [] })
+  })
+
+  it('maps a null packages wire value to an empty installed-agent registry', async () => {
+    const client = createCpClient({
+      fetchImpl: mockFetch([json({ packages: null, total: 0 })])
+    })
+
+    await expect(readInstalledAgents(client)).resolves.toEqual({ exists: true, agents: [] })
+  })
+
   // Contracts 2 and 3: auth is conditional and late-bound providers are re-read.
   it('late-binds base URL and API key on every call', async () => {
     let host = 'http://one'
@@ -169,6 +198,18 @@ describe('createCpClient', () => {
     })
     expect(result.status).toBe(terminal)
     expect(lines).toEqual(['one', 'two', 'three'])
+  })
+
+  it('normalizes null job lines while watching', async () => {
+    const emitted: string[] = []
+    const client = createCpClient({
+      fetchImpl: mockFetch([json({ ...job('succeeded'), lines: null })])
+    })
+
+    const result = await client.watchInstallJob('job/1', (line) => emitted.push(line))
+
+    expect(result.lines).toEqual([])
+    expect(emitted).toEqual([])
   })
 
   it('reports when a job disappears while it is being watched', async () => {

--- a/desktop/src/main/cpClient.ts
+++ b/desktop/src/main/cpClient.ts
@@ -278,11 +278,15 @@ export function createCpClient(options: CpClientOptions = {}): CpClient {
         body: JSON.stringify(body)
       }, true)
     },
-    getInstallJob(jobId) {
-      return request(`/api/ui/v1/agents/packages/install/jobs/${encodeURIComponent(jobId)}`)
+    async getInstallJob(jobId) {
+      const job = await request<Omit<InstallJob, 'lines'> & { lines: string[] | null }>(
+        `/api/ui/v1/agents/packages/install/jobs/${encodeURIComponent(jobId)}`
+      )
+      return { ...job, lines: job.lines ?? [] }
     },
-    listInstallJobs() {
-      return request('/api/ui/v1/agents/packages/install/jobs')
+    async listInstallJobs() {
+      const jobs = await request<InstallJob[] | null>('/api/ui/v1/agents/packages/install/jobs')
+      return jobs ?? []
     },
     uninstallPackage(packageId) {
       return request(
@@ -298,8 +302,13 @@ export function createCpClient(options: CpClientOptions = {}): CpClient {
         true
       )
     },
-    listPackages() {
-      return request('/api/ui/v1/agents/packages')
+    async listPackages() {
+      const response = await request<
+        Omit<PackageListResponse, 'packages'> & { packages: PackageInfo[] | null }
+      >(
+        '/api/ui/v1/agents/packages'
+      )
+      return { ...response, packages: response.packages ?? [] }
     },
     startAgent(agentId, startOptions) {
       return request(
@@ -318,11 +327,17 @@ export function createCpClient(options: CpClientOptions = {}): CpClient {
     getAgentStatus(agentId) {
       return request(`/api/ui/v1/agents/${encodeURIComponent(agentId)}/status`)
     },
-    listRunningAgents() {
-      return request('/api/ui/v1/agents/running')
+    async listRunningAgents() {
+      const response = await request<
+        Omit<RunningAgentsResponse, 'running_agents'> & { running_agents: RunningAgent[] | null }
+      >('/api/ui/v1/agents/running')
+      return { ...response, running_agents: response.running_agents ?? [] }
     },
-    listAgentSecrets(agentId) {
-      return request(`/api/ui/v1/agents/${encodeURIComponent(agentId)}/secrets`)
+    async listAgentSecrets(agentId) {
+      const response = await request<{ secrets: AgentSecretStatus[] | null }>(
+        `/api/ui/v1/agents/${encodeURIComponent(agentId)}/secrets`
+      )
+      return { ...response, secrets: response.secrets ?? [] }
     },
     setAgentSecret(agentId, key, value, scope) {
       const body = scope === undefined ? { key, value } : { key, value, scope }
@@ -342,8 +357,9 @@ export function createCpClient(options: CpClientOptions = {}): CpClient {
         true
       )
     },
-    listAllSecrets() {
-      return request('/api/ui/v1/secrets')
+    async listAllSecrets() {
+      const response = await request<{ secrets: SecretReference[] | null }>('/api/ui/v1/secrets')
+      return { ...response, secrets: response.secrets ?? [] }
     },
     async hasInstallApi() {
       try {

--- a/desktop/src/main/cpClient.ts
+++ b/desktop/src/main/cpClient.ts
@@ -1,5 +1,5 @@
-import { getBaseUrl, type FetchLike } from './agentfield'
-export type { FetchLike } from './agentfield'
+import { getApiKey, getBaseUrl } from './connection'
+export type FetchLike = typeof fetch
 
 const READ_TIMEOUT_MS = 3_000
 const MUTATION_TIMEOUT_MS = 10_000
@@ -243,7 +243,7 @@ async function apiError(response: Response): Promise<CpApiError> {
  */
 export function createCpClient(options: CpClientOptions = {}): CpClient {
   const baseUrl = options.baseUrl ?? getBaseUrl
-  const apiKey = options.apiKey ?? (() => null)
+  const apiKey = options.apiKey ?? getApiKey
   const fetchImpl = options.fetchImpl ?? fetch
   const sleep =
     options.sleep ?? ((milliseconds: number) => new Promise((resolve) => setTimeout(resolve, milliseconds)))

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -1,12 +1,15 @@
 import { join, resolve } from 'node:path'
 import { BrowserWindow, Menu, app, ipcMain, nativeTheme, shell } from 'electron'
 import { CATALOG } from '../shared/catalog'
+import { RAILWAY_TEMPLATE_URL } from '../shared/cloudLinks'
 import { DEEP_LINK_SCHEME, type View, deepLinkFromArgv, parseDeepLink } from '../shared/deeplink'
 import type { DesktopSettings } from '../shared/types'
 import { spawn } from 'node:child_process'
 import { getBaseUrl, getSnapshot, setActiveControlPlanePort } from './agentfield'
 import { type AgentAction, runAgentAction, startControlPlane, uninstallAgent } from './agents'
 import { runAutostart } from './autostart'
+import { testCloudConnection, applyConnectionProfile } from './cloud'
+import { isCloudActive } from './connection'
 import { getCliCommand, initializeCli, installBundledCli, refreshCliStatus } from './cli'
 import { childEnv, initUserPath } from './env'
 import { installAgent, installFromSource, updateAgent } from './installer'
@@ -275,6 +278,7 @@ function main(): void {
   app.whenReady().then(async () => {
     installAppMenu()
     settings = await loadSettings(settingsFile())
+    applyConnectionProfile(settings)
     nativeTheme.themeSource = settings.appearance
     applyLoginItem(settings)
 
@@ -289,7 +293,7 @@ function main(): void {
     // with no AgentField at all this provisions the bundled CLI, so a
     // desktop-app-only install still gets a working `af`.
     await initializeCli(bundledCliPath())
-    if (settings.installSkills) syncSkills()
+    if (settings.installSkills && !isCloudActive()) syncSkills()
 
     // macOS only: provision + install the af-tray menu-bar companion so a
     // desktop-app-only install gets the menu-bar icon. Runs after initializeCli
@@ -375,6 +379,12 @@ function main(): void {
       return runAgentAction(action as AgentAction, name)
     })
     ipcMain.handle('agentfield:start-control-plane', async () => {
+      if (isCloudActive()) {
+        return {
+          ok: false,
+          message: 'Cloud control plane active — local server management is disabled'
+        }
+      }
       const port = settings.controlPlanePort ?? (await pickFreePort())
       setActiveControlPlanePort(port)
       const result = await startControlPlane(port)
@@ -460,6 +470,12 @@ function main(): void {
     // checks from Settings still work anywhere.
     if (app.isPackaged) updater.startAutoCheck()
     ipcMain.handle('agentfield:settings-get', () => settings)
+    ipcMain.handle('agentfield:cloud-test', (_event, url: string, apiKey: string) =>
+      testCloudConnection(url, apiKey)
+    )
+    ipcMain.handle('agentfield:cloud-deploy-railway', () =>
+      shell.openExternal(RAILWAY_TEMPLATE_URL)
+    )
     ipcMain.handle('agentfield:settings-set', async (_event, patch: unknown) => {
       const prev = settings
       settings = mergeSettings(settings, patch)
@@ -470,6 +486,7 @@ function main(): void {
       // macOS: reflect a flipped tray toggle (install ↔ uninstall) right away.
       if (settings.trayCompanion !== prev.trayCompanion) syncTray(settings.trayCompanion)
       await saveSettings(settingsFile(), settings)
+      applyConnectionProfile(settings)
       return settings
     })
 

--- a/desktop/src/main/settings.test.ts
+++ b/desktop/src/main/settings.test.ts
@@ -10,6 +10,7 @@ afterAll(() => rmSync(dir, { recursive: true, force: true }))
 describe('normalizeSettings', () => {
   it('accepts a valid shape as-is', () => {
     const s = {
+      cloud: { enabled: true, serverUrl: 'https://cloud.example', apiKey: 'secret' },
       openAtLogin: true,
       appearance: 'dark' as const,
       autostartControlPlane: false,
@@ -56,6 +57,20 @@ describe('normalizeSettings', () => {
     expect(normalizeSettings({ openAtLogin: 'yes', autostartAgents: 42 })).toEqual(
       DEFAULT_SETTINGS
     )
+  })
+
+  it('normalizes cloud profile values and defaults old settings', () => {
+    expect(normalizeSettings({}).cloud).toEqual(DEFAULT_SETTINGS.cloud)
+    expect(
+      normalizeSettings({
+        cloud: { enabled: 'yes', serverUrl: '  https://cp.example/  ', apiKey: ' key ' }
+      }).cloud
+    ).toEqual({ enabled: true, serverUrl: 'https://cp.example/', apiKey: 'key' })
+    expect(normalizeSettings({ cloud: { enabled: 0, serverUrl: 7, apiKey: null } }).cloud).toEqual({
+      enabled: false,
+      serverUrl: '',
+      apiKey: ''
+    })
   })
 
   it('drops non-string agent names and dedupes', () => {
@@ -118,6 +133,7 @@ describe('load/save round trip', () => {
   it('persists and reloads settings', async () => {
     const file = join(dir, 'nested', 'settings.json')
     const s = {
+      cloud: { enabled: true, serverUrl: 'https://cloud.example', apiKey: 'round-trip-key' },
       openAtLogin: true,
       appearance: 'light' as const,
       autostartControlPlane: true,

--- a/desktop/src/main/settings.ts
+++ b/desktop/src/main/settings.ts
@@ -7,6 +7,7 @@ import { dirname } from 'node:path'
 import type { DesktopSettings } from '../shared/types'
 
 export const DEFAULT_SETTINGS: DesktopSettings = {
+  cloud: { enabled: false, serverUrl: '', apiKey: '' },
   openAtLogin: false,
   appearance: 'system',
   autostartControlPlane: true,
@@ -34,10 +35,19 @@ function normalizePort(value: unknown): number | null {
  */
 export function normalizeSettings(raw: unknown): DesktopSettings {
   const obj = typeof raw === 'object' && raw !== null ? (raw as Record<string, unknown>) : {}
+  const cloud =
+    typeof obj.cloud === 'object' && obj.cloud !== null
+      ? (obj.cloud as Record<string, unknown>)
+      : {}
   const agents = Array.isArray(obj.autostartAgents)
     ? [...new Set(obj.autostartAgents.filter((n): n is string => typeof n === 'string'))]
     : DEFAULT_SETTINGS.autostartAgents
   return {
+    cloud: {
+      enabled: Boolean(cloud.enabled),
+      serverUrl: typeof cloud.serverUrl === 'string' ? cloud.serverUrl.trim() : '',
+      apiKey: typeof cloud.apiKey === 'string' ? cloud.apiKey.trim() : ''
+    },
     openAtLogin:
       typeof obj.openAtLogin === 'boolean' ? obj.openAtLogin : DEFAULT_SETTINGS.openAtLogin,
     appearance:

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,8 +1,12 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import type { AgentFieldApi } from '../shared/types'
 
+type PreloadApi = AgentFieldApi & {
+  cloudDeployRailway(): Promise<void>
+}
+
 // Sandboxed preload: only contextBridge/ipcRenderer are used, no Node APIs.
-const api: AgentFieldApi = {
+const api: PreloadApi = {
   getSnapshot: () => ipcRenderer.invoke('agentfield:snapshot'),
   getCatalog: () => ipcRenderer.invoke('agentfield:catalog'),
   install: (name) => ipcRenderer.invoke('agentfield:install', name),
@@ -24,6 +28,8 @@ const api: AgentFieldApi = {
   revokeSecret: (key, scope) => ipcRenderer.invoke('agentfield:secrets-revoke', key, scope),
   getSettings: () => ipcRenderer.invoke('agentfield:settings-get'),
   setSettings: (patch) => ipcRenderer.invoke('agentfield:settings-set', patch),
+  cloudTest: (url, apiKey) => ipcRenderer.invoke('agentfield:cloud-test', url, apiKey),
+  cloudDeployRailway: () => ipcRenderer.invoke('agentfield:cloud-deploy-railway'),
   getCliStatus: () => ipcRenderer.invoke('agentfield:cli-status'),
   updateCli: () => ipcRenderer.invoke('agentfield:cli-update'),
   getAppUpdateStatus: () => ipcRenderer.invoke('agentfield:app-update-get'),

--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -8,6 +8,7 @@ import { AgentsPanel } from './components/AgentsPanel'
 import { ActivityPanel } from './components/ActivityPanel'
 import { InstallPanel } from './components/InstallPanel'
 import { SettingsPanel } from './components/SettingsPanel'
+import { CloudPanel } from './components/CloudPanel'
 import { StarBanner } from './components/StarBanner'
 import { UpdateBanner } from './components/UpdateBanner'
 
@@ -43,11 +44,12 @@ const VIEW_TITLES: Record<View, string> = {
   install: 'Agents',
   agents: 'Agents',
   activity: 'Activity',
-  settings: 'Settings'
+  settings: 'Settings',
+  cloud: 'Cloud'
 }
 
-// ⌘1–⌘4 (Ctrl on Win/Linux) in nav order (DESIGN.md §4.17).
-const SHORTCUT_VIEWS: View[] = ['home', 'agents', 'activity', 'settings']
+// ⌘1–⌘5 (Ctrl on Win/Linux) in nav order (DESIGN.md §4.17).
+const SHORTCUT_VIEWS: View[] = ['home', 'agents', 'activity', 'settings', 'cloud']
 
 /** True when the keystroke belongs to a text control, not the app. */
 function isEditableTarget(target: EventTarget | null): boolean {
@@ -281,6 +283,7 @@ export default function App() {
                 />
               )}
               {view === 'settings' && <SettingsPanel agents={snapshot?.registry.agents ?? []} />}
+              {view === 'cloud' && <CloudPanel />}
             </m.div>
           </AnimatePresence>
         </div>

--- a/desktop/src/renderer/src/components/CloudPanel.tsx
+++ b/desktop/src/renderer/src/components/CloudPanel.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useState } from 'react'
+import type { AgentFieldApi, CloudTestResult, DesktopSettings } from '../../../shared/types'
+
+type CloudDeployApi = AgentFieldApi & {
+  cloudDeployRailway(): Promise<void>
+}
+
+export function CloudPanel() {
+  const [settings, setSettings] = useState<DesktopSettings | null>(null)
+  const [serverUrl, setServerUrl] = useState('')
+  const [apiKey, setApiKey] = useState('')
+  const [showKey, setShowKey] = useState(false)
+  const [testing, setTesting] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [result, setResult] = useState<CloudTestResult | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    void window.agentfield.getSettings().then((next) => {
+      setSettings(next)
+      setServerUrl(next.cloud?.serverUrl ?? '')
+      setApiKey(next.cloud?.apiKey ?? '')
+    })
+  }, [])
+
+  const cloud = settings?.cloud
+  const enabled = cloud?.enabled ?? false
+  const canSubmit = serverUrl.trim() !== '' && apiKey.trim() !== ''
+
+  const test = async () => {
+    setTesting(true)
+    setError(null)
+    setResult(null)
+    try {
+      setResult(await window.agentfield.cloudTest(serverUrl.trim(), apiKey.trim()))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  const saveCloud = async () => {
+    if (!result?.ok) {
+      const proceed = window.confirm(
+        'The connection has not passed its test. Switch to this cloud control plane anyway?'
+      )
+      if (!proceed) return
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      const next = await window.agentfield.setSettings({
+        cloud: {
+          enabled: true,
+          serverUrl: serverUrl.trim(),
+          apiKey: apiKey.trim()
+        }
+      })
+      setSettings(next)
+      setServerUrl(next.cloud?.serverUrl ?? serverUrl.trim())
+      setApiKey(next.cloud?.apiKey ?? apiKey.trim())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const disconnect = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      const next = await window.agentfield.setSettings({
+        cloud: {
+          enabled: false,
+          serverUrl: serverUrl.trim(),
+          apiKey: apiKey.trim()
+        }
+      })
+      setSettings(next)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  // TODO(integration): fold into AgentFieldApi
+  const deployApi = window.agentfield as CloudDeployApi
+
+  if (!settings) {
+    return (
+      <div className="panel">
+        <div className="empty secondary">Loading…</div>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <p className="view-lede">
+        Connect AgentField Desktop to a control plane hosted in the cloud.
+      </p>
+
+      {error && <div className="callout error">{error}</div>}
+
+      <section className="settings-section">
+        <div className="subhead">
+          <h2 className="section-title">Status</h2>
+        </div>
+        <div className="panel">
+          <ul className="row-list">
+            <li className="row">
+              <div className="row-main">
+                <span className="row-title">
+                  {enabled ? `Cloud: ${cloud?.serverUrl || serverUrl}` : 'Local control plane'}
+                </span>
+                {enabled && (
+                  <span className="row-sub">
+                    Local server management is disabled while this cloud connection is active.
+                  </span>
+                )}
+              </div>
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section className="settings-section">
+        <div className="subhead">
+          <h2 className="section-title">Connect</h2>
+        </div>
+        <div className="panel">
+          <ul className="row-list">
+            <li className="row">
+              <div className="row-main">
+                <label className="row-title" htmlFor="cloud-server-url">Server URL</label>
+                <span className="row-sub">The public address of your AgentField control plane.</span>
+              </div>
+              <div className="row-side">
+                <input
+                  id="cloud-server-url"
+                  className="env-input cloud-input"
+                  placeholder="https://your-cp.up.railway.app"
+                  value={serverUrl}
+                  onChange={(event) => {
+                    setServerUrl(event.target.value)
+                    setResult(null)
+                  }}
+                />
+              </div>
+            </li>
+            <li className="row">
+              <div className="row-main">
+                <label className="row-title" htmlFor="cloud-api-key">API key</label>
+                <span className="row-sub">Stored on this computer and sent only to your server.</span>
+              </div>
+              <div className="row-side env-row-controls">
+                <input
+                  id="cloud-api-key"
+                  className="env-input cloud-input"
+                  type={showKey ? 'text' : 'password'}
+                  value={apiKey}
+                  onChange={(event) => {
+                    setApiKey(event.target.value)
+                    setResult(null)
+                  }}
+                />
+                <button className="action-button" type="button" onClick={() => setShowKey(!showKey)}>
+                  {showKey ? 'Hide' : 'Show'}
+                </button>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div className="cloud-actions">
+          <button className="action-button" disabled={!canSubmit || testing} onClick={() => void test()}>
+            {testing ? 'Testing…' : 'Test connection'}
+          </button>
+          <button
+            className="action-button primary"
+            disabled={!canSubmit || saving}
+            onClick={() => void saveCloud()}
+          >
+            {saving ? 'Saving…' : 'Save & switch to cloud'}
+          </button>
+        </div>
+        {result && (
+          <div className={`callout ${result.ok ? '' : 'error'}`}>
+            <div>
+              <div>{result.message}</div>
+              <div className="cloud-checks">
+                Reachable: {result.healthy ? 'Yes' : 'No'} · Auth: {result.authOk ? 'Passed' : 'Failed'} ·
+                Install API: {result.installApi ? 'Available' : 'Unavailable'}
+                {result.version ? ` · Version: ${result.version}` : ''}
+              </div>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {enabled && (
+        <section className="settings-section">
+          <div className="subhead">
+            <h2 className="section-title">Disconnect</h2>
+          </div>
+          <div className="panel">
+            <div className="row">
+              <div className="row-main">
+                <span className="row-title">Switch back to local</span>
+                <span className="row-sub">Your cloud address and key stay saved for next time.</span>
+              </div>
+              <div className="row-side">
+                <button className="action-button" disabled={saving} onClick={() => void disconnect()}>
+                  Switch back to local
+                </button>
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      <section className="settings-section">
+        <div className="subhead">
+          <h2 className="section-title">Deploy on Railway</h2>
+        </div>
+        <div className="panel">
+          <div className="row">
+            <div className="row-main">
+              <span className="row-title">Host your own cloud control plane</span>
+              <span className="row-sub">1. Deploy the AgentField control plane template on Railway.</span>
+              <span className="row-sub">
+                2. Copy its public URL and the AGENTFIELD_API_KEY value from the service variables.
+              </span>
+              <span className="row-sub">3. Paste both above, then Test and Save.</span>
+            </div>
+            <div className="row-side">
+              <button
+                className="action-button"
+                type="button"
+                onClick={() => void deployApi.cloudDeployRailway()}
+              >
+                Open Railway template
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
+  )
+}

--- a/desktop/src/renderer/src/components/CloudPanel.tsx
+++ b/desktop/src/renderer/src/components/CloudPanel.tsx
@@ -5,6 +5,11 @@ type CloudDeployApi = AgentFieldApi & {
   cloudDeployRailway(): Promise<void>
 }
 
+type Confirmation = {
+  mode: 'cloud' | 'local'
+  host?: string
+}
+
 export function CloudPanel() {
   const [settings, setSettings] = useState<DesktopSettings | null>(null)
   const [serverUrl, setServerUrl] = useState('')
@@ -14,6 +19,7 @@ export function CloudPanel() {
   const [saving, setSaving] = useState(false)
   const [result, setResult] = useState<CloudTestResult | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [confirmation, setConfirmation] = useState<Confirmation | null>(null)
 
   useEffect(() => {
     void window.agentfield.getSettings().then((next) => {
@@ -23,13 +29,21 @@ export function CloudPanel() {
     })
   }, [])
 
+  useEffect(() => {
+    if (!confirmation) return
+    const timeout = window.setTimeout(() => setConfirmation(null), 4000)
+    return () => window.clearTimeout(timeout)
+  }, [confirmation])
+
   const cloud = settings?.cloud
   const enabled = cloud?.enabled ?? false
   const canSubmit = serverUrl.trim() !== '' && apiKey.trim() !== ''
+  const busy = testing || saving
 
   const test = async () => {
     setTesting(true)
     setError(null)
+    setConfirmation(null)
     setResult(null)
     try {
       setResult(await window.agentfield.cloudTest(serverUrl.trim(), apiKey.trim()))
@@ -49,6 +63,7 @@ export function CloudPanel() {
     }
     setSaving(true)
     setError(null)
+    setConfirmation(null)
     try {
       const next = await window.agentfield.setSettings({
         cloud: {
@@ -60,6 +75,10 @@ export function CloudPanel() {
       setSettings(next)
       setServerUrl(next.cloud?.serverUrl ?? serverUrl.trim())
       setApiKey(next.cloud?.apiKey ?? apiKey.trim())
+      setConfirmation({
+        mode: 'cloud',
+        host: displayHost(next.cloud?.serverUrl ?? serverUrl.trim())
+      })
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
@@ -70,6 +89,7 @@ export function CloudPanel() {
   const disconnect = async () => {
     setSaving(true)
     setError(null)
+    setConfirmation(null)
     try {
       const next = await window.agentfield.setSettings({
         cloud: {
@@ -79,6 +99,7 @@ export function CloudPanel() {
         }
       })
       setSettings(next)
+      setConfirmation({ mode: 'local' })
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
@@ -104,6 +125,13 @@ export function CloudPanel() {
       </p>
 
       {error && <div className="callout error">{error}</div>}
+      {confirmation && (
+        <div className="callout success cloud-confirmation" role="status">
+          {confirmation.mode === 'cloud'
+            ? `✓ Now managing ${confirmation.host}`
+            : '✓ Switched back to the local control plane'}
+        </div>
+      )}
 
       <section className="settings-section">
         <div className="subhead">
@@ -112,9 +140,13 @@ export function CloudPanel() {
         <div className="panel">
           <ul className="row-list">
             <li className="row">
+              <span
+                className={`cloud-status-dot ${enabled ? 'connected' : ''}`}
+                aria-hidden="true"
+              />
               <div className="row-main">
-                <span className="row-title">
-                  {enabled ? `Cloud: ${cloud?.serverUrl || serverUrl}` : 'Local control plane'}
+                <span className="row-title cloud-status-title">
+                  {enabled ? displayHost(cloud?.serverUrl || serverUrl) : 'Local control plane'}
                 </span>
                 {enabled && (
                   <span className="row-sub">
@@ -131,73 +163,72 @@ export function CloudPanel() {
         <div className="subhead">
           <h2 className="section-title">Connect</h2>
         </div>
-        <div className="panel">
-          <ul className="row-list">
-            <li className="row">
-              <div className="row-main">
-                <label className="row-title" htmlFor="cloud-server-url">Server URL</label>
-                <span className="row-sub">The public address of your AgentField control plane.</span>
-              </div>
-              <div className="row-side">
-                <input
-                  id="cloud-server-url"
-                  className="env-input cloud-input"
-                  placeholder="https://your-cp.up.railway.app"
-                  value={serverUrl}
-                  onChange={(event) => {
-                    setServerUrl(event.target.value)
-                    setResult(null)
-                  }}
-                />
-              </div>
-            </li>
-            <li className="row">
-              <div className="row-main">
-                <label className="row-title" htmlFor="cloud-api-key">API key</label>
-                <span className="row-sub">Stored on this computer and sent only to your server.</span>
-              </div>
-              <div className="row-side env-row-controls">
-                <input
-                  id="cloud-api-key"
-                  className="env-input cloud-input"
-                  type={showKey ? 'text' : 'password'}
-                  value={apiKey}
-                  onChange={(event) => {
-                    setApiKey(event.target.value)
-                    setResult(null)
-                  }}
-                />
-                <button className="action-button" type="button" onClick={() => setShowKey(!showKey)}>
-                  {showKey ? 'Hide' : 'Show'}
-                </button>
-              </div>
-            </li>
-          </ul>
+        <div className="panel cloud-form">
+          <div className="cloud-field">
+            <label className="row-title" htmlFor="cloud-server-url">
+              Server URL
+            </label>
+            <span className="row-sub">The public address of your AgentField control plane.</span>
+            <div className="cloud-input-row">
+              <input
+                id="cloud-server-url"
+                className="env-input cloud-input"
+                placeholder="https://your-cp.up.railway.app"
+                value={serverUrl}
+                disabled={busy}
+                onChange={(event) => {
+                  setServerUrl(event.target.value)
+                  setResult(null)
+                }}
+              />
+            </div>
+          </div>
+          <div className="cloud-field">
+            <label className="row-title" htmlFor="cloud-api-key">
+              API key
+            </label>
+            <span className="row-sub">Stored on this computer and sent only to your server.</span>
+            <div className="cloud-input-row cloud-key-row">
+              <input
+                id="cloud-api-key"
+                className="env-input cloud-input"
+                type={showKey ? 'text' : 'password'}
+                value={apiKey}
+                disabled={busy}
+                onChange={(event) => {
+                  setApiKey(event.target.value)
+                  setResult(null)
+                }}
+              />
+              <button
+                className="action-button cloud-key-toggle"
+                type="button"
+                disabled={busy}
+                onClick={() => setShowKey(!showKey)}
+              >
+                {showKey ? 'Hide' : 'Show'}
+              </button>
+            </div>
+          </div>
         </div>
         <div className="cloud-actions">
-          <button className="action-button" disabled={!canSubmit || testing} onClick={() => void test()}>
+          <button
+            className={`action-button ${!result || !result.ok || !result.installApi ? 'primary' : ''}`}
+            disabled={!canSubmit || busy}
+            onClick={() => void test()}
+          >
+            {testing && <span className="cloud-spinner" aria-hidden="true" />}
             {testing ? 'Testing…' : 'Test connection'}
           </button>
           <button
-            className="action-button primary"
-            disabled={!canSubmit || saving}
+            className={`action-button ${result?.ok && result.installApi ? 'primary' : ''}`}
+            disabled={!canSubmit || busy}
             onClick={() => void saveCloud()}
           >
             {saving ? 'Saving…' : 'Save & switch to cloud'}
           </button>
         </div>
-        {result && (
-          <div className={`callout ${result.ok ? '' : 'error'}`}>
-            <div>
-              <div>{result.message}</div>
-              <div className="cloud-checks">
-                Reachable: {result.healthy ? 'Yes' : 'No'} · Auth: {result.authOk ? 'Passed' : 'Failed'} ·
-                Install API: {result.installApi ? 'Available' : 'Unavailable'}
-                {result.version ? ` · Version: ${result.version}` : ''}
-              </div>
-            </div>
-          </div>
-        )}
+        {result && <CloudTestFeedback result={result} />}
       </section>
 
       {enabled && (
@@ -225,28 +256,85 @@ export function CloudPanel() {
         <div className="subhead">
           <h2 className="section-title">Deploy on Railway</h2>
         </div>
-        <div className="panel">
-          <div className="row">
-            <div className="row-main">
-              <span className="row-title">Host your own cloud control plane</span>
-              <span className="row-sub">1. Deploy the AgentField control plane template on Railway.</span>
-              <span className="row-sub">
-                2. Copy its public URL and the AGENTFIELD_API_KEY value from the service variables.
-              </span>
-              <span className="row-sub">3. Paste both above, then Test and Save.</span>
-            </div>
-            <div className="row-side">
-              <button
-                className="action-button"
-                type="button"
-                onClick={() => void deployApi.cloudDeployRailway()}
-              >
-                Open Railway template
-              </button>
-            </div>
+        <div className="panel cloud-railway">
+          <div className="cloud-railway-content">
+            <span className="row-title">Host your own cloud control plane</span>
+            <ol className="cloud-steps">
+              <li>Deploy the AgentField control plane template on Railway.</li>
+              <li>
+                Copy its public URL and the AGENTFIELD_API_KEY value from the service variables.
+              </li>
+              <li>Paste both above, then Test and Save.</li>
+            </ol>
+            <button
+              className="action-button"
+              type="button"
+              onClick={() => void deployApi.cloudDeployRailway()}
+            >
+              Open Railway template
+            </button>
           </div>
         </div>
       </section>
     </>
   )
+}
+
+function CloudTestFeedback({ result }: { result: CloudTestResult }) {
+  const success = result.ok && result.installApi
+  const degraded = result.ok && !result.installApi
+  const state = success ? 'success' : degraded ? 'warning' : 'error'
+  const heading = success
+    ? `✓ Connected${result.version ? ` — control plane v${result.version.replace(/^v/, '')}` : ''}`
+    : degraded
+      ? '⚠ Connected, but this control plane is too old for desktop agent management — update the AgentField server, then test again.'
+      : result.message
+
+  const checks: Array<{ label: string; state: 'passed' | 'warning' | 'failed' | 'pending' }> = [
+    { label: 'Reachable', state: result.healthy ? 'passed' : 'failed' },
+    {
+      label: 'API key accepted',
+      state: result.authOk ? 'passed' : result.healthy ? 'failed' : 'pending'
+    },
+    {
+      label: 'Agent management available',
+      state: result.installApi
+        ? 'passed'
+        : degraded
+          ? 'warning'
+          : result.authOk
+            ? 'failed'
+            : 'pending'
+    }
+  ]
+
+  return (
+    <div className={`callout ${state} cloud-result`} role={success ? 'status' : 'alert'}>
+      <div className="cloud-result-heading">{heading}</div>
+      <ul className="cloud-checks">
+        {checks.map((check) => (
+          <li key={check.label} className={check.state}>
+            <span className="cloud-check-icon" aria-hidden="true">
+              {check.state === 'passed'
+                ? '✓'
+                : check.state === 'warning'
+                  ? '⚠'
+                  : check.state === 'failed'
+                    ? '✗'
+                    : '—'}
+            </span>
+            <span>{check.label}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function displayHost(serverUrl: string) {
+  try {
+    return new URL(serverUrl).host
+  } catch {
+    return serverUrl
+  }
 }

--- a/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/desktop/src/renderer/src/components/Sidebar.tsx
@@ -42,6 +42,7 @@ const ICONS: Record<View, string> = {
   install: 'M12 3v12M7 10l5 5l5-5M4 21h16',
   agents: 'M12 8V4H8M2 14h2M20 14h2M15 13v2M9 13v2M16 20H8a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2z',
   activity: 'M3 12h4l3-8l4 16l3-8h4',
+  cloud: 'M17.5 19H7a5 5 0 1 1 1.2-9.85A6 6 0 0 1 19.7 11.2A4 4 0 0 1 17.5 19z',
   settings: 'M4 21v-7M4 10V3M12 21v-9M12 8V3M20 21v-5M20 12V3M1 14h6M9 8h6M17 16h6'
 }
 
@@ -52,7 +53,8 @@ const NAV: Array<{ id: View; label: string }> = [
   { id: 'home', label: 'Home' },
   { id: 'agents', label: 'Agents' },
   { id: 'activity', label: 'Activity' },
-  { id: 'settings', label: 'Settings' }
+  { id: 'settings', label: 'Settings' },
+  { id: 'cloud', label: 'Cloud' }
 ]
 
 // UI-furniture spring (DESIGN.md §5.1) — fast, settles with no felt overshoot.

--- a/desktop/src/renderer/src/styles.css
+++ b/desktop/src/renderer/src/styles.css
@@ -1239,6 +1239,21 @@ section > .section-title {
   margin-bottom: 0;
 }
 
+.cloud-input {
+  width: min(300px, 36vw);
+}
+
+.cloud-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.cloud-checks {
+  margin-top: 4px;
+  font-size: 11.5px;
+}
+
 .switch {
   -webkit-app-region: no-drag;
   position: relative;

--- a/desktop/src/renderer/src/styles.css
+++ b/desktop/src/renderer/src/styles.css
@@ -1240,18 +1240,174 @@ section > .section-title {
 }
 
 .cloud-input {
-  width: min(300px, 36vw);
+  width: 100%;
+  min-height: 32px;
 }
 
 .cloud-actions {
   display: flex;
-  justify-content: flex-end;
-  gap: 6px;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.cloud-form {
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.cloud-field {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.cloud-field .row-sub {
+  white-space: normal;
+  margin-bottom: var(--space-2);
+}
+
+.cloud-input-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.cloud-key-row {
+  position: relative;
+}
+
+.cloud-key-row .cloud-input {
+  padding-right: 62px;
+}
+
+.cloud-key-toggle {
+  position: absolute;
+  right: 3px;
+  top: 50%;
+  min-width: 54px;
+  transform: translateY(-50%);
+  background: transparent;
+  color: var(--text-secondary);
+}
+
+.cloud-key-toggle:active:not(:disabled) {
+  transform: translateY(-50%) scale(0.985);
+}
+
+.cloud-status-dot {
+  flex: none;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--neutral);
+}
+
+.cloud-status-dot.connected {
+  background: var(--ok);
+}
+
+.cloud-status-title {
+  line-height: 1.45;
+}
+
+.cloud-spinner {
+  flex: none;
+  width: 12px;
+  height: 12px;
+  border: 2px solid color-mix(in oklch, currentColor 30%, transparent);
+  border-top-color: currentColor;
+  border-radius: 50%;
+  animation: cloud-spin 0.8s linear infinite;
+}
+
+@keyframes cloud-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.callout.success {
+  background: color-mix(in oklch, var(--ok) 10%, transparent);
+  color: var(--ok);
+}
+
+.callout.warning {
+  background: color-mix(in oklch, var(--warn) 12%, transparent);
+  color: var(--warn);
+}
+
+.cloud-confirmation {
+  font-weight: var(--weight-body);
+}
+
+.cloud-result {
+  display: block;
+}
+
+.cloud-result-heading {
+  font-weight: var(--weight-body);
 }
 
 .cloud-checks {
-  margin-top: 4px;
+  list-style: none;
+  margin: var(--space-2) 0 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-1);
   font-size: 11.5px;
+}
+
+.cloud-checks li {
+  display: grid;
+  grid-template-columns: 16px 1fr;
+  align-items: baseline;
+  column-gap: var(--space-1);
+  color: var(--text-secondary);
+}
+
+.cloud-check-icon {
+  text-align: center;
+  font-weight: 700;
+}
+
+.cloud-checks .passed .cloud-check-icon {
+  color: var(--ok);
+}
+
+.cloud-checks .warning .cloud-check-icon {
+  color: var(--warn);
+}
+
+.cloud-checks .failed .cloud-check-icon {
+  color: var(--danger);
+}
+
+.cloud-checks .pending .cloud-check-icon {
+  color: var(--neutral);
+}
+
+.cloud-railway {
+  padding: var(--space-4);
+}
+
+.cloud-railway-content {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.cloud-steps {
+  margin: var(--space-2) 0 var(--space-3);
+  padding-left: var(--space-5);
+  color: var(--text-secondary);
+  font-size: var(--text-secondary-size);
+}
+
+.cloud-steps li + li {
+  margin-top: var(--space-1);
 }
 
 .switch {
@@ -1648,6 +1804,17 @@ code {
     animation: none;
     border-top-color: color-mix(in oklch, var(--ok) 30%, transparent);
     opacity: 0.85;
+  }
+
+  .cloud-spinner {
+    animation: none;
+    border-color: transparent;
+  }
+
+  .cloud-spinner::after {
+    content: '…';
+    display: block;
+    transform: translate(-1px, -8px);
   }
 
   .view-content {

--- a/desktop/src/shared/cloudLinks.ts
+++ b/desktop/src/shared/cloudLinks.ts
@@ -1,0 +1,1 @@
+export const RAILWAY_TEMPLATE_URL = 'https://railway.com/deploy/controlplane-template'

--- a/desktop/src/shared/deeplink.test.ts
+++ b/desktop/src/shared/deeplink.test.ts
@@ -8,6 +8,7 @@ describe('parseDeepLink', () => {
     expect(parseDeepLink('agentfield://agents')).toBe('agents')
     expect(parseDeepLink('agentfield://activity')).toBe('activity')
     expect(parseDeepLink('agentfield://settings')).toBe('settings')
+    expect(parseDeepLink('agentfield://cloud')).toBe('cloud')
   })
 
   it('migrates legacy dashboard and secrets hosts', () => {
@@ -57,7 +58,7 @@ describe('deepLinkFromArgv', () => {
 
 describe('isView', () => {
   it('accepts exactly the app views', () => {
-    for (const v of ['home', 'install', 'agents', 'activity', 'settings']) {
+    for (const v of ['home', 'install', 'agents', 'activity', 'settings', 'cloud']) {
       expect(isView(v)).toBe(true)
     }
     expect(isView('dashboard')).toBe(false)

--- a/desktop/src/shared/deeplink.ts
+++ b/desktop/src/shared/deeplink.ts
@@ -8,7 +8,7 @@
 export const DEEP_LINK_SCHEME = 'agentfield'
 
 /** The app's views, also the vocabulary of deep-link targets. */
-export const VIEWS = ['home', 'install', 'agents', 'activity', 'settings'] as const
+export const VIEWS = ['home', 'install', 'agents', 'activity', 'settings', 'cloud'] as const
 export type View = (typeof VIEWS)[number]
 
 /** Pre-IA rename hosts that still open the app on the successor view. */

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -170,6 +170,8 @@ export interface CliStatus {
  * moment Claude/Codex/anything asks.
  */
 export interface DesktopSettings {
+  /** Remote control-plane profile. The API key remains in main-process settings. */
+  cloud: { enabled: boolean; serverUrl: string; apiKey: string }
   /** Launch the app when you log in (starts hidden, in the tray). */
   openAtLogin: boolean
   /** Follow the OS appearance, or explicitly force the light/dark palette. */
@@ -215,6 +217,15 @@ export interface DesktopSettings {
   starPrompt: 'pending' | 'done'
   /** ISO timestamp until which the star prompt is snoozed (Later = +7 days). null = not snoozed. */
   starPromptSnoozedUntil: string | null
+}
+
+export interface CloudTestResult {
+  ok: boolean
+  healthy: boolean
+  authOk: boolean
+  installApi: boolean
+  version?: string
+  message: string
 }
 
 /** A newer app release found on GitHub (the desktop app's update channel). */
@@ -297,6 +308,9 @@ export interface AgentFieldSnapshot {
 
 /** Surface exposed on window.agentfield by the preload script. */
 export interface AgentFieldApi {
+  cloudTest(url: string, apiKey: string): Promise<CloudTestResult>
+  /** Open the guided Railway deployment flow for a hosted control plane. */
+  cloudDeployRailway(): Promise<boolean>
   getSnapshot(): Promise<AgentFieldSnapshot>
   getCatalog(): Promise<CatalogEntry[]>
   /** Install a catalog entry by name. Resolves when `af install` exits. */


### PR DESCRIPTION
## Summary

The final piece of the one-management-path arc (#837 → #841 → #842 → #843 → #844): AgentField Desktop can now connect to a **remote control plane** with a saved `{server_url, api_key}` profile, managing agents on that box exactly the way it manages a local one — same client, same flows, only the base URL changes.

## What's new

**Cloud tab** (`agentfield://cloud`, ⌘/Ctrl+5): connection status, server URL + API key form, live **Test connection** verdict (reachable / auth / install API / server version), **Save & switch**, and **Switch back to local** (keeps the saved profile for one-click re-enable). A **Deploy on Railway** section opens the control-plane template with paste-back instructions, via a dedicated IPC channel — no generic URL-opener hole.

**Connection core**: a new cycle-free connection-state module supplies base URL + API key to `cpClient` *and* the five raw dashboard/tray fetches that previously bypassed auth entirely. URL normalization refuses plaintext `http://` to public hosts, so keys can't leak over cleartext. The cloud profile is applied at startup and immediately on settings change, and survives restarts (`normalizeSettings` extended — it silently drops unknown keys otherwise).

**Guardrails in cloud mode**: no local port probing, no `af server` spawn, no agent autostart (one remote health check instead), local-server-start IPC refuses politely, skills sync skipped. Switching back restores previous local behavior exactly.

Also fixes a latent bug: `fetchUsageStats` ignored the active base URL.

## Validation

- **Live E2E (5/5)** against a real CP running with `AGENTFIELD_API_KEY` enforcement: full management lifecycle (install → secrets → start → stop → uninstall) driven through the cloud profile; test-connection matrix verified live (valid key / rejected key / unreachable); autostart gating and local-mode restore confirmed. Notable: with a key configured, the CP properly 401s missing/wrong keys — fail-closed as required.
- 339 desktop tests green (up from 323), `typecheck` clean, `dist:dir` builds.
- API key is stored in the desktop settings JSON for now (same trust level as existing `~/.agentfield` config material); moving it to Electron `safeStorage` is a noted follow-up.

## Follow-ups (not in this PR)

- Railway template v2 (point at the `control-plane-cloud` image + volume + generated key default)
- Automated Railway deploy via loopback+PKCE OAuth (needs an OAuth client registration)
- Electron `safeStorage` for the API key at rest

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
