### PR TITLE
fix(control-plane): require a trusted caller for package install and credential endpoints

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,6 +22,12 @@ When using AgentField:
 
 - Keep your control plane and SDKs updated to the latest version
 - Use environment variables for sensitive configuration (API keys, database URLs)
+- Set `AGENTFIELD_API_KEY` on any control plane reachable from beyond the machine
+  it runs on. The control plane listens on every interface, and installing a
+  package runs that package's own build and dependency steps — so an unprotected
+  control plane on a shared network lets anyone on it run code as the user
+  running the server. Without a key, those endpoints are refused for every
+  non-local caller.
 - Enable TLS in production deployments
 - Review agent permissions and limit scope where possible
 - Monitor workflow audit logs for unexpected behavior

--- a/control-plane/.env.example
+++ b/control-plane/.env.example
@@ -18,6 +18,15 @@ AGENTFIELD_UI_DIST_PATH=./web/client/dist
 AGENTFIELD_UI_DEV_PORT=5173
 
 # API Configuration
+
+# API key for the control plane. Leave unset for a local single-user setup:
+# endpoints that install packages or handle credentials are then restricted to
+# callers on the local machine. Set it whenever the control plane is reachable
+# from anywhere else — another machine on the network, a container bridge, or a
+# reverse proxy — or those endpoints stay refused. Clients send it as X-API-Key;
+# `af auth login` stores it for the CLI.
+# AGENTFIELD_API_KEY=change-me
+
 AGENTFIELD_API_CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173,http://localhost:8080
 AGENTFIELD_API_CORS_ALLOWED_METHODS=GET,POST,PUT,DELETE,OPTIONS
 AGENTFIELD_API_CORS_ALLOWED_HEADERS=Origin,Content-Type,Accept,Authorization,X-Requested-With,X-API-Key,X-Admin-Token

