### PR TITLE
fix(release): restore macOS signing and let containerized control planes be managed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -547,10 +547,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
-    env:
-      # Never auto-discover identities from the runner keychain; macOS signing
-      # uses the explicit CSC_LINK cert, Windows stays unsigned.
-      CSC_IDENTITY_AUTO_DISCOVERY: 'false'
     steps:
       - name: Checkout release commit
         uses: actions/checkout@v4
@@ -608,6 +604,14 @@ jobs:
       # Missing secrets degrade the artifact instead of blocking the release:
       # no CSC_LINK → unsigned (ad-hoc) build, no APPLE_APP_SPECIFIC_PASSWORD
       # → signed but un-notarized build, each with a workflow warning.
+      #
+      # Do NOT set CSC_IDENTITY_AUTO_DISCOVERY=false for this step. It reads as
+      # "don't guess an identity from the keychain", but electron-builder treats
+      # it as "skip code signing entirely" even when CSC_LINK is supplied — the
+      # app then gets ad-hoc signed, and notarization of an unsigned app comes
+      # back Invalid. That is what happened to v0.1.118-rc.10, which shipped
+      # without its macOS DMG. Providing CSC_LINK is already explicit, so
+      # nothing is auto-discovered here.
       - name: Build installers (macOS, signed + notarized)
         if: runner.os == 'macOS'
         working-directory: desktop
@@ -618,18 +622,25 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          if [ -z "$CSC_LINK" ] || [ -z "$APPLE_APP_SPECIFIC_PASSWORD" ]; then
-            echo "::warning::signing/notarization secrets incomplete; electron-builder will skip what it lacks credentials for"
+          if [ -z "$CSC_LINK" ] || [ -z "$CSC_KEY_PASSWORD" ] || [ -z "$APPLE_ID" ] \
+            || [ -z "$APPLE_APP_SPECIFIC_PASSWORD" ] || [ -z "$APPLE_TEAM_ID" ]; then
+            echo "::warning::signing/notarization secrets incomplete; producing an unsigned build"
             # Partial APPLE_* env makes electron-builder hard-fail, and an
             # unsigned app can never notarize; drop the set entirely so it
-            # degrades to a skip-with-warning instead.
+            # degrades to a skip-with-warning instead. Auto-discovery stays off
+            # so an unsigned build cannot silently pick up a keychain identity.
             unset APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID
+            export CSC_IDENTITY_AUTO_DISCOVERY=false
           fi
           npm run dist
 
       - name: Build installers (Windows)
         if: runner.os == 'Windows'
         working-directory: desktop
+        env:
+          # Windows releases are unsigned; keep electron-builder from picking up
+          # any identity that happens to be on the runner.
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
         run: npm run dist
 
       # The .app inside the DMG is already notarized + stapled; notarizing and
@@ -644,9 +655,15 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
         run: |
           set -euo pipefail
-          if [ -z "$CSC_LINK" ] || [ -z "$APPLE_APP_SPECIFIC_PASSWORD" ]; then
+          # Same condition as the build step above. If they disagree, an
+          # incomplete secret set produces an unsigned app here and then fails
+          # the release on a notarization rejection instead of degrading to a
+          # warning.
+          if [ -z "$CSC_LINK" ] || [ -z "$CSC_KEY_PASSWORD" ] || [ -z "$APPLE_ID" ] \
+            || [ -z "$APPLE_APP_SPECIFIC_PASSWORD" ] || [ -z "$APPLE_TEAM_ID" ]; then
             echo "::warning::signing/notarization secrets incomplete; skipping DMG notarization and Gatekeeper verification"
             exit 0
           fi
@@ -657,11 +674,32 @@ jobs:
             exit 1
           fi
           for dmg in "${dmgs[@]}"; do
+            # `notarytool submit --wait` exits 0 even when Apple answers
+            # Invalid, so the status has to be read out of the output rather
+            # than inferred from the exit code. rc.10 sailed past this point and
+            # only failed later in `stapler`, which reports a ticket lookup
+            # error instead of the actual rejection.
+            submit_log="$(mktemp)"
+            # `|| true` so that a hard notarytool failure still reaches the
+            # status check below and gets its reason printed, rather than
+            # tripping `set -e` with no explanation.
             xcrun notarytool submit "$dmg" \
               --apple-id "$APPLE_ID" \
               --password "$APPLE_APP_SPECIFIC_PASSWORD" \
               --team-id "$APPLE_TEAM_ID" \
