### PR TITLE
fix(control-plane): reconcile must honor granted node status leases

### DIFF
--- a/control-plane/internal/handlers/coverage_additional_test.go
+++ b/control-plane/internal/handlers/coverage_additional_test.go
@@ -159,6 +159,7 @@ func (s *cleanupStorageStub) CleanupWorkflow(ctx context.Context, workflowID str
 
 type nodeRESTStorageStub struct {
 	storage.StorageProvider
+	mu               sync.Mutex
 	agent            *types.AgentNode
 	versionedAgent   *types.AgentNode
 	listAgents       []*types.AgentNode
@@ -170,6 +171,7 @@ type nodeRESTStorageStub struct {
 	lastVersion      string
 	updatedLifecycle *types.AgentLifecycleStatus
 	registeredAgent  *types.AgentNode
+	healthUpdates    []types.HealthStatus
 }
 
 func (s *nodeRESTStorageStub) GetAgent(ctx context.Context, id string) (*types.AgentNode, error) {
@@ -193,9 +195,18 @@ func (s *nodeRESTStorageStub) GetAgentVersion(ctx context.Context, id, version s
 }
 
 func (s *nodeRESTStorageStub) UpdateAgentHeartbeat(ctx context.Context, id, version string, ts time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.lastHeartbeatID = id
 	s.lastVersion = version
 	s.heartbeats = append(s.heartbeats, ts)
+	return nil
+}
+
+func (s *nodeRESTStorageStub) UpdateAgentHealth(ctx context.Context, id string, status types.HealthStatus) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.healthUpdates = append(s.healthUpdates, status)
 	return nil
 }
 

--- a/control-plane/internal/handlers/nodes_rest.go
+++ b/control-plane/internal/handlers/nodes_rest.go
@@ -61,6 +61,9 @@ func NodeStatusLeaseHandler(storageProvider storage.StorageProvider, statusManag
 		if agent.LifecycleStatus == types.AgentStatusPendingApproval {
 			logger.Logger.Debug().Str("node_id", nodeID).Msg("ignoring status update: agent is pending_approval")
 			now := time.Now().UTC()
+			if statusManager != nil {
+				statusManager.RecordLease(nodeID, now.Add(leaseTTL))
+			}
 			_ = storageProvider.UpdateAgentHeartbeat(ctx, nodeID, agent.Version, now)
 			if presenceManager != nil {
 				presenceManager.Touch(nodeID, agent.Version, now)
@@ -116,6 +119,9 @@ func NodeStatusLeaseHandler(storageProvider storage.StorageProvider, statusManag
 		}
 
 		now := time.Now().UTC()
+		if statusManager != nil {
+			statusManager.RecordLease(nodeID, now.Add(leaseTTL))
+		}
 		if err := storageProvider.UpdateAgentHeartbeat(ctx, nodeID, agent.Version, now); err != nil {
 			logger.Logger.Warn().Err(err).Str("node_id", nodeID).Msg("failed to persist heartbeat during status update")
 		}

--- a/control-plane/internal/handlers/nodes_rest_test.go
+++ b/control-plane/internal/handlers/nodes_rest_test.go
@@ -334,3 +334,49 @@ func TestNodeStatusLeaseHandler_SkipsHealthMonitorForServerless(t *testing.T) {
 	assert.False(t, healthMonitor.IsMonitoring("lease-serverless"),
 		"serverless nodes have no /status endpoint and must not be HTTP-polled")
 }
+
+func TestNodeStatusLeaseHandler_RecordsGrantedLease(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	for _, tt := range []struct {
+		name      string
+		lifecycle types.AgentLifecycleStatus
+		body      string
+	}{
+		{name: "normal", lifecycle: types.AgentStatusReady, body: `{"phase":"ready"}`},
+		{name: "pending approval", lifecycle: types.AgentStatusPendingApproval, body: `{}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			node := &types.AgentNode{
+				ID:              "lease-contract-node",
+				Version:         "1.0.0",
+				HealthStatus:    types.HealthStatusActive,
+				LifecycleStatus: tt.lifecycle,
+				LastHeartbeat:   time.Now().Add(-2 * time.Minute),
+			}
+			store := &nodeRESTStorageStub{agent: node, listAgents: []*types.AgentNode{node}}
+			statusManager := services.NewStatusManager(store, services.StatusManagerConfig{
+				ReconcileInterval:       5 * time.Millisecond,
+				HeartbeatStaleThreshold: time.Minute,
+			}, nil, nil)
+			statusManager.Start()
+			defer statusManager.Stop()
+
+			router := gin.New()
+			router.PATCH("/nodes/:node_id/status", NodeStatusLeaseHandler(store, statusManager, nil, nil, time.Minute))
+			req := httptest.NewRequest(http.MethodPatch, "/nodes/lease-contract-node/status", bytes.NewBufferString(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			// Several reconcile cycles elapse while the persisted heartbeat remains
+			// deliberately stale. The granted lease must prevent an inactive update.
+			time.Sleep(25 * time.Millisecond)
+			store.mu.Lock()
+			updates := append([]types.HealthStatus(nil), store.healthUpdates...)
+			store.mu.Unlock()
+			assert.NotContains(t, updates, types.HealthStatusInactive)
+		})
+	}
+}

--- a/control-plane/internal/services/status_manager.go
+++ b/control-plane/internal/services/status_manager.go
@@ -37,6 +37,10 @@ type StatusManager struct {
 	activeTransitions map[string]*types.StateTransition
 	transitionMutex   sync.RWMutex
 
+	// Granted status leases, keyed by node ID.
+	leaseExpiries map[string]time.Time
+	leaseMutex    sync.RWMutex
+
 	// Control channels
 	stopCh chan struct{}
 
@@ -98,9 +102,40 @@ func NewStatusManager(storage storage.StorageProvider, config StatusManagerConfi
 		agentClient:       agentClient,
 		statusCache:       make(map[string]*cachedAgentStatus),
 		activeTransitions: make(map[string]*types.StateTransition),
+		leaseExpiries:     make(map[string]time.Time),
 		stopCh:            make(chan struct{}),
 		eventHandlers:     make([]StatusEventHandler, 0),
 	}
+}
+
+const grantedLeaseGrace = 30 * time.Second
+
+// RecordLease records the expiry of a status lease granted to a node.
+func (sm *StatusManager) RecordLease(nodeID string, expiresAt time.Time) {
+	sm.leaseMutex.Lock()
+	sm.leaseExpiries[nodeID] = expiresAt
+	sm.leaseMutex.Unlock()
+}
+
+func (sm *StatusManager) hasUnexpiredLease(nodeID string, now time.Time) bool {
+	sm.leaseMutex.RLock()
+	expiresAt, ok := sm.leaseExpiries[nodeID]
+	sm.leaseMutex.RUnlock()
+	if !ok {
+		return false
+	}
+
+	if now.Before(expiresAt.Add(grantedLeaseGrace)) {
+		return true
+	}
+
+	// Lease entries need no sweeper; discard them lazily once their grace period ends.
+	sm.leaseMutex.Lock()
+	if current, exists := sm.leaseExpiries[nodeID]; exists && current.Equal(expiresAt) {
+		delete(sm.leaseExpiries, nodeID)
+	}
+	sm.leaseMutex.Unlock()
+	return false
 }
 
 // Start begins the status manager background processes
@@ -735,9 +770,17 @@ func (sm *StatusManager) performReconciliation() {
 
 // needsReconciliation checks if an agent needs status reconciliation
 func (sm *StatusManager) needsReconciliation(agent *types.AgentNode) bool {
-	// Check if last heartbeat is too old (uses configurable threshold, default 60s)
-	timeSinceHeartbeat := time.Since(agent.LastHeartbeat)
-	if timeSinceHeartbeat > sm.config.HeartbeatStaleThreshold && agent.HealthStatus == types.HealthStatusActive {
+	now := time.Now()
+	timeSinceHeartbeat := now.Sub(agent.LastHeartbeat)
+
+	// A granted lease is the server's promise that it will not declare the node
+	// dead while that lease (plus a small scheduling grace) is still running.
+	// Lease-holder liveness is still guarded by the HTTP health monitor, whose
+	// consecutive probe failures can mark a dead node inactive before lease expiry.
+	// Nodes without granted leases continue to use heartbeat staleness unchanged.
+	if timeSinceHeartbeat > sm.config.HeartbeatStaleThreshold &&
+		agent.HealthStatus == types.HealthStatusActive &&
+		!sm.hasUnexpiredLease(agent.ID, now) {
 		return true
 	}
 

--- a/control-plane/internal/services/status_manager_test.go
+++ b/control-plane/internal/services/status_manager_test.go
@@ -593,6 +593,46 @@ func TestStatusManager_Reconciliation_UsesConfiguredThreshold(t *testing.T) {
 		"Agent past startup grace with fresh heartbeat but still 'starting' should need reconciliation (issue #484)")
 }
 
+func TestStatusManager_Reconciliation_HonorsGrantedLeases(t *testing.T) {
+	provider, _ := setupStatusManagerStorage(t)
+	sm := NewStatusManager(provider, StatusManagerConfig{
+		HeartbeatStaleThreshold: time.Minute,
+	}, nil, nil)
+
+	staleActive := func(id string) *types.AgentNode {
+		return &types.AgentNode{
+			ID:            id,
+			HealthStatus:  types.HealthStatusActive,
+			LastHeartbeat: time.Now().Add(-2 * time.Minute),
+		}
+	}
+
+	t.Run("unexpired lease protects a stale heartbeat", func(t *testing.T) {
+		agent := staleActive("leased-node")
+		sm.RecordLease(agent.ID, time.Now().Add(time.Minute))
+		assert.False(t, sm.needsReconciliation(agent))
+	})
+
+	t.Run("expired lease and grace restore stale reconciliation", func(t *testing.T) {
+		agent := staleActive("expired-lease-node")
+		sm.RecordLease(agent.ID, time.Now().Add(-grantedLeaseGrace-time.Second))
+		assert.True(t, sm.needsReconciliation(agent))
+	})
+
+	t.Run("heartbeat-only node is unchanged", func(t *testing.T) {
+		assert.True(t, sm.needsReconciliation(staleActive("heartbeat-node")))
+	})
+
+	t.Run("renewal overwrites and extends the lease horizon", func(t *testing.T) {
+		agent := staleActive("renewed-node")
+		sm.RecordLease(agent.ID, time.Now().Add(-grantedLeaseGrace-time.Second))
+		assert.True(t, sm.needsReconciliation(agent))
+
+		sm.RecordLease(agent.ID, time.Now().Add(time.Minute))
+		assert.False(t, sm.needsReconciliation(agent))
+	})
+}
+
 // TestStatusManager_StuckStartingIsReconciledToReady reproduces issue #484 end-to-end:
 // an agent registers, sends heartbeats indefinitely with status="starting" (the Python SDK's
 // default, since it never transitions _current_status to READY), and is expected to be


### PR DESCRIPTION
## Bug

Idle Go-SDK nodes deterministically flap offline ~30s out of every 2-minute lease cycle. Measured on a live cloud deploy with a 10s poll: the node reads active for ~90s, disappears from `/api/v1/nodes` for ~30s, then returns on the next lease renewal — repeating indefinitely. Reproduced locally with an idle agent: **33/42 polls active** over 7 minutes on current main.

## Root cause

Three constants that never met each other:

- `NodeStatusLeaseHandler` grants nodes a **5-minute** lease (`DefaultLeaseTTL`) and tells them so (`lease_seconds`, `next_lease_renewal`).
- The Go SDK renews every **2 minutes** — comfortably inside its granted lease.
- The status manager's reconcile sweep marks any active node inactive once its heartbeat is older than `HeartbeatStaleThreshold` (**60s** default).

The server promises "you're good for 300s" and then declares the node dead at 60s. Busy nodes are masked (execution traffic keeps status fresh); idle nodes flap every cycle. This is the remaining half of the lease-liveness work from #847 (which fixed the frozen `last_seen` snapshot).

## Fix

`StatusManager` now records each granted lease expiry (`RecordLease`, called from both lease-granting paths in the handler), and the heartbeat-staleness reconcile rule skips nodes whose recorded lease (+30s grace) is still running. Entries are overwritten on renewal and lazily dropped after expiry.

Deliberately unchanged:
- **Dead-node detection stays fast.** The HTTP health monitor's consecutive-failure path is untouched; its heartbeat gate stops protecting a node once the heartbeat goes stale, so a dead lease-holder is still marked inactive after N failed probes — it does not get to hide behind an unexpired lease.
- **Python-SDK heartbeaters are unaffected.** Nodes that never receive a lease grant have no registry entry; the 60s staleness rule applies to them exactly as before.
- All other reconcile rules (stuck-starting, unknown-with-fresh-heartbeat, inconsistent status).

## Verification

- Idle-agent A/B, same harness (local CP + Go-SDK agent, 10s poll, ≥3 lease cycles): main **33/42** active → this branch **42/42**.
- New unit tests derive from the contract: unexpired lease suppresses staleness reconcile; expired lease (+grace) restores it; no-lease nodes unchanged; renewal extends the horizon; handler records leases on both the normal and `pending_approval` paths.
- `gofmt` clean on touched files; `go build ./...` clean; `go test ./...`: `internal/services` and `internal/handlers` (home of all changed code) pass. `internal/server`'s `TestStartAndStopCoverAdditionalBranches` fails identically on unmodified main in my environment (a local process holds the admin gRPC port) — pre-existing and environmental, expecting CI to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)