--- a/control-plane/internal/cli/agent_commands.go
+++ b/control-plane/internal/cli/agent_commands.go
@@ -691,7 +691,7 @@ func defaultCodeForStatus(statusCode int) string {
 func defaultHintForStatus(statusCode int) string {
 	switch statusCode {
 	case http.StatusUnauthorized:
-		return "Provide a valid API key with --api-key or AGENTFIELD_API_KEY."
+		return "Provide a valid API key with --api-key or AGENTFIELD_API_KEY, or store one with `af auth login`."
 	case http.StatusForbidden:
 		return "API key is valid but lacks required permissions for this endpoint."
 	case http.StatusNotFound:

--- a/control-plane/internal/cli/auth.go
+++ b/control-plane/internal/cli/auth.go
@@ -1,0 +1,228 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// NewAuthCommand returns the `af auth` command tree for managing the API key
+// the CLI presents to a control plane.
+func NewAuthCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Manage control plane credentials",
+		Long: `Store and inspect the API key the CLI sends to a control plane.
+
+A control plane started without an API key needs no credentials at all — local
+commands keep working untouched, and nothing is written to disk. When one is
+configured (AGENTFIELD_API_KEY on the server, or api.auth.api_key in
+~/.agentfield/agentfield.yaml), run "af auth login" once and every later
+command authenticates automatically.
+
+Credentials are stored per control plane URL in ~/.agentfield/credentials.json
+with 0600 permissions.`,
+	}
+
+	cmd.AddCommand(newAuthLoginCommand())
+	cmd.AddCommand(newAuthStatusCommand())
+	cmd.AddCommand(newAuthLogoutCommand())
+	return cmd
+}
+
+func newAuthLoginCommand() *cobra.Command {
+	var skipVerify bool
+
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "Store an API key for a control plane",
+		Long: `Stores an API key for the control plane selected by --server (default:
+http://localhost:8080, or $AGENTFIELD_SERVER).
+
+The key is prompted for without echo. Pass --api-key to supply it directly when
+scripting. Before saving, the key is checked against the control plane; a
+rejected key is not stored. Use --no-verify to store one for a control plane
+that is not running yet.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			server := normalizedServerURL()
+
+			key := strings.TrimSpace(apiKey)
+			if key == "" {
+				value, err := readHiddenValue(fmt.Sprintf("API key for %s", server))
+				if err != nil {
+					return err
+				}
+				key = strings.TrimSpace(value)
+			}
+			if key == "" {
+				return fmt.Errorf("api key must not be empty")
+			}
+
+			if !skipVerify {
+				ctx, cancel := commandContext()
+				defer cancel()
+				if err := verifyAPIKey(ctx, server, key); err != nil {
+					return err
+				}
+			}
+
+			store, err := credentialStore()
+			if err != nil {
+				return err
+			}
+			if err := store.Save(server, key); err != nil {
+				return err
+			}
+
+			PrintSuccess(fmt.Sprintf("Stored API key %s for %s", maskAPIKey(key), server))
+			PrintBullet(fmt.Sprintf("Saved to %s (permissions 0600)", store.Path()))
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&skipVerify, "no-verify", false, "Store the key without checking it against the control plane")
+	return cmd
+}
+
+func newAuthStatusCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show which credential the CLI would use",
+		Long: `Reports the control plane the CLI is pointed at and the credential it would
+send, masked. The full key is never printed.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			server := normalizedServerURL()
+			key, source := resolveAPIKeyWithSource()
+
+			PrintHeader("Control plane")
+			PrintBullet(server)
+			PrintHeader("Credential")
+
+			if key == "" {
+				PrintBullet("none — requests are sent unauthenticated")
+				PrintBullet(fmt.Sprintf("If this control plane requires a key: af auth login --server %s", server))
+				return nil
+			}
+
+			PrintBullet(fmt.Sprintf("%s (from %s)", maskAPIKey(key), source))
+			if stored := storedAPIKey(server); stored != "" && source != apiKeySourceStored {
+				PrintBullet(fmt.Sprintf("A key stored by af auth login (%s) is being overridden by %s", maskAPIKey(stored), source))
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newAuthLogoutCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "logout",
+		Short: "Remove the stored API key for a control plane",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			server := normalizedServerURL()
+
+			store, err := credentialStore()
+			if err != nil {
+				return err
+			}
+			removed, err := store.Delete(server)
+			if err != nil {
+				return err
+			}
+			if !removed {
+				PrintInfo(fmt.Sprintf("No stored API key for %s", server))
+				return nil
+			}
+
+			PrintSuccess(fmt.Sprintf("Removed the stored API key for %s", server))
+			// Removing the file entry does not stop an exported key from being
+			// sent, so say so rather than letting the user believe otherwise.
+			if _, source := resolveAPIKeyWithSource(); source != apiKeySourceNone {
+				PrintBullet(fmt.Sprintf("%s still supplies a key for this server", source))
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+// normalizedServerURL is the control plane URL the auth commands operate on,
+// trimmed so it matches how it is stored and displayed.
+func normalizedServerURL() string {
+	return strings.TrimRight(strings.TrimSpace(GetServerURL()), "/")
+}
+
+// authVerifyPath is the endpoint `af auth login` probes. The node list is
+// registered on every control plane (unlike the UI-only routes), is cheap, and
+// sits behind the API key middleware when one is configured — so a 401 means
+// the key is wrong and anything else means it was accepted.
+const authVerifyPath = "/api/v1/nodes"
+
+// verifyAPIKey reports whether the control plane accepts key. Only an outright
+// 401 counts as a rejection: a 404 or a 500 says something about the server,
+// not about the credential, and should not block the user from saving it.
+func verifyAPIKey(ctx context.Context, server, key string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server+authVerifyPath, nil)
+	if err != nil {
+		return fmt.Errorf("build verification request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "af-cli/auth")
+	req.Header.Set("X-API-Key", key)
+
+	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+	if err != nil {
+		//nolint:staticcheck // deliberate multi-line user-facing hint
+		return fmt.Errorf("could not reach %s to verify the key: %w\nStart the control plane, or re-run with --no-verify to store the key anyway", server, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("%s rejected that API key; nothing was saved", server)
+	}
+	return nil
+}
+
+// authRequiredError is the single place the CLI turns a 401 from the control
+// plane into something the user can act on. Every helper that talks to the
+// control plane routes through it so the remedy is worded once.
+func authRequiredError(serverURL string, body []byte) error {
+	server := strings.TrimRight(strings.TrimSpace(serverURL), "/")
+	if server == "" {
+		server = normalizedServerURL()
+	}
+
+	message := fmt.Sprintf("authentication required by %s", server)
+	if detail := serverAuthMessage(body); detail != "" {
+		message += ": " + detail
+	}
+	return fmt.Errorf("%s; run: af auth login --server %s", message, server)
+}
+
+// serverAuthMessage pulls the explanation out of the control plane's 401 body
+// so the reason (bad key vs. remote caller on an unauthenticated server) is not
+// lost. A body that is not the expected envelope yields "".
+func serverAuthMessage(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	var payload struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return ""
+	}
+	if msg := strings.TrimSpace(payload.Message); msg != "" {
+		return msg
+	}
+	return strings.TrimSpace(payload.Error)
+}

--- a/control-plane/internal/cli/auth_test.go
+++ b/control-plane/internal/cli/auth_test.go
@@ -1,0 +1,275 @@
+package cli
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Agent-Field/agentfield/control-plane/internal/packages"
+	"github.com/stretchr/testify/require"
+)
+
+// isolateCredentials points credential storage at a throwaway home and clears
+// the flag/env credentials, so a test never reads or writes the real
+// ~/.agentfield and never inherits the developer's own key.
+func isolateCredentials(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("AGENTFIELD_HOME", home)
+	t.Setenv("AGENTFIELD_API_KEY", "")
+
+	oldServer, oldAPIKey := serverURL, apiKey
+	serverURL, apiKey = "", ""
+	t.Cleanup(func() {
+		serverURL, apiKey = oldServer, oldAPIKey
+	})
+	return home
+}
+
+// Contract: the CLI sends the most specific credential the user supplied —
+// flag, then environment, then the one `af auth login` stored for this server —
+// and sends nothing at all when none exists.
+func TestGetAPIKey_Precedence(t *testing.T) {
+	home := isolateCredentials(t)
+	t.Setenv("AGENTFIELD_SERVER", "http://localhost:8080")
+
+	require.Equal(t, "", GetAPIKey(), "a machine with no key configured must send no credential")
+
+	require.NoError(t, packages.NewCredentialStore(home).Save("http://localhost:8080", "stored-key"))
+	key, source := resolveAPIKeyWithSource()
+	require.Equal(t, "stored-key", key)
+	require.Equal(t, apiKeySourceStored, source)
+
+	t.Setenv("AGENTFIELD_API_KEY", "env-key")
+	key, source = resolveAPIKeyWithSource()
+	require.Equal(t, "env-key", key, "AGENTFIELD_API_KEY must win over a stored credential")
+	require.Equal(t, apiKeySourceEnv, source)
+
+	apiKey = "flag-key"
+	key, source = resolveAPIKeyWithSource()
+	require.Equal(t, "flag-key", key, "--api-key must win over everything")
+	require.Equal(t, apiKeySourceFlag, source)
+}
+
+// Contract: a stored credential belongs to the control plane it was stored
+// for. Pointing the CLI somewhere else must not replay the key at a server the
+// user never logged into.
+func TestGetAPIKey_StoredCredentialIsScopedToServer(t *testing.T) {
+	home := isolateCredentials(t)
+	require.NoError(t, packages.NewCredentialStore(home).Save("http://localhost:8080", "stored-key"))
+
+	t.Setenv("AGENTFIELD_SERVER", "http://localhost:8080/")
+	require.Equal(t, "stored-key", GetAPIKey(), "a trailing slash names the same control plane")
+
+	t.Setenv("AGENTFIELD_SERVER", "https://someone-elses-cp.example.com")
+	require.Equal(t, "", GetAPIKey())
+}
+
+// Contract: reading a credential never creates one. A user who never runs
+// `af auth login` sees no new files.
+func TestGetAPIKey_DoesNotCreateCredentialsFile(t *testing.T) {
+	home := isolateCredentials(t)
+	t.Setenv("AGENTFIELD_SERVER", "http://localhost:8080")
+
+	require.Equal(t, "", GetAPIKey())
+
+	store, err := credentialStore()
+	require.NoError(t, err)
+	require.NoFileExists(t, store.Path())
+	require.DirExists(t, home)
+}
+
+// Contract: displayed keys are recognisable but not reusable — enough to tell
+// two keys apart, never enough to authenticate with.
+func TestMaskAPIKey(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want string
+	}{
+		{name: "empty", key: "", want: ""},
+		{name: "short key fully masked", key: "abcd", want: "••••"},
+		{name: "boundary length fully masked", key: "abcdefgh", want: "••••••••"},
+		{name: "vendor prefix kept", key: "af_live_0123456789abcdef", want: "af_live_…cdef"},
+		{name: "dashed prefix kept", key: "sk-0123456789abcdef", want: "sk-…cdef"},
+		{name: "no prefix shows three chars", key: "0123456789abcdef", want: "012…cdef"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := maskAPIKey(tc.key)
+			require.Equal(t, tc.want, got)
+			if len(tc.key) > 8 {
+				require.NotContains(t, got, tc.key, "the full key must never be rendered")
+			}
+		})
+	}
+}
+
+// Contract: a 401 tells the user what to run, naming the server they were
+// actually talking to, and carries the control plane's own explanation.
+func TestAuthRequiredError(t *testing.T) {
+	err := authRequiredError("http://cp.example.com/", []byte(`{"error":"unauthorized","message":"invalid or missing API key"}`))
+	require.ErrorContains(t, err, "authentication required by http://cp.example.com")
+	require.ErrorContains(t, err, "invalid or missing API key")
+	require.ErrorContains(t, err, "af auth login --server http://cp.example.com")
+
+	// A body that is not the control plane's envelope still yields the remedy.
+	err = authRequiredError("http://cp.example.com", []byte("not json"))
+	require.ErrorContains(t, err, "authentication required by http://cp.example.com")
+	require.ErrorContains(t, err, "af auth login --server http://cp.example.com")
+}
+
+// Contract: every command that talks to the control plane surfaces a 401 as an
+// instruction, not as a bare status code.
+func TestMakeRequest_UnauthorizedIsActionable(t *testing.T) {
+	isolateCredentials(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized","message":"invalid or missing API key"}`))
+	}))
+	defer server.Close()
+	t.Setenv("AGENTFIELD_SERVER", server.URL)
+
+	resp, err := makeRequest(context.Background(), http.MethodGet, "/api/v1/nodes", nil, "application/json")
+	require.Nil(t, resp)
+	require.ErrorContains(t, err, "authentication required by "+server.URL)
+	require.ErrorContains(t, err, "af auth login --server "+server.URL)
+}
+
+// Contract: `af auth login` verifies the key, stores it for the current server,
+// and confirms with a masked value — never the key itself.
+func TestAuthLogin_StoresVerifiedKey(t *testing.T) {
+	isolateCredentials(t)
+
+	var sawKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawKey = r.Header.Get("X-API-Key")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"nodes":[]}`))
+	}))
+	defer server.Close()
+	t.Setenv("AGENTFIELD_SERVER", server.URL)
+
+	apiKey = "af_live_0123456789abcdef"
+	output := captureOutput(t, func() {
+		cmd := NewAuthCommand()
+		cmd.SetArgs([]string{"login"})
+		require.NoError(t, cmd.Execute())
+	})
+
+	require.Equal(t, "af_live_0123456789abcdef", sawKey, "the key must be verified against the control plane")
+	require.Contains(t, output, "af_live_…cdef")
+	require.NotContains(t, output, "af_live_0123456789abcdef", "the full key must never be printed")
+
+	apiKey = ""
+	require.Equal(t, "af_live_0123456789abcdef", GetAPIKey(), "the stored key must be used by later commands")
+}
+
+// Contract: a key the control plane rejects is not saved. Storing it would
+// leave the user with a credential that silently fails on every command.
+func TestAuthLogin_RejectedKeyIsNotStored(t *testing.T) {
+	isolateCredentials(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer server.Close()
+	t.Setenv("AGENTFIELD_SERVER", server.URL)
+
+	apiKey = "wrong-key-0123456789"
+	cmd := NewAuthCommand()
+	cmd.SetArgs([]string{"login"})
+	err := cmd.Execute()
+	require.ErrorContains(t, err, "rejected that API key")
+
+	apiKey = ""
+	require.Equal(t, "", GetAPIKey())
+	store, storeErr := credentialStore()
+	require.NoError(t, storeErr)
+	require.NoFileExists(t, store.Path())
+}
+
+// Contract: --no-verify stores a key for a control plane that is not running,
+// so an operator can provision credentials before starting the server.
+func TestAuthLogin_NoVerifySkipsTheProbe(t *testing.T) {
+	isolateCredentials(t)
+	t.Setenv("AGENTFIELD_SERVER", "http://127.0.0.1:1")
+
+	apiKey = "af_live_0123456789abcdef"
+	captureOutput(t, func() {
+		cmd := NewAuthCommand()
+		cmd.SetArgs([]string{"login", "--no-verify"})
+		require.NoError(t, cmd.Execute())
+	})
+
+	apiKey = ""
+	require.Equal(t, "af_live_0123456789abcdef", GetAPIKey())
+}
+
+// Contract: `af auth status` reports the server, whether a key is in play and
+// where it came from, always masked.
+func TestAuthStatus_ReportsSourceWithoutRevealingKey(t *testing.T) {
+	home := isolateCredentials(t)
+	t.Setenv("AGENTFIELD_SERVER", "http://localhost:8080")
+
+	output := captureOutput(t, func() {
+		cmd := NewAuthCommand()
+		cmd.SetArgs([]string{"status"})
+		require.NoError(t, cmd.Execute())
+	})
+	require.Contains(t, output, "http://localhost:8080")
+	require.Contains(t, output, "none")
+	require.Contains(t, output, "af auth login --server http://localhost:8080")
+
+	require.NoError(t, packages.NewCredentialStore(home).Save("http://localhost:8080", "af_live_0123456789abcdef"))
+	output = captureOutput(t, func() {
+		cmd := NewAuthCommand()
+		cmd.SetArgs([]string{"status"})
+		require.NoError(t, cmd.Execute())
+	})
+	require.Contains(t, output, "af_live_…cdef")
+	require.Contains(t, output, apiKeySourceStored)
+	require.NotContains(t, output, "af_live_0123456789abcdef")
+
+	// An environment variable shadowing the stored key is called out, so the
+	// user knows why the stored one is not being sent.
+	t.Setenv("AGENTFIELD_API_KEY", "env-key-0123456789")
+	output = captureOutput(t, func() {
+		cmd := NewAuthCommand()
+		cmd.SetArgs([]string{"status"})
+		require.NoError(t, cmd.Execute())
+	})
+	require.Contains(t, output, apiKeySourceEnv)
+	require.Contains(t, output, "overridden")
+	require.NotContains(t, output, "env-key-0123456789")
+}
+
+// Contract: `af auth logout` removes the stored key for the current server and
+// leaves other servers alone.
+func TestAuthLogout_RemovesOnlyTheCurrentServer(t *testing.T) {
+	home := isolateCredentials(t)
+	store := packages.NewCredentialStore(home)
+	require.NoError(t, store.Save("http://localhost:8080", "local-key-0123456789"))
+	require.NoError(t, store.Save("https://cp.example.com", "remote-key-0123456789"))
+
+	t.Setenv("AGENTFIELD_SERVER", "http://localhost:8080")
+	captureOutput(t, func() {
+		cmd := NewAuthCommand()
+		cmd.SetArgs([]string{"logout"})
+		require.NoError(t, cmd.Execute())
+	})
+
+	require.Equal(t, "", store.Lookup("http://localhost:8080"))
+	require.Equal(t, "remote-key-0123456789", store.Lookup("https://cp.example.com"))
+
+	// Logging out again is a no-op rather than an error.
+	output := captureOutput(t, func() {
+		cmd := NewAuthCommand()
+		cmd.SetArgs([]string{"logout"})
+		require.NoError(t, cmd.Execute())
+	})
+	require.Contains(t, output, "No stored API key")
+}

--- a/control-plane/internal/cli/credentials.go
+++ b/control-plane/internal/cli/credentials.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Agent-Field/agentfield/control-plane/internal/packages"
+)
+
+// Where GetAPIKey found the credential it returned. Used by `af auth status`
+// so the user can tell a stored key from one an env var or flag is shadowing.
+const (
+	apiKeySourceNone   = ""
+	apiKeySourceFlag   = "--api-key flag"
+	apiKeySourceEnv    = "AGENTFIELD_API_KEY"
+	apiKeySourceStored = "af auth login"
+)
+
+// credentialStore opens the credential file backing `af auth`. It deliberately
+// does not go through getAgentFieldHomeDir(): that creates directories and
+// exits the process on failure, neither of which belongs on a lookup that runs
+// before every single control plane request.
+func credentialStore() (*packages.CredentialStore, error) {
+	home, err := packages.AgentFieldHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve the AgentField home directory: %w", err)
+	}
+	return packages.NewCredentialStore(home), nil
+}
+
+// storedAPIKey returns the key `af auth login` saved for serverURL, or "".
+func storedAPIKey(serverURL string) string {
+	store, err := credentialStore()
+	if err != nil {
+		return ""
+	}
+	return store.Lookup(serverURL)
+}
+
+// resolveAPIKeyWithSource is the single credential resolution point for the
+// CLI. Precedence, highest first:
+//
+//	--api-key / -k        explicit, one command
+//	AGENTFIELD_API_KEY    explicit, one shell
+//	credentials.json      persisted by `af auth login` for this server
+//	""                    no key: the default local setup, unauthenticated
+func resolveAPIKeyWithSource() (string, string) {
+	if apiKey != "" {
+		return apiKey, apiKeySourceFlag
+	}
+	if env := os.Getenv("AGENTFIELD_API_KEY"); env != "" {
+		return env, apiKeySourceEnv
+	}
+	if stored := storedAPIKey(GetServerURL()); stored != "" {
+		return stored, apiKeySourceStored
+	}
+	return "", apiKeySourceNone
+}
+
+// maskAPIKey renders a key for display: a recognisable prefix, then the last
+// four characters. Short keys are masked completely — there is nothing to
+// recognise and every revealed character is a character an onlooker gets for
+// free. The full key is never printed anywhere in the CLI.
+func maskAPIKey(key string) string {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return ""
+	}
+	const revealed = 4
+	if len(key) <= revealed*2 {
+		return strings.Repeat("•", len(key))
+	}
+
+	head := key[:len(key)-revealed]
+	tail := key[len(key)-revealed:]
+	// Keep a vendor prefix ("af_live_", "sk-") intact when there is one,
+	// otherwise show the first three characters.
+	if idx := strings.LastIndexAny(head, "_-"); idx > 0 && idx < 12 {
+		head = head[:idx+1]
+	} else if len(head) > 3 {
+		head = head[:3]
+	}
+	return head + "…" + tail
+}

--- a/control-plane/internal/cli/doctor.go
+++ b/control-plane/internal/cli/doctor.go
@@ -368,6 +368,12 @@ func checkControlPlane(url string) ControlPlaneStatus {
 	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
 	defer cancel()
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(url, "/")+"/api/v1/health", nil)
+	// Health is public today, but a control plane can be fronted by something
+	// that is not; send the same credential as every other CLI request so a
+	// reachable control plane never reports as unreachable.
+	if key := strings.TrimSpace(GetAPIKey()); key != "" {
+		req.Header.Set("X-API-Key", key)
+	}
 	resp, err := http.DefaultClient.Do(req)
 	if err == nil {
 		defer resp.Body.Close()

--- a/control-plane/internal/cli/execution.go
+++ b/control-plane/internal/cli/execution.go
@@ -232,8 +232,13 @@ func runExecutionAction(cfg executionActionConfig) (map[string]any, error) {
 	if cfg.withReason || cfg.withBody {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	if cfg.opts.token != "" {
-		req.Header.Set("Authorization", "Bearer "+cfg.opts.token)
+	// --token / AGENTFIELD_TOKEN stays authoritative for callers already using
+	// it; otherwise fall back to the API key every other command sends, so a
+	// stored credential covers these endpoints too.
+	if token := strings.TrimSpace(cfg.opts.token); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	} else if key := strings.TrimSpace(GetAPIKey()); key != "" {
+		req.Header.Set("X-API-Key", key)
 	}
 
 	resp, err := client.Do(req)

--- a/control-plane/internal/cli/list.go
+++ b/control-plane/internal/cli/list.go
@@ -197,8 +197,8 @@ func fetchControlPlaneNodes(serverURL string) (map[string]controlPlaneNode, bool
 	if err != nil {
 		return nil, false
 	}
-	if key := GetAPIKey(); key != "" {
-		req.Header.Set("Authorization", "Bearer "+key)
+	if key := strings.TrimSpace(GetAPIKey()); key != "" {
+		req.Header.Set("X-API-Key", key)
 	}
 
 	resp, err := client.Do(req)

--- a/control-plane/internal/cli/nodes.go
+++ b/control-plane/internal/cli/nodes.go
@@ -67,8 +67,12 @@ func newRegisterServerlessCommand() *cobra.Command {
 				return fmt.Errorf("build request: %w", err)
 			}
 			req.Header.Set("Content-Type", "application/json")
-			if opts.token != "" {
-				req.Header.Set("Authorization", "Bearer "+opts.token)
+			// --token / AGENTFIELD_TOKEN stays authoritative; otherwise fall
+			// back to the API key every other command sends.
+			if token := strings.TrimSpace(opts.token); token != "" {
+				req.Header.Set("Authorization", "Bearer "+token)
+			} else if key := strings.TrimSpace(GetAPIKey()); key != "" {
+				req.Header.Set("X-API-Key", key)
 			}
 
 			resp, err := client.Do(req)

--- a/control-plane/internal/cli/root.go
+++ b/control-plane/internal/cli/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Agent-Field/agentfield/control-plane/internal/cli/commands"
 	"github.com/Agent-Field/agentfield/control-plane/internal/config"
 	"github.com/Agent-Field/agentfield/control-plane/internal/logger"
+	"github.com/Agent-Field/agentfield/control-plane/internal/packages"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -52,6 +53,11 @@ AI Agent? Run "af agent help" for structured JSON output optimized for programma
 			if verbose {
 				logger.Logger.Debug().Msg("Verbose logging enabled.")
 			}
+			// Hand the flag-supplied key to the package layer so agent child
+			// processes spawned by `af run` inherit the same credential the
+			// CLI itself is using. Env vars and stored credentials are read
+			// there directly; only the flag has to be pushed across.
+			packages.SetAPIKeyOverride(apiKey)
 			return nil
 		},
 		// Default to server mode when no subcommand is provided (backward compatibility)
@@ -119,6 +125,7 @@ AI Agent? Run "af agent help" for structured JSON output optimized for programma
 
 	// Add remaining old commands (not yet migrated)
 	RootCmd.AddCommand(NewUninstallCommand())
+	RootCmd.AddCommand(NewAuthCommand())
 	RootCmd.AddCommand(NewSecretsCommand())
 	RootCmd.AddCommand(NewListCommand())
 	RootCmd.AddCommand(NewStopCommand())
@@ -224,11 +231,13 @@ func GetServerURL() string {
 	return "http://localhost:8080"
 }
 
+// GetAPIKey returns the API key to send to the control plane: the --api-key
+// flag, then AGENTFIELD_API_KEY, then the key `af auth login` stored for the
+// current server. Empty means no key is configured anywhere, which is the
+// default local setup and stays unauthenticated.
 func GetAPIKey() string {
-	if apiKey != "" {
-		return apiKey
-	}
-	return os.Getenv("AGENTFIELD_API_KEY")
+	key, _ := resolveAPIKeyWithSource()
+	return key
 }
 
 func GetOutputFormat() string {

--- a/control-plane/internal/cli/stop.go
+++ b/control-plane/internal/cli/stop.go
@@ -329,8 +329,8 @@ func queryRunningExecutions(serverURL, nodeID string) ([]runningExecution, error
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	if key := GetAPIKey(); key != "" {
-		req.Header.Set("Authorization", "Bearer "+key)
+	if key := strings.TrimSpace(GetAPIKey()); key != "" {
+		req.Header.Set("X-API-Key", key)
 	}
 
 	resp, err := client.Do(req)

--- a/control-plane/internal/cli/trigger_common.go
+++ b/control-plane/internal/cli/trigger_common.go
@@ -332,6 +332,16 @@ func makeRequest(ctx context.Context, method, path string, body interface{}, acc
 		}
 		return nil, controlPlaneUnreachableError(err)
 	}
+
+	// A 401 is never something the caller can recover from by inspecting the
+	// body: the request needs a credential the CLI did not send. Convert it
+	// here so every command that goes through makeRequest tells the user how
+	// to fix it instead of printing a bare status code.
+	if resp.StatusCode == http.StatusUnauthorized {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<10))
+		resp.Body.Close()
+		return nil, authRequiredError(server, body)
+	}
 	return resp, nil
 }
 

--- a/control-plane/internal/core/services/agent_service.go
+++ b/control-plane/internal/core/services/agent_service.go
@@ -630,6 +630,13 @@ func (as *DefaultAgentService) buildProcessConfig(agentNode packages.InstalledPa
 	env = append(env, "AGENTFIELD_STRICT_PORT=1")
 	env = append(env, fmt.Sprintf("AGENTFIELD_SERVER=%s", serverURL))
 	env = append(env, fmt.Sprintf("AGENTFIELD_SERVER_URL=%s", serverURL))
+	// A control plane with an API key configured rejects an unauthenticated
+	// registration, so the node needs the same credential the CLI resolved
+	// (flag, environment, or `af auth login`). Absent on a default local
+	// setup, where the variable is simply not exported.
+	if key := packages.ResolveAPIKey(); key != "" {
+		env = append(env, fmt.Sprintf("AGENTFIELD_API_KEY=%s", key))
+	}
 	env = packages.PythonUTF8Env(env)
 
 	// Resolve declared variables from the encrypted secret store. Secrets are

--- a/control-plane/internal/core/services/dev_service.go
+++ b/control-plane/internal/core/services/dev_service.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/Agent-Field/agentfield/control-plane/internal/core/domain"
 	"github.com/Agent-Field/agentfield/control-plane/internal/core/interfaces"
+	"github.com/Agent-Field/agentfield/control-plane/internal/packages"
 )
 
 type DefaultDevService struct {
@@ -196,6 +197,11 @@ func (ds *DefaultDevService) startDevProcess(packagePath string, port int, optio
 	}
 	env = append(env, fmt.Sprintf("AGENTFIELD_SERVER_URL=%s", resolveServerURL()))
 	env = append(env, "AGENTFIELD_DEV_MODE=true")
+	// Same contract as `af run`: pass the resolved API key through so the agent
+	// can register against a control plane with authentication enabled.
+	if key := packages.ResolveAPIKey(); key != "" {
+		env = append(env, fmt.Sprintf("AGENTFIELD_API_KEY=%s", key))
+	}
 
 	// Load environment variables from package .env file
 	if envVars, err := ds.loadDevEnvFile(packagePath); err == nil {

--- a/control-plane/internal/packages/credentials.go
+++ b/control-plane/internal/packages/credentials.go
@@ -1,0 +1,225 @@
+package packages
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Credential layout under the AgentField home directory:
+//
+//	~/.agentfield/credentials.json   # 0600, one API key per control plane
+//
+// `af auth login` writes this file so later commands authenticate against a
+// control plane that has an API key configured, without the user exporting
+// AGENTFIELD_API_KEY in every shell. Unlike the secret store the value is not
+// encrypted at rest: it has to be replayed verbatim on every request, so the
+// protection is 0600 file permissions — the same posture as ~/.docker/config.json
+// or an npm token.
+//
+// Nothing here creates the file. A machine that never runs `af auth login`
+// never grows one, which keeps the default local setup (no API key anywhere)
+// exactly as it was.
+
+const (
+	credentialsFileName = "credentials.json"
+	credentialsFilePerm = 0o600
+)
+
+// ServerCredential is the credential set stored for a single control plane.
+type ServerCredential struct {
+	APIKey string `json:"api_key"`
+}
+
+// Credentials is the on-disk shape of credentials.json.
+type Credentials struct {
+	Servers map[string]ServerCredential `json:"servers"`
+}
+
+// CredentialStore reads and writes credentials.json under an AgentField home.
+type CredentialStore struct {
+	path string
+}
+
+// NewCredentialStore returns a store rooted at the given AgentField home.
+func NewCredentialStore(agentFieldHome string) *CredentialStore {
+	return &CredentialStore{path: filepath.Join(agentFieldHome, credentialsFileName)}
+}
+
+// Path returns the credentials file path. The file may not exist.
+func (cs *CredentialStore) Path() string {
+	return cs.path
+}
+
+// NormalizeServerURL canonicalises a control plane URL so it is a stable map
+// key: "http://localhost:8080/", "http://localhost:8080" and
+// "HTTP://LocalHost:8080" all resolve to the same entry. A URL that cannot be
+// parsed degrades to a trimmed, lowercased string rather than being dropped.
+func NormalizeServerURL(raw string) string {
+	trimmed := strings.TrimRight(strings.TrimSpace(raw), "/")
+	if trimmed == "" {
+		return ""
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return strings.ToLower(trimmed)
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	parsed.Host = strings.ToLower(parsed.Host)
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String()
+}
+
+// Load returns the stored credentials. A missing file is not an error and is
+// never created by reading it.
+func (cs *CredentialStore) Load() (*Credentials, error) {
+	creds := &Credentials{Servers: map[string]ServerCredential{}}
+
+	data, err := os.ReadFile(cs.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return creds, nil
+		}
+		return nil, fmt.Errorf("failed to read credentials: %w", err)
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return creds, nil
+	}
+	if err := json.Unmarshal(data, creds); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", cs.path, err)
+	}
+	if creds.Servers == nil {
+		creds.Servers = map[string]ServerCredential{}
+	}
+	return creds, nil
+}
+
+// Lookup returns the API key stored for serverURL, or "" when there is none.
+// An unreadable or corrupt file also resolves to "" so a broken credentials
+// file degrades to "unauthenticated" instead of breaking every command.
+func (cs *CredentialStore) Lookup(serverURL string) string {
+	key := NormalizeServerURL(serverURL)
+	if key == "" {
+		return ""
+	}
+	creds, err := cs.Load()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(creds.Servers[key].APIKey)
+}
+
+// Save stores apiKey for serverURL, replacing any existing entry.
+func (cs *CredentialStore) Save(serverURL, apiKey string) error {
+	key := NormalizeServerURL(serverURL)
+	if key == "" {
+		return fmt.Errorf("a control plane URL is required to store a credential")
+	}
+	if strings.TrimSpace(apiKey) == "" {
+		return fmt.Errorf("api key must not be empty")
+	}
+
+	creds, err := cs.Load()
+	if err != nil {
+		return err
+	}
+	creds.Servers[key] = ServerCredential{APIKey: strings.TrimSpace(apiKey)}
+	return cs.write(creds)
+}
+
+// Delete removes the entry for serverURL and reports whether one existed.
+func (cs *CredentialStore) Delete(serverURL string) (bool, error) {
+	creds, err := cs.Load()
+	if err != nil {
+		return false, err
+	}
+	key := NormalizeServerURL(serverURL)
+	if _, ok := creds.Servers[key]; !ok {
+		return false, nil
+	}
+	delete(creds.Servers, key)
+	return true, cs.write(creds)
+}
+
+// Servers returns the control plane URLs that have a stored key, sorted.
+func (cs *CredentialStore) Servers() ([]string, error) {
+	creds, err := cs.Load()
+	if err != nil {
+		return nil, err
+	}
+	servers := make([]string, 0, len(creds.Servers))
+	for server := range creds.Servers {
+		servers = append(servers, server)
+	}
+	sort.Strings(servers)
+	return servers, nil
+}
+
+func (cs *CredentialStore) write(creds *Credentials) error {
+	data, err := json.MarshalIndent(creds, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to encode credentials: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cs.path), 0o755); err != nil {
+		return fmt.Errorf("failed to create credentials directory: %w", err)
+	}
+	if err := os.WriteFile(cs.path, append(data, '\n'), credentialsFilePerm); err != nil {
+		return fmt.Errorf("failed to write credentials: %w", err)
+	}
+	// WriteFile only applies the mode when it creates the file, so an entry
+	// rewritten into a pre-existing, loosely permissioned file would keep the
+	// old mode. Chmod every time instead of trusting what was there.
+	if err := os.Chmod(cs.path, credentialsFilePerm); err != nil {
+		return fmt.Errorf("failed to secure credentials file: %w", err)
+	}
+	return nil
+}
+
+// AgentFieldHomeDir resolves the AgentField home directory (honouring
+// AGENTFIELD_HOME) without creating it. Credential lookup happens on every
+// command, so it must not have side effects on disk.
+func AgentFieldHomeDir() (string, error) {
+	if custom := strings.TrimSpace(os.Getenv("AGENTFIELD_HOME")); custom != "" {
+		return custom, nil
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get user home directory: %w", err)
+	}
+	return filepath.Join(homeDir, ".agentfield"), nil
+}
+
+// apiKeyOverride carries a key supplied out of band — in practice the CLI's
+// --api-key flag, which lives in the cli package and cannot be read from here.
+// The CLI sets it once during startup so a child agent process inherits the
+// same credential the CLI itself is using.
+var apiKeyOverride string
+
+// SetAPIKeyOverride records an out-of-band API key. An empty value clears it.
+func SetAPIKeyOverride(key string) {
+	apiKeyOverride = strings.TrimSpace(key)
+}
+
+// ResolveAPIKey returns the API key to hand to the control plane: the CLI flag
+// first, then AGENTFIELD_API_KEY, then whatever `af auth login` stored for the
+// resolved server URL. It returns "" on a default local setup with no key
+// configured anywhere, which is the common case and stays unauthenticated.
+func ResolveAPIKey() string {
+	if apiKeyOverride != "" {
+		return apiKeyOverride
+	}
+	if env := strings.TrimSpace(os.Getenv("AGENTFIELD_API_KEY")); env != "" {
+		return env
+	}
+	home, err := AgentFieldHomeDir()
+	if err != nil {
+		return ""
+	}
+	return NewCredentialStore(home).Lookup(resolveServerURL())
+}

--- a/control-plane/internal/packages/credentials_test.go
+++ b/control-plane/internal/packages/credentials_test.go
@@ -1,0 +1,297 @@
+package packages
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func newTestCredentialStore(t *testing.T) (*CredentialStore, string) {
+	t.Helper()
+	home := t.TempDir()
+	return NewCredentialStore(home), home
+}
+
+// Contract: URLs that name the same control plane resolve to the same entry,
+// so `af auth login --server http://localhost:8080/` is found by a later
+// command that resolved the server as http://localhost:8080.
+func TestNormalizeServerURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "already canonical", in: "http://localhost:8080", want: "http://localhost:8080"},
+		{name: "trailing slash", in: "http://localhost:8080/", want: "http://localhost:8080"},
+		{name: "repeated trailing slashes", in: "http://localhost:8080///", want: "http://localhost:8080"},
+		{name: "surrounding whitespace", in: "  http://localhost:8080 ", want: "http://localhost:8080"},
+		{name: "uppercase scheme and host", in: "HTTP://LocalHost:8080", want: "http://localhost:8080"},
+		{name: "path preserved", in: "https://cp.example.com/agentfield/", want: "https://cp.example.com/agentfield"},
+		{name: "query and fragment dropped", in: "https://cp.example.com?x=1#frag", want: "https://cp.example.com"},
+		{name: "empty", in: "   ", want: ""},
+		{name: "unparseable falls back to lowercase", in: "LocalHost:8080", want: "localhost:8080"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NormalizeServerURL(tc.in); got != tc.want {
+				t.Fatalf("NormalizeServerURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// Contract: a key stored for a server comes back for any spelling of that
+// server's URL, and disappears once deleted.
+func TestCredentialStore_SaveLookupDeleteRoundtrip(t *testing.T) {
+	store, _ := newTestCredentialStore(t)
+
+	if err := store.Save("http://localhost:8080/", "af_live_secret_value"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	for _, spelling := range []string{
+		"http://localhost:8080",
+		"http://localhost:8080/",
+		"HTTP://LOCALHOST:8080",
+	} {
+		if got := store.Lookup(spelling); got != "af_live_secret_value" {
+			t.Fatalf("Lookup(%q) = %q, want the stored key", spelling, got)
+		}
+	}
+
+	removed, err := store.Delete("http://localhost:8080")
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if !removed {
+		t.Fatal("Delete reported no entry, want removed=true")
+	}
+	if got := store.Lookup("http://localhost:8080"); got != "" {
+		t.Fatalf("Lookup after Delete = %q, want empty", got)
+	}
+
+	removed, err = store.Delete("http://localhost:8080")
+	if err != nil {
+		t.Fatalf("Delete (second): %v", err)
+	}
+	if removed {
+		t.Fatal("Delete reported removed=true for an entry that no longer exists")
+	}
+}
+
+// Contract: entries for different control planes do not overwrite each other.
+func TestCredentialStore_SeparateEntriesPerServer(t *testing.T) {
+	store, _ := newTestCredentialStore(t)
+
+	if err := store.Save("http://localhost:8080", "local-key"); err != nil {
+		t.Fatalf("Save local: %v", err)
+	}
+	if err := store.Save("https://cp.example.com", "remote-key"); err != nil {
+		t.Fatalf("Save remote: %v", err)
+	}
+
+	if got := store.Lookup("http://localhost:8080"); got != "local-key" {
+		t.Fatalf("local lookup = %q, want local-key", got)
+	}
+	if got := store.Lookup("https://cp.example.com"); got != "remote-key" {
+		t.Fatalf("remote lookup = %q, want remote-key", got)
+	}
+
+	servers, err := store.Servers()
+	if err != nil {
+		t.Fatalf("Servers: %v", err)
+	}
+	want := []string{"http://localhost:8080", "https://cp.example.com"}
+	if len(servers) != len(want) {
+		t.Fatalf("Servers() = %v, want %v", servers, want)
+	}
+	for i, server := range want {
+		if servers[i] != server {
+			t.Fatalf("Servers() = %v, want %v", servers, want)
+		}
+	}
+}
+
+// Contract: the credentials file is only readable by its owner. It holds a
+// replayable API key in plaintext, so a group- or world-readable file is a
+// leak, including when an existing file is rewritten.
+func TestCredentialStore_FileIsOwnerReadableOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix file modes are not meaningful on windows")
+	}
+	store, home := newTestCredentialStore(t)
+
+	if err := store.Save("http://localhost:8080", "first-key"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	path := filepath.Join(home, credentialsFileName)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("credentials file mode = %o, want 600", perm)
+	}
+
+	// A file that was loosened by hand is tightened on the next write rather
+	// than left as found.
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	if err := store.Save("http://localhost:8080", "second-key"); err != nil {
+		t.Fatalf("Save (rewrite): %v", err)
+	}
+	info, err = os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat after rewrite: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("credentials file mode after rewrite = %o, want 600", perm)
+	}
+}
+
+// Contract: a machine that never ran `af auth login` behaves exactly as before
+// — reads succeed, report no credential, and create nothing on disk.
+func TestCredentialStore_MissingFileIsNotAnError(t *testing.T) {
+	store, home := newTestCredentialStore(t)
+
+	creds, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load on a missing file: %v", err)
+	}
+	if len(creds.Servers) != 0 {
+		t.Fatalf("Load returned %d servers, want 0", len(creds.Servers))
+	}
+	if got := store.Lookup("http://localhost:8080"); got != "" {
+		t.Fatalf("Lookup = %q, want empty", got)
+	}
+	if removed, err := store.Delete("http://localhost:8080"); err != nil || removed {
+		t.Fatalf("Delete on a missing file = (%v, %v), want (false, nil)", removed, err)
+	}
+
+	entries, err := os.ReadDir(home)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("reading credentials created %v; the home directory must stay untouched", entries)
+	}
+}
+
+// Contract: an empty or corrupt file degrades to "no credential" instead of
+// breaking every command that resolves a key.
+func TestCredentialStore_UnusableFileResolvesToNoKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantErr bool
+	}{
+		{name: "empty file", content: "", wantErr: false},
+		{name: "whitespace only", content: "  \n", wantErr: false},
+		{name: "corrupt json", content: "{not json", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store, home := newTestCredentialStore(t)
+			path := filepath.Join(home, credentialsFileName)
+			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+
+			if _, err := store.Load(); (err != nil) != tc.wantErr {
+				t.Fatalf("Load error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if got := store.Lookup("http://localhost:8080"); got != "" {
+				t.Fatalf("Lookup = %q, want empty", got)
+			}
+		})
+	}
+}
+
+// Contract: an empty key or an empty server URL is rejected, so a stored entry
+// is never a placeholder that silently sends nothing.
+func TestCredentialStore_SaveRejectsEmptyInput(t *testing.T) {
+	store, _ := newTestCredentialStore(t)
+
+	if err := store.Save("", "key"); err == nil {
+		t.Fatal("Save with an empty server URL succeeded, want an error")
+	}
+	if err := store.Save("http://localhost:8080", "   "); err == nil {
+		t.Fatal("Save with an empty key succeeded, want an error")
+	}
+}
+
+// Contract: the key handed to a spawned agent node follows the same precedence
+// as the CLI's own requests — flag, then environment, then stored credential,
+// then nothing at all on a default local setup.
+func TestResolveAPIKey_Precedence(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENTFIELD_HOME", home)
+	t.Setenv("AGENTFIELD_SERVER", "http://localhost:8080")
+	t.Setenv("AGENTFIELD_API_KEY", "")
+	t.Cleanup(func() { SetAPIKeyOverride("") })
+
+	SetAPIKeyOverride("")
+	if got := ResolveAPIKey(); got != "" {
+		t.Fatalf("ResolveAPIKey with nothing configured = %q, want empty", got)
+	}
+
+	if err := NewCredentialStore(home).Save("http://localhost:8080", "stored-key"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if got := ResolveAPIKey(); got != "stored-key" {
+		t.Fatalf("ResolveAPIKey with a stored credential = %q, want stored-key", got)
+	}
+
+	t.Setenv("AGENTFIELD_API_KEY", "env-key")
+	if got := ResolveAPIKey(); got != "env-key" {
+		t.Fatalf("ResolveAPIKey with AGENTFIELD_API_KEY set = %q, want env-key", got)
+	}
+
+	SetAPIKeyOverride("flag-key")
+	if got := ResolveAPIKey(); got != "flag-key" {
+		t.Fatalf("ResolveAPIKey with a flag override = %q, want flag-key", got)
+	}
+}
+
+// Contract: a stored credential is scoped to the control plane it was stored
+// for; pointing the CLI at a different server does not reuse it.
+func TestResolveAPIKey_ScopedToServer(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENTFIELD_HOME", home)
+	t.Setenv("AGENTFIELD_API_KEY", "")
+	t.Cleanup(func() { SetAPIKeyOverride("") })
+	SetAPIKeyOverride("")
+
+	if err := NewCredentialStore(home).Save("http://localhost:8080", "local-key"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	t.Setenv("AGENTFIELD_SERVER", "http://localhost:8080")
+	if got := ResolveAPIKey(); got != "local-key" {
+		t.Fatalf("ResolveAPIKey for the stored server = %q, want local-key", got)
+	}
+
+	t.Setenv("AGENTFIELD_SERVER", "https://other.example.com")
+	if got := ResolveAPIKey(); got != "" {
+		t.Fatalf("ResolveAPIKey for a different server = %q, want empty", got)
+	}
+}
+
+// Contract: AGENTFIELD_HOME steers credential storage, so an isolated test or
+// desktop instance never reads or writes the real ~/.agentfield.
+func TestAgentFieldHomeDir_HonoursOverride(t *testing.T) {
+	custom := t.TempDir()
+	t.Setenv("AGENTFIELD_HOME", custom)
+
+	got, err := AgentFieldHomeDir()
+	if err != nil {
+		t.Fatalf("AgentFieldHomeDir: %v", err)
+	}
+	if got != custom {
+		t.Fatalf("AgentFieldHomeDir = %q, want %q", got, custom)
+	}
+}

--- a/control-plane/internal/packages/runner.go
+++ b/control-plane/internal/packages/runner.go
@@ -154,6 +154,13 @@ func (ar *AgentNodeRunner) startAgentNodeProcess(agentNode InstalledPackage, por
 	env = append(env, fmt.Sprintf("PORT=%d", port))
 	env = append(env, fmt.Sprintf("AGENTFIELD_SERVER=%s", serverURL))
 	env = append(env, fmt.Sprintf("AGENTFIELD_SERVER_URL=%s", serverURL))
+	// A control plane with an API key configured rejects an unauthenticated
+	// registration, so the node needs the same credential the CLI resolved
+	// (flag, environment, or `af auth login`). Absent on a default local
+	// setup, where the variable is simply not exported.
+	if key := ResolveAPIKey(); key != "" {
+		env = append(env, fmt.Sprintf("AGENTFIELD_API_KEY=%s", key))
+	}
 	env = PythonUTF8Env(env)
 
 	// Resolve declared variables from the encrypted secret store, prompting for

--- a/control-plane/internal/server/middleware/privileged.go
+++ b/control-plane/internal/server/middleware/privileged.go
@@ -1,0 +1,103 @@
+package middleware
+
+import (
+	"crypto/subtle"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// PrivilegedAccess guards the control-plane endpoints that can execute
+// arbitrary code (package install/update/uninstall) or read and write
+// credentials (the encrypted secret store and agent .env files).
+//
+// These routes would otherwise inherit the global posture, where an empty
+// API key disables authentication entirely. Combined with the wildcard bind
+// in Start(), that leaves anything on the same network able to make the
+// control plane clone and build an arbitrary repository, or overwrite the
+// credentials an installed agent runs with.
+//
+// The rule:
+//
+//	API key configured -> the key is required, like any other protected route.
+//	No API key         -> only loopback callers may use these endpoints, so a
+//	                      local CLI or desktop app keeps working untouched
+//	                      while remote callers are told to configure a key.
+//
+// The peer address is read from Request.RemoteAddr rather than c.ClientIP():
+// gin trusts every proxy by default, so ClientIP() honours a caller-supplied
+// X-Forwarded-For header and a remote host could simply claim to be 127.0.0.1.
+//
+// The corollary is that a reverse proxy sharing a host with the control plane
+// makes every forwarded request look local, and the loopback rule then protects
+// nothing. Such a deployment has to configure an API key; the docs say so.
+func PrivilegedAccess(config AuthConfig) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if config.APIKey != "" {
+			if privilegedKeyMatches(c, config.APIKey) {
+				c.Set("auth_level", "api_key")
+				c.Next()
+				return
+			}
+			c.Set("auth_level", "public")
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"error":   "unauthorized",
+				"message": "invalid or missing API key. This endpoint manages packages and credentials; provide the key via X-API-Key header or Authorization: Bearer <token>",
+				"help": map[string]string{
+					"cli": "af auth login --server <control-plane-url>",
+				},
+			})
+			return
+		}
+
+		if isLoopbackRequest(c.Request) {
+			c.Next()
+			return
+		}
+
+		c.Set("auth_level", "public")
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+			"error":   "unauthorized",
+			"message": "this endpoint installs packages and manages credentials, so it is restricted to local callers while the control plane runs without authentication. Configure an API key to use it from another host.",
+			"help": map[string]string{
+				"enable_auth": "set AGENTFIELD_API_KEY on the control plane, or api.auth.api_key in ~/.agentfield/agentfield.yaml, then restart it",
+				"cli":         "af auth login --server <control-plane-url>",
+			},
+		})
+	}
+}
+
+// privilegedKeyMatches reports whether the request carries the configured API
+// key. Unlike the global middleware this deliberately does not accept the key
+// as a query parameter: that fallback exists for browser EventSource and
+// WebSocket clients, which never call these routes, and query strings leak
+// into access logs and browser history.
+func privilegedKeyMatches(c *gin.Context, configuredKey string) bool {
+	provided := c.GetHeader("X-API-Key")
+	if provided == "" {
+		if authHeader := c.GetHeader("Authorization"); strings.HasPrefix(authHeader, "Bearer ") {
+			provided = strings.TrimPrefix(authHeader, "Bearer ")
+		}
+	}
+	return subtle.ConstantTimeCompare([]byte(provided), []byte(configuredKey)) == 1
+}
+
+// isLoopbackRequest reports whether the request's TCP peer is the local host.
+// An address that cannot be parsed is treated as remote, so an unexpected
+// transport fails closed rather than granting privileged access.
+func isLoopbackRequest(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	ip := net.ParseIP(strings.TrimSpace(host))
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
+}

