### PR TITLE
feat(desktop): cloud mode — connect to a remote control plane or one-click deploy it to Railway

### DIFF
--- a/control-plane/internal/handlers/nodes_rest.go
+++ b/control-plane/internal/handlers/nodes_rest.go
@@ -82,7 +82,10 @@ func NodeStatusLeaseHandler(storageProvider storage.StorageProvider, statusManag
 		}
 
 		update := &types.AgentStatusUpdate{
-			Source:  types.StatusSourceManual,
+			// A lease renewal is the Go SDK's proof-of-life signal. Classifying it
+			// as a heartbeat keeps the status snapshot and persisted heartbeat in
+			// sync without changing the public lease wire contract.
+			Source:  types.StatusSourceHeartbeat,
 			Version: agent.Version,
 		}
 

--- a/control-plane/internal/handlers/ui/agent_secrets.go
+++ b/control-plane/internal/handlers/ui/agent_secrets.go
@@ -35,7 +35,25 @@ type agentSecretStatus struct {
 	IsSet bool   `json:"is_set"`
 	// Scope reports where the stored value lives ("node" or "global");
 	// empty when the key is not set anywhere.
-	Scope string `json:"scope,omitempty"`
+	Scope            string `json:"scope,omitempty"`
+	DeclaredScope    string `json:"declared_scope,omitempty"`
+	Description      string `json:"description,omitempty"`
+	Secret           bool   `json:"secret,omitempty"`
+	Default          string `json:"default,omitempty"`
+	Requirement      string `json:"requirement,omitempty"`
+	Group            string `json:"group,omitempty"`
+	GroupDescription string `json:"group_description,omitempty"`
+}
+
+type declaredAgentEnvironmentVar struct {
+	Name             string `json:"name"`
+	Description      string `json:"description"`
+	Type             string `json:"type"`
+	Scope            string `json:"scope"`
+	Default          string `json:"default"`
+	Requirement      string `json:"-"`
+	Group            string `json:"-"`
+	GroupDescription string `json:"-"`
 }
 
 type setAgentSecretRequest struct {
@@ -82,9 +100,18 @@ func (h *AgentSecretsHandler) ListAgentSecretsHandler(c *gin.Context) {
 		inGlobal[key] = true
 	}
 
+	includeEnvironment := c.Query("include") == "env"
+	declared := declaredAgentSecrets(agentPackage.ConfigurationSchema)
 	listed := make(map[string]struct{})
-	for key := range declaredAgentSecrets(agentPackage.ConfigurationSchema) {
+	for key := range declared {
 		listed[key] = struct{}{}
+	}
+	var environment map[string]declaredAgentEnvironmentVar
+	if includeEnvironment {
+		environment = declaredAgentEnvironment(agentPackage.ConfigurationSchema)
+		for key := range environment {
+			listed[key] = struct{}{}
+		}
 	}
 	for _, key := range nodeKeys {
 		listed[key] = struct{}{}
@@ -106,6 +133,17 @@ func (h *AgentSecretsHandler) ListAgentSecretsHandler(c *gin.Context) {
 		case inGlobal[key]:
 			status.IsSet = true
 			status.Scope = globalSecretScope
+		}
+		if includeEnvironment {
+			if variable, ok := environment[key]; ok {
+				status.DeclaredScope = variable.Scope
+				status.Description = variable.Description
+				status.Secret = variable.Type == "secret"
+				status.Default = variable.Default
+				status.Requirement = variable.Requirement
+				status.Group = variable.Group
+				status.GroupDescription = variable.GroupDescription
+			}
 		}
 		secrets = append(secrets, status)
 	}
@@ -270,6 +308,49 @@ func declaredAgentSecrets(schema json.RawMessage) map[string]string {
 		for _, variable := range group.Options {
 			record(variable)
 		}
+	}
+	return declared
+}
+
+func declaredAgentEnvironment(schema json.RawMessage) map[string]declaredAgentEnvironmentVar {
+	var manifest struct {
+		UserEnvironment struct {
+			Required     []declaredAgentEnvironmentVar `json:"required"`
+			Optional     []declaredAgentEnvironmentVar `json:"optional"`
+			RequireOneOf []struct {
+				ID          string                        `json:"id"`
+				Description string                        `json:"description"`
+				Options     []declaredAgentEnvironmentVar `json:"options"`
+			} `json:"require_one_of"`
+		} `json:"user_environment"`
+	}
+	if json.Unmarshal(schema, &manifest) != nil {
+		return nil
+	}
+
+	declared := make(map[string]declaredAgentEnvironmentVar)
+	record := func(v declaredAgentEnvironmentVar, requirement, group, groupDescription string) {
+		if v.Name == "" {
+			return
+		}
+		if v.Scope != "node" {
+			v.Scope = globalSecretScope
+		}
+		v.Requirement = requirement
+		v.Group = group
+		v.GroupDescription = groupDescription
+		declared[v.Name] = v
+	}
+	for _, variable := range manifest.UserEnvironment.Required {
+		record(variable, "required", "", "")
+	}
+	for _, group := range manifest.UserEnvironment.RequireOneOf {
+		for _, variable := range group.Options {
+			record(variable, "one_of", group.ID, group.Description)
+		}
+	}
+	for _, variable := range manifest.UserEnvironment.Optional {
+		record(variable, "optional", "", "")
 	}
 	return declared
 }

--- a/control-plane/internal/handlers/ui/agent_secrets_test.go
+++ b/control-plane/internal/handlers/ui/agent_secrets_test.go
@@ -30,10 +30,14 @@ func newAgentSecretsTestRouter(t *testing.T) (*gin.Engine, string) {
 		ConfigurationSchema: json.RawMessage(`{
 			"user_environment": {
 				"required": [
-					{"name": "OPENAI_API_KEY", "type": "secret"},
+					{"name": "OPENAI_API_KEY", "description": "OpenAI key", "type": "secret"},
 					{"name": "NODE_SCOPED_KEY", "type": "secret", "scope": "node"}
 				],
-				"require_one_of": [{"options": [{"name": "ANTHROPIC_API_KEY", "type": "secret"}]}]
+				"require_one_of": [{"id":"llm_provider","description":"an LLM provider key","options": [{"name": "ANTHROPIC_API_KEY", "description":"Anthropic key", "type": "secret"}]}],
+				"optional": [
+					{"name":"SWE_DEFAULT_RUNTIME","description":"Coding runtime"},
+					{"name":"AGENTFIELD_SERVER","description":"Control-plane URL","default":"http://localhost:8080"}
+				]
 			}
 		}`),
 	})
@@ -95,6 +99,44 @@ func TestAgentSecretsListNamesOnly(t *testing.T) {
 		{"key":"NODE_SCOPED_KEY","is_set":false},
 		{"key":"OPENAI_API_KEY","is_set":true,"scope":"global"}
 	]}`, response.Body.String())
+}
+
+func TestAgentSecretsListIncludesEnvironmentMetadataOptIn(t *testing.T) {
+	router, home := newAgentSecretsTestRouter(t)
+	store, err := packages.NewSecretStore(home)
+	require.NoError(t, err)
+	require.NoError(t, store.Set(agentSecretsTestScope, "ANTHROPIC_API_KEY", "node-value"))
+	require.NoError(t, store.Set(agentSecretsTestScope, "UNDECLARED_NODE", "value"))
+
+	response := agentSecretsRequest(t, router, http.MethodGet, "/agents/agent-x/secrets?include=env", "")
+	require.Equal(t, http.StatusOK, response.Code)
+	require.NotContains(t, response.Body.String(), "node-value")
+	require.JSONEq(t, `{"secrets":[
+		{"key":"AGENTFIELD_SERVER","is_set":false,"declared_scope":"global","description":"Control-plane URL","default":"http://localhost:8080","requirement":"optional"},
+		{"key":"ANTHROPIC_API_KEY","is_set":true,"scope":"node","declared_scope":"global","description":"Anthropic key","secret":true,"requirement":"one_of","group":"llm_provider","group_description":"an LLM provider key"},
+		{"key":"NODE_SCOPED_KEY","is_set":false,"declared_scope":"node","secret":true,"requirement":"required"},
+		{"key":"OPENAI_API_KEY","is_set":false,"declared_scope":"global","description":"OpenAI key","secret":true,"requirement":"required"},
+		{"key":"SWE_DEFAULT_RUNTIME","is_set":false,"declared_scope":"global","description":"Coding runtime","requirement":"optional"},
+		{"key":"UNDECLARED_NODE","is_set":true,"scope":"node"}
+	]}`, response.Body.String())
+}
+
+func TestAgentSecretsListLegacyShapeIgnoresOtherIncludeValues(t *testing.T) {
+	router, _ := newAgentSecretsTestRouter(t)
+	for _, path := range []string{
+		"/agents/agent-x/secrets",
+		"/agents/agent-x/secrets?include=other",
+	} {
+		response := agentSecretsRequest(t, router, http.MethodGet, path, "")
+		require.Equal(t, http.StatusOK, response.Code)
+		require.JSONEq(t, `{"secrets":[
+			{"key":"ANTHROPIC_API_KEY","is_set":false},
+			{"key":"NODE_SCOPED_KEY","is_set":false},
+			{"key":"OPENAI_API_KEY","is_set":false}
+		]}`, response.Body.String())
+		require.NotContains(t, response.Body.String(), "SWE_DEFAULT_RUNTIME")
+		require.NotContains(t, response.Body.String(), "description")
+	}
 }
 
 // Validation contract 3: DELETE removes the secret and remains idempotent.

--- a/control-plane/internal/server/package_sync.go
+++ b/control-plane/internal/server/package_sync.go
@@ -69,9 +69,10 @@ func SyncPackagesFromRegistry(agentfieldHome string, storageProvider packageStor
 	}
 
 	for pkgName, pkg := range registry.Installed {
+		status := packageStatusFromRegistry(pkg.Status)
 		existing, err := storageProvider.GetAgentPackage(ctx, pkgName)
 		if err == nil && existing != nil && installedStatus(existing.Status) &&
-			existing.InstallPath == pkg.Path && existing.Version == pkg.Version {
+			existing.Status == status && existing.InstallPath == pkg.Path && existing.Version == pkg.Version {
 			continue // Already reconciled
 		}
 		// Load agentfield-package.yaml
@@ -98,7 +99,7 @@ func SyncPackagesFromRegistry(agentfieldHome string, storageProvider packageStor
 			Description:         &pkg.Description,
 			InstallPath:         pkg.Path,
 			ConfigurationSchema: schemaJson,
-			Status:              types.PackageStatusInstalled,
+			Status:              status,
 			ConfigurationStatus: types.ConfigurationStatusDraft,
 			InstalledAt:         installedAt,
 			UpdatedAt:           now,
@@ -133,6 +134,17 @@ func SyncPackagesFromRegistry(agentfieldHome string, storageProvider packageStor
 		_ = updatePackage(storageProvider, ctx, row)
 	}
 	return nil
+}
+
+func packageStatusFromRegistry(status string) types.PackageStatus {
+	switch status {
+	case string(types.PackageStatusRunning):
+		return types.PackageStatusRunning
+	case string(types.PackageStatusStopped):
+		return types.PackageStatusStopped
+	default:
+		return types.PackageStatusInstalled
+	}
 }
 
 // installedStatus reports whether a package status implies the package is on

--- a/control-plane/internal/server/package_sync_test.go
+++ b/control-plane/internal/server/package_sync_test.go
@@ -47,6 +47,98 @@ schema:
 	require.NotEmpty(t, pkg.ConfigurationSchema)
 }
 
+func TestSyncPackagesFromRegistryMapsRunningStatus(t *testing.T) {
+	t.Parallel()
+
+	agentfieldHome := t.TempDir()
+	pkgDir := filepath.Join(agentfieldHome, "running-agent")
+	require.NoError(t, os.MkdirAll(pkgDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(agentfieldHome, "installed.yaml"), []byte(`installed:
+  running-agent:
+    name: Running Agent
+    version: 1.0.0
+    path: `+pkgDir+`
+    status: running
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "agentfield-package.yaml"),
+		[]byte("name: Running Agent\nversion: 1.0.0\n"), 0o644))
+
+	storage := newStubPackageStorage()
+	require.NoError(t, SyncPackagesFromRegistry(agentfieldHome, storage))
+	require.Equal(t, types.PackageStatusRunning, storage.packages["running-agent"].Status)
+}
+
+func TestSyncPackagesFromRegistryUpdatesLifecycleStatus(t *testing.T) {
+	t.Parallel()
+
+	agentfieldHome := t.TempDir()
+	pkgDir := filepath.Join(agentfieldHome, "lifecycle-agent")
+	require.NoError(t, os.MkdirAll(pkgDir, 0o755))
+	registryPath := filepath.Join(agentfieldHome, "installed.yaml")
+	runningRegistry := `installed:
+  lifecycle-agent:
+    name: Lifecycle Agent
+    version: 1.0.0
+    path: ` + pkgDir + `
+    status: running
+`
+	require.NoError(t, os.WriteFile(registryPath, []byte(runningRegistry), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "agentfield-package.yaml"),
+		[]byte("name: Lifecycle Agent\nversion: 1.0.0\n"), 0o644))
+
+	storage := newStubPackageStorage()
+	require.NoError(t, SyncPackagesFromRegistry(agentfieldHome, storage))
+	require.Equal(t, types.PackageStatusRunning, storage.packages["lifecycle-agent"].Status)
+
+	stoppedRegistry := `installed:
+  lifecycle-agent:
+    name: Lifecycle Agent
+    version: 1.0.0
+    path: ` + pkgDir + `
+    status: stopped
+`
+	require.NoError(t, os.WriteFile(registryPath, []byte(stoppedRegistry), 0o644))
+	require.NoError(t, SyncPackagesFromRegistry(agentfieldHome, storage))
+	require.Equal(t, types.PackageStatusStopped, storage.packages["lifecycle-agent"].Status)
+}
+
+func TestSyncPackagesFromRegistryDefaultsUnknownStatusToInstalled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status string
+	}{
+		{name: "missing"},
+		{name: "unknown", status: "unknown"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			agentfieldHome := t.TempDir()
+			pkgDir := filepath.Join(agentfieldHome, "default-agent")
+			require.NoError(t, os.MkdirAll(pkgDir, 0o755))
+			installed := `installed:
+  default-agent:
+    name: Default Agent
+    version: 1.0.0
+    path: ` + pkgDir + "\n"
+			if tt.status != "" {
+				installed += "    status: " + tt.status + "\n"
+			}
+			require.NoError(t, os.WriteFile(filepath.Join(agentfieldHome, "installed.yaml"), []byte(installed), 0o644))
+			require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "agentfield-package.yaml"),
+				[]byte("name: Default Agent\nversion: 1.0.0\n"), 0o644))
+
+			storage := newStubPackageStorage()
+			require.NoError(t, SyncPackagesFromRegistry(agentfieldHome, storage))
+			require.Equal(t, types.PackageStatusInstalled, storage.packages["default-agent"].Status)
+		})
+	}
+}
+
 func TestSyncPackagesSkipsExistingEntries(t *testing.T) {
 	t.Parallel()
 

--- a/control-plane/internal/services/status_manager_test.go
+++ b/control-plane/internal/services/status_manager_test.go
@@ -694,7 +694,7 @@ func TestStatusManager_UpdateAgentStatus_ActivePromotesStarting(t *testing.T) {
 // TestStatusManager_ReadyLeaseRenewalPromotesHealthImmediately reproduces the Go SDK
 // "unknown forever" wedge: an agent registers (health "unknown", lifecycle "starting")
 // and its ONLY keep-alive is the status lease (PATCH /nodes/:id/status with
-// phase=ready → State=active + lifecycle=ready, Source=manual). The starting→active
+// phase=ready → State=active + lifecycle=ready, Source=heartbeat). The starting→active
 // transition used to be held open as "pending" instead of completing, so State stayed
 // "starting" and health persisted as "unknown" while lifecycle said "ready" — and
 // because the Go SDK renews the lease every 2 minutes (exactly MaxTransitionTime),
@@ -725,7 +725,7 @@ func TestStatusManager_ReadyLeaseRenewalPromotesHealthImmediately(t *testing.T) 
 	renewal := &types.AgentStatusUpdate{
 		State:           &active,
 		LifecycleStatus: &ready,
-		Source:          types.StatusSourceManual,
+		Source:          types.StatusSourceHeartbeat,
 		Version:         "1.0.0",
 	}
 	require.NoError(t, sm.UpdateAgentStatus(ctx, "lease-node", renewal))
@@ -741,6 +741,85 @@ func TestStatusManager_ReadyLeaseRenewalPromotesHealthImmediately(t *testing.T) 
 	stable, err := provider.GetAgent(ctx, "lease-node")
 	require.NoError(t, err)
 	assert.Equal(t, types.HealthStatusActive, stable.HealthStatus)
+}
+
+func TestStatusManager_LeaseRenewalRefreshesLastSeenButManualUpdateDoesNot(t *testing.T) {
+	provider, ctx := setupStatusManagerStorage(t)
+	registerTestAgent(t, provider, ctx, "lease-liveness-node")
+
+	sm := NewStatusManager(provider, StatusManagerConfig{}, nil, nil)
+	before, err := sm.GetAgentStatusSnapshot(ctx, "lease-liveness-node", nil)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond)
+	require.NoError(t, sm.UpdateAgentStatus(ctx, "lease-liveness-node", &types.AgentStatusUpdate{
+		Source:  types.StatusSourceHeartbeat,
+		Version: "1.0.0",
+		Reason:  "status lease renewal",
+	}))
+
+	afterLease, err := sm.GetAgentStatusSnapshot(ctx, "lease-liveness-node", nil)
+	require.NoError(t, err)
+	assert.True(t, afterLease.LastSeen.After(before.LastSeen),
+		"a lease renewal must advance the cached status snapshot's LastSeen")
+
+	time.Sleep(time.Millisecond)
+	require.NoError(t, sm.UpdateAgentStatus(ctx, "lease-liveness-node", &types.AgentStatusUpdate{
+		Source: types.StatusSourceManual,
+		Reason: "admin metadata update",
+	}))
+
+	afterManual, err := sm.GetAgentStatusSnapshot(ctx, "lease-liveness-node", nil)
+	require.NoError(t, err)
+	assert.Equal(t, afterLease.LastSeen, afterManual.LastSeen,
+		"a genuinely manual update must preserve LastSeen")
+}
+
+func TestStatusManager_ReconciliationUsesLeaseHeartbeatFreshness(t *testing.T) {
+	provider, ctx := setupStatusManagerStorage(t)
+
+	now := time.Now()
+	for _, node := range []*types.AgentNode{
+		{
+			ID:              "current-lease",
+			TeamID:          "team",
+			Version:         "1.0.0",
+			HealthStatus:    types.HealthStatusActive,
+			LifecycleStatus: types.AgentStatusReady,
+			LastHeartbeat:   now.Add(-time.Second),
+			Reasoners:       []types.ReasonerDefinition{},
+			Skills:          []types.SkillDefinition{},
+		},
+		{
+			ID:              "expired-lease",
+			TeamID:          "team",
+			Version:         "1.0.0",
+			HealthStatus:    types.HealthStatusActive,
+			LifecycleStatus: types.AgentStatusReady,
+			LastHeartbeat:   now.Add(-2 * time.Minute),
+			Reasoners:       []types.ReasonerDefinition{},
+			Skills:          []types.SkillDefinition{},
+		},
+	} {
+		require.NoError(t, provider.RegisterAgent(ctx, node))
+	}
+
+	sm := NewStatusManager(provider, StatusManagerConfig{
+		HeartbeatStaleThreshold: 30 * time.Second,
+	}, nil, nil)
+	sm.performReconciliation()
+
+	current, err := provider.GetAgent(ctx, "current-lease")
+	require.NoError(t, err)
+	assert.Equal(t, types.HealthStatusActive, current.HealthStatus,
+		"a current lease heartbeat must keep the agent active")
+	assert.Equal(t, types.AgentStatusReady, current.LifecycleStatus)
+
+	expired, err := provider.GetAgent(ctx, "expired-lease")
+	require.NoError(t, err)
+	assert.Equal(t, types.HealthStatusInactive, expired.HealthStatus,
+		"the agent must become inactive after lease renewals stop")
+	assert.Equal(t, types.AgentStatusOffline, expired.LifecycleStatus)
 }
 
 // TestStatusManager_NeedsReconciliation_UnknownHealthFreshHeartbeat covers the

