### PR TITLE
fix(sdk): extract opencode token usage from step_finish parts (Go + Python)

### DIFF
--- a/sdk/go/harness/opencode.go
+++ b/sdk/go/harness/opencode.go
@@ -266,7 +266,10 @@ func (p *OpenCodeProvider) Execute(ctx context.Context, prompt string, options O
 	}
 	raw.Metrics.NumTurns = numTurns
 	raw.Metrics.CostUSD = costFromEvents(events)
-	tokens := extractTokenUsage(events)
+	tokens, foundTokens := tokenUsageFromOpenCodeEvents(events)
+	if !foundTokens {
+		tokens = extractTokenUsage(events)
+	}
 	raw.Metrics.InputTokens = tokens.inputTokens
 	raw.Metrics.OutputTokens = tokens.outputTokens
 	raw.Metrics.CacheReadTokens = tokens.cacheReadTokens
@@ -424,6 +427,36 @@ func costFromEvents(events []map[string]any) *float64 {
 		return nil
 	}
 	return &total
+}
+
+// tokenUsageFromOpenCodeEvents sums token counts from opencode's per-step
+// step_finish.part.tokens objects. The boolean reports whether any step carried
+// a tokens object, allowing callers to fall back to generic event usage shapes
+// when opencode did not report part-level tokens at all.
+func tokenUsageFromOpenCodeEvents(events []map[string]any) (tokenUsage, bool) {
+	var total tokenUsage
+	found := false
+	for _, event := range events {
+		if t, _ := event["type"].(string); t != "step_finish" {
+			continue
+		}
+		part, ok := event["part"].(map[string]any)
+		if !ok {
+			continue
+		}
+		tokens, ok := part["tokens"].(map[string]any)
+		if !ok {
+			continue
+		}
+		found = true
+		total.inputTokens += intField(tokens, "input")
+		total.outputTokens += intField(tokens, "output") + intField(tokens, "reasoning")
+		if cache, ok := tokens["cache"].(map[string]any); ok {
+			total.cacheReadTokens += intField(cache, "read")
+			total.cacheCreationTokens += intField(cache, "write")
+		}
+	}
+	return total, found
 }
 
 // extractOpenCodeEventError pulls a meaningful failure message from an in-band

--- a/sdk/go/harness/opencode_json_test.go
+++ b/sdk/go/harness/opencode_json_test.go
@@ -51,6 +51,39 @@ func TestOpenCode_JSONEventsParsed(t *testing.T) {
 	assert.Contains(t, joined, "run --format json")
 }
 