--- a/control-plane/internal/server/middleware/privileged_test.go
+++ b/control-plane/internal/server/middleware/privileged_test.go
@@ -1,0 +1,232 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupPrivilegedRouter(config AuthConfig) *gin.Engine {
+	router := gin.New()
+	router.Use(PrivilegedAccess(config))
+	router.POST("/api/ui/v1/agents/packages/install", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "installed"})
+	})
+	return router
+}
+
+func privilegedRequest(t *testing.T, router *gin.Engine, remoteAddr string, mutate func(*http.Request)) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/ui/v1/agents/packages/install", nil)
+	req.RemoteAddr = remoteAddr
+	if mutate != nil {
+		mutate(req)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// Without a configured key the endpoint is local-only: the default developer
+// setup keeps working, but nothing else on the network can reach it.
+func TestPrivilegedAccess_NoAPIKey(t *testing.T) {
+	router := setupPrivilegedRouter(AuthConfig{APIKey: ""})
+
+	tests := []struct {
+		name       string
+		remoteAddr string
+		wantStatus int
+	}{
+		{"IPv4 loopback allowed", "127.0.0.1:54321", http.StatusOK},
+		{"IPv4 loopback range allowed", "127.0.1.7:54321", http.StatusOK},
+		{"IPv6 loopback allowed", "[::1]:54321", http.StatusOK},
+		{"private LAN address rejected", "192.168.2.16:54321", http.StatusUnauthorized},
+		{"other private range rejected", "10.4.1.9:54321", http.StatusUnauthorized},
+		{"public address rejected", "203.0.113.9:54321", http.StatusUnauthorized},
+		{"unparseable address rejected", "not-an-address", http.StatusUnauthorized},
+		{"empty address rejected", "", http.StatusUnauthorized},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := privilegedRequest(t, router, tt.remoteAddr, nil)
+			assert.Equal(t, tt.wantStatus, w.Code)
+		})
+	}
+}
+
+// gin trusts every proxy by default, so ClientIP() reflects caller-supplied
+// forwarding headers. The guard must key off the real TCP peer instead, or a
+// remote host can simply announce itself as 127.0.0.1.
+func TestPrivilegedAccess_ForwardedHeadersCannotForgeLoopback(t *testing.T) {
+	router := setupPrivilegedRouter(AuthConfig{APIKey: ""})
+
+	spoofHeaders := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{"X-Forwarded-For", "X-Forwarded-For", "127.0.0.1"},
+		{"X-Forwarded-For chain", "X-Forwarded-For", "127.0.0.1, 10.0.0.1"},
+		{"X-Real-IP", "X-Real-IP", "127.0.0.1"},
+		{"X-Forwarded-For IPv6 loopback", "X-Forwarded-For", "::1"},
+	}
+
+	for _, tt := range spoofHeaders {
+		t.Run(tt.name, func(t *testing.T) {
+			w := privilegedRequest(t, router, "192.168.2.16:54321", func(r *http.Request) {
+				r.Header.Set(tt.key, tt.value)
+			})
+			assert.Equal(t, http.StatusUnauthorized, w.Code,
+				"forwarded headers must not grant privileged access")
+		})
+	}
+}
+
+// Once a key is configured it is required everywhere, including from the local
+// host: enabling authentication should not leave a silent local bypass.
+func TestPrivilegedAccess_WithAPIKey(t *testing.T) {
+	const key = "s3cret-key"
+	router := setupPrivilegedRouter(AuthConfig{APIKey: key})
+
+	tests := []struct {
+		name       string
+		remoteAddr string
+		mutate     func(*http.Request)
+		wantStatus int
+	}{
+		{
+			name:       "remote caller with header key",
+			remoteAddr: "192.168.2.16:54321",
+			mutate:     func(r *http.Request) { r.Header.Set("X-API-Key", key) },
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "remote caller with bearer token",
+			remoteAddr: "192.168.2.16:54321",
+			mutate:     func(r *http.Request) { r.Header.Set("Authorization", "Bearer "+key) },
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "remote caller with wrong key",
+			remoteAddr: "192.168.2.16:54321",
+			mutate:     func(r *http.Request) { r.Header.Set("X-API-Key", "wrong") },
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "remote caller with no key",
+			remoteAddr: "192.168.2.16:54321",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "loopback caller still needs the key",
+			remoteAddr: "127.0.0.1:54321",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "loopback caller with key",
+			remoteAddr: "127.0.0.1:54321",
+			mutate:     func(r *http.Request) { r.Header.Set("X-API-Key", key) },
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := privilegedRequest(t, router, tt.remoteAddr, tt.mutate)
+			assert.Equal(t, tt.wantStatus, w.Code)
+		})
+	}
+}
+
+// The query-string fallback exists for browser EventSource and WebSocket
+// clients, which never call these routes; accepting it here would leak the key
+// into access logs.
+func TestPrivilegedAccess_RejectsQueryStringKey(t *testing.T) {
+	const key = "s3cret-key"
+	router := gin.New()
+	router.Use(PrivilegedAccess(AuthConfig{APIKey: key}))
+	router.POST("/api/ui/v1/agents/packages/install", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "installed"})
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/ui/v1/agents/packages/install?api_key="+key, nil)
+	req.RemoteAddr = "192.168.2.16:54321"
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// A rejected operator needs to know how to fix it, in both rejection modes.
+func TestPrivilegedAccess_RejectionExplainsRemedy(t *testing.T) {
+	t.Run("no api key configured", func(t *testing.T) {
+		router := setupPrivilegedRouter(AuthConfig{APIKey: ""})
+		w := privilegedRequest(t, router, "192.168.2.16:54321", nil)
+
+		require.Equal(t, http.StatusUnauthorized, w.Code)
+		var resp struct {
+			Error   string            `json:"error"`
+			Message string            `json:"message"`
+			Help    map[string]string `json:"help"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, "unauthorized", resp.Error)
+		assert.NotEmpty(t, resp.Message)
+		assert.Contains(t, resp.Help["enable_auth"], "AGENTFIELD_API_KEY")
+		assert.Contains(t, resp.Help["cli"], "af auth login")
+	})
+
+	t.Run("api key configured", func(t *testing.T) {
+		router := setupPrivilegedRouter(AuthConfig{APIKey: "s3cret-key"})
+		w := privilegedRequest(t, router, "192.168.2.16:54321", nil)
+
+		require.Equal(t, http.StatusUnauthorized, w.Code)
+		var resp struct {
+			Error string            `json:"error"`
+			Help  map[string]string `json:"help"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, "unauthorized", resp.Error)
+		assert.Contains(t, resp.Help["cli"], "af auth login")
+	})
+}
+
+// Downstream agentic discovery filters on auth_level; a rejected caller must
+// not be advertised as privileged.
+func TestPrivilegedAccess_SetsAuthLevel(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     AuthConfig
+		remoteAddr string
+		mutate     func(*http.Request)
+		wantLevel  string
+	}{
+		{"authenticated caller", AuthConfig{APIKey: "k"}, "192.168.2.16:1", func(r *http.Request) { r.Header.Set("X-API-Key", "k") }, "api_key"},
+		{"rejected caller", AuthConfig{APIKey: "k"}, "192.168.2.16:1", nil, "public"},
+		{"rejected remote in no-auth mode", AuthConfig{APIKey: ""}, "192.168.2.16:1", nil, "public"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			req := httptest.NewRequest(http.MethodPost, "/api/ui/v1/agents/packages/install", nil)
+			req.RemoteAddr = tt.remoteAddr
+			if tt.mutate != nil {
+				tt.mutate(req)
+			}
+			c.Request = req
+
+			PrivilegedAccess(tt.config)(c)
+
+			level, _ := c.Get("auth_level")
+			assert.Equal(t, tt.wantLevel, level)
+		})
+	}
+}