--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -8,6 +8,7 @@ release/
 # by the release pipeline); only the .gitkeep is tracked
 vendor/*
 !vendor/.gitkeep
+vendor/deploy-engine/
 
 # The root .gitignore excludes build/, but electron-builder reads the app
 # icons from desktop/build — track exactly those.

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run",
     "icons": "electron scripts/make-icons.mjs",
     "bundle-cli": "node scripts/bundle-cli.mjs",
+    "fetch:deploy-engine": "node scripts/fetch-deploy-engine.mjs",
     "dist": "npm run build && electron-builder",
     "dist:dir": "npm run build && electron-builder --dir"
   },
@@ -39,6 +40,10 @@
           "af.exe",
           "af-tray"
         ]
+      },
+      {
+        "from": "vendor/deploy-engine",
+        "to": "bin/deploy-engine"
       }
     ],
     "directories": {
@@ -93,4 +98,3 @@
     "postcss": "8.5.18"
   }
 }
-

--- a/desktop/scripts/fetch-deploy-engine.mjs
+++ b/desktop/scripts/fetch-deploy-engine.mjs
@@ -1,0 +1,75 @@
+import { chmod, copyFile, mkdir, mkdtemp, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const TOFU_VERSION = '1.10.6'
+const RAILWAY_VERSION = '0.6.2'
+const platform = { win32: 'windows', darwin: 'darwin', linux: 'linux' }[process.platform]
+const arch = { x64: 'amd64', arm64: 'arm64' }[process.arch]
+
+if (!platform || !arch) throw new Error(`Unsupported deploy-engine platform: ${process.platform}/${process.arch}`)
+
+const desktopDir = resolve(fileURLToPath(new URL('..', import.meta.url)))
+const destination = join(desktopDir, 'vendor', 'deploy-engine')
+const providerDir = join(destination, 'providers', 'registry.terraform.io', 'terraform-community-providers', 'railway', RAILWAY_VERSION, `${platform}_${arch}`)
+const temporary = await mkdtemp(join(tmpdir(), 'agentfield-deploy-engine-'))
+
+async function download(url, path) {
+  console.log(`Downloading ${basename(path)}...`)
+  const response = await fetch(url, { redirect: 'follow' })
+  if (!response.ok) throw new Error(`Download failed (${response.status}): ${url}`)
+  await BunlessWrite(path, new Uint8Array(await response.arrayBuffer()))
+}
+
+async function BunlessWrite(path, bytes) {
+  const { writeFile } = await import('node:fs/promises')
+  await writeFile(path, bytes)
+}
+
+function command(program, args) {
+  return new Promise((resolveCommand, reject) => {
+    const child = spawn(program, args, { stdio: 'inherit' })
+    child.on('error', reject)
+    child.on('close', (code) => code === 0 ? resolveCommand() : reject(new Error(`${program} exited with ${code}`)))
+  })
+}
+
+async function extract(zip, directory) {
+  await mkdir(directory, { recursive: true })
+  if (process.platform === 'win32') {
+    const escapedZip = zip.replaceAll("'", "''")
+    const escapedDir = directory.replaceAll("'", "''")
+    await command('powershell.exe', ['-NoProfile', '-Command', `Expand-Archive -LiteralPath '${escapedZip}' -DestinationPath '${escapedDir}' -Force`])
+  } else {
+    await command('unzip', ['-o', zip, '-d', directory])
+  }
+}
+
+try {
+  const tofuZip = join(temporary, 'tofu.zip')
+  const providerZip = join(temporary, 'provider.zip')
+  const tofuExtract = join(temporary, 'tofu')
+  const providerExtract = join(temporary, 'provider')
+  await Promise.all([
+    download(`https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_${platform}_${arch}.zip`, tofuZip),
+    download(`https://github.com/terraform-community-providers/terraform-provider-railway/releases/download/v${RAILWAY_VERSION}/terraform-provider-railway_${RAILWAY_VERSION}_${platform}_${arch}.zip`, providerZip)
+  ])
+  await Promise.all([extract(tofuZip, tofuExtract), extract(providerZip, providerExtract)])
+  await mkdir(providerDir, { recursive: true })
+  const tofuName = process.platform === 'win32' ? 'tofu.exe' : 'tofu'
+  const providerName = process.platform === 'win32' ? `terraform-provider-railway_v${RAILWAY_VERSION}.exe` : `terraform-provider-railway_v${RAILWAY_VERSION}`
+  const providerFiles = await readdir(providerExtract)
+  const extractedProvider = providerFiles.find((name) => name.startsWith('terraform-provider-railway'))
+  if (!extractedProvider) throw new Error('Provider archive did not contain the Railway provider binary')
+  await mkdir(destination, { recursive: true })
+  await rm(join(destination, tofuName), { force: true })
+  await rm(join(providerDir, providerName), { force: true })
+  await copyFile(join(tofuExtract, tofuName), join(destination, tofuName))
+  await copyFile(join(providerExtract, extractedProvider), join(providerDir, providerName))
+  if (process.platform !== 'win32') await Promise.all([chmod(join(destination, tofuName), 0o755), chmod(join(providerDir, providerName), 0o755)])
+  console.log(`Deploy engine ${TOFU_VERSION} and Railway provider ${RAILWAY_VERSION} installed in ${destination}`)
+} finally {
+  await rm(temporary, { recursive: true, force: true })
+}

--- a/desktop/src/main/agentfield.test.ts
+++ b/desktop/src/main/agentfield.test.ts
@@ -33,13 +33,15 @@ const API_PACKAGES: PackageInfo[] = [
   {
     id: 'pr-af', name: 'pr-af', version: '0.1.0',
     description: 'Opens draft pull requests from a task description',
-    status: 'running', install_path: '/home/abir/.agentfield/packages/pr-af',
+    status: 'configured', install_status: 'running',
+    install_path: '/home/abir/.agentfield/packages/pr-af',
     port: 9001, process_id: 4242, configuration_required: false,
     configuration_complete: true, author: ''
   },
   {
     id: 'swe-af', name: 'swe-af', version: '0.2.1',
-    description: 'Software engineering agent', status: 'stopped', install_path: '',
+    description: 'Software engineering agent', status: 'not_configured',
+    install_status: 'stopped', install_path: '',
     configuration_required: false, configuration_complete: true, author: ''
   }
 ]
@@ -157,6 +159,15 @@ describe('readInstalledAgents', () => {
     expect(result).toEqual({ exists: true, agents: [] })
   })
 
+  it('prefers install_status and falls back to status for old servers', async () => {
+    const lifecycle = { ...API_PACKAGES[0], status: 'not_configured', install_status: 'installed' }
+    const legacy = { ...API_PACKAGES[1], status: 'running', install_status: undefined }
+
+    const result = await readInstalledAgents(packagesClient([lifecycle, legacy]))
+
+    expect(result.agents.map((agent) => agent.status)).toEqual(['installed', 'running'])
+  })
+
   it('surfaces API failures without throwing', async () => {
     const client = packagesClient()
     vi.mocked(client.listPackages).mockRejectedValue(new Error('offline'))
@@ -176,6 +187,8 @@ describe('deriveAgentBadge', () => {
     ['running', false, 'active', 'running'],
     ['stopped', false, null, 'stopped'],
     ['stopped', false, 'active', 'stopped'],
+    ['installed', false, null, 'unknown'],
+    ['installed', false, 'active', 'unknown'],
     ['error', false, null, 'unknown'],
     [undefined, false, null, 'unknown'],
     // CP view available -> cross-check
@@ -189,6 +202,9 @@ describe('deriveAgentBadge', () => {
     ['stopped', true, 'inactive', 'stopped'],
     ['stopped', true, 'unknown', 'stopped'],
     ['stopped', true, null, 'stopped'],
+    ['installed', true, 'active', 'running'],
+    ['installed', true, 'inactive', 'stopped'],
+    ['installed', true, null, 'stopped'],
     ['error', true, 'active', 'unknown'],
     [undefined, true, null, 'unknown']
   ] as const)(

--- a/desktop/src/main/agentfield.test.ts
+++ b/desktop/src/main/agentfield.test.ts
@@ -290,6 +290,11 @@ describe('fetchControlPlaneNodes', () => {
     )
   })
 
+  it('treats a null nodes slice as an empty control-plane view', async () => {
+    const fetchImpl: FetchLike = async () => jsonResponse({ nodes: null, count: 0 })
+    expect(await fetchControlPlaneNodes('http://localhost:8080', fetchImpl)).toEqual(new Map())
+  })
+
   it('returns null on a non-200 response', async () => {
     const fetchImpl: FetchLike = async () => jsonResponse({ error: 'nope' }, 500)
     expect(await fetchControlPlaneNodes('http://localhost:8080', fetchImpl)).toBeNull()
@@ -356,6 +361,15 @@ describe('fetchExecutions', () => {
       durationMs: 45,
       terminal: true,
       errorMessage: null
+    })
+  })
+
+  it('treats a null runs slice as empty activity', async () => {
+    const fetchImpl: FetchLike = async () =>
+      jsonResponse({ runs: null, total_count: 0 })
+    await expect(fetchExecutions('http://localhost:8080', fetchImpl)).resolves.toEqual({
+      running: [],
+      recent: []
     })
   })
 

--- a/desktop/src/main/agentfield.test.ts
+++ b/desktop/src/main/agentfield.test.ts
@@ -7,6 +7,7 @@ import {
   checkControlPlane,
   deriveAgentBadge,
   fetchControlPlaneNodes,
+  fetchDashboardMetrics,
   fetchExecutions,
   fetchUsageStats,
   getAgentFieldHome,
@@ -19,6 +20,7 @@ import {
 import { DEFAULT_CONTROL_PLANE_PORT } from './ports'
 import { installCommand, sanitizeInstallOutput } from './installer'
 import { CATALOG, catalogEntry } from '../shared/catalog'
+import { setCloudConnection } from './connection'
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -64,6 +66,51 @@ describe('active base URL', () => {
     }
     await checkControlPlane(undefined, fetchImpl)
     expect(seen).toEqual(['http://localhost:9091/health'])
+  })
+})
+
+describe('raw control-plane fetch authentication', () => {
+  afterEach(() => setActiveControlPlanePort(DEFAULT_CONTROL_PLANE_PORT))
+
+  async function callRawReaders(fetchImpl: FetchLike): Promise<void> {
+    await checkControlPlane(undefined, fetchImpl)
+    await fetchControlPlaneNodes(undefined, fetchImpl)
+    await fetchExecutions(undefined, fetchImpl)
+    await fetchDashboardMetrics(undefined, fetchImpl)
+    await fetchUsageStats(undefined, fetchImpl)
+  }
+
+  it('adds X-API-Key to every raw reader in cloud mode', async () => {
+    setCloudConnection('https://cp.example', 'cloud-key')
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/health')) return jsonResponse({ status: 'healthy' })
+      if (url.includes('/nodes')) return jsonResponse({ nodes: [] })
+      if (url.includes('/workflow-runs')) return jsonResponse({ runs: [] })
+      if (url.includes('/dashboard/summary')) return jsonResponse({})
+      return jsonResponse({ totals: {} })
+    }) as FetchLike
+    await callRawReaders(fetchImpl)
+    expect(vi.mocked(fetchImpl).mock.calls).toHaveLength(5)
+    for (const [, init] of vi.mocked(fetchImpl).mock.calls) {
+      expect(new Headers(init?.headers).get('X-API-Key')).toBe('cloud-key')
+    }
+  })
+
+  it('omits X-API-Key from every raw reader in local mode', async () => {
+    setActiveControlPlanePort(8080)
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/health')) return jsonResponse({ status: 'healthy' })
+      if (url.includes('/nodes')) return jsonResponse({ nodes: [] })
+      if (url.includes('/workflow-runs')) return jsonResponse({ runs: [] })
+      if (url.includes('/dashboard/summary')) return jsonResponse({})
+      return jsonResponse({ totals: {} })
+    }) as FetchLike
+    await callRawReaders(fetchImpl)
+    for (const [, init] of vi.mocked(fetchImpl).mock.calls) {
+      expect(new Headers(init?.headers).has('X-API-Key')).toBe(false)
+    }
   })
 })
 

--- a/desktop/src/main/agentfield.ts
+++ b/desktop/src/main/agentfield.ts
@@ -160,9 +160,11 @@ export async function fetchControlPlaneNodes(
     })
     if (!res.ok) return null
     const body: unknown = await res.json()
-    if (!isRecord(body) || !Array.isArray(body.nodes)) return null
+    if (!isRecord(body) || !('nodes' in body)) return null
+    const nodes = body.nodes ?? []
+    if (!Array.isArray(nodes)) return null
     const health = new Map<string, string>()
-    for (const node of body.nodes) {
+    for (const node of nodes) {
       if (!isRecord(node) || typeof node.id !== 'string' || node.id === '') continue
       health.set(node.id, typeof node.health_status === 'string' ? node.health_status : 'unknown')
     }
@@ -249,8 +251,10 @@ export async function fetchExecutions(
     )
     if (!res.ok) return null
     const body: unknown = await res.json()
-    if (!isRecord(body) || !Array.isArray(body.runs)) return null
-    const summaries = body.runs
+    if (!isRecord(body) || !('runs' in body)) return null
+    const runs = body.runs ?? []
+    if (!Array.isArray(runs)) return null
+    const summaries = runs
       .filter(isRecord)
       .map(toExecutionSummary)
       .filter((s): s is ExecutionSummary => s !== null)

--- a/desktop/src/main/agentfield.ts
+++ b/desktop/src/main/agentfield.ts
@@ -20,6 +20,7 @@ import type {
 
 import { DEFAULT_CONTROL_PLANE_PORT, baseUrlForPort } from './ports'
 import { createCpClient, isInstalledPackage, type CpClient, type PackageInfo } from './cpClient'
+import * as connection from './connection'
 
 export const DEFAULT_BASE_URL = baseUrlForPort(DEFAULT_CONTROL_PLANE_PORT)
 
@@ -30,14 +31,12 @@ export const DEFAULT_BASE_URL = baseUrlForPort(DEFAULT_CONTROL_PLANE_PORT)
 // the tray, open-web-ui, AGENTFIELD_SERVER for spawned `af` — reads it via
 // getBaseUrl() so nothing in the app hard-codes 8080.
 
-let activeBaseUrl = DEFAULT_BASE_URL
-
 export function getBaseUrl(): string {
-  return activeBaseUrl
+  return connection.getBaseUrl()
 }
 
 export function setActiveControlPlanePort(port: number): void {
-  activeBaseUrl = baseUrlForPort(port)
+  connection.setLocalPort(port)
 }
 
 const HTTP_TIMEOUT_MS = 3000
@@ -59,6 +58,13 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
 
+function authHeaders(): Headers {
+  const headers = new Headers()
+  const apiKey = connection.getApiKey()
+  if (apiKey !== null) headers.set('X-API-Key', apiKey)
+  return headers
+}
+
 /**
  * Probe GET {baseUrl}/health.
  *  - 200 {"status":"healthy",...}   -> { reachable: true, recognized: true,  healthy: true }
@@ -76,6 +82,7 @@ export async function checkControlPlane(
 ): Promise<ControlPlaneStatus> {
   try {
     const res = await fetchImpl(`${baseUrl}/health`, {
+      headers: authHeaders(),
       signal: AbortSignal.timeout(HTTP_TIMEOUT_MS)
     })
     let raw: unknown
@@ -148,6 +155,7 @@ export async function fetchControlPlaneNodes(
 ): Promise<Map<string, string> | null> {
   try {
     const res = await fetchImpl(`${baseUrl}/api/v1/nodes?show_all=true`, {
+      headers: authHeaders(),
       signal: AbortSignal.timeout(HTTP_TIMEOUT_MS)
     })
     if (!res.ok) return null
@@ -237,7 +245,7 @@ export async function fetchExecutions(
   try {
     const res = await fetchImpl(
       `${baseUrl}/api/ui/v2/workflow-runs?page=1&page_size=25&sort_by=updated_at&sort_order=desc`,
-      { signal: AbortSignal.timeout(HTTP_TIMEOUT_MS) }
+      { headers: authHeaders(), signal: AbortSignal.timeout(HTTP_TIMEOUT_MS) }
     )
     if (!res.ok) return null
     const body: unknown = await res.json()
@@ -265,6 +273,7 @@ export async function fetchDashboardMetrics(
 ): Promise<DashboardMetrics | null> {
   try {
     const res = await fetchImpl(`${baseUrl}/api/ui/v1/dashboard/summary`, {
+      headers: authHeaders(),
       signal: AbortSignal.timeout(HTTP_TIMEOUT_MS)
     })
     if (!res.ok) return null
@@ -306,11 +315,12 @@ function parseUsageGroups(value: unknown): UsageGroup[] {
  * the whole Home. Never throws across IPC.
  */
 export async function fetchUsageStats(
-  baseUrl: string = DEFAULT_BASE_URL,
+  baseUrl: string = getBaseUrl(),
   fetchImpl: FetchLike = fetch
 ): Promise<UsageStats | null> {
   try {
     const res = await fetchImpl(`${baseUrl}/api/ui/v1/usage/stats?window=24h`, {
+      headers: authHeaders(),
       signal: AbortSignal.timeout(HTTP_TIMEOUT_MS)
     })
     if (res.status === 404 || res.status === 401 || res.status === 403) return null

--- a/desktop/src/main/agentfield.ts
+++ b/desktop/src/main/agentfield.ts
@@ -113,7 +113,7 @@ export function packageToInstalledAgent(pkg: PackageInfo): InstalledAgent {
     name: pkg.name,
     version: pkg.version,
     description: pkg.description,
-    status: pkg.status,
+    status: pkg.install_status ?? pkg.status,
     path: pkg.install_path || null,
     port: pkg.port ?? null,
     pid: pkg.process_id ?? null
@@ -180,8 +180,9 @@ export async function fetchControlPlaneNodes(
  * `nodeHealth` is the node's health_status on the control plane, or null when
  * it is not registered there at all.
  *
- * CP view unavailable — trust the registry:
- *   'running' -> 'running' | 'stopped' -> 'stopped' | other/absent -> 'unknown'
+ * CP view unavailable — trust affirmative registry lifecycle states:
+ *   'running' -> 'running' | 'stopped' -> 'stopped'
+ *   'installed' / other / absent -> 'unknown'
  * CP view available — cross-check. Registration presence (not health) proves
  * a running registry entry is live, so transient health dips cannot flicker
  * the badge; health only matters for stopped entries, where an ACTIVE node
@@ -191,6 +192,8 @@ export async function fetchControlPlaneNodes(
  *   registry stopped + health active           -> 'unknown'  (conflict)
  *   registry stopped + otherwise               -> 'stopped'  (stopped nodes stay
  *                                                  registered as inactive/unknown)
+ *   registry installed + health active         -> 'running'  (live evidence)
+ *   registry installed + otherwise             -> 'stopped'  (on disk, not live)
  *   other/absent registry status               -> 'unknown'
  */
 export function deriveAgentBadge(
@@ -208,6 +211,9 @@ export function deriveAgentBadge(
   }
   if (registryStatus === 'stopped') {
     return nodeHealth === 'active' ? 'unknown' : 'stopped'
+  }
+  if (registryStatus === 'installed') {
+    return nodeHealth === 'active' ? 'running' : 'stopped'
   }
   return 'unknown'
 }

--- a/desktop/src/main/autostart.test.ts
+++ b/desktop/src/main/autostart.test.ts
@@ -4,6 +4,7 @@ import {
   autostartAgentPlan,
   controlPlanePortCandidates,
   planControlPlaneBoot,
+  runAutostart,
   type PortProbe
 } from './autostart'
 
@@ -20,8 +21,39 @@ function agent(name: string, badge: SnapshotAgent['badge']): SnapshotAgent {
   }
 }
 
+describe('runAutostart cloud mode', () => {
+  it('only checks and reports the active remote control plane', async () => {
+    let checks = 0
+    let persisted = 0
+    const logs: string[] = []
+    await runAutostart(
+      settings({
+        cloud: { enabled: true, serverUrl: 'https://cloud.example', apiKey: 'secret' },
+        autostartAgents: ['must-not-start']
+      }),
+      (line) => logs.push(line),
+      async () => {
+        persisted++
+      },
+      {
+        getBaseUrl: () => 'https://cloud.example',
+        checkControlPlane: async () => {
+          checks++
+          return { reachable: true, recognized: true, healthy: true }
+        }
+      }
+    )
+    expect(checks).toBe(1)
+    expect(persisted).toBe(0)
+    expect(logs).toEqual([
+      'autostart: remote control plane reachable at https://cloud.example'
+    ])
+  })
+})
+
 function settings(overrides: Partial<DesktopSettings>): DesktopSettings {
   return {
+    cloud: { enabled: false, serverUrl: '', apiKey: '' },
     openAtLogin: false,
     appearance: 'system',
     autostartControlPlane: true,

--- a/desktop/src/main/autostart.ts
+++ b/desktop/src/main/autostart.ts
@@ -20,7 +20,7 @@ import type {
   DesktopSettings,
   SnapshotAgent
 } from '../shared/types'
-import { checkControlPlane, getSnapshot, setActiveControlPlanePort } from './agentfield'
+import { checkControlPlane, getBaseUrl, getSnapshot, setActiveControlPlanePort } from './agentfield'
 import { runAgentAction, startControlPlane } from './agents'
 import { DEFAULT_CONTROL_PLANE_PORT, baseUrlForPort, pickFreePort } from './ports'
 
@@ -128,8 +128,20 @@ export function planControlPlaneBoot(
 export async function runAutostart(
   settings: DesktopSettings,
   log: (message: string) => void,
-  persistPort: (port: number) => Promise<void> = async () => {}
+  persistPort: (port: number) => Promise<void> = async () => {},
+  deps: { checkControlPlane?: typeof checkControlPlane; getBaseUrl?: typeof getBaseUrl } = {}
 ): Promise<void> {
+  if (settings.cloud.enabled) {
+    const baseUrl = (deps.getBaseUrl ?? getBaseUrl)()
+    const status = await (deps.checkControlPlane ?? checkControlPlane)()
+    log(
+      status.reachable
+        ? `autostart: remote control plane reachable at ${baseUrl}`
+        : `autostart: remote control plane unreachable at ${baseUrl}`
+    )
+    return
+  }
+
   const probes: PortProbe[] = []
   for (const port of controlPlanePortCandidates(settings)) {
     probes.push({ port, status: await checkControlPlane(baseUrlForPort(port)) })

--- a/desktop/src/main/cloud.test.ts
+++ b/desktop/src/main/cloud.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getApiKey, getBaseUrl, setLocalPort } from './connection'
+import { applyConnectionProfile, normalizeServerUrl, testCloudConnection } from './cloud'
+import { DEFAULT_SETTINGS } from './settings'
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  })
+}
+
+function fakeFetch(responses: Array<Response | Error>): typeof fetch {
+  return vi.fn(async () => {
+    const next = responses.shift()
+    if (next instanceof Error) throw next
+    if (!next) throw new Error('unexpected fetch')
+    return next
+  }) as unknown as typeof fetch
+}
+
+afterEach(() => setLocalPort(8080))
+
+describe('normalizeServerUrl', () => {
+  it('normalizes host input and removes paths, queries, and trailing slashes', () => {
+    expect(normalizeServerUrl(' cp.example/path/?x=1 ')).toBe('https://cp.example')
+    expect(normalizeServerUrl('https://cp.example:8443///')).toBe('https://cp.example:8443')
+  })
+
+  it('allows insecure HTTP only on local and private hosts', () => {
+    expect(normalizeServerUrl('http://localhost:8080/ui')).toBe('http://localhost:8080')
+    expect(normalizeServerUrl('http://127.0.0.1:8080')).toBe('http://127.0.0.1:8080')
+    expect(normalizeServerUrl('http://10.2.3.4')).toBe('http://10.2.3.4')
+    expect(normalizeServerUrl('http://172.16.1.2')).toBe('http://172.16.1.2')
+    expect(normalizeServerUrl('http://192.168.1.2')).toBe('http://192.168.1.2')
+    expect(normalizeServerUrl('http://cp.example')).toBeNull()
+  })
+
+  it('rejects empty and malformed input', () => {
+    expect(normalizeServerUrl('')).toBeNull()
+    expect(normalizeServerUrl(':// bad')).toBeNull()
+    expect(normalizeServerUrl('ftp://cp.example')).toBeNull()
+  })
+})
+
+describe('testCloudConnection', () => {
+  it('reports healthy authenticated servers, install support, and health version', async () => {
+    const fetchImpl = fakeFetch([
+      json({ status: 'healthy', version: '1.2.3' }),
+      json({ packages: [] }),
+      json([])
+    ])
+    await expect(
+      testCloudConnection('cp.example/', 'secret', { fetchImpl })
+    ).resolves.toEqual({
+      ok: true,
+      healthy: true,
+      authOk: true,
+      installApi: true,
+      version: '1.2.3',
+      message: 'Connection successful'
+    })
+    for (const [, init] of vi.mocked(fetchImpl).mock.calls) {
+      expect(new Headers(init?.headers).get('X-API-Key')).toBe('secret')
+      expect(init?.signal).toBeInstanceOf(AbortSignal)
+    }
+  })
+
+  it('distinguishes a rejected API key', async () => {
+    const fetchImpl = fakeFetch([json({ status: 'healthy' }), json({}, 401)])
+    await expect(testCloudConnection('https://cp.example', 'bad', { fetchImpl })).resolves.toEqual({
+      ok: false,
+      healthy: true,
+      authOk: false,
+      installApi: false,
+      message: 'API key rejected'
+    })
+  })
+
+  it('distinguishes an unreachable server', async () => {
+    const fetchImpl = fakeFetch([new Error('offline')])
+    await expect(testCloudConnection('https://cp.example/', 'key', { fetchImpl })).resolves.toEqual({
+      ok: false,
+      healthy: false,
+      authOk: false,
+      installApi: false,
+      message: 'Could not reach https://cp.example'
+    })
+  })
+
+  it('reports an older control plane without install API and discovers version separately', async () => {
+    const fetchImpl = fakeFetch([
+      json({ status: 'healthy' }),
+      json({ packages: [] }),
+      json({}, 404),
+      json({ server_version: '0.9.0' })
+    ])
+    await expect(
+      testCloudConnection('https://cp.example', 'key', { fetchImpl })
+    ).resolves.toEqual({
+      ok: true,
+      healthy: true,
+      authOk: true,
+      installApi: false,
+      version: '0.9.0',
+      message: 'Connected; install API unavailable'
+    })
+  })
+
+  it('omits an unknown version', async () => {
+    const fetchImpl = fakeFetch([
+      json({ status: 'healthy' }),
+      json({ packages: [] }),
+      json([]),
+      json({}, 404)
+    ])
+    const result = await testCloudConnection('https://cp.example', 'key', { fetchImpl })
+    expect(result.ok).toBe(true)
+    expect(result).not.toHaveProperty('version')
+  })
+})
+
+describe('applyConnectionProfile', () => {
+  it('applies an enabled normalized profile and clears it when disabled', () => {
+    setLocalPort(9091)
+    applyConnectionProfile({
+      ...DEFAULT_SETTINGS,
+      cloud: { enabled: true, serverUrl: ' cp.example/path ', apiKey: 'secret' }
+    })
+    expect(getBaseUrl()).toBe('https://cp.example')
+    expect(getApiKey()).toBe('secret')
+    applyConnectionProfile(DEFAULT_SETTINGS)
+    expect(getBaseUrl()).toBe('http://localhost:9091')
+    expect(getApiKey()).toBeNull()
+  })
+})

--- a/desktop/src/main/cloud.ts
+++ b/desktop/src/main/cloud.ts
@@ -1,0 +1,184 @@
+import type { CloudTestResult, DesktopSettings } from '../shared/types'
+import { clearCloudConnection, setCloudConnection } from './connection'
+
+export type { CloudTestResult } from '../shared/types'
+
+function isPrivateHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '')
+  if (host === 'localhost' || host === '::1') return true
+  const parts = host.split('.').map(Number)
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+    return false
+  }
+  return (
+    parts[0] === 10 ||
+    parts[0] === 127 ||
+    (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
+    (parts[0] === 192 && parts[1] === 168)
+  )
+}
+
+export function normalizeServerUrl(input: string): string | null {
+  const trimmed = input.trim()
+  if (!trimmed) return null
+  const candidate = /^[a-z][a-z\d+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`
+  try {
+    const parsed = new URL(candidate)
+    if (!parsed.hostname || parsed.username || parsed.password) return null
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return null
+    if (parsed.protocol === 'http:' && !isPrivateHost(parsed.hostname)) return null
+    return parsed.origin
+  } catch {
+    return null
+  }
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function versionFrom(value: unknown): string | undefined {
+  const body = record(value)
+  if (!body) return undefined
+  for (const key of ['version', 'server_version', 'build_version']) {
+    if (typeof body[key] === 'string' && body[key] !== '') return body[key] as string
+  }
+  const build = record(body.build)
+  return build && typeof build.version === 'string' && build.version !== ''
+    ? build.version
+    : undefined
+}
+
+async function jsonBestEffort(response: Response): Promise<unknown> {
+  try {
+    return await response.json()
+  } catch {
+    return undefined
+  }
+}
+
+export async function testCloudConnection(
+  url: string,
+  apiKey: string,
+  deps: { fetchImpl?: typeof fetch } = {}
+): Promise<CloudTestResult> {
+  const normalized = normalizeServerUrl(url)
+  if (!normalized) {
+    return {
+      ok: false,
+      healthy: false,
+      authOk: false,
+      installApi: false,
+      message: 'Enter a valid server URL'
+    }
+  }
+  const fetchImpl = deps.fetchImpl ?? globalThis.fetch
+  const headers = { 'X-API-Key': apiKey }
+
+  let health: Response
+  try {
+    health = await fetchImpl(`${normalized}/health`, {
+      method: 'GET',
+      headers,
+      signal: AbortSignal.timeout(5000)
+    })
+  } catch {
+    return {
+      ok: false,
+      healthy: false,
+      authOk: false,
+      installApi: false,
+      message: `Could not reach ${normalized}`
+    }
+  }
+
+  const healthBody = await jsonBestEffort(health)
+  const healthy = health.ok
+  let version = versionFrom(healthBody)
+  if (!healthy) {
+    return {
+      ok: false,
+      healthy: false,
+      authOk: false,
+      installApi: false,
+      ...(version ? { version } : {}),
+      message: `Control plane at ${normalized} is not healthy`
+    }
+  }
+
+  let authResponse: Response
+  try {
+    authResponse = await fetchImpl(`${normalized}/api/ui/v1/agents/packages`, {
+      method: 'GET',
+      headers,
+      signal: AbortSignal.timeout(5000)
+    })
+  } catch {
+    return {
+      ok: false,
+      healthy: true,
+      authOk: false,
+      installApi: false,
+      ...(version ? { version } : {}),
+      message: 'Could not verify API access'
+    }
+  }
+  const authOk = authResponse.ok
+  if (!authOk) {
+    return {
+      ok: false,
+      healthy: true,
+      authOk: false,
+      installApi: false,
+      ...(version ? { version } : {}),
+      message:
+        authResponse.status === 401 || authResponse.status === 403
+          ? 'API key rejected'
+          : `API request failed with status ${authResponse.status}`
+    }
+  }
+
+  let installApi = false
+  try {
+    const installResponse = await fetchImpl(
+      `${normalized}/api/ui/v1/agents/packages/install/jobs`,
+      { method: 'GET', headers, signal: AbortSignal.timeout(5000) }
+    )
+    installApi = installResponse.status !== 404
+  } catch {
+    installApi = false
+  }
+
+  if (!version) {
+    try {
+      const versionResponse = await fetchImpl(`${normalized}/api/v1/version`, {
+        method: 'GET',
+        headers,
+        signal: AbortSignal.timeout(5000)
+      })
+      if (versionResponse.ok) version = versionFrom(await jsonBestEffort(versionResponse))
+    } catch {
+      // Version discovery is best-effort.
+    }
+  }
+
+  return {
+    ok: true,
+    healthy: true,
+    authOk: true,
+    installApi,
+    ...(version ? { version } : {}),
+    message: installApi ? 'Connection successful' : 'Connected; install API unavailable'
+  }
+}
+
+export function applyConnectionProfile(settings: DesktopSettings): void {
+  const normalized = normalizeServerUrl(settings.cloud?.serverUrl ?? '')
+  if (settings.cloud?.enabled && normalized) {
+    setCloudConnection(normalized, settings.cloud.apiKey || null)
+  } else {
+    clearCloudConnection()
+  }
+}

--- a/desktop/src/main/connection.test.ts
+++ b/desktop/src/main/connection.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  clearCloudConnection,
+  getApiKey,
+  getBaseUrl,
+  isCloudActive,
+  setCloudConnection,
+  setLocalPort
+} from './connection'
+
+afterEach(() => setLocalPort(8080))
+
+describe('connection state', () => {
+  it('switches to cloud and restores the last local port', () => {
+    setLocalPort(9091)
+    setCloudConnection('https://cp.example', 'secret')
+    expect(getBaseUrl()).toBe('https://cp.example')
+    expect(getApiKey()).toBe('secret')
+    expect(isCloudActive()).toBe(true)
+    clearCloudConnection()
+    expect(getBaseUrl()).toBe('http://localhost:9091')
+    expect(getApiKey()).toBeNull()
+    expect(isCloudActive()).toBe(false)
+  })
+
+  it('setting a local port clears cloud state', () => {
+    setCloudConnection('https://cp.example', 'secret')
+    setLocalPort(8082)
+    expect(getBaseUrl()).toBe('http://localhost:8082')
+    expect(getApiKey()).toBeNull()
+    expect(isCloudActive()).toBe(false)
+  })
+})

--- a/desktop/src/main/connection.ts
+++ b/desktop/src/main/connection.ts
@@ -1,0 +1,37 @@
+const DEFAULT_LOCAL_URL = 'http://localhost:8080'
+
+let localUrl = DEFAULT_LOCAL_URL
+let baseUrl = localUrl
+let apiKey: string | null = null
+let cloudActive = false
+
+export function getBaseUrl(): string {
+  return baseUrl
+}
+
+export function setLocalPort(port: number): void {
+  localUrl = `http://localhost:${port}`
+  baseUrl = localUrl
+  apiKey = null
+  cloudActive = false
+}
+
+export function setCloudConnection(url: string, key: string | null): void {
+  baseUrl = url
+  apiKey = key
+  cloudActive = true
+}
+
+export function clearCloudConnection(): void {
+  baseUrl = localUrl
+  apiKey = null
+  cloudActive = false
+}
+
+export function getApiKey(): string | null {
+  return apiKey
+}
+
+export function isCloudActive(): boolean {
+  return cloudActive
+}

--- a/desktop/src/main/cpClient.test.ts
+++ b/desktop/src/main/cpClient.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { setCloudConnection, setLocalPort } from './connection'
 import {
   CpApiError,
   createCpClient,
@@ -29,6 +30,7 @@ const job = (status: InstallJob['status'], lines: string[] = []): InstallJob => 
 })
 
 describe('createCpClient', () => {
+  afterEach(() => setLocalPort(8080))
   // Contract 1: every wrapper uses the documented method, path, body, and result.
   it('wraps all management endpoints', async () => {
     const payloads: unknown[] = [
@@ -108,6 +110,15 @@ describe('createCpClient', () => {
     expect(new Headers(calls[0][1]?.headers).has('X-API-Key')).toBe(false)
     expect(calls[1][0]).toBe('http://two/api/ui/v1/agents/packages')
     expect(new Headers(calls[1][1]?.headers).get('X-API-Key')).toBe('cloud-key')
+  })
+
+  it('uses the default connection-state API key provider', async () => {
+    const fetchImpl = mockFetch([json({ packages: [], total: 0 })])
+    setCloudConnection('https://cp.example', 'state-key')
+    await createCpClient({ fetchImpl }).listPackages()
+    const [url, init] = vi.mocked(fetchImpl).mock.calls[0]
+    expect(url).toBe('https://cp.example/api/ui/v1/agents/packages')
+    expect(new Headers(init?.headers).get('X-API-Key')).toBe('state-key')
   })
 
   // Contract 4: HTTP errors retain status and parsed server details.

--- a/desktop/src/main/cpClient.test.ts
+++ b/desktop/src/main/cpClient.test.ts
@@ -83,7 +83,7 @@ describe('createCpClient', () => {
       ['http://cp/api/ui/v1/agents/agent%2Fname/stop', 'POST'],
       ['http://cp/api/ui/v1/agents/agent%2Fname/status', 'GET'],
       ['http://cp/api/ui/v1/agents/running', 'GET'],
-      ['http://cp/api/ui/v1/agents/agent%2Fname/secrets', 'GET'],
+      ['http://cp/api/ui/v1/agents/agent%2Fname/secrets?include=env', 'GET'],
       ['http://cp/api/ui/v1/agents/agent%2Fname/secrets', 'PUT'],
       ['http://cp/api/ui/v1/agents/agent%2Fname/secrets/TOKEN?scope=node', 'DELETE'],
       ['http://cp/api/ui/v1/secrets', 'GET']

--- a/desktop/src/main/cpClient.test.ts
+++ b/desktop/src/main/cpClient.test.ts
@@ -8,6 +8,7 @@ import {
   type InstallJob,
   type PackageInfo
 } from './cpClient'
+import { readInstalledAgents } from './agentfield'
 
 function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -94,6 +95,34 @@ describe('createCpClient', () => {
     expect(JSON.parse(String(calls[6][1]?.body))).toEqual({ port: 9000, detach: false })
   })
 
+  it('normalizes Go nil slices in list responses', async () => {
+    const fetchImpl = mockFetch([
+      json({ packages: null, total: 0 }),
+      json(null),
+      json({ running_agents: null, total_count: 0 }),
+      json({ secrets: null }),
+      json({ secrets: null })
+    ])
+    const client = createCpClient({ fetchImpl })
+
+    await expect(client.listPackages()).resolves.toEqual({ packages: [], total: 0 })
+    await expect(client.listInstallJobs()).resolves.toEqual([])
+    await expect(client.listRunningAgents()).resolves.toEqual({
+      running_agents: [],
+      total_count: 0
+    })
+    await expect(client.listAgentSecrets('agent')).resolves.toEqual({ secrets: [] })
+    await expect(client.listAllSecrets()).resolves.toEqual({ secrets: [] })
+  })
+
+  it('maps a null packages wire value to an empty installed-agent registry', async () => {
+    const client = createCpClient({
+      fetchImpl: mockFetch([json({ packages: null, total: 0 })])
+    })
+
+    await expect(readInstalledAgents(client)).resolves.toEqual({ exists: true, agents: [] })
+  })
+
   // Contracts 2 and 3: auth is conditional and late-bound providers are re-read.
   it('late-binds base URL and API key on every call', async () => {
     let host = 'http://one'
@@ -169,6 +198,18 @@ describe('createCpClient', () => {
     })
     expect(result.status).toBe(terminal)
     expect(lines).toEqual(['one', 'two', 'three'])
+  })
+
+  it('normalizes null job lines while watching', async () => {
+    const emitted: string[] = []
+    const client = createCpClient({
+      fetchImpl: mockFetch([json({ ...job('succeeded'), lines: null })])
+    })
+
+    const result = await client.watchInstallJob('job/1', (line) => emitted.push(line))
+
+    expect(result.lines).toEqual([])
+    expect(emitted).toEqual([])
   })
 
   it('reports when a job disappears while it is being watched', async () => {

--- a/desktop/src/main/cpClient.ts
+++ b/desktop/src/main/cpClient.ts
@@ -127,6 +127,13 @@ export interface AgentSecretStatus {
   key: string
   is_set: boolean
   scope?: SecretScope
+  declared_scope?: SecretScope
+  description?: string
+  secret?: boolean
+  default?: string
+  requirement?: 'required' | 'one_of' | 'optional' | ''
+  group?: string
+  group_description?: string
 }
 
 export interface SecretReference {
@@ -185,7 +192,7 @@ export interface CpClient {
   getAgentStatus(agentId: string): Promise<AgentStatusResponse>
   /** GET /api/ui/v1/agents/running. */
   listRunningAgents(): Promise<RunningAgentsResponse>
-  /** GET /api/ui/v1/agents/:agentId/secrets. */
+  /** GET /api/ui/v1/agents/:agentId/secrets?include=env. */
   listAgentSecrets(agentId: string): Promise<{ secrets: AgentSecretStatus[] }>
   /** PUT /api/ui/v1/agents/:agentId/secrets. */
   setAgentSecret(
@@ -335,7 +342,7 @@ export function createCpClient(options: CpClientOptions = {}): CpClient {
     },
     async listAgentSecrets(agentId) {
       const response = await request<{ secrets: AgentSecretStatus[] | null }>(
-        `/api/ui/v1/agents/${encodeURIComponent(agentId)}/secrets`
+        `/api/ui/v1/agents/${encodeURIComponent(agentId)}/secrets?include=env`
       )
       return { ...response, secrets: response.secrets ?? [] }
     },

--- a/desktop/src/main/cpClient.ts
+++ b/desktop/src/main/cpClient.ts
@@ -278,11 +278,15 @@ export function createCpClient(options: CpClientOptions = {}): CpClient {
         body: JSON.stringify(body)
       }, true)
     },
-    getInstallJob(jobId) {
-      return request(`/api/ui/v1/agents/packages/install/jobs/${encodeURIComponent(jobId)}`)
+    async getInstallJob(jobId) {
+      const job = await request<Omit<InstallJob, 'lines'> & { lines: string[] | null }>(
+        `/api/ui/v1/agents/packages/install/jobs/${encodeURIComponent(jobId)}`
+      )
+      return { ...job, lines: job.lines ?? [] }
     },
-    listInstallJobs() {
-      return request('/api/ui/v1/agents/packages/install/jobs')
+    async listInstallJobs() {
+      const jobs = await request<InstallJob[] | null>('/api/ui/v1/agents/packages/install/jobs')
+      return jobs ?? []
     },
     uninstallPackage(packageId) {
       return request(
@@ -298,8 +302,13 @@ export function createCpClient(options: CpClientOptions = {}): CpClient {
         true
       )
     },
-    listPackages() {
-      return request('/api/ui/v1/agents/packages')
+    async listPackages() {
+      const response = await request<
+        Omit<PackageListResponse, 'packages'> & { packages: PackageInfo[] | null }
+      >(
+        '/api/ui/v1/agents/packages'
+      )
+      return { ...response, packages: response.packages ?? [] }
     },
     startAgent(agentId, startOptions) {
       return request(
@@ -318,11 +327,17 @@ export function createCpClient(options: CpClientOptions = {}): CpClient {
     getAgentStatus(agentId) {
       return request(`/api/ui/v1/agents/${encodeURIComponent(agentId)}/status`)
     },
-    listRunningAgents() {
-      return request('/api/ui/v1/agents/running')
+    async listRunningAgents() {
+      const response = await request<
+        Omit<RunningAgentsResponse, 'running_agents'> & { running_agents: RunningAgent[] | null }
+      >('/api/ui/v1/agents/running')
+      return { ...response, running_agents: response.running_agents ?? [] }
     },
-    listAgentSecrets(agentId) {
-      return request(`/api/ui/v1/agents/${encodeURIComponent(agentId)}/secrets`)
+    async listAgentSecrets(agentId) {
+      const response = await request<{ secrets: AgentSecretStatus[] | null }>(
+        `/api/ui/v1/agents/${encodeURIComponent(agentId)}/secrets`
+      )
+      return { ...response, secrets: response.secrets ?? [] }
     },
     setAgentSecret(agentId, key, value, scope) {
       const body = scope === undefined ? { key, value } : { key, value, scope }
@@ -342,8 +357,9 @@ export function createCpClient(options: CpClientOptions = {}): CpClient {
         true
       )
     },
-    listAllSecrets() {
-      return request('/api/ui/v1/secrets')
+    async listAllSecrets() {
+      const response = await request<{ secrets: SecretReference[] | null }>('/api/ui/v1/secrets')
+      return { ...response, secrets: response.secrets ?? [] }
     },
     async hasInstallApi() {
       try {

--- a/desktop/src/main/cpClient.ts
+++ b/desktop/src/main/cpClient.ts
@@ -1,5 +1,5 @@
-import { getBaseUrl, type FetchLike } from './agentfield'
-export type { FetchLike } from './agentfield'
+import { getApiKey, getBaseUrl } from './connection'
+export type FetchLike = typeof fetch
 
 const READ_TIMEOUT_MS = 3_000
 const MUTATION_TIMEOUT_MS = 10_000
@@ -243,7 +243,7 @@ async function apiError(response: Response): Promise<CpApiError> {
  */
 export function createCpClient(options: CpClientOptions = {}): CpClient {
   const baseUrl = options.baseUrl ?? getBaseUrl
-  const apiKey = options.apiKey ?? (() => null)
+  const apiKey = options.apiKey ?? getApiKey
   const fetchImpl = options.fetchImpl ?? fetch
   const sleep =
     options.sleep ?? ((milliseconds: number) => new Promise((resolve) => setTimeout(resolve, milliseconds)))

--- a/desktop/src/main/deployEngine.test.ts
+++ b/desktop/src/main/deployEngine.test.ts
@@ -237,4 +237,34 @@ describe('destroy', () => {
     const failed = harness([{ stdout: '{"type":"diagnostic","diagnostic":{"severity":"error","summary":"delete denied"}}\n', code: 1 }])
     expect(await runDestroy(fixture.opts, failed.deps)).toEqual({ ok: false, message: 'delete denied' })
   })
+
+  it('recovers the workspace id from state — tear-down has no workspace picker', async () => {
+    const fixture = workspace()
+    mkdirSync(fixture.opts.workspaceDir, { recursive: true })
+    writeFileSync(join(fixture.opts.workspaceDir, 'terraform.tfstate'), JSON.stringify({
+      resources: [
+        { type: 'railway_project', name: 'cp', instances: [{ attributes: { workspace_id: 'ws-from-state' } }] },
+        { type: 'railway_service_domain', name: 'cp', instances: [{ attributes: { subdomain: 'agentfield-dead' } }] }
+      ],
+      outputs: { api_key: { value: 'prior-key' } }
+    }))
+    const fake = harness([{ stdout: '{"type":"apply_complete","@message":"Destroyed"}\n' }])
+    expect(await runDestroy({ ...fixture.opts, workspaceId: '' }, fake.deps)).toEqual({
+      ok: true,
+      message: 'Railway deployment destroyed.'
+    })
+    expect(fake.calls[0].env.TF_VAR_workspace_id).toBe('ws-from-state')
+  })
+
+  it('refuses with a clear message when no workspace id is known', async () => {
+    const fixture = workspace()
+    mkdirSync(fixture.opts.workspaceDir, { recursive: true })
+    writeFileSync(join(fixture.opts.workspaceDir, 'terraform.tfstate'), deployedState())
+    const fake = harness([])
+    expect(await runDestroy({ ...fixture.opts, workspaceId: '' }, fake.deps)).toEqual({
+      ok: false,
+      message: 'Could not determine the Railway workspace of this deployment — sign in and re-run deploy first.'
+    })
+    expect(fake.calls).toHaveLength(0)
+  })
 })

--- a/desktop/src/main/deployEngine.test.ts
+++ b/desktop/src/main/deployEngine.test.ts
@@ -1,0 +1,240 @@
+import { EventEmitter } from 'node:events'
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { PassThrough } from 'node:stream'
+import { delimiter, join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { mkdtempSync } from 'node:fs'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { generateApiKey, hasDeployment, resolveTofuBinary, runDeploy, runDestroy } from './deployEngine'
+
+type Script = { stdout?: string; stderr?: string; code?: number }
+
+function harness(scripts: Script[], fetchImpl: typeof fetch = vi.fn(async () => new Response(JSON.stringify({
+  data: { project: { volumes: { edges: [{ node: { id: 'volume', name: 'data' } }] } } }
+}), { status: 200, headers: { 'Content-Type': 'application/json' } }))) {
+  const calls: Array<{ args: string[]; env: NodeJS.ProcessEnv }> = []
+  const spawnImpl = vi.fn((...raw: unknown[]) => {
+    const args = raw[1] as string[]
+    const options = raw[2] as { env: NodeJS.ProcessEnv }
+    calls.push({ args, env: options.env })
+    const script = scripts.shift() ?? {}
+    const child = new EventEmitter() as EventEmitter & { stdout: PassThrough; stderr: PassThrough }
+    child.stdout = new PassThrough()
+    child.stderr = new PassThrough()
+    queueMicrotask(() => {
+      if (script.stdout) child.stdout.write(script.stdout)
+      if (script.stderr) child.stderr.write(script.stderr)
+      child.stdout.end()
+      child.stderr.end()
+      child.emit('close', script.code ?? 0)
+    })
+    return child
+  }) as unknown as typeof import('node:child_process').spawn
+  return { calls, deps: { spawnImpl, fetchImpl }, remaining: scripts }
+}
+
+function outputs(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    url: { value: 'https://cp.test' },
+    api_key: { value: 'key' },
+    project_id: { value: 'project' },
+    environment_id: { value: 'environment' },
+    service_id: { value: 'service' },
+    ...overrides
+  })
+}
+
+function workspace(mirror = false) {
+  const root = mkdtempSync(join(tmpdir(), 'deploy-engine-test-'))
+  const binaryDir = join(root, 'bin')
+  mkdirSync(binaryDir, { recursive: true })
+  writeFileSync(join(binaryDir, process.platform === 'win32' ? 'tofu.exe' : 'tofu'), '')
+  if (mirror) mkdirSync(join(binaryDir, 'providers'), { recursive: true })
+  return { root, binaryDir, opts: { railwayToken: 'token', workspaceId: 'workspace', workspaceDir: join(root, 'work'), binaryDir } }
+}
+
+function deployedState(apiKey = 'prior-key', subdomain = 'agentfield-dead') {
+  return JSON.stringify({
+    resources: [{ type: 'railway_service_domain', name: 'cp', instances: [{ attributes: { subdomain } }] }],
+    outputs: { api_key: { value: apiKey } }
+  })
+}
+
+describe('deployment module and execution', () => {
+  it('writes the module and a CLI mirror config only when a mirror exists', async () => {
+    const withMirror = workspace(true)
+    const fake = harness([
+      {},
+      { stdout: '{"type":"apply_complete","@message":"Apply complete"}\n' },
+      { stdout: outputs() }
+    ])
+    const result = await runDeploy(withMirror.opts, fake.deps)
+    expect(result).toMatchObject({ ok: true, url: 'https://cp.test', apiKey: 'key' })
+    const module = readFileSync(join(withMirror.opts.workspaceDir, 'main.tf'), 'utf8')
+    expect(module).toContain('resource "railway_project" "cp"')
+    expect(module).toContain('workspace_id = var.workspace_id')
+    expect(module).toContain('source_image = "agentfield/control-plane-cloud:staging-0.1.118-rc.7"')
+    expect(module).not.toMatch(/\bvolume\s*=/)
+    expect(module).toContain('output "project_id"')
+    expect(module).toContain('output "environment_id"')
+    expect(module).toContain('output "service_id"')
+    expect(readFileSync(join(withMirror.opts.workspaceDir, 'deploy.tfrc'), 'utf8')).toContain('filesystem_mirror')
+    expect(fake.calls[0].env.TF_CLI_CONFIG_FILE).toContain('deploy.tfrc')
+
+    const withoutMirror = workspace()
+    const other = harness([{}, {}, { stdout: outputs({ url: { value: 'u' }, api_key: { value: 'k' } }) }])
+    await runDeploy(withoutMirror.opts, other.deps)
+    expect(() => readFileSync(join(withoutMirror.opts.workspaceDir, 'deploy.tfrc'))).toThrow()
+    expect(other.calls[0].env.TF_CLI_CONFIG_FILE).toBeUndefined()
+  })
+
+  it('forwards supported NDJSON in order and skips malformed lines', async () => {
+    const fixture = workspace()
+    const lines: string[] = []
+    const fake = harness([{}, {
+      stdout: [
+        'not json',
+        '{"type":"apply_progress","@message":"Creating"}',
+        '{"type":"other","@message":"hidden"}',
+        '{"type":"apply_complete","@message":"Created"}'
+      ].join('\n') + '\n'
+    }, { stdout: outputs({ url: { value: 'https://x' }, api_key: { value: 'k' } }) }])
+    expect((await runDeploy({ ...fixture.opts, onLine: (line) => lines.push(line) }, fake.deps)).ok).toBe(true)
+    expect(lines).toEqual(['Creating', 'Created', 'Attaching storage volume…', 'Storage volume ready'])
+  })
+
+  it('surfaces diagnostic summaries and preserves state for reconciliation', async () => {
+    const fixture = workspace()
+    const fake = harness([{}, {
+      stdout: '{"type":"diagnostic","diagnostic":{"severity":"error","summary":"domain unavailable","detail":"choose another"}}\n', code: 1
+    }])
+    const result = await runDeploy(fixture.opts, fake.deps)
+    expect(result).toEqual({ ok: false, message: 'domain unavailable. State was kept; re-run deploy to reconcile.' })
+  })
+
+  it('rejects missing output values', async () => {
+    const fixture = workspace()
+    const fake = harness([{}, {}, { stdout: '{"url":{"value":"https://x"}}' }])
+    expect(await runDeploy(fixture.opts, fake.deps)).toMatchObject({ ok: false, message: expect.stringContaining('outputs are missing') })
+  })
+
+  it('generates a fresh 48-hex key and reuses state credentials and subdomain', async () => {
+    expect(generateApiKey()).toMatch(/^[a-f0-9]{48}$/)
+    const fresh = workspace()
+    const first = harness([{}, {}, { stdout: outputs({ url: { value: 'u' }, api_key: { value: 'returned' } }) }])
+    await runDeploy(fresh.opts, first.deps)
+    expect(first.calls[0].env.TF_VAR_api_key).toMatch(/^[a-f0-9]{48}$/)
+    expect(first.calls[0].env.TF_VAR_subdomain).toMatch(/^agentfield-[a-f0-9]{4}$/)
+
+    const existing = workspace()
+    mkdirSync(existing.opts.workspaceDir, { recursive: true })
+    writeFileSync(join(existing.opts.workspaceDir, 'terraform.tfstate'), deployedState())
+    const again = harness([{}, {}, { stdout: outputs({ url: { value: 'u' }, api_key: { value: 'prior-key' } }) }])
+    await runDeploy(existing.opts, again.deps)
+    expect(again.calls[0].env.TF_VAR_api_key).toBe('prior-key')
+    expect(again.calls[0].env.TF_VAR_subdomain).toBe('agentfield-dead')
+    expect(hasDeployment(existing.opts.workspaceDir)).toBe(true)
+  })
+
+  it('creates a missing volume with the deployment IDs and Railway-compatible headers', async () => {
+    const fixture = workspace()
+    const lines: string[] = []
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ data: { project: { volumes: { edges: [] } } } }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ data: { volumeCreate: { id: 'volume', name: 'data' } } }), { status: 200 })) as typeof fetch
+    const fake = harness([{}, {}, { stdout: outputs() }], fetchImpl)
+
+    expect(await runDeploy({ ...fixture.opts, onLine: (line) => lines.push(line) }, fake.deps)).toEqual({
+      ok: true, url: 'https://cp.test', apiKey: 'key', message: 'AgentField deployed to Railway.'
+    })
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    const requests = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls as unknown as Array<[string, RequestInit]>
+    for (const [url, init] of requests) {
+      expect(url).toBe('https://backboard.railway.com/graphql/v2')
+      expect(init.headers).toMatchObject({ Authorization: 'Bearer token', 'Content-Type': 'application/json', 'User-Agent': 'agentfield-desktop' })
+    }
+    expect(JSON.parse(String(requests[0][1].body))).toMatchObject({ variables: { projectId: 'project' } })
+    expect(JSON.parse(String(requests[1][1].body))).toMatchObject({
+      variables: { projectId: 'project', environmentId: 'environment', serviceId: 'service', mountPath: '/data' }
+    })
+    expect(JSON.parse(String(requests[1][1].body)).query).toContain('mutation VolumeCreate')
+    expect(lines).toEqual(['Attaching storage volume…', 'Storage volume ready'])
+  })
+
+  it('does not create a volume when one already exists', async () => {
+    const fixture = workspace()
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      data: { project: { volumes: { edges: [{ node: { id: 'existing', name: 'data' } }] } } }
+    }), { status: 200 })) as typeof fetch
+    const fake = harness([{}, {}, { stdout: outputs() }], fetchImpl)
+    expect((await runDeploy(fixture.opts, fake.deps)).ok).toBe(true)
+    expect(fetchImpl).toHaveBeenCalledOnce()
+    expect(JSON.parse(String((fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0][1].body)).query).not.toContain('mutation VolumeCreate')
+  })
+
+  it('keeps parsed outputs internal and reports a retryable volume creation failure', async () => {
+    const fixture = workspace()
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ data: { project: { volumes: { edges: [] } } } }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errors: [{ message: 'volume denied' }] }), { status: 200 })) as typeof fetch
+    const fake = harness([{}, {}, { stdout: outputs() }], fetchImpl)
+    expect(await runDeploy(fixture.opts, fake.deps)).toEqual({
+      ok: false,
+      message: 'Deployed, but attaching the storage volume failed: volume denied. Re-run deploy to retry.'
+    })
+  })
+})
+
+describe('binary resolution', () => {
+  const originalPath = process.env.PATH
+  const bundled = join(process.cwd(), 'vendor', 'deploy-engine', process.platform === 'win32' ? 'tofu.exe' : 'tofu')
+  const parked = `${bundled}.resolution-test`
+  beforeAll(() => { if (existsSync(bundled)) renameSync(bundled, parked) })
+  afterAll(() => { if (existsSync(parked)) renameSync(parked, bundled) })
+  afterEach(() => { process.env.PATH = originalPath })
+
+  it('prefers the override and then tofu over terraform on PATH', () => {
+    const override = workspace().binaryDir
+    const pathDir = mkdtempSync(join(tmpdir(), 'deploy-path-'))
+    const suffix = process.platform === 'win32' ? '.exe' : ''
+    writeFileSync(join(pathDir, `tofu${suffix}`), '')
+    writeFileSync(join(pathDir, `terraform${suffix}`), '')
+    process.env.PATH = [pathDir, originalPath].filter(Boolean).join(delimiter)
+    expect(resolveTofuBinary(override)).toBe(join(override, `tofu${suffix}`))
+    expect(resolveTofuBinary('/does/not/exist')).toBe(join(pathDir, `tofu${suffix}`))
+  })
+
+  it('uses terraform as the final fallback and returns null when PATH is empty', () => {
+    const pathDir = mkdtempSync(join(tmpdir(), 'deploy-path-'))
+    const suffix = process.platform === 'win32' ? '.exe' : ''
+    writeFileSync(join(pathDir, `terraform${suffix}`), '')
+    process.env.PATH = pathDir
+    expect(resolveTofuBinary('/does/not/exist')).toBe(join(pathDir, `terraform${suffix}`))
+    process.env.PATH = ''
+    expect(resolveTofuBinary('/does/not/exist')).toBeNull()
+  })
+
+  it('uses .exe names on Windows', () => {
+    const platform = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const binaryDir = mkdtempSync(join(tmpdir(), 'deploy-windows-'))
+    writeFileSync(join(binaryDir, 'tofu.exe'), '')
+    expect(resolveTofuBinary(binaryDir)).toBe(join(binaryDir, 'tofu.exe'))
+    platform.mockRestore()
+  })
+})
+
+describe('destroy', () => {
+  it('streams a successful destroy and reports failure diagnostics', async () => {
+    const fixture = workspace()
+    mkdirSync(fixture.opts.workspaceDir, { recursive: true })
+    writeFileSync(join(fixture.opts.workspaceDir, 'terraform.tfstate'), deployedState())
+    const lines: string[] = []
+    const success = harness([{ stdout: '{"type":"apply_complete","@message":"Destroyed"}\n' }])
+    expect(await runDestroy({ ...fixture.opts, onLine: (line) => lines.push(line) }, success.deps)).toEqual({ ok: true, message: 'Railway deployment destroyed.' })
+    expect(lines).toEqual(['Destroyed'])
+    expect(success.calls[0].args).toEqual(['destroy', '-auto-approve', '-input=false', '-json'])
+
+    const failed = harness([{ stdout: '{"type":"diagnostic","diagnostic":{"severity":"error","summary":"delete denied"}}\n', code: 1 }])
+    expect(await runDestroy(fixture.opts, failed.deps)).toEqual({ ok: false, message: 'delete denied' })
+  })
+})

--- a/desktop/src/main/deployEngine.ts
+++ b/desktop/src/main/deployEngine.ts
@@ -1,0 +1,344 @@
+import { spawn } from 'node:child_process'
+import { randomBytes } from 'node:crypto'
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { delimiter, dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export interface DeploySpawnDeps {
+  spawnImpl?: typeof import('node:child_process').spawn
+  fetchImpl?: typeof fetch
+  env?: Record<string, string>
+}
+
+export interface DeployEngineOptions {
+  railwayToken: string
+  workspaceId: string
+  projectName?: string
+  workspaceDir: string
+  binaryDir?: string | null
+  onLine?: (line: string) => void
+}
+
+export interface DeployResult {
+  ok: boolean
+  url?: string
+  apiKey?: string
+  message: string
+}
+
+const MODULE = `terraform {
+  required_providers {
+    railway = { source = "terraform-community-providers/railway", version = "0.6.2" }
+  }
+}
+provider "railway" {}
+variable "workspace_id" { type = string }
+variable "project_name" {
+  type    = string
+  default = "agentfield"
+}
+variable "subdomain" { type = string }
+variable "api_key" {
+  type      = string
+  sensitive = true
+}
+resource "railway_project" "cp" {
+  name         = var.project_name
+  workspace_id = var.workspace_id
+}
+resource "railway_service" "cp" {
+  name         = "control-plane"
+  project_id   = railway_project.cp.id
+  source_image = "agentfield/control-plane-cloud:staging-0.1.118-rc.7"
+}
+resource "railway_variable" "api_key" {
+  name           = "AGENTFIELD_API_KEY"
+  value          = var.api_key
+  environment_id = railway_project.cp.default_environment.id
+  service_id     = railway_service.cp.id
+}
+resource "railway_variable" "port" {
+  name           = "AGENTFIELD_PORT"
+  value          = "8080"
+  environment_id = railway_project.cp.default_environment.id
+  service_id     = railway_service.cp.id
+}
+resource "railway_service_domain" "cp" {
+  subdomain      = var.subdomain
+  environment_id = railway_project.cp.default_environment.id
+  service_id     = railway_service.cp.id
+}
+output "url"     { value = "https://\${railway_service_domain.cp.domain}" }
+output "project_id"     { value = railway_project.cp.id }
+output "environment_id" { value = railway_project.cp.default_environment.id }
+output "service_id"     { value = railway_service.cp.id }
+output "api_key" {
+  value     = var.api_key
+  sensitive = true
+}
+`
+
+const NO_ENGINE = 'Deploy engine not bundled. Install OpenTofu or rebuild AgentField Desktop with the deploy engine.'
+
+function executableName(): string {
+  return process.platform === 'win32' ? 'tofu.exe' : 'tofu'
+}
+
+function executableFile(path: string): boolean {
+  try {
+    return statSync(path).isFile()
+  } catch {
+    return false
+  }
+}
+
+function findOnPath(name: string): string | null {
+  const names = process.platform === 'win32' && !name.endsWith('.exe') ? [`${name}.exe`, name] : [name]
+  for (const dir of (process.env.PATH ?? '').split(delimiter)) {
+    for (const candidate of names) {
+      const path = join(dir, candidate)
+      if (dir && executableFile(path)) return path
+    }
+  }
+  return null
+}
+
+export function resolveTofuBinary(binaryDir?: string | null): string | null {
+  if (binaryDir) {
+    const candidate = join(binaryDir, executableName())
+    if (executableFile(candidate)) return candidate
+  }
+  const here = dirname(fileURLToPath(import.meta.url))
+  const vendor = resolve(here, '../../vendor/deploy-engine', executableName())
+  if (executableFile(vendor)) return vendor
+  return findOnPath('tofu') ?? findOnPath('terraform')
+}
+
+type TfState = {
+  resources?: Array<{ type?: string; name?: string; instances?: Array<{ attributes?: Record<string, unknown> }> }>
+  outputs?: Record<string, { value?: unknown }>
+}
+
+function readState(workspaceDir: string): TfState | null {
+  try {
+    return JSON.parse(readFileSync(join(workspaceDir, 'terraform.tfstate'), 'utf8')) as TfState
+  } catch {
+    return null
+  }
+}
+
+export function hasDeployment(workspaceDir: string): boolean {
+  return (readState(workspaceDir)?.resources?.length ?? 0) > 0
+}
+
+export function generateApiKey(): string {
+  return randomBytes(24).toString('hex')
+}
+
+function stateOutput(state: TfState | null, name: string): string | null {
+  const value = state?.outputs?.[name]?.value
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+function stateSubdomain(state: TfState | null): string | null {
+  const resource = state?.resources?.find((item) => item.type === 'railway_service_domain' && item.name === 'cp')
+  const attrs = resource?.instances?.[0]?.attributes
+  if (typeof attrs?.subdomain === 'string' && attrs.subdomain) return attrs.subdomain
+  if (typeof attrs?.domain === 'string' && attrs.domain) return attrs.domain.split('.')[0] || null
+  return null
+}
+
+function writeConfig(workspaceDir: string, binaryDir?: string | null): string | null {
+  if (!binaryDir) return null
+  const mirror = join(binaryDir, 'providers')
+  if (!existsSync(mirror)) return null
+  const config = join(workspaceDir, 'deploy.tfrc')
+  writeFileSync(config, `provider_installation {
+  filesystem_mirror { path = ${JSON.stringify(mirror)} }
+  direct {}
+}
+`)
+  return config
+}
+
+type CommandResult = { code: number; stdout: string; lastError?: string }
+
+function runCommand(
+  binary: string,
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  deps: DeploySpawnDeps,
+  streamJson: boolean,
+  onLine?: (line: string) => void
+): Promise<CommandResult> {
+  return new Promise((resolveCommand) => {
+    const child = (deps.spawnImpl ?? spawn)(binary, args, { cwd, env, windowsHide: true })
+    let stdout = ''
+    let stderr = ''
+    let pending = ''
+    let lastError: string | undefined
+
+    const consume = (text: string, final = false): void => {
+      pending += text
+      const lines = pending.split(/\r?\n/)
+      pending = final ? '' : (lines.pop() ?? '')
+      for (const line of lines) {
+        if (!line.trim() || !streamJson) continue
+        try {
+          const event = JSON.parse(line) as Record<string, unknown>
+          const type = String(event.type ?? '')
+          if (!['apply_progress', 'apply_complete', 'apply_errored', 'diagnostic'].includes(type)) continue
+          const diagnostic = event.diagnostic as Record<string, unknown> | undefined
+          const summary = typeof diagnostic?.summary === 'string' ? diagnostic.summary : undefined
+          const detail = typeof diagnostic?.detail === 'string' ? diagnostic.detail : undefined
+          const message = type === 'diagnostic' ? [summary, detail].filter(Boolean).join(': ') : event['@message']
+          if (typeof message === 'string' && message) onLine?.(message)
+          if (type === 'apply_errored' || (type === 'diagnostic' && diagnostic?.severity === 'error')) {
+            lastError = summary ?? detail ?? (typeof event['@message'] === 'string' ? event['@message'] : lastError)
+          }
+        } catch {
+          // OpenTofu may mix non-JSON notices into the JSON stream; ignore them.
+        }
+      }
+    }
+
+    child.stdout?.on('data', (chunk: Buffer | string) => {
+      const text = chunk.toString()
+      stdout += text
+      consume(text)
+    })
+    child.stderr?.on('data', (chunk: Buffer | string) => { stderr += chunk.toString() })
+    child.on('error', (error) => resolveCommand({ code: -1, stdout, lastError: error.message }))
+    child.on('close', (code) => {
+      consume('', true)
+      resolveCommand({ code: code ?? -1, stdout, lastError: lastError ?? (stderr.trim() || undefined) })
+    })
+  })
+}
+
+function deployEnv(opts: DeployEngineOptions, apiKey: string, subdomain: string, cliConfig: string | null, deps: DeploySpawnDeps): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    ...deps.env,
+    RAILWAY_TOKEN: opts.railwayToken,
+    TF_VAR_workspace_id: opts.workspaceId,
+    TF_VAR_project_name: opts.projectName ?? 'agentfield',
+    TF_VAR_subdomain: subdomain,
+    TF_VAR_api_key: apiKey,
+    TF_IN_AUTOMATION: '1',
+    ...(cliConfig ? { TF_CLI_CONFIG_FILE: cliConfig } : {})
+  }
+}
+
+function providerReady(workspaceDir: string): boolean {
+  if (!existsSync(join(workspaceDir, '.terraform'))) return false
+  try {
+    return /version\s*=\s*"0\.6\.2"/.test(readFileSync(join(workspaceDir, '.terraform.lock.hcl'), 'utf8'))
+  } catch {
+    return false
+  }
+}
+
+const RAILWAY_GRAPHQL = 'https://backboard.railway.com/graphql/v2'
+
+async function ensureVolume(
+  railwayToken: string,
+  projectId: string,
+  environmentId: string,
+  serviceId: string,
+  fetchImpl: typeof fetch
+): Promise<void> {
+  const request = async (query: string, variables: Record<string, string>): Promise<Record<string, unknown>> => {
+    const response = await fetchImpl(RAILWAY_GRAPHQL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${railwayToken}`,
+        'Content-Type': 'application/json',
+        'User-Agent': 'agentfield-desktop'
+      },
+      body: JSON.stringify({ query, variables })
+    })
+    const payload = await response.json() as { data?: Record<string, unknown>; errors?: Array<{ message?: string }> }
+    if (!response.ok || payload.errors?.length) {
+      throw new Error(payload.errors?.map((error) => error.message).filter(Boolean).join('; ') || `Railway GraphQL request failed (${response.status})`)
+    }
+    if (!payload.data) throw new Error('Railway GraphQL response contained no data')
+    return payload.data
+  }
+
+  const query = `query Volumes($projectId: String!) {
+  project(id: $projectId) { volumes { edges { node { id name } } } }
+}`
+  const data = await request(query, { projectId })
+  const project = data.project as { volumes?: { edges?: unknown[] } } | undefined
+  if ((project?.volumes?.edges?.length ?? 0) > 0) return
+
+  const mutation = `mutation VolumeCreate($projectId: String!, $environmentId: String!, $serviceId: String!, $mountPath: String!) {
+  volumeCreate(input: {projectId: $projectId, environmentId: $environmentId, serviceId: $serviceId, mountPath: $mountPath}) { id name }
+}`
+  await request(mutation, { projectId, environmentId, serviceId, mountPath: '/data' })
+}
+
+export async function runDeploy(opts: DeployEngineOptions, deps: DeploySpawnDeps = {}): Promise<DeployResult> {
+  const binary = resolveTofuBinary(opts.binaryDir)
+  if (!binary) return { ok: false, message: NO_ENGINE }
+  mkdirSync(opts.workspaceDir, { recursive: true })
+  writeFileSync(join(opts.workspaceDir, 'main.tf'), MODULE)
+  const state = readState(opts.workspaceDir)
+  const existing = (state?.resources?.length ?? 0) > 0
+  // Credentials are deployment identity: only create one for new state and never rotate it on reconciliation.
+  const apiKey = existing ? stateOutput(state, 'api_key') : generateApiKey()
+  if (!apiKey) return { ok: false, message: 'Existing deployment is missing its API key; refusing to rotate it automatically.' }
+  const projectName = opts.projectName ?? 'agentfield'
+  const subdomain = existing ? stateSubdomain(state) : `${projectName}-${randomBytes(2).toString('hex')}`
+  if (!subdomain) return { ok: false, message: 'Existing deployment is missing its Railway subdomain.' }
+  const cliConfig = writeConfig(opts.workspaceDir, opts.binaryDir)
+  const env = deployEnv(opts, apiKey, subdomain, cliConfig, deps)
+
+  if (!providerReady(opts.workspaceDir)) {
+    const init = await runCommand(binary, ['init', '-input=false'], opts.workspaceDir, env, deps, false)
+    if (init.code !== 0) return { ok: false, message: init.lastError ?? 'OpenTofu initialization failed.' }
+  }
+  const apply = await runCommand(binary, ['apply', '-auto-approve', '-input=false', '-json'], opts.workspaceDir, env, deps, true, opts.onLine)
+  if (apply.code !== 0 || apply.lastError) {
+    return { ok: false, message: `${apply.lastError ?? 'Deployment failed'}. State was kept; re-run deploy to reconcile.` }
+  }
+  const output = await runCommand(binary, ['output', '-json'], opts.workspaceDir, env, deps, false)
+  if (output.code !== 0) return { ok: false, message: output.lastError ?? 'Could not read deployment outputs.' }
+  try {
+    const values = JSON.parse(output.stdout) as Record<string, { value?: unknown }>
+    const url = values.url?.value
+    const outputKey = values.api_key?.value
+    const projectId = values.project_id?.value
+    const environmentId = values.environment_id?.value
+    const serviceId = values.service_id?.value
+    if (typeof url !== 'string' || !url || typeof outputKey !== 'string' || !outputKey ||
+        typeof projectId !== 'string' || !projectId || typeof environmentId !== 'string' || !environmentId ||
+        typeof serviceId !== 'string' || !serviceId) throw new Error('missing')
+    opts.onLine?.('Attaching storage volume…')
+    try {
+      await ensureVolume(opts.railwayToken, projectId, environmentId, serviceId, deps.fetchImpl ?? fetch)
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error)
+      return { ok: false, message: `Deployed, but attaching the storage volume failed: ${detail}. Re-run deploy to retry.` }
+    }
+    opts.onLine?.('Storage volume ready')
+    return { ok: true, url, apiKey: outputKey, message: 'AgentField deployed to Railway.' }
+  } catch {
+    return { ok: false, message: 'Deployment completed, but required outputs are missing.' }
+  }
+}
+
+export async function runDestroy(opts: DeployEngineOptions, deps: DeploySpawnDeps = {}): Promise<{ ok: boolean; message: string }> {
+  // Destroying the Railway project cascades the GraphQL-created volume server-side.
+  const binary = resolveTofuBinary(opts.binaryDir)
+  if (!binary) return { ok: false, message: NO_ENGINE }
+  const state = readState(opts.workspaceDir)
+  const apiKey = stateOutput(state, 'api_key') ?? generateApiKey()
+  const subdomain = stateSubdomain(state) ?? (opts.projectName ?? 'agentfield')
+  const cliConfig = writeConfig(opts.workspaceDir, opts.binaryDir)
+  const result = await runCommand(binary, ['destroy', '-auto-approve', '-input=false', '-json'], opts.workspaceDir, deployEnv(opts, apiKey, subdomain, cliConfig, deps), deps, true, opts.onLine)
+  if (result.code !== 0 || result.lastError) return { ok: false, message: result.lastError ?? 'Destroy failed.' }
+  return { ok: true, message: 'Railway deployment destroyed.' }
+}

--- a/desktop/src/main/deployEngine.ts
+++ b/desktop/src/main/deployEngine.ts
@@ -148,6 +148,12 @@ function stateSubdomain(state: TfState | null): string | null {
   return null
 }
 
+function stateWorkspaceId(state: TfState | null): string | null {
+  const resource = state?.resources?.find((item) => item.type === 'railway_project')
+  const value = resource?.instances?.[0]?.attributes?.workspace_id
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
 function writeConfig(workspaceDir: string, binaryDir?: string | null): string | null {
   if (!binaryDir) return null
   const mirror = join(binaryDir, 'providers')
@@ -337,8 +343,15 @@ export async function runDestroy(opts: DeployEngineOptions, deps: DeploySpawnDep
   const state = readState(opts.workspaceDir)
   const apiKey = stateOutput(state, 'api_key') ?? generateApiKey()
   const subdomain = stateSubdomain(state) ?? (opts.projectName ?? 'agentfield')
+  // The provider validates workspace_id (UUID) even on destroy, and callers
+  // tearing down don't re-prompt for a workspace — the project's own state
+  // records which workspace it was created in.
+  const workspaceId = stateWorkspaceId(state) ?? opts.workspaceId
+  if (!workspaceId) {
+    return { ok: false, message: 'Could not determine the Railway workspace of this deployment — sign in and re-run deploy first.' }
+  }
   const cliConfig = writeConfig(opts.workspaceDir, opts.binaryDir)
-  const result = await runCommand(binary, ['destroy', '-auto-approve', '-input=false', '-json'], opts.workspaceDir, deployEnv(opts, apiKey, subdomain, cliConfig, deps), deps, true, opts.onLine)
+  const result = await runCommand(binary, ['destroy', '-auto-approve', '-input=false', '-json'], opts.workspaceDir, deployEnv({ ...opts, workspaceId }, apiKey, subdomain, cliConfig, deps), deps, true, opts.onLine)
   if (result.code !== 0 || result.lastError) return { ok: false, message: result.lastError ?? 'Destroy failed.' }
   return { ok: true, message: 'Railway deployment destroyed.' }
 }

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -1,12 +1,15 @@
 import { join, resolve } from 'node:path'
 import { BrowserWindow, Menu, app, ipcMain, nativeTheme, shell } from 'electron'
 import { CATALOG } from '../shared/catalog'
+import { RAILWAY_TEMPLATE_URL } from '../shared/cloudLinks'
 import { DEEP_LINK_SCHEME, type View, deepLinkFromArgv, parseDeepLink } from '../shared/deeplink'
 import type { DesktopSettings } from '../shared/types'
 import { spawn } from 'node:child_process'
 import { getBaseUrl, getSnapshot, setActiveControlPlanePort } from './agentfield'
 import { type AgentAction, runAgentAction, startControlPlane, uninstallAgent } from './agents'
 import { runAutostart } from './autostart'
+import { testCloudConnection, applyConnectionProfile } from './cloud'
+import { isCloudActive } from './connection'
 import { getCliCommand, initializeCli, installBundledCli, refreshCliStatus } from './cli'
 import { childEnv, initUserPath } from './env'
 import { installAgent, installFromSource, updateAgent } from './installer'
@@ -275,6 +278,7 @@ function main(): void {
   app.whenReady().then(async () => {
     installAppMenu()
     settings = await loadSettings(settingsFile())
+    applyConnectionProfile(settings)
     nativeTheme.themeSource = settings.appearance
     applyLoginItem(settings)
 
@@ -289,7 +293,7 @@ function main(): void {
     // with no AgentField at all this provisions the bundled CLI, so a
     // desktop-app-only install still gets a working `af`.
     await initializeCli(bundledCliPath())
-    if (settings.installSkills) syncSkills()
+    if (settings.installSkills && !isCloudActive()) syncSkills()
 
     // macOS only: provision + install the af-tray menu-bar companion so a
     // desktop-app-only install gets the menu-bar icon. Runs after initializeCli
@@ -375,6 +379,12 @@ function main(): void {
       return runAgentAction(action as AgentAction, name)
     })
     ipcMain.handle('agentfield:start-control-plane', async () => {
+      if (isCloudActive()) {
+        return {
+          ok: false,
+          message: 'Cloud control plane active — local server management is disabled'
+        }
+      }
       const port = settings.controlPlanePort ?? (await pickFreePort())
       setActiveControlPlanePort(port)
       const result = await startControlPlane(port)
@@ -460,6 +470,12 @@ function main(): void {
     // checks from Settings still work anywhere.
     if (app.isPackaged) updater.startAutoCheck()
     ipcMain.handle('agentfield:settings-get', () => settings)
+    ipcMain.handle('agentfield:cloud-test', (_event, url: string, apiKey: string) =>
+      testCloudConnection(url, apiKey)
+    )
+    ipcMain.handle('agentfield:cloud-deploy-railway', () =>
+      shell.openExternal(RAILWAY_TEMPLATE_URL)
+    )
     ipcMain.handle('agentfield:settings-set', async (_event, patch: unknown) => {
       const prev = settings
       settings = mergeSettings(settings, patch)
@@ -470,6 +486,7 @@ function main(): void {
       // macOS: reflect a flipped tray toggle (install ↔ uninstall) right away.
       if (settings.trayCompanion !== prev.trayCompanion) syncTray(settings.trayCompanion)
       await saveSettings(settingsFile(), settings)
+      applyConnectionProfile(settings)
       return settings
     })
 

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -1,5 +1,6 @@
 import { join, resolve } from 'node:path'
-import { BrowserWindow, Menu, app, ipcMain, nativeTheme, shell } from 'electron'
+import { existsSync } from 'node:fs'
+import { BrowserWindow, Menu, app, ipcMain, nativeTheme, safeStorage, shell } from 'electron'
 import { CATALOG } from '../shared/catalog'
 import { RAILWAY_TEMPLATE_URL } from '../shared/cloudLinks'
 import { DEEP_LINK_SCHEME, type View, deepLinkFromArgv, parseDeepLink } from '../shared/deeplink'
@@ -25,6 +26,15 @@ import { pickFreePort } from './ports'
 import { setupTray } from './tray'
 import { syncTrayCompanion } from './tray-companion'
 import { AppUpdater } from './updates'
+import {
+  getFreshAccessToken,
+  isLoggedIn,
+  listWorkspaces,
+  loginWithRailway,
+  logout,
+  type RailwayAuthDeps
+} from './railwayAuth'
+import { hasDeployment, resolveTofuBinary, runDeploy, runDestroy } from './deployEngine'
 import appIcon from '../../resources/icon.png?asset'
 
 const isMac = process.platform === 'darwin'
@@ -181,10 +191,36 @@ function registerDeepLinks(): void {
 }
 
 let installInFlight = false
+let cloudDeployInFlight = false
 let settings: DesktopSettings
 
 function settingsFile(): string {
   return join(app.getPath('userData'), 'settings.json')
+}
+
+function authDeps(): RailwayAuthDeps {
+  const encrypted = safeStorage.isEncryptionAvailable()
+  if (!encrypted) console.warn('Railway token encryption unavailable; token storage is unencrypted')
+  return {
+    codec: encrypted
+      ? {
+          encrypt: (plain) => safeStorage.encryptString(plain).toString('base64'),
+          decrypt: (blob) => safeStorage.decryptString(Buffer.from(blob, 'base64'))
+        }
+      : { encrypt: (plain) => plain, decrypt: (blob) => blob },
+    storePath: join(app.getPath('userData'), 'railway-auth.json'),
+    openUrl: (url) => shell.openExternal(url).then(() => undefined)
+  }
+}
+
+function deployPaths(): { workspaceDir: string; binaryDir: string | null } {
+  const candidate = app.isPackaged
+    ? join(process.resourcesPath, 'bin', 'deploy-engine')
+    : join(app.getAppPath(), 'vendor', 'deploy-engine')
+  return {
+    workspaceDir: join(app.getPath('userData'), 'cloud-deploy'),
+    binaryDir: existsSync(candidate) ? candidate : null
+  }
 }
 
 // The af CLI shipped inside the app package (see build.extraResources). In
@@ -476,6 +512,75 @@ function main(): void {
     ipcMain.handle('agentfield:cloud-deploy-railway', () =>
       shell.openExternal(RAILWAY_TEMPLATE_URL)
     )
+    ipcMain.handle('agentfield:railway-status', async () => {
+      const deps = authDeps()
+      const { workspaceDir, binaryDir } = deployPaths()
+      const token = isLoggedIn(deps) ? await getFreshAccessToken(deps) : null
+      return {
+        loggedIn: token !== null,
+        engineAvailable: resolveTofuBinary(binaryDir) !== null,
+        hasDeployment: hasDeployment(workspaceDir),
+        workspaces: token ? await listWorkspaces(token) : []
+      }
+    })
+    ipcMain.handle('agentfield:railway-login', async () => {
+      const deps = authDeps()
+      const result = await loginWithRailway(deps)
+      if (!result.ok) return result
+      const token = await getFreshAccessToken(deps)
+      return { ...result, workspaces: token ? await listWorkspaces(token) : [] }
+    })
+    ipcMain.handle('agentfield:railway-logout', () => logout(authDeps()))
+    ipcMain.handle('agentfield:cloud-deploy', async (event, workspaceId: unknown) => {
+      if (typeof workspaceId !== 'string' || workspaceId === '') {
+        return { ok: false, message: 'Choose a Railway workspace first' }
+      }
+      if (cloudDeployInFlight) return { ok: false, message: 'A cloud deployment is already running' }
+      cloudDeployInFlight = true
+      try {
+        const token = await getFreshAccessToken(authDeps())
+        if (!token) return { ok: false, message: 'Sign in with Railway first' }
+        const result = await runDeploy({
+          railwayToken: token,
+          workspaceId,
+          ...deployPaths(),
+          onLine: (line) => {
+            if (!event.sender.isDestroyed()) {
+              event.sender.send('agentfield:cloud-deploy-progress', line)
+            }
+          }
+        })
+        if (result.ok && result.url && result.apiKey) {
+          settings = mergeSettings(settings, {
+            cloud: { enabled: true, serverUrl: result.url, apiKey: result.apiKey }
+          })
+          await saveSettings(settingsFile(), settings)
+          applyConnectionProfile(settings)
+        }
+        return { ok: result.ok, url: result.url, message: result.message }
+      } finally {
+        cloudDeployInFlight = false
+      }
+    })
+    ipcMain.handle('agentfield:cloud-destroy', async () => {
+      if (cloudDeployInFlight) return { ok: false, message: 'A cloud deployment is already running' }
+      cloudDeployInFlight = true
+      try {
+        const token = await getFreshAccessToken(authDeps())
+        if (!token) return { ok: false, message: 'Sign in with Railway first' }
+        const result = await runDestroy({ railwayToken: token, workspaceId: '', ...deployPaths() })
+        if (result.ok) {
+          settings = mergeSettings(settings, {
+            cloud: { ...settings.cloud, enabled: false }
+          })
+          await saveSettings(settingsFile(), settings)
+          applyConnectionProfile(settings)
+        }
+        return result
+      } finally {
+        cloudDeployInFlight = false
+      }
+    })
     ipcMain.handle('agentfield:settings-set', async (_event, patch: unknown) => {
       const prev = settings
       settings = mergeSettings(settings, patch)

--- a/desktop/src/main/railwayAuth.test.ts
+++ b/desktop/src/main/railwayAuth.test.ts
@@ -1,0 +1,220 @@
+// @vitest-environment node
+import { mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { get } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  getFreshAccessToken,
+  isLoggedIn,
+  listWorkspaces,
+  loginWithRailway,
+  logout,
+  railwayAuthTestUtils,
+  type RailwayTokens,
+  type TokenCodec,
+} from './railwayAuth'
+
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  for (const directory of temporaryDirectories.splice(0)) {
+    // Tests only create one known token file in each unique temporary directory.
+    try { logout({ storePath: join(directory, 'tokens.json') }) } catch { /* noop */ }
+  }
+})
+
+function tokenPath(): string {
+  const directory = mkdtempSync(join(tmpdir(), 'agentfield-railway-auth-'))
+  temporaryDirectories.push(directory)
+  return join(directory, 'tokens.json')
+}
+
+function response(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function request(url: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    get(url, (result) => {
+      let body = ''
+      result.setEncoding('utf8')
+      result.on('data', (chunk: string) => { body += chunk })
+      result.on('end', () => resolve({ status: result.statusCode ?? 0, body }))
+    }).on('error', reject)
+  })
+}
+
+const reverseCodec: TokenCodec = {
+  encrypt: (plain) => [...plain].reverse().join(''),
+  decrypt: (blob) => [...blob].reverse().join(''),
+}
+
+function writeTokens(path: string, tokens: RailwayTokens, codec: TokenCodec = reverseCodec): void {
+  writeFileSync(path, JSON.stringify({ v: 1, blob: codec.encrypt(JSON.stringify(tokens)) }), { mode: 0o600 })
+}
+
+describe('PKCE', () => {
+  it('creates a 128-character verifier from the RFC 7636 alphabet', () => {
+    const verifier = railwayAuthTestUtils.createVerifier()
+    expect(verifier).toHaveLength(128)
+    expect(verifier).toMatch(/^[A-Za-z0-9._~-]+$/)
+  })
+
+  it('computes the RFC 7636 S256 challenge', () => {
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'
+    expect(railwayAuthTestUtils.createChallenge(verifier)).toBe('E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM')
+  })
+})
+
+describe('loginWithRailway', () => {
+  it('builds the complete auth URL, ignores other paths, accepts a callback, and exchanges the code', async () => {
+    const storePath = tokenPath()
+    let exchangeBody = ''
+    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
+      exchangeBody = String(init?.body)
+      return response({ access_token: 'access', refresh_token: 'refresh', expires_in: 3600 })
+    })
+    const result = await loginWithRailway({
+      storePath,
+      codec: reverseCodec,
+      now: () => 1_000,
+      fetchImpl,
+      openUrl: async (rawUrl) => {
+        const url = new URL(rawUrl)
+        expect(url.origin + url.pathname).toBe('https://backboard.railway.com/oauth/auth')
+        expect(Object.fromEntries(url.searchParams)).toMatchObject({
+          response_type: 'code',
+          client_id: 'rlwy_oaci_onEklvmksh1hRUiCo7E2zX12',
+          scope: 'openid email profile offline_access workspace:admin project:admin',
+          code_challenge_method: 'S256',
+          prompt: 'consent',
+        })
+        expect(url.searchParams.get('code_challenge')).toMatch(/^[A-Za-z0-9_-]{43}$/)
+        const redirect = new URL(url.searchParams.get('redirect_uri')!)
+        const ignored = await request(`${redirect.origin}/unrelated`)
+        expect(ignored.status).toBe(404)
+        const callback = await request(`${redirect.toString()}?code=auth-code&state=${encodeURIComponent(url.searchParams.get('state')!)}`)
+        expect(callback.status).toBe(200)
+        expect(callback.body).toContain("You're signed in")
+      },
+    })
+
+    expect(result).toEqual({ ok: true, message: 'Signed in to Railway.' })
+    expect(fetchImpl).toHaveBeenCalledOnce()
+    expect(Object.fromEntries(new URLSearchParams(exchangeBody))).toMatchObject({
+      grant_type: 'authorization_code',
+      code: 'auth-code',
+      client_id: 'rlwy_oaci_onEklvmksh1hRUiCo7E2zX12',
+    })
+    expect(isLoggedIn({ storePath, codec: reverseCodec })).toBe(true)
+    expect(statSync(storePath).mode & 0o777).toBe(0o600)
+  })
+
+  it('rejects a bad state with a CSRF failure page', async () => {
+    const result = await loginWithRailway({
+      storePath: tokenPath(),
+      openUrl: async (rawUrl) => {
+        const redirect = new URL(new URL(rawUrl).searchParams.get('redirect_uri')!)
+        const callback = await request(`${redirect.toString()}?code=nope&state=wrong`)
+        expect(callback.status).toBe(400)
+        expect(callback.body).toContain('CSRF validation failed')
+      },
+    })
+    expect(result.ok).toBe(false)
+    expect(result.message).toMatch(/CSRF.*state mismatch/i)
+  })
+
+  it('surfaces an OAuth error parameter and its failure page', async () => {
+    const result = await loginWithRailway({
+      storePath: tokenPath(),
+      openUrl: async (rawUrl) => {
+        const auth = new URL(rawUrl)
+        const redirect = new URL(auth.searchParams.get('redirect_uri')!)
+        const callback = await request(`${redirect.toString()}?error=access_denied&error_description=Nope&state=${encodeURIComponent(auth.searchParams.get('state')!)}`)
+        expect(callback.status).toBe(400)
+        expect(callback.body).toContain('Sign-in failed')
+      },
+    })
+    expect(result).toEqual({ ok: false, message: 'Railway authorization failed: Nope' })
+  })
+
+  it('surfaces token exchange HTTP errors', async () => {
+    const result = await loginWithRailway({
+      storePath: tokenPath(),
+      fetchImpl: async () => response({ error: 'invalid_request', error_description: 'Bad exchange' }, 400),
+      openUrl: async (rawUrl) => {
+        const auth = new URL(rawUrl)
+        const redirect = auth.searchParams.get('redirect_uri')!
+        await request(`${redirect}?code=code&state=${encodeURIComponent(auth.searchParams.get('state')!)}`)
+      },
+    })
+    expect(result).toEqual({ ok: false, message: 'Railway token request failed: Bad exchange' })
+  })
+})
+
+describe('stored sessions and refresh', () => {
+  it('round-trips through a codec and logout deletes the store', () => {
+    const storePath = tokenPath()
+    writeTokens(storePath, { accessToken: 'a', refreshToken: 'r', expiresAt: 10 }, reverseCodec)
+    expect(readFileSync(storePath, 'utf8')).not.toContain('accessToken')
+    expect(isLoggedIn({ storePath, codec: reverseCodec })).toBe(true)
+    logout({ storePath })
+    expect(isLoggedIn({ storePath, codec: reverseCodec })).toBe(false)
+  })
+
+  it('returns a fresh token without making a request', async () => {
+    const storePath = tokenPath()
+    writeTokens(storePath, { accessToken: 'still-fresh', refreshToken: 'r', expiresAt: 100_000 })
+    const fetchImpl = vi.fn<typeof fetch>()
+    expect(await getFreshAccessToken({ storePath, codec: reverseCodec, now: () => 1, fetchImpl })).toBe('still-fresh')
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('refreshes near expiry and persists a rotated refresh token', async () => {
+    const storePath = tokenPath()
+    writeTokens(storePath, { accessToken: 'old', refreshToken: 'old-refresh', expiresAt: 50_000 })
+    let requestBody = ''
+    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
+      requestBody = String(init?.body)
+      return response({ access_token: 'new', refresh_token: 'rotated', expires_in: 120 })
+    })
+    expect(await getFreshAccessToken({ storePath, codec: reverseCodec, now: () => 1_000, fetchImpl })).toBe('new')
+    expect(Object.fromEntries(new URLSearchParams(requestBody))).toMatchObject({
+      grant_type: 'refresh_token', refresh_token: 'old-refresh',
+    })
+    const encrypted = JSON.parse(readFileSync(storePath, 'utf8')) as { blob: string }
+    expect(JSON.parse(reverseCodec.decrypt(encrypted.blob))).toEqual({
+      accessToken: 'new', refreshToken: 'rotated', expiresAt: 121_000,
+    })
+  })
+
+  it('returns null when logged out', async () => {
+    expect(await getFreshAccessToken({ storePath: tokenPath() })).toBeNull()
+  })
+
+  it('clears the store when refresh returns invalid_grant', async () => {
+    const storePath = tokenPath()
+    writeTokens(storePath, { accessToken: 'old', refreshToken: 'bad', expiresAt: 1 })
+    expect(await getFreshAccessToken({
+      storePath,
+      codec: reverseCodec,
+      now: () => 10,
+      fetchImpl: async () => response({ error: 'invalid_grant' }, 400),
+    })).toBeNull()
+    expect(isLoggedIn({ storePath, codec: reverseCodec })).toBe(false)
+  })
+})
+
+describe('listWorkspaces', () => {
+  it('uses the Railway GraphQL endpoint and returns workspaces', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => response({ data: { me: { workspaces: [{ id: 'w', name: 'Team' }] } } }))
+    await expect(listWorkspaces('token', { fetchImpl })).resolves.toEqual([{ id: 'w', name: 'Team' }])
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe('https://backboard.railway.com/graphql/v2')
+    expect(fetchImpl.mock.calls[0]?.[1]?.headers).toMatchObject({ Authorization: 'Bearer token' })
+  })
+})

--- a/desktop/src/main/railwayAuth.test.ts
+++ b/desktop/src/main/railwayAuth.test.ts
@@ -112,7 +112,10 @@ describe('loginWithRailway', () => {
       client_id: 'rlwy_oaci_onEklvmksh1hRUiCo7E2zX12',
     })
     expect(isLoggedIn({ storePath, codec: reverseCodec })).toBe(true)
-    expect(statSync(storePath).mode & 0o777).toBe(0o600)
+    if (process.platform !== 'win32') {
+      // Windows ignores POSIX modes (ACLs apply instead); assert only where chmod is real.
+      expect(statSync(storePath).mode & 0o777).toBe(0o600)
+    }
   })
 
   it('rejects a bad state with a CSRF failure page', async () => {

--- a/desktop/src/main/railwayAuth.ts
+++ b/desktop/src/main/railwayAuth.ts
@@ -1,0 +1,359 @@
+import { createHash, randomBytes, randomInt } from 'node:crypto'
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { createServer, type Server } from 'node:http'
+import { join } from 'node:path'
+
+export interface RailwayTokens {
+  accessToken: string
+  refreshToken: string | null
+  expiresAt: number
+}
+
+export interface TokenCodec {
+  encrypt(plain: string): string
+  decrypt(blob: string): string
+}
+
+export interface RailwayAuthDeps {
+  fetchImpl?: typeof fetch
+  openUrl?: (url: string) => Promise<void>
+  now?: () => number
+  codec?: TokenCodec
+  storePath?: string
+}
+
+export interface RailwayWorkspace {
+  id: string
+  name: string
+}
+
+const OAUTH_BASE = 'https://backboard.railway.com/oauth'
+// AgentField should register its own Railway OAuth client before GA.
+const DEFAULT_CLIENT_ID = 'rlwy_oaci_onEklvmksh1hRUiCo7E2zX12'
+const SCOPES = 'openid email profile offline_access workspace:admin project:admin'
+const CALLBACK_TIMEOUT_MS = 5 * 60 * 1000
+const VERIFIER_CHARACTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~'
+const identityCodec: TokenCodec = { encrypt: (plain) => plain, decrypt: (blob) => blob }
+
+interface StoredTokens {
+  v: 1
+  blob: string
+}
+
+interface TokenResponse {
+  access_token: string
+  refresh_token?: string
+  expires_in: number
+}
+
+interface OAuthErrorBody {
+  error?: string
+  error_description?: string
+}
+
+function clientId(): string {
+  return process.env.RAILWAY_OAUTH_CLIENT_ID || DEFAULT_CLIENT_ID
+}
+
+function resolvedDeps(deps: RailwayAuthDeps = {}): Required<Pick<RailwayAuthDeps, 'fetchImpl' | 'now' | 'codec' | 'storePath'>> {
+  return {
+    fetchImpl: deps.fetchImpl ?? fetch,
+    now: deps.now ?? Date.now,
+    codec: deps.codec ?? identityCodec,
+    storePath: deps.storePath ?? join(process.cwd(), 'railway-auth.json'),
+  }
+}
+
+function base64url(input: Buffer): string {
+  return input.toString('base64url')
+}
+
+function createVerifier(): string {
+  let verifier = ''
+  for (let index = 0; index < 128; index += 1) {
+    verifier += VERIFIER_CHARACTERS[randomInt(VERIFIER_CHARACTERS.length)]
+  }
+  return verifier
+}
+
+function createChallenge(verifier: string): string {
+  return base64url(createHash('sha256').update(verifier, 'ascii').digest())
+}
+
+function readTokens(deps: RailwayAuthDeps = {}): RailwayTokens | null {
+  const { codec, storePath } = resolvedDeps(deps)
+  try {
+    const stored = JSON.parse(readFileSync(storePath, 'utf8')) as Partial<StoredTokens>
+    if (stored.v !== 1 || typeof stored.blob !== 'string') return null
+    const tokens = JSON.parse(codec.decrypt(stored.blob)) as Partial<RailwayTokens>
+    if (
+      typeof tokens.accessToken !== 'string' ||
+      (typeof tokens.refreshToken !== 'string' && tokens.refreshToken !== null) ||
+      typeof tokens.expiresAt !== 'number'
+    ) return null
+    return tokens as RailwayTokens
+  } catch {
+    return null
+  }
+}
+
+function saveTokens(tokens: RailwayTokens, deps: RailwayAuthDeps = {}): void {
+  const { codec, storePath } = resolvedDeps(deps)
+  const stored: StoredTokens = { v: 1, blob: codec.encrypt(JSON.stringify(tokens)) }
+  writeFileSync(storePath, JSON.stringify(stored), { encoding: 'utf8', mode: 0o600 })
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  })[character]!)
+}
+
+function callbackHtml(success: boolean, detail?: string): string {
+  const title = success ? "You're signed in" : 'Sign-in failed'
+  const message = success
+    ? 'Return to AgentField Desktop.'
+    : (detail || 'Return to AgentField Desktop and try again.')
+  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>${title}</title><style>color-scheme:light dark;body{margin:0;min-height:100vh;display:grid;place-items:center;background:#f7f7f5;color:#171714;font:16px system-ui,sans-serif}.card{max-width:34rem;margin:2rem;padding:2rem;border:1px solid #d6b24c;border-radius:14px;background:#fff;box-shadow:0 12px 35px #0002}h1{margin:0 0 .6rem;color:#a06b00;font-size:1.6rem}p{margin:0;line-height:1.5}@media(prefers-color-scheme:dark){body{background:#111214;color:#f4f1e8}.card{background:#1b1c1f;border-color:#8d6b1f}h1{color:#e2b84e}}</style></head><body><main class="card"><h1>${title}</h1><p>${escapeHtml(message)}</p></main></body></html>`
+}
+
+function sendHtml(response: import('node:http').ServerResponse, status: number, html: string): void {
+  response.writeHead(status, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' })
+  response.end(html)
+}
+
+function closeServer(server: Server): void {
+  server.close()
+}
+
+async function listenForCode(state: string): Promise<{ code: Promise<string>; redirectUri: string; cancel: () => void }> {
+  let resolveCode!: (code: string) => void
+  let rejectCode!: (error: Error) => void
+  let settled = false
+  let timer: NodeJS.Timeout
+
+  const code = new Promise<string>((resolve, reject) => {
+    resolveCode = resolve
+    rejectCode = reject
+  })
+
+  const server = createServer((request, response) => {
+    if (!request.url?.startsWith('/callback')) {
+      response.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' })
+      response.end('Not found')
+      return
+    }
+
+    const url = new URL(request.url, 'http://127.0.0.1')
+    const receivedState = url.searchParams.get('state')
+    if (receivedState !== state) {
+      const message = 'CSRF validation failed: OAuth state mismatch.'
+      sendHtml(response, 400, callbackHtml(false, message))
+      if (!settled) {
+        settled = true
+        clearTimeout(timer)
+        rejectCode(new Error(message))
+        closeServer(server)
+      }
+      return
+    }
+
+    const oauthError = url.searchParams.get('error')
+    if (oauthError) {
+      const description = url.searchParams.get('error_description')
+      const message = description ? `Railway authorization failed: ${description}` : `Railway authorization failed: ${oauthError}`
+      sendHtml(response, 400, callbackHtml(false, message))
+      if (!settled) {
+        settled = true
+        clearTimeout(timer)
+        rejectCode(new Error(message))
+        closeServer(server)
+      }
+      return
+    }
+
+    const authorizationCode = url.searchParams.get('code')
+    if (!authorizationCode) {
+      const message = 'Railway authorization failed: callback did not include a code.'
+      sendHtml(response, 400, callbackHtml(false, message))
+      if (!settled) {
+        settled = true
+        clearTimeout(timer)
+        rejectCode(new Error(message))
+        closeServer(server)
+      }
+      return
+    }
+
+    sendHtml(response, 200, callbackHtml(true))
+    if (!settled) {
+      settled = true
+      clearTimeout(timer)
+      resolveCode(authorizationCode)
+      closeServer(server)
+    }
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => resolve())
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    closeServer(server)
+    throw new Error('Could not determine OAuth callback port.')
+  }
+
+  timer = setTimeout(() => {
+    if (!settled) {
+      settled = true
+      rejectCode(new Error('Railway sign-in timed out after 5 minutes.'))
+      closeServer(server)
+    }
+  }, CALLBACK_TIMEOUT_MS)
+  timer.unref()
+
+  return {
+    code,
+    redirectUri: `http://127.0.0.1:${address.port}/callback`,
+    cancel: () => {
+      if (!settled) {
+        settled = true
+        clearTimeout(timer)
+        rejectCode(new Error('Railway sign-in was cancelled.'))
+        closeServer(server)
+      }
+    },
+  }
+}
+
+async function parseTokenResponse(response: Response): Promise<TokenResponse> {
+  const body = await response.json().catch(() => ({})) as Partial<TokenResponse> & OAuthErrorBody
+  if (!response.ok) {
+    const detail = body.error_description || body.error || `${response.status} ${response.statusText}`.trim()
+    throw new Error(`Railway token request failed: ${detail}`)
+  }
+  if (typeof body.access_token !== 'string' || typeof body.expires_in !== 'number') {
+    throw new Error('Railway token response was incomplete.')
+  }
+  return body as TokenResponse
+}
+
+async function requestTokens(parameters: URLSearchParams, fetchImpl: typeof fetch): Promise<TokenResponse> {
+  const response = await fetchImpl(`${OAUTH_BASE}/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: parameters,
+  })
+  return parseTokenResponse(response)
+}
+
+export async function loginWithRailway(deps: RailwayAuthDeps = {}): Promise<{ ok: boolean; message: string }> {
+  let cancelCallback: (() => void) | undefined
+  try {
+    if (!deps.openUrl) throw new Error('No browser opener was configured for Railway sign-in.')
+    const verifier = createVerifier()
+    const state = base64url(randomBytes(32))
+    const callback = await listenForCode(state)
+    cancelCallback = callback.cancel
+    // Browser openers may wait for the page load; attach a handler immediately so
+    // a rejected callback cannot briefly become an unhandled promise rejection.
+    void callback.code.catch(() => undefined)
+    const authorizeUrl = new URL(`${OAUTH_BASE}/auth`)
+    authorizeUrl.search = new URLSearchParams({
+      response_type: 'code',
+      client_id: clientId(),
+      redirect_uri: callback.redirectUri,
+      scope: SCOPES,
+      code_challenge: createChallenge(verifier),
+      code_challenge_method: 'S256',
+      state,
+      prompt: 'consent',
+    }).toString()
+
+    await deps.openUrl(authorizeUrl.toString())
+    const code = await callback.code
+    const { fetchImpl, now } = resolvedDeps(deps)
+    const tokenResponse = await requestTokens(new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: callback.redirectUri,
+      client_id: clientId(),
+      code_verifier: verifier,
+    }), fetchImpl)
+    saveTokens({
+      accessToken: tokenResponse.access_token,
+      refreshToken: tokenResponse.refresh_token ?? null,
+      expiresAt: now() + tokenResponse.expires_in * 1000,
+    }, deps)
+    return { ok: true, message: 'Signed in to Railway.' }
+  } catch (error) {
+    cancelCallback?.()
+    return { ok: false, message: errorMessage(error) }
+  }
+}
+
+export async function getFreshAccessToken(deps: RailwayAuthDeps = {}): Promise<string | null> {
+  const tokens = readTokens(deps)
+  if (!tokens) return null
+  const { fetchImpl, now } = resolvedDeps(deps)
+  if (tokens.expiresAt - now() >= 60_000) return tokens.accessToken
+  if (!tokens.refreshToken) return null
+
+  try {
+    const refreshed = await requestTokens(new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: tokens.refreshToken,
+      client_id: clientId(),
+    }), fetchImpl)
+    const rotated: RailwayTokens = {
+      accessToken: refreshed.access_token,
+      refreshToken: refreshed.refresh_token ?? tokens.refreshToken,
+      expiresAt: now() + refreshed.expires_in * 1000,
+    }
+    saveTokens(rotated, deps)
+    return rotated.accessToken
+  } catch (error) {
+    if (errorMessage(error).includes('invalid_grant')) logout(deps)
+    return null
+  }
+}
+
+export function isLoggedIn(deps: RailwayAuthDeps = {}): boolean {
+  return readTokens(deps) !== null
+}
+
+export function logout(deps: RailwayAuthDeps = {}): void {
+  const { storePath } = resolvedDeps(deps)
+  try {
+    if (existsSync(storePath)) unlinkSync(storePath)
+  } catch {
+    // Logout is intentionally idempotent; an inaccessible store is treated as logged out.
+  }
+}
+
+export async function listWorkspaces(accessToken: string, deps: { fetchImpl?: typeof fetch } = {}): Promise<RailwayWorkspace[]> {
+  const response = await (deps.fetchImpl ?? fetch)('https://backboard.railway.com/graphql/v2', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
+    body: JSON.stringify({ query: 'query { me { workspaces { id name } } }' }),
+  })
+  const body = await response.json().catch(() => ({})) as {
+    data?: { me?: { workspaces?: RailwayWorkspace[] } }
+    errors?: Array<{ message?: string }>
+  }
+  if (!response.ok || body.errors?.length) {
+    const detail = body.errors?.[0]?.message || `${response.status} ${response.statusText}`.trim()
+    throw new Error(`Failed to list Railway workspaces: ${detail}`)
+  }
+  return body.data?.me?.workspaces ?? []
+}
+
+export const railwayAuthTestUtils = {
+  createVerifier,
+  createChallenge,
+}

--- a/desktop/src/main/secrets.test.ts
+++ b/desktop/src/main/secrets.test.ts
@@ -252,7 +252,9 @@ describe('control-plane secret management', () => {
       { name: 'UNSET_KEY', status: 'missing' }
     ])
     expect(reports[0].vars.every((variable) => variable.required && variable.secret)).toBe(true)
-    expect(reports[0].satisfied).toBe(false)
+    // Without metadata a missing key may be an unused one-of alternative, so
+    // the report must not veto Start — the control plane decides at start time.
+    expect(reports[0].satisfied).toBe(true)
   })
 
   it('maps enriched environment metadata, groups, defaults, and optionals', async () => {

--- a/desktop/src/main/secrets.test.ts
+++ b/desktop/src/main/secrets.test.ts
@@ -1,6 +1,6 @@
 import yaml from 'js-yaml'
 import { describe, expect, it, vi } from 'vitest'
-import type { CpClient, PackageInfo } from './cpClient'
+import type { AgentSecretStatus, CpClient, PackageInfo } from './cpClient'
 import {
   buildEnvReport,
   buildSecretsInventory,
@@ -251,6 +251,74 @@ describe('control-plane secret management', () => {
       { name: 'SET_KEY', status: 'stored' },
       { name: 'UNSET_KEY', status: 'missing' }
     ])
+    expect(reports[0].vars.every((variable) => variable.required && variable.secret)).toBe(true)
+    expect(reports[0].satisfied).toBe(false)
+  })
+
+  it('maps enriched environment metadata, groups, defaults, and optionals', async () => {
+    const cpClient = client()
+    const enrichedSecrets: AgentSecretStatus[] = [
+        {
+          key: 'ANTHROPIC_API_KEY', is_set: false, scope: 'global',
+          declared_scope: 'global', description: 'Anthropic API key (Claude)', secret: true,
+          default: '', requirement: 'one_of', group: 'llm_provider',
+          group_description: 'an LLM provider key'
+        },
+        {
+          key: 'OPENROUTER_API_KEY', is_set: true, scope: 'global',
+          declared_scope: 'global', description: 'OpenRouter API key', secret: true,
+          default: '', requirement: 'one_of', group: 'llm_provider',
+          group_description: 'an LLM provider key'
+        },
+        {
+          key: 'GH_TOKEN', is_set: false, scope: 'global', declared_scope: 'global',
+          description: 'GitHub token', secret: true, default: '', requirement: 'required'
+        },
+        {
+          key: 'SWE_DEFAULT_RUNTIME', is_set: false, declared_scope: 'node',
+          description: 'Runtime override', secret: false, default: '', requirement: 'optional'
+        },
+        {
+          key: 'AGENTFIELD_SERVER', is_set: false, description: 'Control-plane URL',
+          default: 'http://localhost:8080', requirement: 'optional'
+        },
+        { key: 'UNDECLARED_KEY', is_set: true, scope: 'node' as const }
+      ]
+    vi.mocked(cpClient.listAgentSecrets).mockResolvedValue({ secrets: enrichedSecrets })
+
+    const [report] = await getEnvReports({ cpClient })
+
+    expect(report.satisfied).toBe(false)
+    expect(report.vars).toEqual([
+      expect.objectContaining({
+        name: 'ANTHROPIC_API_KEY', required: true, group: 'llm_provider',
+        groupDescription: 'an LLM provider key', status: 'missing'
+      }),
+      expect.objectContaining({
+        name: 'OPENROUTER_API_KEY', required: true, group: 'llm_provider',
+        status: 'stored', storedScopes: ['global']
+      }),
+      expect.objectContaining({ name: 'GH_TOKEN', required: true, status: 'missing' }),
+      expect.objectContaining({
+        name: 'SWE_DEFAULT_RUNTIME', required: false, secret: false, scope: 'node',
+        status: 'missing'
+      }),
+      expect.objectContaining({
+        name: 'AGENTFIELD_SERVER', required: false, secret: false, scope: 'global',
+        status: 'default'
+      }),
+      expect.objectContaining({
+        name: 'UNDECLARED_KEY', required: false, secret: false, scope: 'global',
+        group: undefined, status: 'stored', storedScopes: ['agent']
+      })
+    ])
+
+    vi.mocked(cpClient.listAgentSecrets).mockResolvedValue({
+      secrets: enrichedSecrets.map((secret) =>
+        secret.key === 'GH_TOKEN' ? { ...secret, is_set: true } : secret
+      )
+    })
+    expect((await getEnvReports({ cpClient }))[0].satisfied).toBe(true)
   })
 
   it('sets and deletes without sending a scope', async () => {

--- a/desktop/src/main/secrets.ts
+++ b/desktop/src/main/secrets.ts
@@ -197,21 +197,58 @@ export async function getEnvReports(
     const packages = await deps.cpClient.listPackages()
     return await Promise.all(packages.packages.filter(isInstalledPackage).map(async (pkg) => {
       const { secrets } = await deps.cpClient.listAgentSecrets(pkg.id)
-      const vars: AgentEnvVar[] = secrets.map((secret) => ({
-        name: secret.key,
-        description: '',
-        secret: true,
-        scope: secret.scope ?? GLOBAL_SCOPE,
-        required: true,
-        status: secret.is_set ? 'stored' : 'missing',
-        storedScopes: secret.is_set
-          ? [secret.scope === 'node' ? pkg.name : secret.scope ?? GLOBAL_SCOPE]
-          : []
-      }))
+      const hasEnvMetadata = secrets.some((secret) => Boolean(secret.requirement))
+      const vars: AgentEnvVar[] = secrets.map((secret) => {
+        if (!hasEnvMetadata) {
+          return {
+            name: secret.key,
+            description: '',
+            secret: true,
+            scope: secret.scope ?? GLOBAL_SCOPE,
+            required: true,
+            status: secret.is_set ? 'stored' : 'missing',
+            storedScopes: secret.is_set
+              ? [secret.scope === 'node' ? pkg.name : secret.scope ?? GLOBAL_SCOPE]
+              : []
+          }
+        }
+
+        const status: EnvVarStatus = secret.is_set
+          ? 'stored'
+          : secret.default
+            ? 'default'
+            : 'missing'
+        return {
+          name: secret.key,
+          description: secret.description ?? '',
+          secret: secret.secret ?? false,
+          scope: secret.declared_scope ?? GLOBAL_SCOPE,
+          // Group members are `required: true` by app convention (see
+          // AgentEnvVar.required) — EnvEditor's Optional bucket filters on
+          // !required, and the gate below exempts grouped vars instead.
+          required: secret.requirement === 'required' || secret.requirement === 'one_of',
+          group: secret.requirement === 'one_of' ? secret.group || undefined : undefined,
+          groupDescription:
+            secret.requirement === 'one_of' ? secret.group_description || undefined : undefined,
+          status,
+          storedScopes: secret.is_set
+            ? [secret.scope === 'node' ? pkg.name : secret.scope ?? GLOBAL_SCOPE]
+            : []
+        }
+      })
+      const groups = new Set(vars.flatMap((variable) => variable.group ? [variable.group] : []))
+      const requiredOk = vars.every((variable) =>
+        variable.group || !variable.required || variable.status !== 'missing'
+      )
+      const groupsOk = [...groups].every((group) =>
+        vars.some((variable) => variable.group === group && variable.status !== 'missing')
+      )
       return {
         agent: pkg.name,
         vars,
-        satisfied: vars.every((variable) => variable.status !== 'missing')
+        satisfied: hasEnvMetadata
+          ? requiredOk && groupsOk
+          : vars.every((variable) => variable.status !== 'missing')
       }
     }))
   } catch (err) {

--- a/desktop/src/main/secrets.ts
+++ b/desktop/src/main/secrets.ts
@@ -243,12 +243,14 @@ export async function getEnvReports(
       const groupsOk = [...groups].every((group) =>
         vars.some((variable) => variable.group === group && variable.status !== 'missing')
       )
+      // Without metadata, a require_one_of group member is indistinguishable
+      // from a hard-required key, so an unset alternative (e.g. one of two
+      // LLM-provider keys) must not veto Start. Report the keys as declared,
+      // but leave the verdict to the control plane's start-time resolution.
       return {
         agent: pkg.name,
         vars,
-        satisfied: hasEnvMetadata
-          ? requiredOk && groupsOk
-          : vars.every((variable) => variable.status !== 'missing')
+        satisfied: hasEnvMetadata ? requiredOk && groupsOk : true
       }
     }))
   } catch (err) {

--- a/desktop/src/main/settings.test.ts
+++ b/desktop/src/main/settings.test.ts
@@ -10,6 +10,7 @@ afterAll(() => rmSync(dir, { recursive: true, force: true }))
 describe('normalizeSettings', () => {
   it('accepts a valid shape as-is', () => {
     const s = {
+      cloud: { enabled: true, serverUrl: 'https://cloud.example', apiKey: 'secret' },
       openAtLogin: true,
       appearance: 'dark' as const,
       autostartControlPlane: false,
@@ -56,6 +57,20 @@ describe('normalizeSettings', () => {
     expect(normalizeSettings({ openAtLogin: 'yes', autostartAgents: 42 })).toEqual(
       DEFAULT_SETTINGS
     )
+  })
+
+  it('normalizes cloud profile values and defaults old settings', () => {
+    expect(normalizeSettings({}).cloud).toEqual(DEFAULT_SETTINGS.cloud)
+    expect(
+      normalizeSettings({
+        cloud: { enabled: 'yes', serverUrl: '  https://cp.example/  ', apiKey: ' key ' }
+      }).cloud
+    ).toEqual({ enabled: true, serverUrl: 'https://cp.example/', apiKey: 'key' })
+    expect(normalizeSettings({ cloud: { enabled: 0, serverUrl: 7, apiKey: null } }).cloud).toEqual({
+      enabled: false,
+      serverUrl: '',
+      apiKey: ''
+    })
   })
 
   it('drops non-string agent names and dedupes', () => {
@@ -118,6 +133,7 @@ describe('load/save round trip', () => {
   it('persists and reloads settings', async () => {
     const file = join(dir, 'nested', 'settings.json')
     const s = {
+      cloud: { enabled: true, serverUrl: 'https://cloud.example', apiKey: 'round-trip-key' },
       openAtLogin: true,
       appearance: 'light' as const,
       autostartControlPlane: true,

--- a/desktop/src/main/settings.ts
+++ b/desktop/src/main/settings.ts
@@ -7,6 +7,7 @@ import { dirname } from 'node:path'
 import type { DesktopSettings } from '../shared/types'
 
 export const DEFAULT_SETTINGS: DesktopSettings = {
+  cloud: { enabled: false, serverUrl: '', apiKey: '' },
   openAtLogin: false,
   appearance: 'system',
   autostartControlPlane: true,
@@ -34,10 +35,19 @@ function normalizePort(value: unknown): number | null {
  */
 export function normalizeSettings(raw: unknown): DesktopSettings {
   const obj = typeof raw === 'object' && raw !== null ? (raw as Record<string, unknown>) : {}
+  const cloud =
+    typeof obj.cloud === 'object' && obj.cloud !== null
+      ? (obj.cloud as Record<string, unknown>)
+      : {}
   const agents = Array.isArray(obj.autostartAgents)
     ? [...new Set(obj.autostartAgents.filter((n): n is string => typeof n === 'string'))]
     : DEFAULT_SETTINGS.autostartAgents
   return {
+    cloud: {
+      enabled: Boolean(cloud.enabled),
+      serverUrl: typeof cloud.serverUrl === 'string' ? cloud.serverUrl.trim() : '',
+      apiKey: typeof cloud.apiKey === 'string' ? cloud.apiKey.trim() : ''
+    },
     openAtLogin:
       typeof obj.openAtLogin === 'boolean' ? obj.openAtLogin : DEFAULT_SETTINGS.openAtLogin,
     appearance:

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,12 +1,8 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import type { AgentFieldApi } from '../shared/types'
 
-type PreloadApi = AgentFieldApi & {
-  cloudDeployRailway(): Promise<void>
-}
-
 // Sandboxed preload: only contextBridge/ipcRenderer are used, no Node APIs.
-const api: PreloadApi = {
+const api: AgentFieldApi = {
   getSnapshot: () => ipcRenderer.invoke('agentfield:snapshot'),
   getCatalog: () => ipcRenderer.invoke('agentfield:catalog'),
   install: (name) => ipcRenderer.invoke('agentfield:install', name),
@@ -30,6 +26,16 @@ const api: PreloadApi = {
   setSettings: (patch) => ipcRenderer.invoke('agentfield:settings-set', patch),
   cloudTest: (url, apiKey) => ipcRenderer.invoke('agentfield:cloud-test', url, apiKey),
   cloudDeployRailway: () => ipcRenderer.invoke('agentfield:cloud-deploy-railway'),
+  railwayStatus: () => ipcRenderer.invoke('agentfield:railway-status'),
+  railwayLogin: () => ipcRenderer.invoke('agentfield:railway-login'),
+  railwayLogout: () => ipcRenderer.invoke('agentfield:railway-logout'),
+  cloudDeploy: (workspaceId) => ipcRenderer.invoke('agentfield:cloud-deploy', workspaceId),
+  cloudDestroy: () => ipcRenderer.invoke('agentfield:cloud-destroy'),
+  onCloudDeployProgress: (listener) => {
+    const wrapped = (_event: Electron.IpcRendererEvent, line: string) => listener(line)
+    ipcRenderer.on('agentfield:cloud-deploy-progress', wrapped)
+    return () => ipcRenderer.removeListener('agentfield:cloud-deploy-progress', wrapped)
+  },
   getCliStatus: () => ipcRenderer.invoke('agentfield:cli-status'),
   updateCli: () => ipcRenderer.invoke('agentfield:cli-update'),
   getAppUpdateStatus: () => ipcRenderer.invoke('agentfield:app-update-get'),

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,8 +1,12 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import type { AgentFieldApi } from '../shared/types'
 
+type PreloadApi = AgentFieldApi & {
+  cloudDeployRailway(): Promise<void>
+}
+
 // Sandboxed preload: only contextBridge/ipcRenderer are used, no Node APIs.
-const api: AgentFieldApi = {
+const api: PreloadApi = {
   getSnapshot: () => ipcRenderer.invoke('agentfield:snapshot'),
   getCatalog: () => ipcRenderer.invoke('agentfield:catalog'),
   install: (name) => ipcRenderer.invoke('agentfield:install', name),
@@ -24,6 +28,8 @@ const api: AgentFieldApi = {
   revokeSecret: (key, scope) => ipcRenderer.invoke('agentfield:secrets-revoke', key, scope),
   getSettings: () => ipcRenderer.invoke('agentfield:settings-get'),
   setSettings: (patch) => ipcRenderer.invoke('agentfield:settings-set', patch),
+  cloudTest: (url, apiKey) => ipcRenderer.invoke('agentfield:cloud-test', url, apiKey),
+  cloudDeployRailway: () => ipcRenderer.invoke('agentfield:cloud-deploy-railway'),
   getCliStatus: () => ipcRenderer.invoke('agentfield:cli-status'),
   updateCli: () => ipcRenderer.invoke('agentfield:cli-update'),
   getAppUpdateStatus: () => ipcRenderer.invoke('agentfield:app-update-get'),

--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -45,7 +45,7 @@ const VIEW_TITLES: Record<View, string> = {
   agents: 'Agents',
   activity: 'Activity',
   settings: 'Settings',
-  cloud: 'Cloud'
+  cloud: 'Remote'
 }
 
 // ⌘1–⌘5 (Ctrl on Win/Linux) in nav order (DESIGN.md §4.17).

--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -8,6 +8,7 @@ import { AgentsPanel } from './components/AgentsPanel'
 import { ActivityPanel } from './components/ActivityPanel'
 import { InstallPanel } from './components/InstallPanel'
 import { SettingsPanel } from './components/SettingsPanel'
+import { CloudPanel } from './components/CloudPanel'
 import { StarBanner } from './components/StarBanner'
 import { UpdateBanner } from './components/UpdateBanner'
 
@@ -43,11 +44,12 @@ const VIEW_TITLES: Record<View, string> = {
   install: 'Agents',
   agents: 'Agents',
   activity: 'Activity',
-  settings: 'Settings'
+  settings: 'Settings',
+  cloud: 'Cloud'
 }
 
-// ⌘1–⌘4 (Ctrl on Win/Linux) in nav order (DESIGN.md §4.17).
-const SHORTCUT_VIEWS: View[] = ['home', 'agents', 'activity', 'settings']
+// ⌘1–⌘5 (Ctrl on Win/Linux) in nav order (DESIGN.md §4.17).
+const SHORTCUT_VIEWS: View[] = ['home', 'agents', 'activity', 'settings', 'cloud']
 
 /** True when the keystroke belongs to a text control, not the app. */
 function isEditableTarget(target: EventTarget | null): boolean {
@@ -281,6 +283,7 @@ export default function App() {
                 />
               )}
               {view === 'settings' && <SettingsPanel agents={snapshot?.registry.agents ?? []} />}
+              {view === 'cloud' && <CloudPanel />}
             </m.div>
           </AnimatePresence>
         </div>

--- a/desktop/src/renderer/src/components/CloudPanel.tsx
+++ b/desktop/src/renderer/src/components/CloudPanel.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react'
-import type { AgentFieldApi, CloudTestResult, DesktopSettings } from '../../../shared/types'
-
-type CloudDeployApi = AgentFieldApi & {
-  cloudDeployRailway(): Promise<void>
-}
+import type {
+  CloudDeployResult,
+  CloudTestResult,
+  DesktopSettings,
+  RailwayStatus
+} from '../../../shared/types'
 
 type Confirmation = {
   mode: 'cloud' | 'local'
@@ -20,6 +21,14 @@ export function CloudPanel() {
   const [result, setResult] = useState<CloudTestResult | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [confirmation, setConfirmation] = useState<Confirmation | null>(null)
+  const [railway, setRailway] = useState<RailwayStatus | null>(null)
+  const [railwayBusy, setRailwayBusy] = useState<'login' | 'deploy' | 'destroy' | null>(null)
+  const [workspaceId, setWorkspaceId] = useState('')
+  const [deployLines, setDeployLines] = useState<string[]>([])
+  const [deployResult, setDeployResult] = useState<CloudDeployResult | null>(null)
+  const [deleteText, setDeleteText] = useState('')
+  const [showDestroy, setShowDestroy] = useState(false)
+  const [destroyed, setDestroyed] = useState(false)
 
   useEffect(() => {
     void window.agentfield.getSettings().then((next) => {
@@ -28,6 +37,25 @@ export function CloudPanel() {
       setApiKey(next.cloud?.apiKey ?? '')
     })
   }, [])
+
+  useEffect(() => {
+    void window.agentfield.railwayStatus().then(setRailway).catch((err) => {
+      setError(err instanceof Error ? err.message : String(err))
+    })
+    return window.agentfield.onCloudDeployProgress((line) => {
+      setDeployLines((lines) => [...lines.slice(-199), line])
+    })
+  }, [])
+
+  useEffect(() => {
+    if (!railway?.loggedIn) {
+      setWorkspaceId('')
+    } else if (railway.workspaces.length === 1) {
+      setWorkspaceId(railway.workspaces[0].id)
+    } else if (!railway.workspaces.some((workspace) => workspace.id === workspaceId)) {
+      setWorkspaceId('')
+    }
+  }, [railway, workspaceId])
 
   useEffect(() => {
     if (!confirmation) return
@@ -107,8 +135,75 @@ export function CloudPanel() {
     }
   }
 
-  // TODO(integration): fold into AgentFieldApi
-  const deployApi = window.agentfield as CloudDeployApi
+  const refreshRailway = async () => setRailway(await window.agentfield.railwayStatus())
+
+  const railwayLogin = async () => {
+    setRailwayBusy('login')
+    setError(null)
+    try {
+      const login = await window.agentfield.railwayLogin()
+      if (!login.ok) setError(login.message)
+      await refreshRailway()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setRailwayBusy(null)
+    }
+  }
+
+  const railwayLogout = async () => {
+    await window.agentfield.railwayLogout()
+    setDeployResult(null)
+    await refreshRailway()
+  }
+
+  const deploy = async () => {
+    if (!workspaceId) return
+    setRailwayBusy('deploy')
+    setDeployLines([])
+    setDeployResult(null)
+    setDestroyed(false)
+    setError(null)
+    try {
+      const nextResult = await window.agentfield.cloudDeploy(workspaceId)
+      setDeployResult(nextResult)
+      if (nextResult.ok) {
+        const next = await window.agentfield.getSettings()
+        setSettings(next)
+        setServerUrl(next.cloud.serverUrl)
+        setApiKey(next.cloud.apiKey)
+      }
+      await refreshRailway()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setRailwayBusy(null)
+    }
+  }
+
+  const destroy = async () => {
+    if (deleteText !== 'delete') return
+    setRailwayBusy('destroy')
+    setError(null)
+    try {
+      const result = await window.agentfield.cloudDestroy()
+      if (!result.ok) {
+        setError(result.message)
+        return
+      }
+      const next = await window.agentfield.getSettings()
+      setSettings(next)
+      setShowDestroy(false)
+      setDeleteText('')
+      setDeployResult(null)
+      setDestroyed(true)
+      await refreshRailway()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setRailwayBusy(null)
+    }
+  }
 
   if (!settings) {
     return (
@@ -258,21 +353,113 @@ export function CloudPanel() {
         </div>
         <div className="panel cloud-railway">
           <div className="cloud-railway-content">
-            <span className="row-title">Host your own cloud control plane</span>
-            <ol className="cloud-steps">
-              <li>Deploy the AgentField control plane template on Railway.</li>
-              <li>
-                Copy its public URL and the AGENTFIELD_API_KEY value from the service variables.
-              </li>
-              <li>Paste both above, then Test and Save.</li>
-            </ol>
-            <button
-              className="action-button"
-              type="button"
-              onClick={() => void deployApi.cloudDeployRailway()}
-            >
-              Open Railway template
-            </button>
+            {!railway ? (
+              <span className="row-sub">Checking one-click deploy…</span>
+            ) : !railway.engineAvailable ? (
+              <div className="cloud-engine-info">
+                <span className="row-title">One-click deploy isn't bundled in this build</span>
+                <span className="row-sub">You can still use the Railway template below.</span>
+              </div>
+            ) : !railway.loggedIn ? (
+              <>
+                <span className="row-title">Deploy to your Railway account</span>
+                <span className="row-sub cloud-railway-copy">
+                  This deploys the control plane to your Railway account; usage is billed by Railway.
+                </span>
+                <button
+                  className="action-button primary"
+                  type="button"
+                  disabled={railwayBusy !== null}
+                  onClick={() => void railwayLogin()}
+                >
+                  {railwayBusy === 'login' && <span className="cloud-spinner" aria-hidden="true" />}
+                  {railwayBusy === 'login' ? 'Waiting for browser…' : 'Log in with Railway'}
+                </button>
+              </>
+            ) : (
+              <>
+                <div className="cloud-railway-heading">
+                  <span className="row-title">
+                    {railway.hasDeployment ? 'Deployed' : 'Ready to deploy'}
+                  </span>
+                  <button className="cloud-link-button" type="button" onClick={() => void railwayLogout()}>
+                    Log out
+                  </button>
+                </div>
+                {railway.workspaces.length > 1 && (
+                  <label className="cloud-workspace-field">
+                    <span className="row-sub">Railway workspace</span>
+                    <select
+                      className="env-input cloud-input"
+                      value={workspaceId}
+                      disabled={railwayBusy !== null}
+                      onChange={(event) => setWorkspaceId(event.target.value)}
+                    >
+                      <option value="">Choose a workspace…</option>
+                      {railway.workspaces.map((workspace) => (
+                        <option key={workspace.id} value={workspace.id}>{workspace.name}</option>
+                      ))}
+                    </select>
+                  </label>
+                )}
+                {railway.workspaces.length === 0 && (
+                  <div className="callout warning">No Railway workspace is available for this account.</div>
+                )}
+                <div className="cloud-actions">
+                  <button
+                    className="action-button primary"
+                    type="button"
+                    disabled={!workspaceId || railwayBusy !== null}
+                    onClick={() => void deploy()}
+                  >
+                    {railwayBusy === 'deploy' && <span className="cloud-spinner" aria-hidden="true" />}
+                    {railwayBusy === 'deploy'
+                      ? 'Deploying…'
+                      : railway.hasDeployment
+                        ? 'Re-run deploy'
+                        : 'Deploy control plane'}
+                  </button>
+                  {railway.hasDeployment && (
+                    <button className="cloud-link-button danger" type="button" onClick={() => setShowDestroy(true)}>
+                      Tear down
+                    </button>
+                  )}
+                </div>
+                {deployLines.length > 0 && (
+                  <div className="cloud-deploy-log" role="log" aria-live="polite">
+                    {deployLines.map((line, index) => (
+                      <span className="install-progress-line" key={`${index}-${line}`}>{line}</span>
+                    ))}
+                  </div>
+                )}
+                {deployResult && (
+                  <div className={`callout ${deployResult.ok ? 'success' : 'error'}`} role="status">
+                    {deployResult.ok
+                      ? `✓ Deployed — connected to ${displayHost(deployResult.url ?? settings.cloud.serverUrl)}`
+                      : deployResult.message}
+                  </div>
+                )}
+                {showDestroy && (
+                  <div className="cloud-destroy-confirm">
+                    <label className="row-sub" htmlFor="cloud-delete-confirm">Type <strong>delete</strong> to tear down this deployment.</label>
+                    <div className="cloud-actions">
+                      <input id="cloud-delete-confirm" className="env-input" value={deleteText} onChange={(event) => setDeleteText(event.target.value)} />
+                      <button className="action-button danger" disabled={deleteText !== 'delete' || railwayBusy !== null} onClick={() => void destroy()}>
+                        {railwayBusy === 'destroy' ? 'Tearing down…' : 'Tear down'}
+                      </button>
+                      <button className="action-button" disabled={railwayBusy !== null} onClick={() => setShowDestroy(false)}>Cancel</button>
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
+            {destroyed && <div className="callout">Deployment removed. AgentField is using the local control plane.</div>}
+            <span className="cloud-railway-footnote">
+              Powered by bundled OpenTofu.{' '}
+              <button className="cloud-link-button" type="button" onClick={() => void window.agentfield.cloudDeployRailway()}>
+                Use the Railway template instead
+              </button>
+            </span>
           </div>
         </div>
       </section>

--- a/desktop/src/renderer/src/components/CloudPanel.tsx
+++ b/desktop/src/renderer/src/components/CloudPanel.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useState } from 'react'
+import type { AgentFieldApi, CloudTestResult, DesktopSettings } from '../../../shared/types'
+
+type CloudDeployApi = AgentFieldApi & {
+  cloudDeployRailway(): Promise<void>
+}
+
+export function CloudPanel() {
+  const [settings, setSettings] = useState<DesktopSettings | null>(null)
+  const [serverUrl, setServerUrl] = useState('')
+  const [apiKey, setApiKey] = useState('')
+  const [showKey, setShowKey] = useState(false)
+  const [testing, setTesting] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [result, setResult] = useState<CloudTestResult | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    void window.agentfield.getSettings().then((next) => {
+      setSettings(next)
+      setServerUrl(next.cloud?.serverUrl ?? '')
+      setApiKey(next.cloud?.apiKey ?? '')
+    })
+  }, [])
+
+  const cloud = settings?.cloud
+  const enabled = cloud?.enabled ?? false
+  const canSubmit = serverUrl.trim() !== '' && apiKey.trim() !== ''
+
+  const test = async () => {
+    setTesting(true)
+    setError(null)
+    setResult(null)
+    try {
+      setResult(await window.agentfield.cloudTest(serverUrl.trim(), apiKey.trim()))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  const saveCloud = async () => {
+    if (!result?.ok) {
+      const proceed = window.confirm(
+        'The connection has not passed its test. Switch to this cloud control plane anyway?'
+      )
+      if (!proceed) return
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      const next = await window.agentfield.setSettings({
+        cloud: {
+          enabled: true,
+          serverUrl: serverUrl.trim(),
+          apiKey: apiKey.trim()
+        }
+      })
+      setSettings(next)
+      setServerUrl(next.cloud?.serverUrl ?? serverUrl.trim())
+      setApiKey(next.cloud?.apiKey ?? apiKey.trim())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const disconnect = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      const next = await window.agentfield.setSettings({
+        cloud: {
+          enabled: false,
+          serverUrl: serverUrl.trim(),
+          apiKey: apiKey.trim()
+        }
+      })
+      setSettings(next)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  // TODO(integration): fold into AgentFieldApi
+  const deployApi = window.agentfield as CloudDeployApi
+
+  if (!settings) {
+    return (
+      <div className="panel">
+        <div className="empty secondary">Loading…</div>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <p className="view-lede">
+        Connect AgentField Desktop to a control plane hosted in the cloud.
+      </p>
+
+      {error && <div className="callout error">{error}</div>}
+
+      <section className="settings-section">
+        <div className="subhead">
+          <h2 className="section-title">Status</h2>
+        </div>
+        <div className="panel">
+          <ul className="row-list">
+            <li className="row">
+              <div className="row-main">
+                <span className="row-title">
+                  {enabled ? `Cloud: ${cloud?.serverUrl || serverUrl}` : 'Local control plane'}
+                </span>
+                {enabled && (
+                  <span className="row-sub">
+                    Local server management is disabled while this cloud connection is active.
+                  </span>
+                )}
+              </div>
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section className="settings-section">
+        <div className="subhead">
+          <h2 className="section-title">Connect</h2>
+        </div>
+        <div className="panel">
+          <ul className="row-list">
+            <li className="row">
+              <div className="row-main">
+                <label className="row-title" htmlFor="cloud-server-url">Server URL</label>
+                <span className="row-sub">The public address of your AgentField control plane.</span>
+              </div>
+              <div className="row-side">
+                <input
+                  id="cloud-server-url"
+                  className="env-input cloud-input"
+                  placeholder="https://your-cp.up.railway.app"
+                  value={serverUrl}
+                  onChange={(event) => {
+                    setServerUrl(event.target.value)
+                    setResult(null)
+                  }}
+                />
+              </div>
+            </li>
+            <li className="row">
+              <div className="row-main">
+                <label className="row-title" htmlFor="cloud-api-key">API key</label>
+                <span className="row-sub">Stored on this computer and sent only to your server.</span>
+              </div>
+              <div className="row-side env-row-controls">
+                <input
+                  id="cloud-api-key"
+                  className="env-input cloud-input"
+                  type={showKey ? 'text' : 'password'}
+                  value={apiKey}
+                  onChange={(event) => {
+                    setApiKey(event.target.value)
+                    setResult(null)
+                  }}
+                />
+                <button className="action-button" type="button" onClick={() => setShowKey(!showKey)}>
+                  {showKey ? 'Hide' : 'Show'}
+                </button>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div className="cloud-actions">
+          <button className="action-button" disabled={!canSubmit || testing} onClick={() => void test()}>
+            {testing ? 'Testing…' : 'Test connection'}
+          </button>
+          <button
+            className="action-button primary"
+            disabled={!canSubmit || saving}
+            onClick={() => void saveCloud()}
+          >
+            {saving ? 'Saving…' : 'Save & switch to cloud'}
+          </button>
+        </div>
+        {result && (
+          <div className={`callout ${result.ok ? '' : 'error'}`}>
+            <div>
+              <div>{result.message}</div>
+              <div className="cloud-checks">
+                Reachable: {result.healthy ? 'Yes' : 'No'} · Auth: {result.authOk ? 'Passed' : 'Failed'} ·
+                Install API: {result.installApi ? 'Available' : 'Unavailable'}
+                {result.version ? ` · Version: ${result.version}` : ''}
+              </div>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {enabled && (
+        <section className="settings-section">
+          <div className="subhead">
+            <h2 className="section-title">Disconnect</h2>
+          </div>
+          <div className="panel">
+            <div className="row">
+              <div className="row-main">
+                <span className="row-title">Switch back to local</span>
+                <span className="row-sub">Your cloud address and key stay saved for next time.</span>
+              </div>
+              <div className="row-side">
+                <button className="action-button" disabled={saving} onClick={() => void disconnect()}>
+                  Switch back to local
+                </button>
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      <section className="settings-section">
+        <div className="subhead">
+          <h2 className="section-title">Deploy on Railway</h2>
+        </div>
+        <div className="panel">
+          <div className="row">
+            <div className="row-main">
+              <span className="row-title">Host your own cloud control plane</span>
+              <span className="row-sub">1. Deploy the AgentField control plane template on Railway.</span>
+              <span className="row-sub">
+                2. Copy its public URL and the AGENTFIELD_API_KEY value from the service variables.
+              </span>
+              <span className="row-sub">3. Paste both above, then Test and Save.</span>
+            </div>
+            <div className="row-side">
+              <button
+                className="action-button"
+                type="button"
+                onClick={() => void deployApi.cloudDeployRailway()}
+              >
+                Open Railway template
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
+  )
+}

--- a/desktop/src/renderer/src/components/CloudPanel.tsx
+++ b/desktop/src/renderer/src/components/CloudPanel.tsx
@@ -113,7 +113,7 @@ export function CloudPanel() {
     const saveCloud = async () => {
         if (!result?.ok) {
             const proceed = window.confirm(
-                "The connection has not passed its test. Switch to this cloud control plane anyway?",
+                "The connection has not passed its test. Switch to this remote control plane anyway?",
             );
             if (!proceed) return;
         }
@@ -269,12 +269,12 @@ export function CloudPanel() {
                 <div className="row-main">
                     <span className="row-title cloud-status-title">
                         {enabled
-                            ? `Cloud: ${displayHost(cloud?.serverUrl || serverUrl)}`
+                            ? `Remote: ${displayHost(cloud?.serverUrl || serverUrl)}`
                             : "Local control plane"}
                     </span>
                     {enabled && (
                         <span className="row-sub">
-                            Local server management is disabled while this cloud
+                            Local server management is disabled while this remote
                             connection is active.
                         </span>
                     )}
@@ -293,7 +293,7 @@ export function CloudPanel() {
             <div
                 className="cloud-tabs"
                 role="tablist"
-                aria-label="Cloud connection method"
+                aria-label="Remote connection method"
             >
                 {CLOUD_TABS.map((tab) => (
                     <button
@@ -390,7 +390,7 @@ export function CloudPanel() {
                             disabled={!canSubmit || busy}
                             onClick={() => void saveCloud()}
                         >
-                            {saving ? "Saving…" : "Save & switch to cloud"}
+                            {saving ? "Saving…" : "Save & switch to Remote"}
                         </button>
                     </div>
                     {result && <CloudTestFeedback result={result} />}

--- a/desktop/src/renderer/src/components/CloudPanel.tsx
+++ b/desktop/src/renderer/src/components/CloudPanel.tsx
@@ -5,6 +5,11 @@ type CloudDeployApi = AgentFieldApi & {
   cloudDeployRailway(): Promise<void>
 }
 
+type Confirmation = {
+  mode: 'cloud' | 'local'
+  host?: string
+}
+
 export function CloudPanel() {
   const [settings, setSettings] = useState<DesktopSettings | null>(null)
   const [serverUrl, setServerUrl] = useState('')
@@ -14,6 +19,7 @@ export function CloudPanel() {
   const [saving, setSaving] = useState(false)
   const [result, setResult] = useState<CloudTestResult | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [confirmation, setConfirmation] = useState<Confirmation | null>(null)
 
   useEffect(() => {
     void window.agentfield.getSettings().then((next) => {
@@ -23,13 +29,21 @@ export function CloudPanel() {
     })
   }, [])
 
+  useEffect(() => {
+    if (!confirmation) return
+    const timeout = window.setTimeout(() => setConfirmation(null), 4000)
+    return () => window.clearTimeout(timeout)
+  }, [confirmation])
+
   const cloud = settings?.cloud
   const enabled = cloud?.enabled ?? false
   const canSubmit = serverUrl.trim() !== '' && apiKey.trim() !== ''
+  const busy = testing || saving
 
   const test = async () => {
     setTesting(true)
     setError(null)
+    setConfirmation(null)
     setResult(null)
     try {
       setResult(await window.agentfield.cloudTest(serverUrl.trim(), apiKey.trim()))
@@ -49,6 +63,7 @@ export function CloudPanel() {
     }
     setSaving(true)
     setError(null)
+    setConfirmation(null)
     try {
       const next = await window.agentfield.setSettings({
         cloud: {
@@ -60,6 +75,10 @@ export function CloudPanel() {
       setSettings(next)
       setServerUrl(next.cloud?.serverUrl ?? serverUrl.trim())
       setApiKey(next.cloud?.apiKey ?? apiKey.trim())
+      setConfirmation({
+        mode: 'cloud',
+        host: displayHost(next.cloud?.serverUrl ?? serverUrl.trim())
+      })
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
@@ -70,6 +89,7 @@ export function CloudPanel() {
   const disconnect = async () => {
     setSaving(true)
     setError(null)
+    setConfirmation(null)
     try {
       const next = await window.agentfield.setSettings({
         cloud: {
@@ -79,6 +99,7 @@ export function CloudPanel() {
         }
       })
       setSettings(next)
+      setConfirmation({ mode: 'local' })
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
@@ -104,6 +125,13 @@ export function CloudPanel() {
       </p>
 
       {error && <div className="callout error">{error}</div>}
+      {confirmation && (
+        <div className="callout success cloud-confirmation" role="status">
+          {confirmation.mode === 'cloud'
+            ? `✓ Now managing ${confirmation.host}`
+            : '✓ Switched back to the local control plane'}
+        </div>
+      )}
 
       <section className="settings-section">
         <div className="subhead">
@@ -112,9 +140,13 @@ export function CloudPanel() {
         <div className="panel">
           <ul className="row-list">
             <li className="row">
+              <span
+                className={`cloud-status-dot ${enabled ? 'connected' : ''}`}
+                aria-hidden="true"
+              />
               <div className="row-main">
-                <span className="row-title">
-                  {enabled ? `Cloud: ${cloud?.serverUrl || serverUrl}` : 'Local control plane'}
+                <span className="row-title cloud-status-title">
+                  {enabled ? displayHost(cloud?.serverUrl || serverUrl) : 'Local control plane'}
                 </span>
                 {enabled && (
                   <span className="row-sub">
@@ -131,73 +163,72 @@ export function CloudPanel() {
         <div className="subhead">
           <h2 className="section-title">Connect</h2>
         </div>
-        <div className="panel">
-          <ul className="row-list">
-            <li className="row">
-              <div className="row-main">
-                <label className="row-title" htmlFor="cloud-server-url">Server URL</label>
-                <span className="row-sub">The public address of your AgentField control plane.</span>
-              </div>
-              <div className="row-side">
-                <input
-                  id="cloud-server-url"
-                  className="env-input cloud-input"
-                  placeholder="https://your-cp.up.railway.app"
-                  value={serverUrl}
-                  onChange={(event) => {
-                    setServerUrl(event.target.value)
-                    setResult(null)
-                  }}
-                />
-              </div>
-            </li>
-            <li className="row">
-              <div className="row-main">
-                <label className="row-title" htmlFor="cloud-api-key">API key</label>
-                <span className="row-sub">Stored on this computer and sent only to your server.</span>
-              </div>
-              <div className="row-side env-row-controls">
-                <input
-                  id="cloud-api-key"
-                  className="env-input cloud-input"
-                  type={showKey ? 'text' : 'password'}
-                  value={apiKey}
-                  onChange={(event) => {
-                    setApiKey(event.target.value)
-                    setResult(null)
-                  }}
-                />
-                <button className="action-button" type="button" onClick={() => setShowKey(!showKey)}>
-                  {showKey ? 'Hide' : 'Show'}
-                </button>
-              </div>
-            </li>
-          </ul>
+        <div className="panel cloud-form">
+          <div className="cloud-field">
+            <label className="row-title" htmlFor="cloud-server-url">
+              Server URL
+            </label>
+            <span className="row-sub">The public address of your AgentField control plane.</span>
+            <div className="cloud-input-row">
+              <input
+                id="cloud-server-url"
+                className="env-input cloud-input"
+                placeholder="https://your-cp.up.railway.app"
+                value={serverUrl}
+                disabled={busy}
+                onChange={(event) => {
+                  setServerUrl(event.target.value)
+                  setResult(null)
+                }}
+              />
+            </div>
+          </div>
+          <div className="cloud-field">
+            <label className="row-title" htmlFor="cloud-api-key">
+              API key
+            </label>
+            <span className="row-sub">Stored on this computer and sent only to your server.</span>
+            <div className="cloud-input-row cloud-key-row">
+              <input
+                id="cloud-api-key"
+                className="env-input cloud-input"
+                type={showKey ? 'text' : 'password'}
+                value={apiKey}
+                disabled={busy}
+                onChange={(event) => {
+                  setApiKey(event.target.value)
+                  setResult(null)
+                }}
+              />
+              <button
+                className="action-button cloud-key-toggle"
+                type="button"
+                disabled={busy}
+                onClick={() => setShowKey(!showKey)}
+              >
+                {showKey ? 'Hide' : 'Show'}
+              </button>
+            </div>
+          </div>
         </div>
         <div className="cloud-actions">
-          <button className="action-button" disabled={!canSubmit || testing} onClick={() => void test()}>
+          <button
+            className={`action-button ${!result || !result.ok || !result.installApi ? 'primary' : ''}`}
+            disabled={!canSubmit || busy}
+            onClick={() => void test()}
+          >
+            {testing && <span className="cloud-spinner" aria-hidden="true" />}
             {testing ? 'Testing…' : 'Test connection'}
           </button>
           <button
-            className="action-button primary"
-            disabled={!canSubmit || saving}
+            className={`action-button ${result?.ok && result.installApi ? 'primary' : ''}`}
+            disabled={!canSubmit || busy}
             onClick={() => void saveCloud()}
           >
             {saving ? 'Saving…' : 'Save & switch to cloud'}
           </button>
         </div>
-        {result && (
-          <div className={`callout ${result.ok ? '' : 'error'}`}>
-            <div>
-              <div>{result.message}</div>
-              <div className="cloud-checks">
-                Reachable: {result.healthy ? 'Yes' : 'No'} · Auth: {result.authOk ? 'Passed' : 'Failed'} ·
-                Install API: {result.installApi ? 'Available' : 'Unavailable'}
-                {result.version ? ` · Version: ${result.version}` : ''}
-              </div>
-            </div>
-          </div>
-        )}
+        {result && <CloudTestFeedback result={result} />}
       </section>
 
       {enabled && (
@@ -225,28 +256,85 @@ export function CloudPanel() {
         <div className="subhead">
           <h2 className="section-title">Deploy on Railway</h2>
         </div>
-        <div className="panel">
-          <div className="row">
-            <div className="row-main">
-              <span className="row-title">Host your own cloud control plane</span>
-              <span className="row-sub">1. Deploy the AgentField control plane template on Railway.</span>
-              <span className="row-sub">
-                2. Copy its public URL and the AGENTFIELD_API_KEY value from the service variables.
-              </span>
-              <span className="row-sub">3. Paste both above, then Test and Save.</span>
-            </div>
-            <div className="row-side">
-              <button
-                className="action-button"
-                type="button"
-                onClick={() => void deployApi.cloudDeployRailway()}
-              >
-                Open Railway template
-              </button>
-            </div>
+        <div className="panel cloud-railway">
+          <div className="cloud-railway-content">
+            <span className="row-title">Host your own cloud control plane</span>
+            <ol className="cloud-steps">
+              <li>Deploy the AgentField control plane template on Railway.</li>
+              <li>
+                Copy its public URL and the AGENTFIELD_API_KEY value from the service variables.
+              </li>
+              <li>Paste both above, then Test and Save.</li>
+            </ol>
+            <button
+              className="action-button"
+              type="button"
+              onClick={() => void deployApi.cloudDeployRailway()}
+            >
+              Open Railway template
+            </button>
           </div>
         </div>
       </section>
     </>
   )
+}
+
+function CloudTestFeedback({ result }: { result: CloudTestResult }) {
+  const success = result.ok && result.installApi
+  const degraded = result.ok && !result.installApi
+  const state = success ? 'success' : degraded ? 'warning' : 'error'
+  const heading = success
+    ? `✓ Connected${result.version ? ` — control plane v${result.version.replace(/^v/, '')}` : ''}`
+    : degraded
+      ? '⚠ Connected, but this control plane is too old for desktop agent management — update the AgentField server, then test again.'
+      : result.message
+
+  const checks: Array<{ label: string; state: 'passed' | 'warning' | 'failed' | 'pending' }> = [
+    { label: 'Reachable', state: result.healthy ? 'passed' : 'failed' },
+    {
+      label: 'API key accepted',
+      state: result.authOk ? 'passed' : result.healthy ? 'failed' : 'pending'
+    },
+    {
+      label: 'Agent management available',
+      state: result.installApi
+        ? 'passed'
+        : degraded
+          ? 'warning'
+          : result.authOk
+            ? 'failed'
+            : 'pending'
+    }
+  ]
+
+  return (
+    <div className={`callout ${state} cloud-result`} role={success ? 'status' : 'alert'}>
+      <div className="cloud-result-heading">{heading}</div>
+      <ul className="cloud-checks">
+        {checks.map((check) => (
+          <li key={check.label} className={check.state}>
+            <span className="cloud-check-icon" aria-hidden="true">
+              {check.state === 'passed'
+                ? '✓'
+                : check.state === 'warning'
+                  ? '⚠'
+                  : check.state === 'failed'
+                    ? '✗'
+                    : '—'}
+            </span>
+            <span>{check.label}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function displayHost(serverUrl: string) {
+  try {
+    return new URL(serverUrl).host
+  } catch {
+    return serverUrl
+  }
 }

--- a/desktop/src/renderer/src/components/CloudPanel.tsx
+++ b/desktop/src/renderer/src/components/CloudPanel.tsx
@@ -1,527 +1,721 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState } from "react";
 import type {
-  CloudDeployResult,
-  CloudTestResult,
-  DesktopSettings,
-  RailwayStatus
-} from '../../../shared/types'
+    CloudDeployResult,
+    CloudTestResult,
+    DesktopSettings,
+    RailwayStatus,
+} from "../../../shared/types";
 
 type Confirmation = {
-  mode: 'cloud' | 'local'
-  host?: string
-}
+    mode: "cloud" | "local";
+    host?: string;
+};
+
+type CloudTab = "railway" | "manual";
+
+const CLOUD_TABS: Array<{ id: CloudTab; label: string }> = [
+    { id: "railway", label: "Railway" },
+    { id: "manual", label: "Manual" },
+];
 
 export function CloudPanel() {
-  const [settings, setSettings] = useState<DesktopSettings | null>(null)
-  const [serverUrl, setServerUrl] = useState('')
-  const [apiKey, setApiKey] = useState('')
-  const [showKey, setShowKey] = useState(false)
-  const [testing, setTesting] = useState(false)
-  const [saving, setSaving] = useState(false)
-  const [result, setResult] = useState<CloudTestResult | null>(null)
-  const [error, setError] = useState<string | null>(null)
-  const [confirmation, setConfirmation] = useState<Confirmation | null>(null)
-  const [railway, setRailway] = useState<RailwayStatus | null>(null)
-  const [railwayBusy, setRailwayBusy] = useState<'login' | 'deploy' | 'destroy' | null>(null)
-  const [workspaceId, setWorkspaceId] = useState('')
-  const [deployLines, setDeployLines] = useState<string[]>([])
-  const [deployResult, setDeployResult] = useState<CloudDeployResult | null>(null)
-  const [deleteText, setDeleteText] = useState('')
-  const [showDestroy, setShowDestroy] = useState(false)
-  const [destroyed, setDestroyed] = useState(false)
+    const [settings, setSettings] = useState<DesktopSettings | null>(null);
+    const [serverUrl, setServerUrl] = useState("");
+    const [apiKey, setApiKey] = useState("");
+    const [showKey, setShowKey] = useState(false);
+    const [testing, setTesting] = useState(false);
+    const [saving, setSaving] = useState(false);
+    const [result, setResult] = useState<CloudTestResult | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [confirmation, setConfirmation] = useState<Confirmation | null>(null);
+    const [railway, setRailway] = useState<RailwayStatus | null>(null);
+    const [railwayBusy, setRailwayBusy] = useState<
+        "login" | "deploy" | "destroy" | null
+    >(null);
+    const [workspaceId, setWorkspaceId] = useState("");
+    const [deployLines, setDeployLines] = useState<string[]>([]);
+    const [deployResult, setDeployResult] = useState<CloudDeployResult | null>(
+        null,
+    );
+    const [deleteText, setDeleteText] = useState("");
+    const [showDestroy, setShowDestroy] = useState(false);
+    const [destroyed, setDestroyed] = useState(false);
+    const [activeTab, setActiveTab] = useState<CloudTab>("railway");
 
-  useEffect(() => {
-    void window.agentfield.getSettings().then((next) => {
-      setSettings(next)
-      setServerUrl(next.cloud?.serverUrl ?? '')
-      setApiKey(next.cloud?.apiKey ?? '')
-    })
-  }, [])
+    useEffect(() => {
+        void window.agentfield.getSettings().then((next) => {
+            setSettings(next);
+            setServerUrl(next.cloud?.serverUrl ?? "");
+            setApiKey(next.cloud?.apiKey ?? "");
+        });
+    }, []);
 
-  useEffect(() => {
-    void window.agentfield.railwayStatus().then(setRailway).catch((err) => {
-      setError(err instanceof Error ? err.message : String(err))
-    })
-    return window.agentfield.onCloudDeployProgress((line) => {
-      setDeployLines((lines) => [...lines.slice(-199), line])
-    })
-  }, [])
+    useEffect(() => {
+        void window.agentfield
+            .railwayStatus()
+            .then(setRailway)
+            .catch((err) => {
+                setError(err instanceof Error ? err.message : String(err));
+            });
+        return window.agentfield.onCloudDeployProgress((line) => {
+            setDeployLines((lines) => [...lines.slice(-199), line]);
+        });
+    }, []);
 
-  useEffect(() => {
-    if (!railway?.loggedIn) {
-      setWorkspaceId('')
-    } else if (railway.workspaces.length === 1) {
-      setWorkspaceId(railway.workspaces[0].id)
-    } else if (!railway.workspaces.some((workspace) => workspace.id === workspaceId)) {
-      setWorkspaceId('')
-    }
-  }, [railway, workspaceId])
-
-  useEffect(() => {
-    if (!confirmation) return
-    const timeout = window.setTimeout(() => setConfirmation(null), 4000)
-    return () => window.clearTimeout(timeout)
-  }, [confirmation])
-
-  const cloud = settings?.cloud
-  const enabled = cloud?.enabled ?? false
-  const canSubmit = serverUrl.trim() !== '' && apiKey.trim() !== ''
-  const busy = testing || saving
-
-  const test = async () => {
-    setTesting(true)
-    setError(null)
-    setConfirmation(null)
-    setResult(null)
-    try {
-      setResult(await window.agentfield.cloudTest(serverUrl.trim(), apiKey.trim()))
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-    } finally {
-      setTesting(false)
-    }
-  }
-
-  const saveCloud = async () => {
-    if (!result?.ok) {
-      const proceed = window.confirm(
-        'The connection has not passed its test. Switch to this cloud control plane anyway?'
-      )
-      if (!proceed) return
-    }
-    setSaving(true)
-    setError(null)
-    setConfirmation(null)
-    try {
-      const next = await window.agentfield.setSettings({
-        cloud: {
-          enabled: true,
-          serverUrl: serverUrl.trim(),
-          apiKey: apiKey.trim()
+    useEffect(() => {
+        if (!railway?.loggedIn) {
+            setWorkspaceId("");
+        } else if (railway.workspaces.length === 1) {
+            setWorkspaceId(railway.workspaces[0].id);
+        } else if (
+            !railway.workspaces.some(
+                (workspace) => workspace.id === workspaceId,
+            )
+        ) {
+            setWorkspaceId("");
         }
-      })
-      setSettings(next)
-      setServerUrl(next.cloud?.serverUrl ?? serverUrl.trim())
-      setApiKey(next.cloud?.apiKey ?? apiKey.trim())
-      setConfirmation({
-        mode: 'cloud',
-        host: displayHost(next.cloud?.serverUrl ?? serverUrl.trim())
-      })
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-    } finally {
-      setSaving(false)
-    }
-  }
+    }, [railway, workspaceId]);
 
-  const disconnect = async () => {
-    setSaving(true)
-    setError(null)
-    setConfirmation(null)
-    try {
-      const next = await window.agentfield.setSettings({
-        cloud: {
-          enabled: false,
-          serverUrl: serverUrl.trim(),
-          apiKey: apiKey.trim()
+    useEffect(() => {
+        if (railway && !railway.engineAvailable) setActiveTab("manual");
+    }, [railway?.engineAvailable]);
+
+    useEffect(() => {
+        if (!confirmation) return;
+        const timeout = window.setTimeout(() => setConfirmation(null), 4000);
+        return () => window.clearTimeout(timeout);
+    }, [confirmation]);
+
+    const cloud = settings?.cloud;
+    const enabled = cloud?.enabled ?? false;
+    const canSubmit = serverUrl.trim() !== "" && apiKey.trim() !== "";
+    const busy = testing || saving;
+
+    const test = async () => {
+        setTesting(true);
+        setError(null);
+        setConfirmation(null);
+        setResult(null);
+        try {
+            setResult(
+                await window.agentfield.cloudTest(
+                    serverUrl.trim(),
+                    apiKey.trim(),
+                ),
+            );
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setTesting(false);
         }
-      })
-      setSettings(next)
-      setConfirmation({ mode: 'local' })
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-    } finally {
-      setSaving(false)
+    };
+
+    const saveCloud = async () => {
+        if (!result?.ok) {
+            const proceed = window.confirm(
+                "The connection has not passed its test. Switch to this cloud control plane anyway?",
+            );
+            if (!proceed) return;
+        }
+        setSaving(true);
+        setError(null);
+        setConfirmation(null);
+        try {
+            const next = await window.agentfield.setSettings({
+                cloud: {
+                    enabled: true,
+                    serverUrl: serverUrl.trim(),
+                    apiKey: apiKey.trim(),
+                },
+            });
+            setSettings(next);
+            setServerUrl(next.cloud?.serverUrl ?? serverUrl.trim());
+            setApiKey(next.cloud?.apiKey ?? apiKey.trim());
+            setConfirmation({
+                mode: "cloud",
+                host: displayHost(next.cloud?.serverUrl ?? serverUrl.trim()),
+            });
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const disconnect = async () => {
+        setSaving(true);
+        setError(null);
+        setConfirmation(null);
+        try {
+            const next = await window.agentfield.setSettings({
+                cloud: {
+                    enabled: false,
+                    serverUrl: serverUrl.trim(),
+                    apiKey: apiKey.trim(),
+                },
+            });
+            setSettings(next);
+            setConfirmation({ mode: "local" });
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const refreshRailway = async () =>
+        setRailway(await window.agentfield.railwayStatus());
+
+    const railwayLogin = async () => {
+        setRailwayBusy("login");
+        setError(null);
+        try {
+            const login = await window.agentfield.railwayLogin();
+            if (!login.ok) setError(login.message);
+            await refreshRailway();
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setRailwayBusy(null);
+        }
+    };
+
+    const railwayLogout = async () => {
+        await window.agentfield.railwayLogout();
+        setDeployResult(null);
+        await refreshRailway();
+    };
+
+    const deploy = async () => {
+        if (!workspaceId) return;
+        setRailwayBusy("deploy");
+        setDeployLines([]);
+        setDeployResult(null);
+        setDestroyed(false);
+        setError(null);
+        try {
+            const nextResult = await window.agentfield.cloudDeploy(workspaceId);
+            setDeployResult(nextResult);
+            if (nextResult.ok) {
+                const next = await window.agentfield.getSettings();
+                setSettings(next);
+                setServerUrl(next.cloud.serverUrl);
+                setApiKey(next.cloud.apiKey);
+            }
+            await refreshRailway();
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setRailwayBusy(null);
+        }
+    };
+
+    const destroy = async () => {
+        if (deleteText !== "delete") return;
+        setRailwayBusy("destroy");
+        setError(null);
+        try {
+            const result = await window.agentfield.cloudDestroy();
+            if (!result.ok) {
+                setError(result.message);
+                return;
+            }
+            const next = await window.agentfield.getSettings();
+            setSettings(next);
+            setShowDestroy(false);
+            setDeleteText("");
+            setDeployResult(null);
+            setDestroyed(true);
+            await refreshRailway();
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setRailwayBusy(null);
+        }
+    };
+
+    if (!settings) {
+        return (
+            <div className="panel">
+                <div className="empty secondary">Loading…</div>
+            </div>
+        );
     }
-  }
 
-  const refreshRailway = async () => setRailway(await window.agentfield.railwayStatus())
-
-  const railwayLogin = async () => {
-    setRailwayBusy('login')
-    setError(null)
-    try {
-      const login = await window.agentfield.railwayLogin()
-      if (!login.ok) setError(login.message)
-      await refreshRailway()
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-    } finally {
-      setRailwayBusy(null)
-    }
-  }
-
-  const railwayLogout = async () => {
-    await window.agentfield.railwayLogout()
-    setDeployResult(null)
-    await refreshRailway()
-  }
-
-  const deploy = async () => {
-    if (!workspaceId) return
-    setRailwayBusy('deploy')
-    setDeployLines([])
-    setDeployResult(null)
-    setDestroyed(false)
-    setError(null)
-    try {
-      const nextResult = await window.agentfield.cloudDeploy(workspaceId)
-      setDeployResult(nextResult)
-      if (nextResult.ok) {
-        const next = await window.agentfield.getSettings()
-        setSettings(next)
-        setServerUrl(next.cloud.serverUrl)
-        setApiKey(next.cloud.apiKey)
-      }
-      await refreshRailway()
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-    } finally {
-      setRailwayBusy(null)
-    }
-  }
-
-  const destroy = async () => {
-    if (deleteText !== 'delete') return
-    setRailwayBusy('destroy')
-    setError(null)
-    try {
-      const result = await window.agentfield.cloudDestroy()
-      if (!result.ok) {
-        setError(result.message)
-        return
-      }
-      const next = await window.agentfield.getSettings()
-      setSettings(next)
-      setShowDestroy(false)
-      setDeleteText('')
-      setDeployResult(null)
-      setDestroyed(true)
-      await refreshRailway()
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-    } finally {
-      setRailwayBusy(null)
-    }
-  }
-
-  if (!settings) {
     return (
-      <div className="panel">
-        <div className="empty secondary">Loading…</div>
-      </div>
-    )
-  }
+        <>
+            <p className="view-lede">
+                Run your agents from a control plane in the cloud. Deploy one to
+                Railway, or connect to a server you already run.
+            </p>
 
-  return (
-    <>
-      <p className="view-lede">
-        Connect AgentField Desktop to a control plane hosted in the cloud.
-      </p>
-
-      {error && <div className="callout error">{error}</div>}
-      {confirmation && (
-        <div className="callout success cloud-confirmation" role="status">
-          {confirmation.mode === 'cloud'
-            ? `✓ Now managing ${confirmation.host}`
-            : '✓ Switched back to the local control plane'}
-        </div>
-      )}
-
-      <section className="settings-section">
-        <div className="subhead">
-          <h2 className="section-title">Status</h2>
-        </div>
-        <div className="panel">
-          <ul className="row-list">
-            <li className="row">
-              <span
-                className={`cloud-status-dot ${enabled ? 'connected' : ''}`}
-                aria-hidden="true"
-              />
-              <div className="row-main">
-                <span className="row-title cloud-status-title">
-                  {enabled ? displayHost(cloud?.serverUrl || serverUrl) : 'Local control plane'}
-                </span>
-                {enabled && (
-                  <span className="row-sub">
-                    Local server management is disabled while this cloud connection is active.
-                  </span>
-                )}
-              </div>
-            </li>
-          </ul>
-        </div>
-      </section>
-
-      <section className="settings-section">
-        <div className="subhead">
-          <h2 className="section-title">Connect</h2>
-        </div>
-        <div className="panel cloud-form">
-          <div className="cloud-field">
-            <label className="row-title" htmlFor="cloud-server-url">
-              Server URL
-            </label>
-            <span className="row-sub">The public address of your AgentField control plane.</span>
-            <div className="cloud-input-row">
-              <input
-                id="cloud-server-url"
-                className="env-input cloud-input"
-                placeholder="https://your-cp.up.railway.app"
-                value={serverUrl}
-                disabled={busy}
-                onChange={(event) => {
-                  setServerUrl(event.target.value)
-                  setResult(null)
-                }}
-              />
-            </div>
-          </div>
-          <div className="cloud-field">
-            <label className="row-title" htmlFor="cloud-api-key">
-              API key
-            </label>
-            <span className="row-sub">Stored on this computer and sent only to your server.</span>
-            <div className="cloud-input-row cloud-key-row">
-              <input
-                id="cloud-api-key"
-                className="env-input cloud-input"
-                type={showKey ? 'text' : 'password'}
-                value={apiKey}
-                disabled={busy}
-                onChange={(event) => {
-                  setApiKey(event.target.value)
-                  setResult(null)
-                }}
-              />
-              <button
-                className="action-button cloud-key-toggle"
-                type="button"
-                disabled={busy}
-                onClick={() => setShowKey(!showKey)}
-              >
-                {showKey ? 'Hide' : 'Show'}
-              </button>
-            </div>
-          </div>
-        </div>
-        <div className="cloud-actions">
-          <button
-            className={`action-button ${!result || !result.ok || !result.installApi ? 'primary' : ''}`}
-            disabled={!canSubmit || busy}
-            onClick={() => void test()}
-          >
-            {testing && <span className="cloud-spinner" aria-hidden="true" />}
-            {testing ? 'Testing…' : 'Test connection'}
-          </button>
-          <button
-            className={`action-button ${result?.ok && result.installApi ? 'primary' : ''}`}
-            disabled={!canSubmit || busy}
-            onClick={() => void saveCloud()}
-          >
-            {saving ? 'Saving…' : 'Save & switch to cloud'}
-          </button>
-        </div>
-        {result && <CloudTestFeedback result={result} />}
-      </section>
-
-      {enabled && (
-        <section className="settings-section">
-          <div className="subhead">
-            <h2 className="section-title">Disconnect</h2>
-          </div>
-          <div className="panel">
-            <div className="row">
-              <div className="row-main">
-                <span className="row-title">Switch back to local</span>
-                <span className="row-sub">Your cloud address and key stay saved for next time.</span>
-              </div>
-              <div className="row-side">
-                <button className="action-button" disabled={saving} onClick={() => void disconnect()}>
-                  Switch back to local
-                </button>
-              </div>
-            </div>
-          </div>
-        </section>
-      )}
-
-      <section className="settings-section">
-        <div className="subhead">
-          <h2 className="section-title">Deploy on Railway</h2>
-        </div>
-        <div className="panel cloud-railway">
-          <div className="cloud-railway-content">
-            {!railway ? (
-              <span className="row-sub">Checking one-click deploy…</span>
-            ) : !railway.engineAvailable ? (
-              <div className="cloud-engine-info">
-                <span className="row-title">One-click deploy isn't bundled in this build</span>
-                <span className="row-sub">You can still use the Railway template below.</span>
-              </div>
-            ) : !railway.loggedIn ? (
-              <>
-                <span className="row-title">Deploy to your Railway account</span>
-                <span className="row-sub cloud-railway-copy">
-                  This deploys the control plane to your Railway account; usage is billed by Railway.
-                </span>
-                <button
-                  className="action-button primary"
-                  type="button"
-                  disabled={railwayBusy !== null}
-                  onClick={() => void railwayLogin()}
+            {error && <div className="callout error">{error}</div>}
+            {confirmation && (
+                <div
+                    className="callout success cloud-confirmation"
+                    role="status"
                 >
-                  {railwayBusy === 'login' && <span className="cloud-spinner" aria-hidden="true" />}
-                  {railwayBusy === 'login' ? 'Waiting for browser…' : 'Log in with Railway'}
-                </button>
-              </>
-            ) : (
-              <>
-                <div className="cloud-railway-heading">
-                  <span className="row-title">
-                    {railway.hasDeployment ? 'Deployed' : 'Ready to deploy'}
-                  </span>
-                  <button className="cloud-link-button" type="button" onClick={() => void railwayLogout()}>
-                    Log out
-                  </button>
+                    {confirmation.mode === "cloud"
+                        ? `✓ Now managing ${confirmation.host}`
+                        : "✓ Switched back to the local control plane"}
                 </div>
-                {railway.workspaces.length > 1 && (
-                  <label className="cloud-workspace-field">
-                    <span className="row-sub">Railway workspace</span>
-                    <select
-                      className="env-input cloud-input"
-                      value={workspaceId}
-                      disabled={railwayBusy !== null}
-                      onChange={(event) => setWorkspaceId(event.target.value)}
-                    >
-                      <option value="">Choose a workspace…</option>
-                      {railway.workspaces.map((workspace) => (
-                        <option key={workspace.id} value={workspace.id}>{workspace.name}</option>
-                      ))}
-                    </select>
-                  </label>
-                )}
-                {railway.workspaces.length === 0 && (
-                  <div className="callout warning">No Railway workspace is available for this account.</div>
-                )}
-                <div className="cloud-actions">
-                  <button
-                    className="action-button primary"
-                    type="button"
-                    disabled={!workspaceId || railwayBusy !== null}
-                    onClick={() => void deploy()}
-                  >
-                    {railwayBusy === 'deploy' && <span className="cloud-spinner" aria-hidden="true" />}
-                    {railwayBusy === 'deploy'
-                      ? 'Deploying…'
-                      : railway.hasDeployment
-                        ? 'Re-run deploy'
-                        : 'Deploy control plane'}
-                  </button>
-                  {railway.hasDeployment && (
-                    <button className="cloud-link-button danger" type="button" onClick={() => setShowDestroy(true)}>
-                      Tear down
-                    </button>
-                  )}
-                </div>
-                {deployLines.length > 0 && (
-                  <div className="cloud-deploy-log" role="log" aria-live="polite">
-                    {deployLines.map((line, index) => (
-                      <span className="install-progress-line" key={`${index}-${line}`}>{line}</span>
-                    ))}
-                  </div>
-                )}
-                {deployResult && (
-                  <div className={`callout ${deployResult.ok ? 'success' : 'error'}`} role="status">
-                    {deployResult.ok
-                      ? `✓ Deployed — connected to ${displayHost(deployResult.url ?? settings.cloud.serverUrl)}`
-                      : deployResult.message}
-                  </div>
-                )}
-                {showDestroy && (
-                  <div className="cloud-destroy-confirm">
-                    <label className="row-sub" htmlFor="cloud-delete-confirm">Type <strong>delete</strong> to tear down this deployment.</label>
-                    <div className="cloud-actions">
-                      <input id="cloud-delete-confirm" className="env-input" value={deleteText} onChange={(event) => setDeleteText(event.target.value)} />
-                      <button className="action-button danger" disabled={deleteText !== 'delete' || railwayBusy !== null} onClick={() => void destroy()}>
-                        {railwayBusy === 'destroy' ? 'Tearing down…' : 'Tear down'}
-                      </button>
-                      <button className="action-button" disabled={railwayBusy !== null} onClick={() => setShowDestroy(false)}>Cancel</button>
-                    </div>
-                  </div>
-                )}
-              </>
             )}
-            {destroyed && <div className="callout">Deployment removed. AgentField is using the local control plane.</div>}
-            <span className="cloud-railway-footnote">
-              Powered by bundled OpenTofu.{' '}
-              <button className="cloud-link-button" type="button" onClick={() => void window.agentfield.cloudDeployRailway()}>
-                Use the Railway template instead
-              </button>
-            </span>
-          </div>
-        </div>
-      </section>
-    </>
-  )
+
+            <div className="panel cloud-status-strip">
+                <span
+                    className={`cloud-status-dot ${enabled ? "connected" : ""}`}
+                    aria-hidden="true"
+                />
+                <div className="row-main">
+                    <span className="row-title cloud-status-title">
+                        {enabled
+                            ? `Cloud: ${displayHost(cloud?.serverUrl || serverUrl)}`
+                            : "Local control plane"}
+                    </span>
+                    {enabled && (
+                        <span className="row-sub">
+                            Local server management is disabled while this cloud
+                            connection is active.
+                        </span>
+                    )}
+                </div>
+                {enabled && (
+                    <button
+                        className="action-button"
+                        disabled={saving}
+                        onClick={() => void disconnect()}
+                    >
+                        Switch back to local
+                    </button>
+                )}
+            </div>
+
+            <div
+                className="cloud-tabs"
+                role="tablist"
+                aria-label="Cloud connection method"
+            >
+                {CLOUD_TABS.map((tab) => (
+                    <button
+                        key={tab.id}
+                        className={`cloud-tab ${activeTab === tab.id ? "active" : ""}`}
+                        type="button"
+                        role="tab"
+                        aria-selected={activeTab === tab.id}
+                        onClick={() => setActiveTab(tab.id)}
+                    >
+                        {tab.label}
+                    </button>
+                ))}
+            </div>
+
+            {activeTab === "manual" && (
+                <section className="settings-section" role="tabpanel">
+                    <div className="panel cloud-form">
+                        <div className="cloud-field">
+                            <label
+                                className="row-title"
+                                htmlFor="cloud-server-url"
+                            >
+                                Server URL
+                            </label>
+                            <span className="row-sub">
+                                The public address of your AgentField control
+                                plane.
+                            </span>
+                            <div className="cloud-input-row">
+                                <input
+                                    id="cloud-server-url"
+                                    className="env-input cloud-input"
+                                    placeholder="https://your-cp.up.railway.app"
+                                    value={serverUrl}
+                                    disabled={busy}
+                                    onChange={(event) => {
+                                        setServerUrl(event.target.value);
+                                        setResult(null);
+                                    }}
+                                />
+                            </div>
+                        </div>
+                        <div className="cloud-field">
+                            <label
+                                className="row-title"
+                                htmlFor="cloud-api-key"
+                            >
+                                API key
+                            </label>
+                            <span className="row-sub">
+                                Stored on this computer and sent only to your
+                                server.
+                            </span>
+                            <div className="cloud-input-row cloud-key-row">
+                                <input
+                                    id="cloud-api-key"
+                                    className="env-input cloud-input"
+                                    type={showKey ? "text" : "password"}
+                                    value={apiKey}
+                                    disabled={busy}
+                                    onChange={(event) => {
+                                        setApiKey(event.target.value);
+                                        setResult(null);
+                                    }}
+                                />
+                                <button
+                                    className="action-button cloud-key-toggle"
+                                    type="button"
+                                    disabled={busy}
+                                    onClick={() => setShowKey(!showKey)}
+                                >
+                                    {showKey ? "Hide" : "Show"}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                    <div className="cloud-actions">
+                        <button
+                            className={`action-button ${!result || !result.ok || !result.installApi ? "primary" : ""}`}
+                            disabled={!canSubmit || busy}
+                            onClick={() => void test()}
+                        >
+                            {testing && (
+                                <span
+                                    className="cloud-spinner"
+                                    aria-hidden="true"
+                                />
+                            )}
+                            {testing ? "Testing…" : "Test connection"}
+                        </button>
+                        <button
+                            className={`action-button ${result?.ok && result.installApi ? "primary" : ""}`}
+                            disabled={!canSubmit || busy}
+                            onClick={() => void saveCloud()}
+                        >
+                            {saving ? "Saving…" : "Save & switch to cloud"}
+                        </button>
+                    </div>
+                    {result && <CloudTestFeedback result={result} />}
+                </section>
+            )}
+
+            {activeTab === "railway" && (
+                <section className="settings-section" role="tabpanel">
+                    <div className="panel cloud-railway">
+                        <div className="cloud-railway-content">
+                            {!railway ? (
+                                <span className="row-sub">
+                                    Checking one-click deploy…
+                                </span>
+                            ) : !railway.engineAvailable ? (
+                                <div className="cloud-engine-info cloud-guided-state">
+                                    <span className="row-title">
+                                        One-click deploy isn't bundled in this
+                                        build
+                                    </span>
+                                    <button
+                                        className="cloud-link-button"
+                                        type="button"
+                                        onClick={() =>
+                                            void window.agentfield.cloudDeployRailway()
+                                        }
+                                    >
+                                        Use the Railway template instead
+                                    </button>
+                                </div>
+                            ) : !railway.loggedIn ? (
+                                <div className="cloud-guided-state">
+                                    <span className="row-sub cloud-railway-copy">
+                                        Deploys the control plane to YOUR
+                                        Railway account — usage is billed by
+                                        Railway.
+                                    </span>
+                                    <button
+                                        className="action-button primary"
+                                        type="button"
+                                        disabled={railwayBusy !== null}
+                                        onClick={() => void railwayLogin()}
+                                    >
+                                        {railwayBusy === "login" && (
+                                            <span
+                                                className="cloud-spinner"
+                                                aria-hidden="true"
+                                            />
+                                        )}
+                                        {railwayBusy === "login"
+                                            ? "Waiting for browser…"
+                                            : "Log in with Railway"}
+                                    </button>
+                                </div>
+                            ) : railwayBusy === "deploy" ? (
+                                <div className="cloud-guided-state">
+                                    <span className="row-title cloud-progress-title">
+                                        <span
+                                            className="cloud-spinner"
+                                            aria-hidden="true"
+                                        />{" "}
+                                        Deploying control plane…
+                                    </span>
+                                    <div
+                                        className="cloud-deploy-log"
+                                        role="log"
+                                        aria-live="polite"
+                                    >
+                                        {deployLines.map((line, index) => (
+                                            <span
+                                                className="install-progress-line"
+                                                key={`${index}-${line}`}
+                                            >
+                                                {line}
+                                            </span>
+                                        ))}
+                                    </div>
+                                </div>
+                            ) : railway.hasDeployment || deployResult?.ok ? (
+                                <div className="cloud-guided-state">
+                                    <div
+                                        className="callout success"
+                                        role="status"
+                                    >
+                                        ✓ Deployed — connected to{" "}
+                                        {displayHost(
+                                            deployResult?.url ??
+                                                settings.cloud.serverUrl,
+                                        )}
+                                    </div>
+                                    <div className="cloud-actions">
+                                        <button
+                                            className="action-button primary"
+                                            type="button"
+                                            disabled={
+                                                !workspaceId ||
+                                                railwayBusy !== null
+                                            }
+                                            onClick={() => void deploy()}
+                                        >
+                                            Re-run deploy
+                                        </button>
+                                        <button
+                                            className="cloud-link-button danger"
+                                            type="button"
+                                            onClick={() => setShowDestroy(true)}
+                                        >
+                                            Tear down
+                                        </button>
+                                    </div>
+                                    {showDestroy && (
+                                        <div className="cloud-destroy-confirm">
+                                            <label
+                                                className="row-sub"
+                                                htmlFor="cloud-delete-confirm"
+                                            >
+                                                Type <strong>delete</strong> to
+                                                tear down this deployment.
+                                            </label>
+                                            <div className="cloud-actions">
+                                                <input
+                                                    id="cloud-delete-confirm"
+                                                    className="env-input"
+                                                    value={deleteText}
+                                                    onChange={(event) =>
+                                                        setDeleteText(
+                                                            event.target.value,
+                                                        )
+                                                    }
+                                                />
+                                                <button
+                                                    className="action-button danger"
+                                                    disabled={
+                                                        deleteText !==
+                                                            "delete" ||
+                                                        railwayBusy !== null
+                                                    }
+                                                    onClick={() =>
+                                                        void destroy()
+                                                    }
+                                                >
+                                                    {railwayBusy === "destroy"
+                                                        ? "Tearing down…"
+                                                        : "Tear down"}
+                                                </button>
+                                                <button
+                                                    className="action-button"
+                                                    disabled={
+                                                        railwayBusy !== null
+                                                    }
+                                                    onClick={() =>
+                                                        setShowDestroy(false)
+                                                    }
+                                                >
+                                                    Cancel
+                                                </button>
+                                            </div>
+                                        </div>
+                                    )}
+                                </div>
+                            ) : (
+                                <div className="cloud-guided-state">
+                                    <div className="cloud-railway-heading">
+                                        <span className="row-title">
+                                            Ready to deploy
+                                        </span>
+                                        <button
+                                            className="cloud-link-button"
+                                            type="button"
+                                            onClick={() => void railwayLogout()}
+                                        >
+                                            Sign out
+                                        </button>
+                                    </div>
+                                    {railway.workspaces.length > 1 && (
+                                        <label className="cloud-workspace-field">
+                                            <span className="row-sub">
+                                                Railway workspace
+                                            </span>
+                                            <select
+                                                className="env-input cloud-input"
+                                                value={workspaceId}
+                                                disabled={railwayBusy !== null}
+                                                onChange={(event) =>
+                                                    setWorkspaceId(
+                                                        event.target.value,
+                                                    )
+                                                }
+                                            >
+                                                <option value="">
+                                                    Choose a workspace…
+                                                </option>
+                                                {railway.workspaces.map(
+                                                    (workspace) => (
+                                                        <option
+                                                            key={workspace.id}
+                                                            value={workspace.id}
+                                                        >
+                                                            {workspace.name}
+                                                        </option>
+                                                    ),
+                                                )}
+                                            </select>
+                                        </label>
+                                    )}
+                                    {railway.workspaces.length === 0 && (
+                                        <div className="callout warning">
+                                            No Railway workspace is available
+                                            for this account.
+                                        </div>
+                                    )}
+                                    <div className="cloud-actions">
+                                        <button
+                                            className="action-button primary"
+                                            type="button"
+                                            disabled={
+                                                !workspaceId ||
+                                                railwayBusy !== null
+                                            }
+                                            onClick={() => void deploy()}
+                                        >
+                                            Deploy control plane
+                                        </button>
+                                    </div>
+                                    {deployResult && !deployResult.ok && (
+                                        <div
+                                            className={`callout ${deployResult.ok ? "success" : "error"}`}
+                                            role="status"
+                                        >
+                                            {deployResult.message}
+                                        </div>
+                                    )}
+                                </div>
+                            )}
+                            {destroyed && (
+                                <div className="callout">
+                                    Deployment removed. AgentField is using the
+                                    local control plane.
+                                </div>
+                            )}
+                            <span className="cloud-railway-footnote">
+                                Powered by bundled OpenTofu.{" "}
+                                <button
+                                    className="cloud-link-button"
+                                    type="button"
+                                    onClick={() =>
+                                        void window.agentfield.cloudDeployRailway()
+                                    }
+                                >
+                                    Use the Railway template instead
+                                </button>
+                            </span>
+                        </div>
+                    </div>
+                </section>
+            )}
+        </>
+    );
 }
 
 function CloudTestFeedback({ result }: { result: CloudTestResult }) {
-  const success = result.ok && result.installApi
-  const degraded = result.ok && !result.installApi
-  const state = success ? 'success' : degraded ? 'warning' : 'error'
-  const heading = success
-    ? `✓ Connected${result.version ? ` — control plane v${result.version.replace(/^v/, '')}` : ''}`
-    : degraded
-      ? '⚠ Connected, but this control plane is too old for desktop agent management — update the AgentField server, then test again.'
-      : result.message
-
-  const checks: Array<{ label: string; state: 'passed' | 'warning' | 'failed' | 'pending' }> = [
-    { label: 'Reachable', state: result.healthy ? 'passed' : 'failed' },
-    {
-      label: 'API key accepted',
-      state: result.authOk ? 'passed' : result.healthy ? 'failed' : 'pending'
-    },
-    {
-      label: 'Agent management available',
-      state: result.installApi
-        ? 'passed'
+    const success = result.ok && result.installApi;
+    const degraded = result.ok && !result.installApi;
+    const state = success ? "success" : degraded ? "warning" : "error";
+    const heading = success
+        ? `✓ Connected${result.version ? ` — control plane v${result.version.replace(/^v/, "")}` : ""}`
         : degraded
-          ? 'warning'
-          : result.authOk
-            ? 'failed'
-            : 'pending'
-    }
-  ]
+          ? "⚠ Connected, but this control plane is too old for desktop agent management — update the AgentField server, then test again."
+          : result.message;
 
-  return (
-    <div className={`callout ${state} cloud-result`} role={success ? 'status' : 'alert'}>
-      <div className="cloud-result-heading">{heading}</div>
-      <ul className="cloud-checks">
-        {checks.map((check) => (
-          <li key={check.label} className={check.state}>
-            <span className="cloud-check-icon" aria-hidden="true">
-              {check.state === 'passed'
-                ? '✓'
-                : check.state === 'warning'
-                  ? '⚠'
-                  : check.state === 'failed'
-                    ? '✗'
-                    : '—'}
-            </span>
-            <span>{check.label}</span>
-          </li>
-        ))}
-      </ul>
-    </div>
-  )
+    const checks: Array<{
+        label: string;
+        state: "passed" | "warning" | "failed" | "pending";
+    }> = [
+        { label: "Reachable", state: result.healthy ? "passed" : "failed" },
+        {
+            label: "API key accepted",
+            state: result.authOk
+                ? "passed"
+                : result.healthy
+                  ? "failed"
+                  : "pending",
+        },
+        {
+            label: "Agent management available",
+            state: result.installApi
+                ? "passed"
+                : degraded
+                  ? "warning"
+                  : result.authOk
+                    ? "failed"
+                    : "pending",
+        },
+    ];
+
+    return (
+        <div
+            className={`callout ${state} cloud-result`}
+            role={success ? "status" : "alert"}
+        >
+            <div className="cloud-result-heading">{heading}</div>
+            <ul className="cloud-checks">
+                {checks.map((check) => (
+                    <li key={check.label} className={check.state}>
+                        <span className="cloud-check-icon" aria-hidden="true">
+                            {check.state === "passed"
+                                ? "✓"
+                                : check.state === "warning"
+                                  ? "⚠"
+                                  : check.state === "failed"
+                                    ? "✗"
+                                    : "—"}
+                        </span>
+                        <span>{check.label}</span>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
 }
 
 function displayHost(serverUrl: string) {
-  try {
-    return new URL(serverUrl).host
-  } catch {
-    return serverUrl
-  }
+    try {
+        return new URL(serverUrl).host;
+    } catch {
+        return serverUrl;
+    }
 }

--- a/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/desktop/src/renderer/src/components/Sidebar.tsx
@@ -49,12 +49,12 @@ const ICONS: Record<View, string> = {
 // Nav v2 (DESIGN.md §2.1): 4 items. Installing is an action on the Agents
 // library ("+ Add agent"), not a place — `install` stays a valid deep-link
 // View that App maps to Agents with add-mode open.
-const NAV: Array<{ id: View; label: string }> = [
+const NAV: Array<{ id: View; label: string; tag?: string }> = [
   { id: 'home', label: 'Home' },
   { id: 'agents', label: 'Agents' },
   { id: 'activity', label: 'Activity' },
   { id: 'settings', label: 'Settings' },
-  { id: 'cloud', label: 'Cloud' }
+  { id: 'cloud', label: 'Remote', tag: 'Beta' }
 ]
 
 // UI-furniture spring (DESIGN.md §5.1) — fast, settles with no felt overshoot.
@@ -118,7 +118,8 @@ export function Sidebar({
                   />
                 ))}
               <Icon d={ICONS[item.id]} />
-              {item.label}
+              <span className="nav-item-label">{item.label}</span>
+              {item.tag && <span className="nav-item-tag">{item.tag}</span>}
             </button>
           )
         })}

--- a/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/desktop/src/renderer/src/components/Sidebar.tsx
@@ -42,6 +42,7 @@ const ICONS: Record<View, string> = {
   install: 'M12 3v12M7 10l5 5l5-5M4 21h16',
   agents: 'M12 8V4H8M2 14h2M20 14h2M15 13v2M9 13v2M16 20H8a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2z',
   activity: 'M3 12h4l3-8l4 16l3-8h4',
+  cloud: 'M17.5 19H7a5 5 0 1 1 1.2-9.85A6 6 0 0 1 19.7 11.2A4 4 0 0 1 17.5 19z',
   settings: 'M4 21v-7M4 10V3M12 21v-9M12 8V3M20 21v-5M20 12V3M1 14h6M9 8h6M17 16h6'
 }
 
@@ -52,7 +53,8 @@ const NAV: Array<{ id: View; label: string }> = [
   { id: 'home', label: 'Home' },
   { id: 'agents', label: 'Agents' },
   { id: 'activity', label: 'Activity' },
-  { id: 'settings', label: 'Settings' }
+  { id: 'settings', label: 'Settings' },
+  { id: 'cloud', label: 'Cloud' }
 ]
 
 // UI-furniture spring (DESIGN.md §5.1) — fast, settles with no felt overshoot.

--- a/desktop/src/renderer/src/styles.css
+++ b/desktop/src/renderer/src/styles.css
@@ -316,6 +316,27 @@ body[data-platform="darwin"] .sidebar {
   opacity: 0.75;
 }
 
+.nav-item-label {
+  min-width: 0;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.nav-item-tag {
+  flex: none;
+  padding: 2px 5px;
+  border: 1px solid color-mix(in oklch, var(--accent) 38%, var(--hairline));
+  border-radius: var(--radius-pill);
+  background: var(--accent-soft);
+  color: var(--accent-ink);
+  font-size: 10px;
+  font-weight: var(--weight-chip);
+  line-height: 1;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
 .nav-item:hover {
   background: var(--pill);
   color: var(--text);

--- a/desktop/src/renderer/src/styles.css
+++ b/desktop/src/renderer/src/styles.css
@@ -55,9 +55,9 @@
 
   /* Type */
   --font-sans:
-    -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI Variable', 'Segoe UI', system-ui,
-    sans-serif;
-  --font-mono: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+        -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI Variable",
+        "Segoe UI", system-ui, sans-serif;
+    --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   --text-brand: 13.5px;
   --text-title: 19px;
   --text-section: 12px;
@@ -114,12 +114,12 @@
 }
 
 /* Solid surfaces off macOS — panel translucency must not depend on vibrancy. */
-body:not([data-platform='darwin']) {
+body:not([data-platform="darwin"]) {
   --panel: var(--bg-elevated);
 }
 
 @media (prefers-color-scheme: dark) {
-  body:not([data-platform='darwin']) {
+    body:not([data-platform="darwin"]) {
     --panel: var(--bg-elevated);
   }
 }
@@ -148,11 +148,11 @@ body {
   user-select: text;
 }
 
-body[data-platform='darwin'] {
+body[data-platform="darwin"] {
   background: transparent;
 }
 
-body[data-platform='darwin'] .sidebar {
+body[data-platform="darwin"] .sidebar {
   background: transparent;
 }
 
@@ -213,7 +213,7 @@ code,
   padding: 14px 10px;
 }
 
-body[data-platform='darwin'] .sidebar {
+body[data-platform="darwin"] .sidebar {
   padding-top: 48px;
 }
 
@@ -352,7 +352,7 @@ body[data-platform='darwin'] .sidebar {
 
 /* macOS: vibrancy is the sidebar's material only — the canvas stays solid so
    system blur never bleeds under content (§3.6). */
-body[data-platform='darwin'] .main {
+body[data-platform="darwin"] .main {
   background: var(--bg);
 }
 
@@ -1312,6 +1312,52 @@ section > .section-title {
   line-height: 1.45;
 }
 
+.cloud-status-strip {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+}
+
+.cloud-tabs {
+    align-self: flex-start;
+    display: inline-flex;
+    gap: 2px;
+    padding: 3px;
+    margin-left: 4px;
+    border: 1px solid var(--hairline);
+    border-radius: var(--radius-pill);
+    background: var(--empty-surface);
+}
+
+.cloud-tab {
+    border: 0;
+    border-radius: var(--radius-pill);
+    padding: 5px 14px;
+    background: transparent;
+    color: var(--text-secondary);
+    font: inherit;
+    font-size: var(--text-chip);
+    font-weight: var(--weight-chip);
+    cursor: pointer;
+}
+
+.cloud-tab:hover {
+    color: var(--text);
+    background: var(--pill);
+}
+
+.cloud-tab.active {
+    color: var(--accent-ink);
+    background: var(--accent-soft);
+}
+
+@media (prefers-color-scheme: dark) {
+    .cloud-tab.active {
+        color: var(--accent);
+    }
+}
+
 .cloud-spinner {
   flex: none;
   width: 12px;
@@ -1398,6 +1444,20 @@ section > .section-title {
   flex-direction: column;
   align-items: flex-start;
   gap: var(--space-3);
+}
+
+.cloud-guided-state {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-3);
+}
+
+.cloud-progress-title {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
 }
 
 .cloud-railway-copy,
@@ -1658,7 +1718,8 @@ section > .section-title {
   background: currentColor;
   opacity: var(--dot-rest);
   transform: scale(0.72);
-  animation: dot-field-flow var(--dot-duration) cubic-bezier(0.4, 0, 0.2, 1) infinite;
+    animation: dot-field-flow var(--dot-duration) cubic-bezier(0.4, 0, 0.2, 1)
+        infinite;
   animation-delay: var(--dot-delay);
 }
 
@@ -1871,7 +1932,7 @@ code {
   }
 
   .cloud-spinner::after {
-    content: '…';
+        content: "…";
     display: block;
     transform: translate(-1px, -8px);
   }

--- a/desktop/src/renderer/src/styles.css
+++ b/desktop/src/renderer/src/styles.css
@@ -5,6 +5,8 @@
 /* --- tokens ------------------------------------------------------------------ */
 
 :root {
+  /* Native widgets (select popups, scrollbars) follow the app theme. */
+  color-scheme: light;
   /* Surfaces — cool neutral, chroma toward accent hue (~250) */
   --bg: oklch(0.97 0.005 250);
   --bg-elevated: oklch(1 0 0);
@@ -90,6 +92,7 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
+    color-scheme: dark;
     --bg: oklch(0.19 0.01 250);
     --bg-elevated: oklch(0.22 0.012 250);
     --sidebar: oklch(0.14 0.012 250);
@@ -2447,4 +2450,11 @@ a.action-button {
     animation: none;
     background: var(--pill);
   }
+}
+
+/* Native select popup: explicit colors so options stay readable even where
+   the platform ignores color-scheme for the dropdown list. */
+select.env-input option {
+  background: var(--bg-elevated);
+  color: var(--text);
 }

--- a/desktop/src/renderer/src/styles.css
+++ b/desktop/src/renderer/src/styles.css
@@ -1397,6 +1397,65 @@ section > .section-title {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  gap: var(--space-3);
+}
+
+.cloud-railway-copy,
+.cloud-railway-footnote {
+  white-space: normal;
+}
+
+.cloud-railway-heading {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.cloud-engine-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.cloud-link-button {
+  border: 0;
+  padding: 0;
+  background: none;
+  color: var(--text-secondary);
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.cloud-link-button.danger,
+.action-button.danger {
+  color: var(--danger);
+}
+
+.cloud-workspace-field,
+.cloud-destroy-confirm {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.cloud-deploy-log {
+  width: 100%;
+  max-height: 140px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--space-3);
+  border-radius: var(--radius-control);
+  background: var(--empty-surface);
+}
+
+.cloud-railway-footnote {
+  color: var(--text-tertiary);
+  font-size: 11px;
 }
 
 .cloud-steps {

--- a/desktop/src/renderer/src/styles.css
+++ b/desktop/src/renderer/src/styles.css
@@ -1239,6 +1239,21 @@ section > .section-title {
   margin-bottom: 0;
 }
 
+.cloud-input {
+  width: min(300px, 36vw);
+}
+
+.cloud-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.cloud-checks {
+  margin-top: 4px;
+  font-size: 11.5px;
+}
+
 .switch {
   -webkit-app-region: no-drag;
   position: relative;

--- a/desktop/src/renderer/src/styles.css
+++ b/desktop/src/renderer/src/styles.css
@@ -1240,18 +1240,174 @@ section > .section-title {
 }
 
 .cloud-input {
-  width: min(300px, 36vw);
+  width: 100%;
+  min-height: 32px;
 }
 
 .cloud-actions {
   display: flex;
-  justify-content: flex-end;
-  gap: 6px;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.cloud-form {
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.cloud-field {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.cloud-field .row-sub {
+  white-space: normal;
+  margin-bottom: var(--space-2);
+}
+
+.cloud-input-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.cloud-key-row {
+  position: relative;
+}
+
+.cloud-key-row .cloud-input {
+  padding-right: 62px;
+}
+
+.cloud-key-toggle {
+  position: absolute;
+  right: 3px;
+  top: 50%;
+  min-width: 54px;
+  transform: translateY(-50%);
+  background: transparent;
+  color: var(--text-secondary);
+}
+
+.cloud-key-toggle:active:not(:disabled) {
+  transform: translateY(-50%) scale(0.985);
+}
+
+.cloud-status-dot {
+  flex: none;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--neutral);
+}
+
+.cloud-status-dot.connected {
+  background: var(--ok);
+}
+
+.cloud-status-title {
+  line-height: 1.45;
+}
+
+.cloud-spinner {
+  flex: none;
+  width: 12px;
+  height: 12px;
+  border: 2px solid color-mix(in oklch, currentColor 30%, transparent);
+  border-top-color: currentColor;
+  border-radius: 50%;
+  animation: cloud-spin 0.8s linear infinite;
+}
+
+@keyframes cloud-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.callout.success {
+  background: color-mix(in oklch, var(--ok) 10%, transparent);
+  color: var(--ok);
+}
+
+.callout.warning {
+  background: color-mix(in oklch, var(--warn) 12%, transparent);
+  color: var(--warn);
+}
+
+.cloud-confirmation {
+  font-weight: var(--weight-body);
+}
+
+.cloud-result {
+  display: block;
+}
+
+.cloud-result-heading {
+  font-weight: var(--weight-body);
 }
 
 .cloud-checks {
-  margin-top: 4px;
+  list-style: none;
+  margin: var(--space-2) 0 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-1);
   font-size: 11.5px;
+}
+
+.cloud-checks li {
+  display: grid;
+  grid-template-columns: 16px 1fr;
+  align-items: baseline;
+  column-gap: var(--space-1);
+  color: var(--text-secondary);
+}
+
+.cloud-check-icon {
+  text-align: center;
+  font-weight: 700;
+}
+
+.cloud-checks .passed .cloud-check-icon {
+  color: var(--ok);
+}
+
+.cloud-checks .warning .cloud-check-icon {
+  color: var(--warn);
+}
+
+.cloud-checks .failed .cloud-check-icon {
+  color: var(--danger);
+}
+
+.cloud-checks .pending .cloud-check-icon {
+  color: var(--neutral);
+}
+
+.cloud-railway {
+  padding: var(--space-4);
+}
+
+.cloud-railway-content {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.cloud-steps {
+  margin: var(--space-2) 0 var(--space-3);
+  padding-left: var(--space-5);
+  color: var(--text-secondary);
+  font-size: var(--text-secondary-size);
+}
+
+.cloud-steps li + li {
+  margin-top: var(--space-1);
 }
 
 .switch {
@@ -1648,6 +1804,17 @@ code {
     animation: none;
     border-top-color: color-mix(in oklch, var(--ok) 30%, transparent);
     opacity: 0.85;
+  }
+
+  .cloud-spinner {
+    animation: none;
+    border-color: transparent;
+  }
+
+  .cloud-spinner::after {
+    content: '…';
+    display: block;
+    transform: translate(-1px, -8px);
   }
 
   .view-content {

--- a/desktop/src/shared/cloudLinks.ts
+++ b/desktop/src/shared/cloudLinks.ts
@@ -1,0 +1,1 @@
+export const RAILWAY_TEMPLATE_URL = 'https://railway.com/deploy/controlplane-template'

--- a/desktop/src/shared/deeplink.test.ts
+++ b/desktop/src/shared/deeplink.test.ts
@@ -8,6 +8,7 @@ describe('parseDeepLink', () => {
     expect(parseDeepLink('agentfield://agents')).toBe('agents')
     expect(parseDeepLink('agentfield://activity')).toBe('activity')
     expect(parseDeepLink('agentfield://settings')).toBe('settings')
+    expect(parseDeepLink('agentfield://cloud')).toBe('cloud')
   })
 
   it('migrates legacy dashboard and secrets hosts', () => {
@@ -57,7 +58,7 @@ describe('deepLinkFromArgv', () => {
 
 describe('isView', () => {
   it('accepts exactly the app views', () => {
-    for (const v of ['home', 'install', 'agents', 'activity', 'settings']) {
+    for (const v of ['home', 'install', 'agents', 'activity', 'settings', 'cloud']) {
       expect(isView(v)).toBe(true)
     }
     expect(isView('dashboard')).toBe(false)

--- a/desktop/src/shared/deeplink.ts
+++ b/desktop/src/shared/deeplink.ts
@@ -8,7 +8,7 @@
 export const DEEP_LINK_SCHEME = 'agentfield'
 
 /** The app's views, also the vocabulary of deep-link targets. */
-export const VIEWS = ['home', 'install', 'agents', 'activity', 'settings'] as const
+export const VIEWS = ['home', 'install', 'agents', 'activity', 'settings', 'cloud'] as const
 export type View = (typeof VIEWS)[number]
 
 /** Pre-IA rename hosts that still open the app on the successor view. */

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -170,6 +170,8 @@ export interface CliStatus {
  * moment Claude/Codex/anything asks.
  */
 export interface DesktopSettings {
+  /** Remote control-plane profile. The API key remains in main-process settings. */
+  cloud: { enabled: boolean; serverUrl: string; apiKey: string }
   /** Launch the app when you log in (starts hidden, in the tray). */
   openAtLogin: boolean
   /** Follow the OS appearance, or explicitly force the light/dark palette. */
@@ -215,6 +217,15 @@ export interface DesktopSettings {
   starPrompt: 'pending' | 'done'
   /** ISO timestamp until which the star prompt is snoozed (Later = +7 days). null = not snoozed. */
   starPromptSnoozedUntil: string | null
+}
+
+export interface CloudTestResult {
+  ok: boolean
+  healthy: boolean
+  authOk: boolean
+  installApi: boolean
+  version?: string
+  message: string
 }
 
 /** A newer app release found on GitHub (the desktop app's update channel). */
@@ -297,6 +308,9 @@ export interface AgentFieldSnapshot {
 
 /** Surface exposed on window.agentfield by the preload script. */
 export interface AgentFieldApi {
+  cloudTest(url: string, apiKey: string): Promise<CloudTestResult>
+  /** Open the guided Railway deployment flow for a hosted control plane. */
+  cloudDeployRailway(): Promise<boolean>
   getSnapshot(): Promise<AgentFieldSnapshot>
   getCatalog(): Promise<CatalogEntry[]>
   /** Install a catalog entry by name. Resolves when `af install` exits. */

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -228,6 +228,19 @@ export interface CloudTestResult {
   message: string
 }
 
+export interface RailwayStatus {
+  loggedIn: boolean
+  engineAvailable: boolean
+  hasDeployment: boolean
+  workspaces: Array<{ id: string; name: string }>
+}
+
+export interface CloudDeployResult {
+  ok: boolean
+  url?: string
+  message: string
+}
+
 /** A newer app release found on GitHub (the desktop app's update channel). */
 export interface AppUpdateInfo {
   /** Release version without the v prefix (e.g. "0.1.110"). */
@@ -311,6 +324,12 @@ export interface AgentFieldApi {
   cloudTest(url: string, apiKey: string): Promise<CloudTestResult>
   /** Open the guided Railway deployment flow for a hosted control plane. */
   cloudDeployRailway(): Promise<boolean>
+  railwayStatus(): Promise<RailwayStatus>
+  railwayLogin(): Promise<{ ok: boolean; message: string; workspaces?: RailwayStatus['workspaces'] }>
+  railwayLogout(): Promise<void>
+  cloudDeploy(workspaceId: string): Promise<CloudDeployResult>
+  cloudDestroy(): Promise<{ ok: boolean; message: string }>
+  onCloudDeployProgress(listener: (line: string) => void): () => void
   getSnapshot(): Promise<AgentFieldSnapshot>
   getCatalog(): Promise<CatalogEntry[]>
   /** Install a catalog entry by name. Resolves when `af install` exits. */


### PR DESCRIPTION
## Summary

The complete desktop cloud-mode feature, in one PR. AgentField Desktop can now manage a **remote control plane** exactly like a local one — same client, same flows, only the base URL changes — and can **deploy that control plane to the user's own Railway account in one click**. This is the final piece of the one-management-path arc (#837 → #841 → #842 → #843 → #844).

## The Cloud tab

New nav view (`agentfield://cloud`, ⌘/Ctrl+5): a status strip showing the active connection (with switch-back-to-local), and two subtabs — more providers slot in later:

- **Railway (guided)**: **Log in with Railway** → pick a workspace → **Deploy control plane** with a live progress stream → the app is connected the moment the deploy finishes. Once deployed: re-run (reconciles) or tear down (typed confirmation) which returns the app to local mode.
- **Manual**: server URL + API key, with a colored test-connection verdict (reachable / auth / install API / server version), including a distinct amber state for control planes too old for desktop agent management.

## How the pieces work

**Connection core** — a cycle-free connection-state module supplies base URL + API key to the CP client *and* the raw dashboard/tray fetches that previously sent no auth. URL normalization refuses plaintext `http://` to public hosts. The cloud profile persists in settings and is applied at startup and on every change. In cloud mode the app never spawns, adopts, or port-probes a local server and never auto-starts agents; switching back restores prior local behavior. List-shaped CP responses tolerate Go nil-slice `null`s (a fresh CP returns `{"packages":null}` — found in live testing).

**Log in with Railway** — real OAuth (Authorization Code + PKCE, loopback redirect on 127.0.0.1 with CSRF state checks), protocol-compatible with the Railway CLI, reduced scopes (no `ssh_keys`). Tokens are encrypted with Electron `safeStorage` into a 0600 file — never in settings.json, never sent to the renderer — and short-lived access tokens auto-refresh with rotation.

**Deploy engine** — bundled **OpenTofu** (MPL) + the community Railway provider, vendored per platform by `scripts/fetch-deploy-engine.mjs` (builds without the vendor dir feature-detect and fall back to the Railway template link, so CI needs no binaries). An embedded single-image module creates: project (workspace-aware) → `control-plane-cloud` service → generated 48-hex API key → public domain. The volume is attached by a direct idempotent GraphQL call because the provider's `service.volume` attribute creates the volume but reads it back as `null`, failing the apply (verified live). State is kept on failure — re-running reconciles; teardown destroys the project (Railway cascades the volume).

## Validation

- **Live end-to-end on a real Railway account (26s)**: deploy → CP healthy with fail-closed auth (wrong key rejected) and install API present → destroy. Volume-attach and idempotence paths included.
- **Live manual E2E of the connection layer** against a key-enforcing CP: install → secrets → start/stop → uninstall through the cloud profile; test-connection verdict matrix (valid / rejected / unreachable); autostart gating; local-mode restore.
- 368 desktop tests, typecheck, and `dist:dir` green on Linux + the Windows CI leg (one Windows-only fix: POSIX file-mode assertions don't hold there).
- OAuth module tested against a real loopback server; generated HCL proven with `tofu validate` against the real provider.

## Notes / follow-ups

- The OAuth client ID is the Railway CLI's public client (env-overridable) — register an AgentField OAuth client with Railway before GA.
- Deploying creates billable resources on the user's Railway account; the UI states this before the button.
- The cloud profile's API key still lives in settings.json (same trust level as existing `~/.agentfield` config material); moving it to `safeStorage` alongside the OAuth tokens is a follow-up.
- Supersedes #845 (its commits are included here).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