-              --wait
+              --wait 2>&1 | tee "$submit_log" || true
+            status="$(sed -n 's/^ *status: *//p' "$submit_log" | tail -1)"
+            if [ "$status" != "Accepted" ]; then
+              echo "::error::notarization of $dmg returned '${status:-unknown}'; Apple's report follows"
+              submission_id="$(sed -n 's/^ *id: *//p' "$submit_log" | head -1)"
+              if [ -n "$submission_id" ]; then
+                xcrun notarytool log "$submission_id" \
+                  --apple-id "$APPLE_ID" \
+                  --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+                  --team-id "$APPLE_TEAM_ID" || true
+              fi
+              exit 1
+            fi
             xcrun stapler staple "$dmg"
             xcrun stapler validate "$dmg"
           done

--- a/deployments/docker/README.md
+++ b/deployments/docker/README.md
@@ -16,6 +16,25 @@ docker compose --profile python-demo up --build
 Open the UI:
 - `http://localhost:8080/ui/`
 
+### Managing agents from the host
+
+Running agents, browsing workflows and the observability APIs work as-is. But
+installing packages and reading or writing credentials (the secret store, agent
+`env`, agent `config`) require the caller to be local, and a client on your host
+reaches this container through Docker's bridge — from the control plane's point
+of view that is another machine, so those calls come back `401`. Publishing the
+port to `127.0.0.1` does not change it; the connection still arrives from the
+bridge address.
+
+Set an API key to manage the stack from the host:
+
+```bash
+AGENTFIELD_API_KEY=$(openssl rand -hex 24) docker compose up --build
+```
+
+Clients send it as `X-API-Key`; for the CLI, run `af auth login --server
+http://localhost:8080` once and it is sent automatically.
+
 ## Execute an agent via the control plane
 
 Python demo agent (deterministic; no LLM keys required):

--- a/deployments/docker/docker-compose.yml
+++ b/deployments/docker/docker-compose.yml
@@ -26,6 +26,14 @@ services:
       AGENTFIELD_STORAGE_POSTGRES_URL: postgres://agentfield:agentfield@postgres:5432/agentfield?sslmode=disable
       AGENTFIELD_DATABASE_URL: postgres://agentfield:agentfield@postgres:5432/agentfield?sslmode=disable
       AGENTFIELD_HTTP_ADDR: 0.0.0.0:8080
+      # A client on the host reaches this container over the bridge network, so
+      # it is not a local caller as far as the control plane is concerned, and
+      # the endpoints that install packages or handle credentials refuse it.
+      # Set AGENTFIELD_API_KEY in the environment (or a .env file next to this
+      # compose file) to manage this control plane from the host or anywhere
+      # else. Empty keeps the previous behaviour: no authentication, and those
+      # endpoints reachable only from inside the container.
+      AGENTFIELD_API_KEY: "${AGENTFIELD_API_KEY:-}"
       AGENTFIELD_TELEMETRY_ENABLED: "${AGENTFIELD_TELEMETRY_ENABLED:-true}"
       AGENTFIELD_TELEMETRY_ENDPOINT: "${AGENTFIELD_TELEMETRY_ENDPOINT:-https://agentfield.ai/api/oss/telemetry}"
     ports:

--- a/deployments/helm/agentfield/values.yaml
+++ b/deployments/helm/agentfield/values.yaml
@@ -55,6 +55,11 @@ controlPlane:
   tolerations: []
   affinity: {}
 
+# Reaching the control plane through a Service, Ingress or port-forward is not
+# a local connection, so while this is disabled the endpoints that install
+# packages or handle credentials (package install/update/uninstall, the secret
+# store, agent env and agent config) refuse those callers. Enable it to manage
+# the control plane from outside its own pod; everything else works either way.
 apiAuth:
   enabled: false
   apiKey: ""


### PR DESCRIPTION
Two release blockers found while verifying whether v0.1.118-rc.10 was safe to
ship. They are independent; the commits are separate.

## 1. The macOS Desktop build was never signed, so notarization failed

rc.10 published its CLI binaries, the Windows installer and the Python wheels,
but **no macOS DMG or zip**. The desktop job failed and every other artifact had
already published by then.

The job set `CSC_IDENTITY_AUTO_DISCOVERY=false` at job level, with the comment
"never auto-discover identities from the runner keychain; macOS signing uses the
explicit CSC_LINK cert". That reads sensibly and is wrong: electron-builder
treats the flag as *skip code signing entirely*.