--- a/control-plane/internal/server/middleware/privileged_test.go
+++ b/control-plane/internal/server/middleware/privileged_test.go
@@ -45,6 +45,8 @@ func TestPrivilegedAccess_NoAPIKey(t *testing.T) {
 		{"IPv4 loopback allowed", "127.0.0.1:54321", http.StatusOK},
 		{"IPv4 loopback range allowed", "127.0.1.7:54321", http.StatusOK},
 		{"IPv6 loopback allowed", "[::1]:54321", http.StatusOK},
+		// Dual-stack hosts report an IPv4 client this way; it is genuinely local.
+		{"IPv4-mapped IPv6 loopback allowed", "[::ffff:127.0.0.1]:54321", http.StatusOK},
 		{"private LAN address rejected", "192.168.2.16:54321", http.StatusUnauthorized},
 		{"other private range rejected", "10.4.1.9:54321", http.StatusUnauthorized},
 		{"public address rejected", "203.0.113.9:54321", http.StatusUnauthorized},
@@ -75,6 +77,8 @@ func TestPrivilegedAccess_ForwardedHeadersCannotForgeLoopback(t *testing.T) {
 		{"X-Forwarded-For chain", "X-Forwarded-For", "127.0.0.1, 10.0.0.1"},
 		{"X-Real-IP", "X-Real-IP", "127.0.0.1"},
 		{"X-Forwarded-For IPv6 loopback", "X-Forwarded-For", "::1"},
+		{"X-Forwarded-For IPv4-mapped loopback", "X-Forwarded-For", "::ffff:127.0.0.1"},
+		{"Forwarded (RFC 7239)", "Forwarded", "for=127.0.0.1"},
 	}
 
 	for _, tt := range spoofHeaders {

--- a/control-plane/internal/server/routes_middleware.go
+++ b/control-plane/internal/server/routes_middleware.go
@@ -84,6 +84,8 @@ func (s *AgentFieldServer) applyGlobalMiddleware() {
 	}))
 	if s.config.API.Auth.APIKey != "" {
 		logger.Logger.Info().Msg("🔐 API key authentication enabled")
+	} else {
+		logger.Logger.Info().Msg("🔒 No API key configured: package install and credential endpoints are restricted to callers on this machine. Set AGENTFIELD_API_KEY to manage this control plane from anywhere else.")
 	}
 
 	// DID authentication middleware (applied globally, but only validates when headers present)