+func TestOpenCode_SumsPartNestedTokenUsage(t *testing.T) {
+	stream := strings.Join([]string{
+		`{"type":"step_finish","part":{"cost":0.01,"tokens":{"input":123,"output":456,"reasoning":78,"cache":{"read":9,"write":10}}}}`,
+		`{"type":"step_finish","part":{"cost":0.02}}`,
+		`{"type":"text","part":{"text":"done"}}`,
+		`{"type":"step_finish","part":{"cost":0.03,"tokens":{"input":7,"output":8,"reasoning":2,"cache":{"read":3,"write":4}}}}`,
+	}, "\n")
+
+	raw, err := fakeOpenCode(stream, "", 0, nil).Execute(context.Background(), "prompt", Options{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 130, raw.Metrics.InputTokens)
+	assert.Equal(t, 544, raw.Metrics.OutputTokens)
+	assert.Equal(t, 12, raw.Metrics.CacheReadTokens)
+	assert.Equal(t, 14, raw.Metrics.CacheCreationTokens)
+}
+
+func TestOpenCode_TokenUsageFallsBackWithoutPartTokens(t *testing.T) {
+	stream := strings.Join([]string{
+		`{"type":"step_finish","part":{"cost":0.01}}`,
+		`{"type":"turn.completed","usage":{"input_tokens":11,"output_tokens":12,"cached_input_tokens":13,"cache_creation_input_tokens":14}}`,
+		`{"type":"result","result":"done"}`,
+	}, "\n")
+
+	raw, err := fakeOpenCode(stream, "", 0, nil).Execute(context.Background(), "prompt", Options{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 11, raw.Metrics.InputTokens)
+	assert.Equal(t, 12, raw.Metrics.OutputTokens)
+	assert.Equal(t, 13, raw.Metrics.CacheReadTokens)
+	assert.Equal(t, 14, raw.Metrics.CacheCreationTokens)
+}
+
 // TestOpenCode_ToolUseTurnFallback verifies the turn count falls back to
 // tool_use events when there are no step markers, and that cost is nil when no
 // step_finish carried a cost.

--- a/sdk/python/agentfield/harness/providers/opencode.py
+++ b/sdk/python/agentfield/harness/providers/opencode.py
@@ -83,6 +83,48 @@ def _cost_from_events(events: list[dict[str, object]]) -> float | None:
     return total_cost if found_cost else None
 
 
+def _tokens_from_events(
+    events: list[dict[str, object]],
+) -> tuple[dict[str, int], bool]:
+    """Sum token counts from opencode ``step_finish.part.tokens`` objects."""
+    total = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
+    }
+    found_tokens = False
+
+    def _int(value: object) -> int:
+        if isinstance(value, bool):
+            return 0
+        try:
+            return int(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return 0
+
+    for event in events:
+        if event.get("type") != "step_finish":
+            continue
+        part = event.get("part")
+        if not isinstance(part, dict):
+            continue
+        tokens = part.get("tokens")
+        if not isinstance(tokens, dict):
+            continue
+        found_tokens = True
+        total["input_tokens"] += _int(tokens.get("input"))
+        total["output_tokens"] += _int(tokens.get("output")) + _int(
+            tokens.get("reasoning")
+        )
+        cache = tokens.get("cache")
+        if isinstance(cache, dict):
+            total["cache_read_tokens"] += _int(cache.get("read"))
+            total["cache_creation_tokens"] += _int(cache.get("write"))
+
+    return total, found_tokens
+
+
 def _extract_opencode_event_error(events: list[dict[str, object]]) -> str | None:
     """Pull a meaningful failure message from an in-band JSON error event."""
     for event in events:
@@ -353,7 +395,9 @@ class OpenCodeProvider:
         if num_turns == 0 and result_text:
             num_turns = 1
 
-        tokens = extract_token_usage(events)
+        tokens, found_tokens = _tokens_from_events(events)
+        if not found_tokens:
+            tokens = extract_token_usage(events)
 
         return RawResult(
             result=result_text,

--- a/sdk/python/tests/test_harness_provider_opencode.py
+++ b/sdk/python/tests/test_harness_provider_opencode.py
@@ -205,6 +205,55 @@ async def test_opencode_cost_prefers_stream_cost_when_present(
 
 
 @pytest.mark.asyncio
+async def test_opencode_sums_part_nested_token_usage(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    stdout = "\n".join(
+        [
+            '{"type":"step_finish","part":{"cost":0.01,"tokens":{"input":123,"output":456,"reasoning":78,"cache":{"read":9,"write":10}}}}',
+            '{"type":"step_finish","part":{"cost":0.02}}',
+            '{"type":"text","part":{"text":"done"}}',
+            '{"type":"step_finish","part":{"cost":0.03,"tokens":{"input":7,"output":8,"reasoning":2,"cache":{"read":3,"write":4}}}}',
+        ]
+    )
+
+    async def fake_run_cli(*_args, **_kwargs):
+        return stdout, "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
+    raw = await OpenCodeProvider().execute("hello", {})
+
+    assert raw.metrics.input_tokens == 130
+    assert raw.metrics.output_tokens == 544
+    assert raw.metrics.cache_read_tokens == 12
+    assert raw.metrics.cache_creation_tokens == 14
+
+
+@pytest.mark.asyncio
+async def test_opencode_token_usage_falls_back_without_part_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    stdout = "\n".join(
+        [
+            '{"type":"step_finish","part":{"cost":0.01}}',
+            '{"type":"turn.completed","usage":{"input_tokens":11,"output_tokens":12,"cached_input_tokens":13,"cache_creation_input_tokens":14}}',
+            '{"type":"result","result":"done"}',
+        ]
+    )
+
+    async def fake_run_cli(*_args, **_kwargs):
+        return stdout, "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
+    raw = await OpenCodeProvider().execute("hello", {})
+
+    assert raw.metrics.input_tokens == 11
+    assert raw.metrics.output_tokens == 12
+    assert raw.metrics.cache_read_tokens == 13
+    assert raw.metrics.cache_creation_tokens == 14
+
+
+@pytest.mark.asyncio
 async def test_opencode_cost_none_without_model(monkeypatch: pytest.MonkeyPatch):
     """Without a model, cost estimation returns None (not 0)."""
 


### PR DESCRIPTION
## Summary
opencode-harness executions recorded real cost but all-zero token counts (observed live: `cost_usd: 0.0139, total_tokens: 0`). opencode reports cost AND tokens inside each `step_finish` event's `part` object — both SDKs read the cost from there but sent tokens through the generic extractor, which only understands Codex-style top-level/`item`/`turn` `usage` shapes, so opencode tokens were silently dropped.

## Changes Made
- Both SDKs (mirrored semantics): sum `part.tokens` across steps exactly like cost; `reasoning` folds into `output_tokens` (the usage envelope has no reasoning field); `cache.read`/`cache.write` map to the cache fields; generic-extractor fallback when no step carried tokens. Codex/claude-code paths untouched.
- Token shape sourced from opencode's own session schema (`packages/core/src/session/info.ts`, `cli/cmd/run/session-data.ts`): `tokens: {input, output, reasoning, cache: {read, write}}`.
- Fixture tests on both sides: multi-step summing (incl. a tokenless step), reasoning fold, cache mapping, and the fallback.

## Test Plan
- [x] Go: `gofmt` clean, `go vet`, `go test ./...`
- [x] Python: `ruff check .` clean, full pytest `--no-cov` green
- [x] Cross-SDK goldens inspected — they pin aggregate wire serialization, not provider event shapes, so no golden changes needed

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)