### PR TITLE
fix(security): bump brace-expansion for CVE-2026-14257 DoS

### DIFF
--- a/control-plane/web/client/package-lock.json
+++ b/control-plane/web/client/package-lock.json
@@ -4036,9 +4036,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4595,9 +4595,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9668,9 +9668,9 @@
             }
         },
         "node_modules/sucrase/node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"

--- a/control-plane/web/client/package.json
+++ b/control-plane/web/client/package.json
@@ -88,8 +88,8 @@
         "js-yaml": "4.3.0",
         "esbuild": "0.28.1",
         "ws": "8.21.0",
-        "brace-expansion@1": "1.1.16",
-        "brace-expansion@2": "2.1.2",
+        "brace-expansion@1": "1.1.18",
+        "brace-expansion@2": "2.1.4",
         "postcss": "$postcss"
     },
     "pnpm": {
@@ -97,8 +97,8 @@
             "js-yaml": "4.3.0",
             "esbuild": "0.28.1",
             "ws": "8.21.0",
-            "brace-expansion@1": "1.1.16",
-            "brace-expansion@2": "2.1.2",
+            "brace-expansion@1": "1.1.18",
+            "brace-expansion@2": "2.1.4",
             "postcss": "8.5.18"
         }
     }

--- a/control-plane/web/client/pnpm-lock.yaml
+++ b/control-plane/web/client/pnpm-lock.yaml
@@ -8,8 +8,8 @@ overrides:
   js-yaml: 4.3.0
   esbuild: 0.28.1
   ws: 8.21.0
-  brace-expansion@1: 1.1.16
-  brace-expansion@2: 2.1.2
+  brace-expansion@1: 1.1.18
+  brace-expansion@2: 2.1.4
   postcss: 8.5.18
 
 importers:
@@ -1801,11 +1801,11 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5286,12 +5286,12 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
@@ -6485,11 +6485,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes Dependabot alerts #355 (`package-lock.json`) and #357 (`pnpm-lock.yaml`) for [CVE-2026-14257](https://github.com/advisories/GHSA-mh99-v99m-4gvg) / GHSA-mh99-v99m-4gvg — brace-expansion DoS via unbounded expansion length causing an OOM process crash.

Bumps npm/pnpm overrides in `control-plane/web/client` from vulnerable `1.1.16` / `2.1.2` to patched maintenance releases `1.1.18` / `2.1.4`, and regenerates both lockfiles.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] Tests only
- [ ] CI / tooling
- [ ] Breaking change

## Test plan

- [x] Confirmed lockfiles resolve `brace-expansion@1.1.18` and `brace-expansion@2.1.4`
- [x] `npm audit` no longer reports brace-expansion / GHSA-mh99-v99m-4gvg
- [x] `pnpm audit` no longer reports brace-expansion
- [ ] CI green for web client workflows

## Test coverage

Dependency override / lockfile-only change — no application code paths changed.

- [x] I ran tests for the surface(s) I changed locally. *(audit verification)*
- [x] New code paths are covered by tests in this PR (no bare additions). *(N/A — lockfile only)*
- [x] If I removed code, I updated `coverage-baseline.json` … *(N/A)*
- [ ] The coverage gate check is green in CI before requesting review.

## Checklist

- [x] Commits follow conventional-commits style.
- [x] Related Dependabot alerts: #355, #357

## Related issues / PRs

- Dependabot alert #355 — `control-plane/web/client/package-lock.json`
- Dependabot alert #357 — `control-plane/web/client/pnpm-lock.yaml`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb9cbdaf-bf3b-4984-9a5f-cebc8e73d09d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb9cbdaf-bf3b-4984-9a5f-cebc8e73d09d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