```js
// app-builder-lib/src/util/flags.ts
isAutoDiscoveryCodeSignIdentity() { return process.env.CSC_IDENTITY_AUTO_DISCOVERY !== "false" }

// app-builder-lib/src/codeSign/macCodeSign.ts — findIdentity()
if (isEmptyOrSpaces(identity)) {            // no CSC_NAME
  if (isAutoDiscoveryCodeSignIdentity()) { return _findIdentity(...) }
  else { return Promise.resolve(null) }     // ← no identity, ever
}
```

`CSC_LINK` imports the certificate into a keychain, but the identity still has
to be *found*, and that flag disables the lookup. The rc.10 log shows exactly
this, naming the variable as its reason:

```
• ad-hoc signing (no identity configured)  file=…/AgentField.app
• skipped macOS application code signing   reason=, … CSC_IDENTITY_AUTO_DISCOVERY=false
…
Current status: Invalid........Processing complete
The staple and validate action failed! Error 65.
```

An ad-hoc signed app can never notarize, so Apple returned `Invalid`.

**Fix:** scope the flag to the Windows step, which genuinely is unsigned, and
set it on macOS only when the secrets are incomplete — so an unsigned build
still cannot pick up a stray keychain identity. A comment records the trap so it
does not get reinstated.

Two related repairs in the same job:

- The macOS guard checked 2 of the 5 required secrets. A missing
  `CSC_KEY_PASSWORD` therefore produced an unsigned app, and the notarize step —
  which checked a *different* pair — went ahead and hard-failed the release
  instead of degrading to a warning. Both now check the same five.
- `notarytool submit --wait` **exits 0 even when Apple answers `Invalid`**. That
  is why rc.10 sailed past submission and only died in `stapler`, which reports
  a ticket-lookup error rather than the rejection. The step now reads the
  status, and on anything but `Accepted` prints Apple's own report via
  `notarytool log` — which the job never fetched, so the actual reason for the
  rc.10 rejection was never recorded anywhere.

## 2. Containerized control planes could not be managed from the host

Since the privileged endpoints began requiring a local caller or an API key, a
client on the host talking to a control plane in Docker gets `401` on package
install and the secret/env/config APIs. Reproduced against a container built
from this commit — the server logs the peer as the bridge gateway:

```
172.17.0.1 … POST "/api/ui/v1/agents/packages/install"   → 401
172.17.0.1 … GET  "/api/ui/v1/secrets"                   → 401
172.17.0.1 … GET  "/api/ui/v1/agents/packages"           → 200   (read-only, unaffected)
```

Publishing to `127.0.0.1:PORT` does not change it; the connection still arrives
from the bridge address.

The documented remedy is to set an API key — but `deployments/docker/docker-compose.yml`
had **no `AGENTFIELD_API_KEY` passthrough**, so `AGENTFIELD_API_KEY=… docker compose up`
silently did nothing and the remedy was unreachable without editing the file.

**Fix:** wire the variable through, defaulting to empty so a plain
`docker compose up` keeps today's behaviour exactly. Then say the same thing
where the other deployments hit it — the Docker README explains why host
management needs a key, and the Helm values note that a Service or Ingress is
not a local connection either. Helm already had `apiAuth`; defaults are left
alone so existing installs upgrade unchanged.

## Verification

Signing changes are workflow-only and cannot be exercised without a tagged macOS
release, so they are verified structurally: the YAML parses, both build steps
and the notarize step pass `bash -n`, the macOS step now carries all five
secrets and no auto-discovery override, and the status-parsing logic was
dry-run against real `notarytool` output for both the `Invalid` and `Accepted`
shapes — `Invalid` correctly fails and emits the submission id for the log
fetch.

The compose change was verified live against a container built from this
commit:

| case | result |
| --- | --- |
| `AGENTFIELD_API_KEY` set → rendered into the container | ✅ |
| host → install / secrets, with key | `202` / `200` |
| host → secrets, without key | `401` |
| unset → renders empty, server starts, logs local-only posture | ✅ |
| read-only route from host, no key | `200` |

## Not included

`desktop/package.json` ships `vendor/deploy-engine` as `extraResources`, but
nothing populates it — every installer build logs `file source doesn't exist`
and ships without the engine, leaving one-click cloud deploy falling back to a
system `tofu`/`terraform` that a normal user does not have. The fix is to run
`npm run fetch:deploy-engine` before packaging, but that injects unsigned
third-party Mach-O binaries into a bundle that is about to start being signed
for the first time, which is its own notarization risk. Better to land signing
first, confirm a clean notarized build, then add the engine and observe that
change in isolation. Worth a follow-up.