--- a/control-plane/internal/server/routes_ui.go
+++ b/control-plane/internal/server/routes_ui.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Agent-Field/agentfield/control-plane/internal/handlers"
 	"github.com/Agent-Field/agentfield/control-plane/internal/handlers/agentic"
 	"github.com/Agent-Field/agentfield/control-plane/internal/handlers/ui"
+	"github.com/Agent-Field/agentfield/control-plane/internal/server/middleware"
 	client "github.com/Agent-Field/agentfield/control-plane/web/client"
 
 	"github.com/gin-gonic/gin"
@@ -47,6 +48,13 @@ func (s *AgentFieldServer) registerUIAPI() {
 		return
 	}
 
+	// Endpoints that install code or handle credentials need a trusted caller:
+	// the control plane listens on every interface, and without an API key the
+	// global auth middleware lets anyone through. See middleware.PrivilegedAccess.
+	privileged := middleware.PrivilegedAccess(middleware.AuthConfig{
+		APIKey: s.config.API.Auth.APIKey,
+	})
+
 	uiAPI := s.Router.Group("/api/ui/v1")
 	{
 		// Agents management group - All agent-related operations
@@ -57,13 +65,15 @@ func (s *AgentFieldServer) registerUIAPI() {
 			agents.GET("/packages", packagesHandler.ListPackagesHandler)
 			agents.GET("/packages/:packageId/details", packagesHandler.GetPackageDetailsHandler)
 
-			// Package install/update/uninstall endpoints (async jobs)
+			// Package install/update/uninstall endpoints (async jobs).
+			// Installing runs git clone plus the package's own build and
+			// dependency steps, so these are privileged.
 			installHandler := ui.NewPackageInstallHandler(s.packageJobs)
-			agents.POST("/packages/install", installHandler.InstallPackageHandler)
-			agents.GET("/packages/install/jobs", installHandler.ListInstallJobsHandler)
-			agents.GET("/packages/install/jobs/:jobId", installHandler.GetInstallJobHandler)
-			agents.POST("/packages/:packageId/uninstall", installHandler.UninstallPackageHandler)
-			agents.POST("/packages/:packageId/update", installHandler.UpdatePackageHandler)
+			agents.POST("/packages/install", privileged, installHandler.InstallPackageHandler)
+			agents.GET("/packages/install/jobs", privileged, installHandler.ListInstallJobsHandler)
+			agents.GET("/packages/install/jobs/:jobId", privileged, installHandler.GetInstallJobHandler)
+			agents.POST("/packages/:packageId/uninstall", privileged, installHandler.UninstallPackageHandler)
+			agents.POST("/packages/:packageId/update", privileged, installHandler.UpdatePackageHandler)
 
 			// Agent lifecycle management endpoints
 			lifecycleHandler := ui.NewLifecycleHandler(s.storage, s.agentService)
@@ -79,27 +89,31 @@ func (s *AgentFieldServer) registerUIAPI() {
 			agents.POST("/:agentId/stop", lifecycleHandler.StopAgentHandler)
 			agents.POST("/:agentId/reconcile", lifecycleHandler.ReconcileAgentHandler)
 
-			// Configuration endpoints
+			// Configuration endpoints. The stored configuration carries
+			// encrypted fields, so reads and writes are privileged; the schema
+			// only describes which keys exist and stays open.
 			configHandler := ui.NewConfigHandler(s.storage)
 			agents.GET("/:agentId/config/schema", configHandler.GetConfigSchemaHandler)
-			agents.GET("/:agentId/config", configHandler.GetConfigHandler)
-			agents.POST("/:agentId/config", configHandler.SetConfigHandler)
+			agents.GET("/:agentId/config", privileged, configHandler.GetConfigHandler)
+			agents.POST("/:agentId/config", privileged, configHandler.SetConfigHandler)
 
 			// Encrypted secret store endpoints (the store RunAgent injects from)
 			secretsHandler := ui.NewAgentSecretsHandler(s.storage, s.agentfieldHome)
-			agents.GET("/:agentId/secrets", secretsHandler.ListAgentSecretsHandler)
-			agents.PUT("/:agentId/secrets", secretsHandler.SetAgentSecretHandler)
-			agents.DELETE("/:agentId/secrets/:key", secretsHandler.DeleteAgentSecretHandler)
+			agents.GET("/:agentId/secrets", privileged, secretsHandler.ListAgentSecretsHandler)
+			agents.PUT("/:agentId/secrets", privileged, secretsHandler.SetAgentSecretHandler)
+			agents.DELETE("/:agentId/secrets/:key", privileged, secretsHandler.DeleteAgentSecretHandler)
 			// Store-wide secret references (key + scope, never values),
 			// mirroring `af secrets ls` for management UIs.
-			uiAPI.GET("/secrets", secretsHandler.ListAllSecretsHandler)
+			uiAPI.GET("/secrets", privileged, secretsHandler.ListAllSecretsHandler)
 
-			// Environment file endpoints
+			// Environment file endpoints. GetEnvHandler returns real values for
+			// anything the manifest does not mark secret, so reads are
+			// privileged too, not just writes.
 			envHandler := ui.NewEnvHandler(s.storage, s.agentService, s.agentfieldHome)
-			agents.GET("/:agentId/env", envHandler.GetEnvHandler)
-			agents.PUT("/:agentId/env", envHandler.PutEnvHandler)
-			agents.PATCH("/:agentId/env", envHandler.PatchEnvHandler)
-			agents.DELETE("/:agentId/env/:key", envHandler.DeleteEnvVarHandler)
+			agents.GET("/:agentId/env", privileged, envHandler.GetEnvHandler)
+			agents.PUT("/:agentId/env", privileged, envHandler.PutEnvHandler)
+			agents.PATCH("/:agentId/env", privileged, envHandler.PatchEnvHandler)
+			agents.DELETE("/:agentId/env/:key", privileged, envHandler.DeleteEnvVarHandler)
 
 			// Agent execution history endpoints
 			agentExecutionHandler := ui.NewExecutionHandler(s.storage, s.payloadStore, s.webhookDispatcher)

--- a/control-plane/internal/server/routes_ui_privileged_test.go
+++ b/control-plane/internal/server/routes_ui_privileged_test.go
@@ -1,0 +1,160 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/Agent-Field/agentfield/control-plane/internal/config"
+	"github.com/Agent-Field/agentfield/control-plane/internal/server/apicatalog"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// remotePeer is any address that is not the local host. The control plane
+// binds every interface, so this stands in for another machine on the LAN.
+const remotePeer = "192.168.2.16:54321"
+
+func newPrivilegedRoutesTestServer(t *testing.T, apiKey string) *AgentFieldServer {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	srv := &AgentFieldServer{
+		Router:            gin.New(),
+		storage:           newStubStorage(),
+		payloadStore:      &stubPayloadStore{},
+		webhookDispatcher: &stubWebhookDispatcher{},
+		apiCatalog:        apicatalog.New(),
+		agentfieldHome:    t.TempDir(),
+		config: &config.Config{
+			UI:  config.UIConfig{Enabled: true},
+			API: config.APIConfig{Auth: config.AuthConfig{APIKey: apiKey}},
+		},
+	}
+	srv.setupRoutes()
+	return srv
+}
+
+func callFrom(t *testing.T, srv *AgentFieldServer, method, path, remoteAddr string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = remoteAddr
+	rec := httptest.NewRecorder()
+	srv.Router.ServeHTTP(rec, req)
+	return rec
+}
+
+// concreteParams replaces gin's :param and *wildcard segments so a registered
+// route pattern can be requested.
+func concreteParams(routePath string) string {
+	segments := strings.Split(routePath, "/")
+	for i, seg := range segments {
+		if strings.HasPrefix(seg, ":") || strings.HasPrefix(seg, "*") {
+			segments[i] = "probe-value"
+		}
+	}
+	return strings.Join(segments, "/")
+}
+
+// privilegedPathPattern matches the UI-API surface that installs code or
+// handles credentials. Driving the test off the live route table means a new
+// route in these areas is covered the moment it is registered.
+var privilegedPathPattern = regexp.MustCompile(`^/api/ui/v1/(secrets|agents/(packages/install|packages/[^/]+/(uninstall|update)|[^/]+/(secrets|env|config)))`)
+
+// A route that matches the privileged pattern but is deliberately public.
+func isPrivilegedExempt(routePath string) bool {
+	// The config schema only describes which keys an agent accepts; it carries
+	// no values, and the UI needs it to render the form before authenticating.
+	return strings.HasSuffix(routePath, "/config/schema")
+}
+
+func privilegedRoutes(t *testing.T, srv *AgentFieldServer) []gin.RouteInfo {
+	t.Helper()
+	var found []gin.RouteInfo
+	for _, route := range srv.Router.Routes() {
+		if privilegedPathPattern.MatchString(route.Path) && !isPrivilegedExempt(route.Path) {
+			found = append(found, route)
+		}
+	}
+	return found
+}
+
+// Every code-executing or credential-handling UI-API route must reject a
+// caller from another host while the control plane runs without an API key.
+func TestUIAPI_PrivilegedRoutesRejectRemoteCallersWithoutAPIKey(t *testing.T) {
+	srv := newPrivilegedRoutesTestServer(t, "")
+
+	routes := privilegedRoutes(t, srv)
+	require.NotEmpty(t, routes, "privileged route pattern matched nothing — did the UI API move?")
+
+	// Guards against the pattern silently matching only a subset after a refactor.
+	require.GreaterOrEqual(t, len(routes), 12,
+		"expected the full install/secrets/env/config surface, got %d routes", len(routes))
+
+	for _, route := range routes {
+		t.Run(route.Method+" "+route.Path, func(t *testing.T) {
+			rec := callFrom(t, srv, route.Method, concreteParams(route.Path), remotePeer)
+			assert.Equal(t, http.StatusUnauthorized, rec.Code,
+				"%s %s must not be reachable from another host without an API key", route.Method, route.Path)
+		})
+	}
+}
+
+// The same routes stay reachable from the local host, which is how the CLI,
+// the desktop app and a browser on the same machine use them.
+func TestUIAPI_PrivilegedRoutesAllowLoopbackWithoutAPIKey(t *testing.T) {
+	srv := newPrivilegedRoutesTestServer(t, "")
+
+	// A privileged route backed only by the temp agentfield home, so the
+	// assertion is about the guard rather than the stub storage.
+	rec := callFrom(t, srv, http.MethodGet, "/api/ui/v1/secrets", "127.0.0.1:54321")
+	assert.NotEqual(t, http.StatusUnauthorized, rec.Code,
+		"loopback callers must keep working with no API key configured")
+
+	rec6 := callFrom(t, srv, http.MethodGet, "/api/ui/v1/secrets", "[::1]:54321")
+	assert.NotEqual(t, http.StatusUnauthorized, rec6.Code,
+		"IPv6 loopback callers must keep working with no API key configured")
+}
+
+// With a key configured the routes work from anywhere, provided the caller
+// presents it — this is the documented way to manage a remote control plane.
+func TestUIAPI_PrivilegedRoutesAcceptRemoteCallerWithAPIKey(t *testing.T) {
+	const key = "configured-key"
+	srv := newPrivilegedRoutesTestServer(t, key)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/ui/v1/secrets", nil)
+	req.RemoteAddr = remotePeer
+	req.Header.Set("X-API-Key", key)
+	rec := httptest.NewRecorder()
+	srv.Router.ServeHTTP(rec, req)
+	assert.NotEqual(t, http.StatusUnauthorized, rec.Code)
+
+	// ...and reject it when the key is wrong.
+	reqBad := httptest.NewRequest(http.MethodGet, "/api/ui/v1/secrets", nil)
+	reqBad.RemoteAddr = remotePeer
+	reqBad.Header.Set("X-API-Key", "wrong-key")
+	recBad := httptest.NewRecorder()
+	srv.Router.ServeHTTP(recBad, reqBad)
+	assert.Equal(t, http.StatusUnauthorized, recBad.Code)
+}
+
+// The guard is deliberately narrow: read-only observability routes must not
+// start requiring a local caller, or remote dashboards break.
+func TestUIAPI_ReadOnlyRoutesRemainOpenToRemoteCallers(t *testing.T) {
+	srv := newPrivilegedRoutesTestServer(t, "")
+
+	openRoutes := []struct{ method, path string }{
+		{http.MethodGet, "/api/ui/v1/agents/packages"},
+	}
+
+	for _, r := range openRoutes {
+		t.Run(r.method+" "+r.path, func(t *testing.T) {
+			rec := callFrom(t, srv, r.method, r.path, remotePeer)
+			assert.NotEqual(t, http.StatusUnauthorized, rec.Code,
+				"%s %s should not have been locked down", r.method, r.path)
+		})
+	}
+}

--- a/desktop/src/main/agentfield.test.ts
+++ b/desktop/src/main/agentfield.test.ts
@@ -20,7 +20,7 @@ import {
 import { DEFAULT_CONTROL_PLANE_PORT } from './ports'
 import { installCommand, sanitizeInstallOutput } from './installer'
 import { CATALOG, catalogEntry } from '../shared/catalog'
-import { setCloudConnection } from './connection'
+import { setCloudConnection, setLocalApiKey } from './connection'
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -72,7 +72,21 @@ describe('active base URL', () => {
 })
 
 describe('raw control-plane fetch authentication', () => {
-  afterEach(() => setActiveControlPlanePort(DEFAULT_CONTROL_PLANE_PORT))
+  afterEach(() => {
+    setLocalApiKey(null)
+    setActiveControlPlanePort(DEFAULT_CONTROL_PLANE_PORT)
+  })
+
+  function readerFetch(): FetchLike {
+    return vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/health')) return jsonResponse({ status: 'healthy' })
+      if (url.includes('/nodes')) return jsonResponse({ nodes: [] })
+      if (url.includes('/workflow-runs')) return jsonResponse({ runs: [] })
+      if (url.includes('/dashboard/summary')) return jsonResponse({})
+      return jsonResponse({ totals: {} })
+    }) as FetchLike
+  }
 
   async function callRawReaders(fetchImpl: FetchLike): Promise<void> {
     await checkControlPlane(undefined, fetchImpl)
@@ -84,14 +98,7 @@ describe('raw control-plane fetch authentication', () => {
 
   it('adds X-API-Key to every raw reader in cloud mode', async () => {
     setCloudConnection('https://cp.example', 'cloud-key')
-    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input)
-      if (url.endsWith('/health')) return jsonResponse({ status: 'healthy' })
-      if (url.includes('/nodes')) return jsonResponse({ nodes: [] })
-      if (url.includes('/workflow-runs')) return jsonResponse({ runs: [] })
-      if (url.includes('/dashboard/summary')) return jsonResponse({})
-      return jsonResponse({ totals: {} })
-    }) as FetchLike
+    const fetchImpl = readerFetch()
     await callRawReaders(fetchImpl)
     expect(vi.mocked(fetchImpl).mock.calls).toHaveLength(5)
     for (const [, init] of vi.mocked(fetchImpl).mock.calls) {
@@ -99,19 +106,25 @@ describe('raw control-plane fetch authentication', () => {
     }
   })
 
+  // Default local mode has no key: the control plane authenticates the app by
+  // its loopback address, so nothing must be sent.
   it('omits X-API-Key from every raw reader in local mode', async () => {
     setActiveControlPlanePort(8080)
-    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input)
-      if (url.endsWith('/health')) return jsonResponse({ status: 'healthy' })
-      if (url.includes('/nodes')) return jsonResponse({ nodes: [] })
-      if (url.includes('/workflow-runs')) return jsonResponse({ runs: [] })
-      if (url.includes('/dashboard/summary')) return jsonResponse({})
-      return jsonResponse({ totals: {} })
-    }) as FetchLike
+    const fetchImpl = readerFetch()
     await callRawReaders(fetchImpl)
     for (const [, init] of vi.mocked(fetchImpl).mock.calls) {
       expect(new Headers(init?.headers).has('X-API-Key')).toBe(false)
+    }
+  })
+
+  it('adds X-API-Key to every raw reader when the local server needs one', async () => {
+    setActiveControlPlanePort(8080)
+    setLocalApiKey('local-secret')
+    const fetchImpl = readerFetch()
+    await callRawReaders(fetchImpl)
+    expect(vi.mocked(fetchImpl).mock.calls).toHaveLength(5)
+    for (const [, init] of vi.mocked(fetchImpl).mock.calls) {
+      expect(new Headers(init?.headers).get('X-API-Key')).toBe('local-secret')
     }
   })
 })

--- a/desktop/src/main/autostart.test.ts
+++ b/desktop/src/main/autostart.test.ts
@@ -58,6 +58,7 @@ function settings(overrides: Partial<DesktopSettings>): DesktopSettings {
     appearance: 'system',
     autostartControlPlane: true,
     controlPlanePort: null,
+    localApiKey: '',
     lastControlPlanePort: null,
     autostartAgents: [],
     installSkills: true,

--- a/desktop/src/main/cloud.test.ts
+++ b/desktop/src/main/cloud.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { getApiKey, getBaseUrl, setLocalPort } from './connection'
+import { getApiKey, getBaseUrl, setLocalApiKey, setLocalPort } from './connection'
 import { applyConnectionProfile, normalizeServerUrl, testCloudConnection } from './cloud'
 import { DEFAULT_SETTINGS } from './settings'
 
@@ -19,7 +19,10 @@ function fakeFetch(responses: Array<Response | Error>): typeof fetch {
   }) as unknown as typeof fetch
 }
 
-afterEach(() => setLocalPort(8080))
+afterEach(() => {
+  setLocalApiKey(null)
+  setLocalPort(8080)
+})
 
 describe('normalizeServerUrl', () => {
   it('normalizes host input and removes paths, queries, and trailing slashes', () => {
@@ -132,5 +135,22 @@ describe('applyConnectionProfile', () => {
     applyConnectionProfile(DEFAULT_SETTINGS)
     expect(getBaseUrl()).toBe('http://localhost:9091')
     expect(getApiKey()).toBeNull()
+  })
+
+  it('carries a configured local API key on the local profile', () => {
+    applyConnectionProfile({ ...DEFAULT_SETTINGS, localApiKey: 'local-secret' })
+    expect(getBaseUrl()).toBe('http://localhost:8080')
+    expect(getApiKey()).toBe('local-secret')
+  })
+
+  it('keeps the local key available for the switch back from cloud', () => {
+    applyConnectionProfile({
+      ...DEFAULT_SETTINGS,
+      localApiKey: 'local-secret',
+      cloud: { enabled: true, serverUrl: 'https://cp.example', apiKey: 'cloud-key' }
+    })
+    expect(getApiKey()).toBe('cloud-key')
+    applyConnectionProfile({ ...DEFAULT_SETTINGS, localApiKey: 'local-secret' })
+    expect(getApiKey()).toBe('local-secret')
   })
 })

--- a/desktop/src/main/cloud.ts
+++ b/desktop/src/main/cloud.ts
@@ -1,5 +1,5 @@
 import type { CloudTestResult, DesktopSettings } from '../shared/types'
-import { clearCloudConnection, setCloudConnection } from './connection'
+import { clearCloudConnection, setCloudConnection, setLocalApiKey } from './connection'
 
 export type { CloudTestResult } from '../shared/types'
 
@@ -175,6 +175,9 @@ export async function testCloudConnection(
 }
 
 export function applyConnectionProfile(settings: DesktopSettings): void {
+  // Kept current even while cloud is active, so switching back to local
+  // restores the local credential rather than dropping to no key at all.
+  setLocalApiKey(settings.localApiKey ?? '')
   const normalized = normalizeServerUrl(settings.cloud?.serverUrl ?? '')
   if (settings.cloud?.enabled && normalized) {
     setCloudConnection(normalized, settings.cloud.apiKey || null)

--- a/desktop/src/main/connection.test.ts
+++ b/desktop/src/main/connection.test.ts
@@ -5,10 +5,14 @@ import {
   getBaseUrl,
   isCloudActive,
   setCloudConnection,
+  setLocalApiKey,
   setLocalPort
 } from './connection'
 
-afterEach(() => setLocalPort(8080))
+afterEach(() => {
+  setLocalApiKey(null)
+  setLocalPort(8080)
+})
 
 describe('connection state', () => {
   it('switches to cloud and restores the last local port', () => {
@@ -21,6 +25,24 @@ describe('connection state', () => {
     expect(getBaseUrl()).toBe('http://localhost:9091')
     expect(getApiKey()).toBeNull()
     expect(isCloudActive()).toBe(false)
+  })
+
+  it('sends no key locally until one is configured, and keeps it across ports', () => {
+    expect(getApiKey()).toBeNull()
+    setLocalApiKey('local-secret')
+    expect(getApiKey()).toBe('local-secret')
+    setLocalPort(9091)
+    expect(getApiKey()).toBe('local-secret')
+    setLocalApiKey('')
+    expect(getApiKey()).toBeNull()
+  })
+
+  it('prefers the cloud key while cloud is active and restores the local one after', () => {
+    setLocalApiKey('local-secret')
+    setCloudConnection('https://cp.example', 'cloud-key')
+    expect(getApiKey()).toBe('cloud-key')
+    clearCloudConnection()
+    expect(getApiKey()).toBe('local-secret')
   })
 
   it('setting a local port clears cloud state', () => {

--- a/desktop/src/main/connection.ts
+++ b/desktop/src/main/connection.ts
@@ -2,7 +2,12 @@ const DEFAULT_LOCAL_URL = 'http://localhost:8080'
 
 let localUrl = DEFAULT_LOCAL_URL
 let baseUrl = localUrl
-let apiKey: string | null = null
+let cloudApiKey: string | null = null
+// Optional credential for the LOCAL control plane. Normally null: a control
+// plane started without AGENTFIELD_API_KEY authenticates loopback callers by
+// their peer address alone. Set only when the user runs their local server
+// with authentication enabled (see settings.localApiKey).
+let localApiKey: string | null = null
 let cloudActive = false
 
 export function getBaseUrl(): string {
@@ -12,24 +17,29 @@ export function getBaseUrl(): string {
 export function setLocalPort(port: number): void {
   localUrl = `http://localhost:${port}`
   baseUrl = localUrl
-  apiKey = null
+  cloudApiKey = null
   cloudActive = false
+}
+
+/** Credential for the local control plane; '' / null means unauthenticated. */
+export function setLocalApiKey(key: string | null): void {
+  localApiKey = key !== null && key !== '' ? key : null
 }
 
 export function setCloudConnection(url: string, key: string | null): void {
   baseUrl = url
-  apiKey = key
+  cloudApiKey = key
   cloudActive = true
 }
 
 export function clearCloudConnection(): void {
   baseUrl = localUrl
-  apiKey = null
+  cloudApiKey = null
   cloudActive = false
 }
 
 export function getApiKey(): string | null {
-  return apiKey
+  return cloudActive ? cloudApiKey : localApiKey
 }
 
 export function isCloudActive(): boolean {

--- a/desktop/src/main/cpClient.test.ts
+++ b/desktop/src/main/cpClient.test.ts
@@ -161,6 +161,48 @@ describe('createCpClient', () => {
     expect(error).toMatchObject({ status, message: body.error })
   })
 
+  // Contract 4a: a 401 from the privileged-route guard reaches the user as the
+  // server's sentence plus its CLI hint — never the bare "unauthorized" code.
+  it('surfaces the server message and CLI hint for a 401', async () => {
+    const client = createCpClient({
+      fetchImpl: mockFetch([
+        json(
+          {
+            error: 'unauthorized',
+            message:
+              'this endpoint installs packages and manages credentials, so it is restricted to local callers while the control plane runs without authentication.',
+            help: {
+              enable_auth: 'set AGENTFIELD_API_KEY on the control plane',
+              cli: 'af auth login --server <control-plane-url>'
+            }
+          },
+          401
+        )
+      ])
+    })
+    const error = await client.installPackage('https://github.com/acme/agent').catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(CpApiError)
+    expect((error as CpApiError).status).toBe(401)
+    expect((error as CpApiError).message).toBe(
+      'this endpoint installs packages and manages credentials, so it is restricted to local callers while the control plane runs without authentication. Run: af auth login --server <control-plane-url>'
+    )
+  })
+
+  it('still explains a 401 with no usable body', async () => {
+    const client = createCpClient({ fetchImpl: mockFetch([new Response('', { status: 401 })]) })
+    const error = await client.listPackages().catch((e: unknown) => e)
+    expect(error).toMatchObject({
+      status: 401,
+      message: 'The control plane rejected this request: it requires an API key.'
+    })
+  })
+
+  it('keeps a human-readable 401 error field when no message is sent', async () => {
+    const client = createCpClient({ fetchImpl: mockFetch([json({ error: 'API key rejected' }, 401)]) })
+    const error = await client.listPackages().catch((e: unknown) => e)
+    expect(error).toMatchObject({ status: 401, message: 'API key rejected' })
+  })
+
   // Contract 4: malformed error JSON still produces a status-bearing error.
   it('retains status for malformed error JSON', async () => {
     const fetchImpl = mockFetch([new Response('{', { status: 500 })])

--- a/desktop/src/main/cpClient.ts
+++ b/desktop/src/main/cpClient.ts
@@ -240,8 +240,33 @@ async function apiError(response: Response): Promise<CpApiError> {
   return new CpApiError({
     status: response.status,
     code,
-    message: serverMessage ?? `Control plane request failed with status ${response.status}`
+    message:
+      response.status === 401
+        ? unauthorizedMessage(record, serverMessage)
+        : (serverMessage ?? `Control plane request failed with status ${response.status}`)
   })
+}
+
+/**
+ * Message for a 401 from the control plane's auth guards, whose body is
+ * `{error:"unauthorized", message:"<human readable>", help:{cli, …}}`.
+ * `error` there is a machine code, so the generic "prefer error" path above
+ * would show the user nothing but "unauthorized" — take the sentence instead,
+ * and append the CLI hint when the server offers one.
+ */
+function unauthorizedMessage(
+  record: Record<string, unknown> | undefined,
+  fallback: string | undefined
+): string {
+  const message =
+    (typeof record?.message === 'string' && record.message !== '' ? record.message : undefined) ??
+    // Older/other responses put a real sentence in `error` instead.
+    (fallback !== undefined && fallback !== 'unauthorized' ? fallback : undefined) ??
+    'The control plane rejected this request: it requires an API key.'
+  const help = record?.help
+  const cli =
+    isRecord(help) && typeof help.cli === 'string' && help.cli !== '' ? help.cli : undefined
+  return cli ? `${message} Run: ${cli}` : message
 }
 
 /**

--- a/desktop/src/main/settings.test.ts
+++ b/desktop/src/main/settings.test.ts
@@ -15,6 +15,7 @@ describe('normalizeSettings', () => {
       appearance: 'dark' as const,
       autostartControlPlane: false,
       controlPlanePort: 9091,
+      localApiKey: 'local-secret',
       lastControlPlanePort: 8081,
       autostartAgents: ['a', 'b'],
       installSkills: false,
@@ -35,6 +36,12 @@ describe('normalizeSettings', () => {
     expect(normalizeSettings({ controlPlanePort: '8080' }).controlPlanePort).toBeNull()
     expect(normalizeSettings({ lastControlPlanePort: -1 }).lastControlPlanePort).toBeNull()
     expect(normalizeSettings({ lastControlPlanePort: 9091 }).lastControlPlanePort).toBe(9091)
+  })
+
+  it('keeps a trimmed local API key and drops non-strings', () => {
+    expect(normalizeSettings({}).localApiKey).toBe('')
+    expect(normalizeSettings({ localApiKey: '  af_local_key  ' }).localApiKey).toBe('af_local_key')
+    expect(normalizeSettings({ localApiKey: 42 }).localApiKey).toBe('')
   })
 
   it('defaults trayCompanion on and coerces non-booleans', () => {
@@ -138,6 +145,7 @@ describe('load/save round trip', () => {
       appearance: 'light' as const,
       autostartControlPlane: true,
       controlPlanePort: null,
+      localApiKey: 'round-trip-local-key',
       lastControlPlanePort: 9091,
       autostartAgents: ['swe-planner'],
       installSkills: true,

--- a/desktop/src/main/settings.ts
+++ b/desktop/src/main/settings.ts
@@ -12,6 +12,7 @@ export const DEFAULT_SETTINGS: DesktopSettings = {
   appearance: 'system',
   autostartControlPlane: true,
   controlPlanePort: null,
+  localApiKey: '',
   lastControlPlanePort: null,
   autostartAgents: [],
   installSkills: true,
@@ -59,6 +60,7 @@ export function normalizeSettings(raw: unknown): DesktopSettings {
         ? obj.autostartControlPlane
         : DEFAULT_SETTINGS.autostartControlPlane,
     controlPlanePort: normalizePort(obj.controlPlanePort),
+    localApiKey: typeof obj.localApiKey === 'string' ? obj.localApiKey.trim() : '',
     lastControlPlanePort: normalizePort(obj.lastControlPlanePort),
     autostartAgents: agents,
     installSkills:

--- a/desktop/src/renderer/src/components/SettingsPanel.tsx
+++ b/desktop/src/renderer/src/components/SettingsPanel.tsx
@@ -80,6 +80,10 @@ export function SettingsPanel({ agents }: SettingsPanelProps) {
               value={settings.controlPlanePort}
               onCommit={(port) => update({ controlPlanePort: port })}
             />
+            <LocalApiKeyRow
+              value={settings.localApiKey}
+              onCommit={(key) => update({ localApiKey: key })}
+            />
             <ToggleRow
               title="Keep coding-agent skills installed"
               sub="Teach Claude Code, Codex, and friends how to use AgentField (via `af skill install`)."
@@ -427,6 +431,63 @@ function PortRow({
             if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
           }}
         />
+      </div>
+    </li>
+  )
+}
+
+/**
+ * Credential for a local AgentField server that runs with authentication on
+ * (AGENTFIELD_API_KEY). Empty for almost everyone — a server started without a
+ * key trusts this app because it connects over loopback. Committed on
+ * blur/Enter like the port, so half-typed keys are never persisted or sent.
+ */
+function LocalApiKeyRow({
+  value,
+  onCommit
+}: {
+  value: string
+  onCommit: (key: string) => void
+}) {
+  const [text, setText] = useState(value)
+  const [show, setShow] = useState(false)
+
+  // Reflect what main actually persisted (it trims).
+  useEffect(() => {
+    setText(value)
+  }, [value])
+
+  const commit = () => {
+    const trimmed = text.trim()
+    if (trimmed !== value) onCommit(trimmed)
+  }
+
+  return (
+    <li className="row">
+      <div className="row-main">
+        <span className="row-title">Server API key</span>
+        <span className="row-sub">
+          Only needed when your AgentField server requires authentication. Stored on this
+          computer and sent only to that server.
+        </span>
+      </div>
+      <div className="row-side">
+        <input
+          className="env-input"
+          type={show ? 'text' : 'password'}
+          placeholder="none"
+          autoComplete="off"
+          spellCheck={false}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
+          }}
+        />
+        <button className="action-button" type="button" onClick={() => setShow(!show)}>
+          {show ? 'Hide' : 'Show'}
+        </button>
       </div>
     </li>
   )

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -185,6 +185,14 @@ export interface DesktopSettings {
    */
   controlPlanePort: number | null
   /**
+   * API key for the LOCAL control plane, or '' when it needs none. A local
+   * server started without AGENTFIELD_API_KEY authenticates this app by its
+   * loopback address, so this stays empty for almost everyone; set it when
+   * you run your own server with authentication enabled. Like cloud.apiKey,
+   * the value lives in main-process settings on this computer.
+   */
+  localApiKey: string
+  /**
    * The port of the control plane this app last started or adopted. App-
    * managed, not a user preference: it lets a restarted app rediscover a
    * control plane it put on a non-default port instead of starting a second

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -45,6 +45,30 @@ If set, the control plane requires an API key for most endpoints.
 
 - `AGENTFIELD_API_KEY` or `AGENTFIELD_API_AUTH_API_KEY`: API key checked by the control plane.
 
+It is optional only for a control plane used from the machine it runs on. The
+endpoints that install packages or read and write credentials — package
+install/update/uninstall, the secret store, agent `env` and agent `config` —
+additionally require the caller to be on the local host while no key is set, and
+refuse everything else with `401`. That covers the default single-user setup
+without a key, and means any other topology needs one:
+
+- another machine on the network, including a browser on your laptop pointed at
+  a control plane running on a server
+- a container, where a client on the host reaches the server through a bridge
+  network rather than loopback
+- anything behind a reverse proxy or tunnel
+
+The reverse-proxy case needs a key for a different reason than the others: the
+check looks at the connection's real peer address, so if the proxy runs on the
+same host as the control plane, every forwarded request already looks local and
+the restriction protects nothing. Forwarded headers such as `X-Forwarded-For`
+are deliberately ignored here — trusting them would let any caller claim to be
+local — so a proxied deployment must set a key.
+
+Clients send the key as the `X-API-Key` header (or `Authorization: Bearer`). For
+the CLI, `af auth login` stores it and every later command sends it
+automatically.
+
 ### UI
 
 - `AGENTFIELD_UI_ENABLED` (default: `true`)

--- a/sdk/go/agent/agent.go
+++ b/sdk/go/agent/agent.go
@@ -357,6 +357,14 @@ type Config struct {
 	// an Authorization: Bearer <token> header on control-plane requests.
 	Token string
 
+	// APIKey authenticates control-plane requests via the X-API-Key header.
+	// Optional. Defaults to the AGENTFIELD_API_KEY environment variable, which
+	// `af run` exports for the agents it starts, so an agent registers against
+	// an authenticated control plane without carrying the key in its code.
+	// Unlike Token this is only ever sent outbound; it is not used to validate
+	// incoming requests.
+	APIKey string
+
 	// DeploymentType describes how the agent runs (affects execution behavior).
 	// Optional. Default: "long_running". Common values: "long_running",
 	// "serverless". Use a descriptive string for custom modes.
@@ -560,6 +568,9 @@ func New(cfg Config) (*Agent, error) {
 	if cfg.TeamID == "" {
 		cfg.TeamID = "default"
 	}
+	if strings.TrimSpace(cfg.APIKey) == "" {
+		cfg.APIKey = strings.TrimSpace(os.Getenv("AGENTFIELD_API_KEY"))
+	}
 	if cfg.ListenAddress == "" {
 		cfg.ListenAddress = ":8001"
 	}
@@ -635,6 +646,9 @@ func New(cfg Config) (*Agent, error) {
 
 	if strings.TrimSpace(cfg.AgentFieldURL) != "" {
 		opts := []client.Option{client.WithHTTPClient(httpClient), client.WithBearerToken(cfg.Token)}
+		if apiKey := strings.TrimSpace(cfg.APIKey); apiKey != "" {
+			opts = append(opts, client.WithAPIKey(apiKey))
+		}
 		if cfg.DID != "" && cfg.PrivateKeyJWK != "" {
 			opts = append(opts, client.WithDIDAuth(cfg.DID, cfg.PrivateKeyJWK))
 		}

--- a/sdk/go/agent/agent_apikey_test.go
+++ b/sdk/go/agent/agent_apikey_test.go
@@ -1,0 +1,127 @@
+package agent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// captureAPIKeyServer records the credential headers of the first request and
+// answers with an empty JSON object so the client call completes.
+func captureAPIKeyServer(t *testing.T, apiKey, authorization *string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*apiKey = r.Header.Get("X-API-Key")
+		*authorization = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// An agent configured with an API key must present it on control-plane
+// requests, so it can register against a control plane that has authentication
+// enabled.
+func TestNew_ConfigAPIKeyIsSentToControlPlane(t *testing.T) {
+	var gotAPIKey, gotAuth string
+	srv := captureAPIKeyServer(t, &gotAPIKey, &gotAuth)
+
+	a, err := New(Config{
+		NodeID:        "node-1",
+		Version:       "1.0.0",
+		AgentFieldURL: srv.URL,
+		APIKey:        "config-key",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, a.client)
+
+	_, err = a.client.GetNode(context.Background(), "node-1")
+	require.NoError(t, err)
+	require.Equal(t, "config-key", gotAPIKey)
+}
+
+// `af run` and `af dev` export AGENTFIELD_API_KEY for the agents they start, so
+// an agent that names no key in code still authenticates.
+func TestNew_APIKeyDefaultsFromEnvironment(t *testing.T) {
+	var gotAPIKey, gotAuth string
+	srv := captureAPIKeyServer(t, &gotAPIKey, &gotAuth)
+
+	t.Setenv("AGENTFIELD_API_KEY", "env-key")
+
+	a, err := New(Config{
+		NodeID:        "node-1",
+		Version:       "1.0.0",
+		AgentFieldURL: srv.URL,
+	})
+	require.NoError(t, err)
+
+	_, err = a.client.GetNode(context.Background(), "node-1")
+	require.NoError(t, err)
+	require.Equal(t, "env-key", gotAPIKey)
+}
+
+// An explicit key wins over the environment, so a caller can always override
+// what the parent process exported.
+func TestNew_ConfigAPIKeyOverridesEnvironment(t *testing.T) {
+	var gotAPIKey, gotAuth string
+	srv := captureAPIKeyServer(t, &gotAPIKey, &gotAuth)
+
+	t.Setenv("AGENTFIELD_API_KEY", "env-key")
+
+	a, err := New(Config{
+		NodeID:        "node-1",
+		Version:       "1.0.0",
+		AgentFieldURL: srv.URL,
+		APIKey:        "config-key",
+	})
+	require.NoError(t, err)
+
+	_, err = a.client.GetNode(context.Background(), "node-1")
+	require.NoError(t, err)
+	require.Equal(t, "config-key", gotAPIKey)
+}
+
+// With no key anywhere the agent must stay exactly as it was: no credential
+// header, which is the default local setup.
+func TestNew_NoAPIKeySendsNoHeader(t *testing.T) {
+	var gotAPIKey, gotAuth string
+	srv := captureAPIKeyServer(t, &gotAPIKey, &gotAuth)
+
+	t.Setenv("AGENTFIELD_API_KEY", "")
+
+	a, err := New(Config{
+		NodeID:        "node-1",
+		Version:       "1.0.0",
+		AgentFieldURL: srv.URL,
+	})
+	require.NoError(t, err)
+
+	_, err = a.client.GetNode(context.Background(), "node-1")
+	require.NoError(t, err)
+	require.Empty(t, gotAPIKey)
+}
+
+// The API key is a separate credential from Token: setting one must not
+// disturb the other, because Token also drives incoming-request auth.
+func TestNew_APIKeyAndTokenCoexist(t *testing.T) {
+	var gotAPIKey, gotAuth string
+	srv := captureAPIKeyServer(t, &gotAPIKey, &gotAuth)
+
+	a, err := New(Config{
+		NodeID:        "node-1",
+		Version:       "1.0.0",
+		AgentFieldURL: srv.URL,
+		APIKey:        "config-key",
+		Token:         "bearer-token",
+	})
+	require.NoError(t, err)
+
+	_, err = a.client.GetNode(context.Background(), "node-1")
+	require.NoError(t, err)
+	require.Equal(t, "config-key", gotAPIKey)
+	require.Equal(t, "Bearer bearer-token", gotAuth)
+}

--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -692,6 +692,7 @@ class Agent(FastAPI):
                                          and None defers entirely to platform defaults.
             api_key (str, optional): API key for authenticating with the AgentField control plane.
                                     When set, will be sent as X-API-Key header on all requests.
+                                    Defaults to the AGENTFIELD_API_KEY environment variable.
             **kwargs: Additional keyword arguments passed to FastAPI constructor.
 
         Example:
@@ -786,7 +787,11 @@ class Agent(FastAPI):
         # Initialize async configuration
         self.async_config = async_config or AsyncConfig.from_environment()
 
-        # Store API key for authentication
+        # Store API key for authentication. `af run` exports AGENTFIELD_API_KEY
+        # for agents it starts, so an agent registers against a control plane
+        # that has authentication enabled without needing the key in its code.
+        if api_key is None:
+            api_key = os.environ.get("AGENTFIELD_API_KEY") or None
         self.api_key = api_key
 
         # Initialize AgentFieldClient with async configuration and API key


### PR DESCRIPTION
## What

Endpoints that install code or handle credentials are no longer reachable from
other machines on the network when the control plane runs without an API key.

`POST /api/ui/v1/agents/packages/install` accepts any `github.com` URL, clones it
and runs the package's own build and dependency steps. The global auth
middleware treats an empty `api.auth.api_key` as "authentication disabled"
(`middleware/auth.go`), which is the default, and `Start()` binds `":"+port`,
i.e. every interface. Anything that could reach the port could therefore run
code as the user running the server, with no prior state — it did not need a
package to already be installed.

Reproduced on `main` before the fix, from another address on the LAN with no
credentials of any kind:

```
POST http://<control-plane-lan-address>:8080/api/ui/v1/agents/packages/install
  {"source":"https://github.com/<attacker>/<repo>"}
→ 202 {"job_id":"…"}
```

and the job log showed the control plane had run `git clone` on it. The same
caller could `PUT`/`DELETE` the encrypted secret store and read agent `.env`
values, which contain provider API keys.

The install and secret-store routes arrived in #837, whose description noted
that scoped tokens for process-spawning surfaces were a planned follow-up. #842
then made this API the only agent-management path and #847 made the control
plane internet-reachable, so the exposure is worth closing now rather than
later.

## How

A `PrivilegedAccess` middleware in front of the routes that execute code or
touch credentials:

| server state | privileged endpoints |
| --- | --- |
| no API key configured (default) | loopback callers only |
| API key configured | the key is required, from every caller |

That keeps the ordinary local setup exactly as it is — the CLI, the desktop app
and a browser on the same machine are all loopback — while anything arriving
over the network needs a credential.

The peer address comes from `Request.RemoteAddr`, never `c.ClientIP()`.
`SetTrustedProxies` is never called in this repo, so gin trusts all proxies and
`ClientIP()` returns whatever a caller puts in `X-Forwarded-For`; a loopback
check built on it would be trivially bypassable. There is a test for exactly
that.

Guarded: package install/update/uninstall and install-job polling, the
encrypted secret store (`/agents/:id/secrets`, `/secrets`), agent `env`, and
agent `config` (its stored document carries `encrypted_fields`). Deliberately
not guarded: the read-only observability surface, and `config/schema`, which
describes which keys exist but holds no values.

Start/stop/reconcile are left alone. They predate this wave and cannot
introduce new code, only run something the user already installed — worth
revisiting separately rather than widening this change.

## Making authentication usable

Turning on an API key previously broke everything that talks to the control
plane, so this adds the client half:

- **`af auth login|status|logout`** stores a key per control-plane URL in
  `~/.agentfield/credentials.json` (mode `0600`). `login` verifies the key
  against the server before saving and never prints it in full. Resolution
  order is `--api-key` → `AGENTFIELD_API_KEY` → stored file, so nothing changes
  for a user who sets neither.
- A CLI `401` now says what to do: `authentication required by <server>; run:
  af auth login --server <server>`.
- `af run` / `af dev` export `AGENTFIELD_API_KEY` to the agents they spawn, and
  both SDKs now default their API key from that variable (`Config.APIKey` in Go,
  the `api_key` argument in Python). Without this an authenticated control plane
  would reject every local agent's registration.
- Consistency fixes: `af ls` and `af stop` sent the key as `Authorization:
  Bearer` while everything else used `X-API-Key`; `af doctor` sent nothing.
  `af execution` and `af nodes` keep their separate `--token`/`AGENTFIELD_TOKEN`
  credential but now fall back to the API key.
- Desktop: an optional API key for the local control plane in Settings → General
  (local mode previously hard-nulled the key), and 401s now surface the server's
  message and CLI hint instead of a bare "unauthorized".

## Upgrade note

A control plane reached over a network needs `AGENTFIELD_API_KEY` set. Three
cases are affected, all of them ones where the traffic is not really local:

- a browser on another machine pointed at a control plane on a server
- **a container**, where a client on the host arrives over a bridge network
  rather than loopback — `docker compose` users managing agents through the UI
  will need a key
- anything behind a reverse proxy or tunnel

The proxy case is a security caveat rather than a convenience one, and is called
out in the docs and in the middleware comment: the check reads the connection's
real peer, so a proxy on the same host as the control plane makes every
forwarded request look local and the loopback rule stops protecting anything.
Trusting `X-Forwarded-For` instead would be strictly worse — any caller could
then claim to be local — so a proxied deployment has to set a key.

The one-click Railway deploy already generates a key, so cloud mode is
unaffected. Documented in `SECURITY.md`, `docs/ENVIRONMENT_VARIABLES.md` and
`.env.example`, and the server now logs its posture on startup.

## Validation

Contract-first; each test maps to a behavior, not to the implementation.

- `privileged_test.go` — loopback v4/v6 allowed, LAN/public/unparseable
  rejected, `X-Forwarded-For` and `X-Real-IP` cannot forge loopback, key
  required from every caller once configured, query-string keys refused,
  rejection body carries the remedy.
- `routes_ui_privileged_test.go` — drives off the **live route table**, so a new
  route matching the privileged pattern is covered the moment it is registered.
  Verified it fails when the guard is removed from a route.
- Manual, against a real server: the LAN install that returned `202` on `main`
  now returns `401` and creates no job; loopback install still returns `202`;
  spoofed forwarding headers still `401`; read-only routes unaffected. With a key
  set: correct key and bearer token work from the LAN, wrong/missing key and
  query-string key are refused.
- Manual, full round trip with auth on: `af auth login` (wrong key refused and
  nothing written) → agent registers using only the env var → `af call` executes
  through the control plane. And with auth off: agent registers, `af call` works,
  privileged endpoints still work from loopback, no credentials file created.

Gates: control-plane `go build`/`go vet`/`go test ./...`, Go SDK, Python SDK
(`ruff` + 1830 tests), desktop typecheck + 386 vitest tests.

## Known gaps

- The React UI detects "auth required" by probing an endpoint that is not
  guarded, so a remote browser against a keyless control plane gets a 401 on
  env/config without an API key prompt. The message is actionable; a proper
  prompt is a follow-up.
- gin's access log prints the spoofable `ClientIP()`, so a forged
  `X-Forwarded-For` shows an attacker-chosen address in the logs even though the
  guard rejects the request.
- `af share --public` attaches the control-plane key to requests to
  `agentfield.ai`. Pre-existing and out of scope here, but it should be gated on
  the share host.
