### PR TITLE
fix(sdk-go): send the API key on every control-plane request

### DIFF
--- a/sdk/go/agent/agent.go
+++ b/sdk/go/agent/agent.go
@@ -640,7 +640,14 @@ func New(cfg Config) (*Agent, error) {
 		if refreshInterval <= 0 {
 			refreshInterval = 5 * time.Minute
 		}
-		a.localVerifier = NewLocalVerifier(cfg.AgentFieldURL, refreshInterval, cfg.Token)
+		// NewLocalVerifier sends its third argument as X-API-Key. Prefer the
+		// dedicated APIKey, falling back to Token so existing callers that
+		// used it as the key keep working.
+		verifierKey := strings.TrimSpace(cfg.APIKey)
+		if verifierKey == "" {
+			verifierKey = cfg.Token
+		}
+		a.localVerifier = NewLocalVerifier(cfg.AgentFieldURL, refreshInterval, verifierKey)
 		cfg.Logger.Printf("Local verification enabled (refresh every %s)", refreshInterval)
 	}
 
@@ -1631,6 +1638,26 @@ func (a *Agent) executeReasonerAsync(reasoner *Reasoner, input map[string]any, e
 	}
 }
 
+// applyControlPlaneAuth sets the auth headers a control plane accepts on a
+// request this package builds by hand.
+//
+// Everything that goes through the shared client (sdk/go/client) already gets
+// these — see client.do. A handful of paths construct their own *http.Request
+// and have to mirror it, or a control plane running with an API key rejects
+// them with 401. Token and APIKey are separate settings and either may be set
+// alone, so both headers are applied independently.
+func (a *Agent) applyControlPlaneAuth(req *http.Request) {
+	if req == nil {
+		return
+	}
+	if token := strings.TrimSpace(a.cfg.Token); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if apiKey := strings.TrimSpace(a.cfg.APIKey); apiKey != "" {
+		req.Header.Set("X-API-Key", apiKey)
+	}
+}
+
 func (a *Agent) sendExecutionStatus(executionID string, payload map[string]any) error {
 	base := strings.TrimSpace(a.cfg.AgentFieldURL)
 	if executionID == "" || base == "" {
@@ -1656,9 +1683,7 @@ func (a *Agent) postExecutionStatus(ctx context.Context, callbackURL string, pay
 		req.Header.Set("Content-Type", "application/json")
 
 		// Include API auth headers (Bearer token / API key)
-		if a.cfg.Token != "" {
-			req.Header.Set("Authorization", "Bearer "+a.cfg.Token)
-		}
+		a.applyControlPlaneAuth(req)
 
 		// Sign request with DID auth headers if configured
 		if a.client != nil {
@@ -1927,9 +1952,7 @@ func (a *Agent) applyCallHeaders(req *http.Request, execCtx ExecutionContext, ru
 	// Include caller agent identity for permission middleware
 	req.Header.Set("X-Caller-Agent-ID", a.cfg.NodeID)
 
-	if a.cfg.Token != "" {
-		req.Header.Set("Authorization", "Bearer "+a.cfg.Token)
-	}
+	a.applyControlPlaneAuth(req)
 }
 
 // submitAsyncExecution POSTs to /api/v1/execute/async/{target} and returns the
@@ -2449,9 +2472,7 @@ func (a *Agent) sendWorkflowEvent(event types.WorkflowExecutionEvent) error {
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	if a.cfg.Token != "" {
-		req.Header.Set("Authorization", "Bearer "+a.cfg.Token)
-	}
+	a.applyControlPlaneAuth(req)
 
 	// Sign request with DID auth headers if configured
 	if a.client != nil {

--- a/sdk/go/agent/agent_apikey_paths_test.go
+++ b/sdk/go/agent/agent_apikey_paths_test.go
@@ -1,0 +1,250 @@
+package agent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Agent-Field/agentfield/sdk/go/types"
+	"github.com/stretchr/testify/require"
+)
+
+// The shared client is not the only thing that talks to the control plane —
+// several paths build their own *http.Request. Those are the ones that used to
+// drop the API key, which left an agent registered and running while every
+// result it reported came back 401 and the run never finished.
+//
+// Each test below drives one of those paths against a recording server and
+// asserts the credential actually left the process.
+
+// credentialRecorder captures the credential headers of every request it sees.
+type credentialRecorder struct {
+	mu      sync.Mutex
+	apiKeys []string
+	auths   []string
+	paths   []string
+}
+
+func (r *credentialRecorder) record(req *http.Request) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.apiKeys = append(r.apiKeys, req.Header.Get("X-API-Key"))
+	r.auths = append(r.auths, req.Header.Get("Authorization"))
+	r.paths = append(r.paths, req.URL.Path)
+}
+
+func (r *credentialRecorder) seen() ([]string, []string, []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.apiKeys...),
+		append([]string(nil), r.auths...),
+		append([]string(nil), r.paths...)
+}
+
+// recordingControlPlane answers every request with an empty JSON object, which
+// is enough for the fire-and-forget paths and for a single status callback.
+func recordingControlPlane(t *testing.T) (*httptest.Server, *credentialRecorder) {
+	t.Helper()
+	rec := &credentialRecorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.record(r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, rec
+}
+
+func newAgentForCredentialTest(t *testing.T, url, apiKey, token string) *Agent {
+	t.Helper()
+	t.Setenv("AGENTFIELD_API_KEY", "")
+	a, err := New(Config{
+		NodeID:        "node-1",
+		Version:       "1.0.0",
+		AgentFieldURL: url,
+		APIKey:        apiKey,
+		Token:         token,
+	})
+	require.NoError(t, err)
+	return a
+}
+
+// The result of every asynchronous execution is reported over this callback.
+// Without the key the control plane rejects it and the run hangs in "running"
+// forever, which is how this was found.
+func TestSendExecutionStatus_CarriesAPIKey(t *testing.T) {
+	srv, rec := recordingControlPlane(t)
+	a := newAgentForCredentialTest(t, srv.URL, "config-key", "")
+
+	require.NoError(t, a.sendExecutionStatus("exec-1", map[string]any{"status": "succeeded"}))
+
+	keys, _, paths := rec.seen()
+	require.NotEmpty(t, keys)
+	require.Contains(t, paths[0], "/api/v1/executions/exec-1/status")
+	require.Equal(t, "config-key", keys[0])
+}
+
+// Token is a separate credential and must keep working on its own, so an agent
+// that only sets Token is unaffected by the change.
+func TestSendExecutionStatus_CarriesBearerTokenAlone(t *testing.T) {
+	srv, rec := recordingControlPlane(t)
+	a := newAgentForCredentialTest(t, srv.URL, "", "bearer-token")
+
+	require.NoError(t, a.sendExecutionStatus("exec-1", map[string]any{"status": "succeeded"}))
+
+	keys, auths, _ := rec.seen()
+	require.Equal(t, "Bearer bearer-token", auths[0])
+	require.Empty(t, keys[0])
+}
+
+// Both credentials may be configured at once; neither suppresses the other.
+func TestSendExecutionStatus_CarriesBothCredentials(t *testing.T) {
+	srv, rec := recordingControlPlane(t)
+	a := newAgentForCredentialTest(t, srv.URL, "config-key", "bearer-token")
+
+	require.NoError(t, a.sendExecutionStatus("exec-1", map[string]any{"status": "succeeded"}))
+
+	keys, auths, _ := rec.seen()
+	require.Equal(t, "config-key", keys[0])
+	require.Equal(t, "Bearer bearer-token", auths[0])
+}
+
+// The default local setup has no credentials at all and must send none — this
+// guards the out-of-the-box flow against an accidental empty header.
+func TestSendExecutionStatus_SendsNoCredentialHeadersWhenUnset(t *testing.T) {
+	srv, rec := recordingControlPlane(t)
+	a := newAgentForCredentialTest(t, srv.URL, "", "")
+
+	require.NoError(t, a.sendExecutionStatus("exec-1", map[string]any{"status": "succeeded"}))
+
+	keys, auths, _ := rec.seen()
+	require.Empty(t, keys[0])
+	require.Empty(t, auths[0])
+}
+
+// Agent-to-agent calls submit and then poll; both legs are hand-built requests
+// and both need the key or a cross-node call cannot complete.
+func TestCallHeaders_CarryAPIKey(t *testing.T) {
+	srv, _ := recordingControlPlane(t)
+	a := newAgentForCredentialTest(t, srv.URL, "config-key", "")
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/execute/async/other.reasoner", nil)
+	require.NoError(t, err)
+	a.applyCallHeaders(req, ExecutionContext{RunID: "run-1"}, "run-1")
+
+	require.Equal(t, "config-key", req.Header.Get("X-API-Key"))
+}
+
+// Workflow events feed the DAG the UI renders; dropping them silently loses
+// observability against an authenticated control plane.
+func TestSendWorkflowEvent_CarriesAPIKey(t *testing.T) {
+	srv, rec := recordingControlPlane(t)
+	a := newAgentForCredentialTest(t, srv.URL, "config-key", "")
+
+	require.NoError(t, a.sendWorkflowEvent(types.WorkflowExecutionEvent{
+		ExecutionID: "exec-1",
+		Status:      "succeeded",
+	}))
+
+	keys, _, paths := rec.seen()
+	require.NotEmpty(t, keys)
+	require.Contains(t, paths[0], "/api/v1/workflow/executions/events")
+	require.Equal(t, "config-key", keys[0])
+}
+
+// Notes are written from inside a reasoner and are the user's own audit trail.
+func TestSendNote_CarriesAPIKey(t *testing.T) {
+	srv, rec := recordingControlPlane(t)
+	a := newAgentForCredentialTest(t, srv.URL, "config-key", "")
+
+	// Note is fire-and-forget, so wait for the request to actually land.
+	a.Note(context.Background(), "hello")
+	require.Eventually(t, func() bool {
+		keys, _, _ := rec.seen()
+		return len(keys) > 0
+	}, 5*time.Second, 10*time.Millisecond, "note request never reached the control plane")
+
+	keys, _, paths := rec.seen()
+	require.Contains(t, paths[0], "/api/v1/executions/note")
+	require.Equal(t, "config-key", keys[0])
+}
+
+// Discovery is how an agent finds its peers; without the key it returns an
+// auth error instead of the catalog.
+func TestDiscover_CarriesAPIKey(t *testing.T) {
+	srv, rec := recordingControlPlane(t)
+	a := newAgentForCredentialTest(t, srv.URL, "config-key", "")
+
+	_, err := a.Discover(context.Background())
+	require.NoError(t, err)
+
+	keys, _, paths := rec.seen()
+	require.NotEmpty(t, keys)
+	require.Contains(t, paths[0], "/api/v1/discovery/capabilities")
+	require.Equal(t, "config-key", keys[0])
+}
+
+// A nil request must be tolerated rather than panicking, since the helper is
+// called from several builders.
+func TestApplyControlPlaneAuth_NilRequestIsSafe(t *testing.T) {
+	srv, _ := recordingControlPlane(t)
+	a := newAgentForCredentialTest(t, srv.URL, "config-key", "bearer-token")
+
+	require.NotPanics(t, func() { a.applyControlPlaneAuth(nil) })
+}
+
+// Local verification refreshes policies and revocations from the control
+// plane, and it authenticates with X-API-Key — so the dedicated API key is
+// what it should be given.
+func TestNew_LocalVerifierUsesAPIKey(t *testing.T) {
+	srv, _ := recordingControlPlane(t)
+	t.Setenv("AGENTFIELD_API_KEY", "")
+
+	a, err := New(Config{
+		NodeID:            "node-1",
+		Version:           "1.0.0",
+		AgentFieldURL:     srv.URL,
+		APIKey:            "config-key",
+		LocalVerification: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, a.localVerifier)
+	require.Equal(t, "config-key", a.localVerifier.apiKey)
+}
+
+// Before APIKey existed, callers passed their key as Token and it reached the
+// verifier that way. That has to keep working.
+func TestNew_LocalVerifierFallsBackToToken(t *testing.T) {
+	srv, _ := recordingControlPlane(t)
+	t.Setenv("AGENTFIELD_API_KEY", "")
+
+	a, err := New(Config{
+		NodeID:            "node-1",
+		Version:           "1.0.0",
+		AgentFieldURL:     srv.URL,
+		Token:             "legacy-token",
+		LocalVerification: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, a.localVerifier)
+	require.Equal(t, "legacy-token", a.localVerifier.apiKey)
+}
+
+// DID registration goes through its own client. Without the key an agent on an
+// authenticated control plane comes up with no cryptographic identity.
+func TestInitializeDIDSystem_CarriesAPIKey(t *testing.T) {
+	srv, rec := recordingControlPlane(t)
+	a := newAgentForCredentialTest(t, srv.URL, "config-key", "")
+	a.cfg.EnableDID = true
+
+	// Registration may fail against the stub response; only the credential on
+	// the wire matters here.
+	_ = a.initializeDIDSystem(context.Background())
+
+	keys, _, _ := rec.seen()
+	require.NotEmpty(t, keys, "DID client never called the control plane")
+	require.Equal(t, "config-key", keys[0])
+}

--- a/sdk/go/agent/agent_did.go
+++ b/sdk/go/agent/agent_did.go
@@ -27,6 +27,9 @@ func (a *Agent) initializeDIDSystem(ctx context.Context) error {
 	if a.cfg.Token != "" {
 		didClientOpts = append(didClientOpts, did.WithToken(a.cfg.Token))
 	}
+	if a.cfg.APIKey != "" {
+		didClientOpts = append(didClientOpts, did.WithAPIKey(a.cfg.APIKey))
+	}
 	didClient := did.NewClient(a.cfg.AgentFieldURL, didClientOpts...)
 
 	// Create DID manager.

--- a/sdk/go/agent/discovery.go
+++ b/sdk/go/agent/discovery.go
@@ -212,9 +212,7 @@ func (a *Agent) Discover(ctx context.Context, opts ...DiscoveryOption) (*types.D
 	} else {
 		req.Header.Set("Accept", "application/json")
 	}
-	if a.cfg.Token != "" {
-		req.Header.Set("Authorization", "Bearer "+a.cfg.Token)
-	}
+	a.applyControlPlaneAuth(req)
 
 	resp, err := a.httpClient.Do(req)
 	if err != nil {

--- a/sdk/go/agent/note.go
+++ b/sdk/go/agent/note.go
@@ -93,9 +93,7 @@ func (a *Agent) sendNote(ctx context.Context, message string, tags []string) {
 
 	// Set headers
 	req.Header.Set("Content-Type", "application/json")
-	if a.cfg.Token != "" {
-		req.Header.Set("Authorization", "Bearer "+a.cfg.Token)
-	}
+	a.applyControlPlaneAuth(req)
 
 	// Add execution context headers
 	if execCtx.RunID != "" {

--- a/sdk/go/did/did_client.go
+++ b/sdk/go/did/did_client.go
@@ -21,6 +21,7 @@ type Client struct {
 	baseURL    string
 	httpClient *http.Client
 	token      string
+	apiKey     string
 	signFn     SignRequestFunc
 }
 
@@ -40,6 +41,14 @@ func WithHTTPClient(c *http.Client) ClientOption {
 func WithToken(token string) ClientOption {
 	return func(dc *Client) {
 		dc.token = token
+	}
+}
+
+// WithAPIKey sets the X-API-Key header for authenticated requests. A control
+// plane running with an API key rejects DID and VC calls without it.
+func WithAPIKey(apiKey string) ClientOption {
+	return func(dc *Client) {
+		dc.apiKey = apiKey
 	}
 }
 
@@ -127,6 +136,9 @@ func (c *Client) do(ctx context.Context, method, endpoint string, body any, out 
 
 	if c.token != "" {
 		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	if c.apiKey != "" {
+		req.Header.Set("X-API-Key", c.apiKey)
 	}
 
 	// Apply DID authentication if configured.

--- a/sdk/go/did/did_client_test.go
+++ b/sdk/go/did/did_client_test.go
@@ -233,6 +233,33 @@ func TestClient_WithBearerToken(t *testing.T) {
 	assert.Equal(t, "Bearer my-secret-token", receivedAuth)
 }
 
+// A control plane running with an API key rejects DID registration without it,
+// which would leave an otherwise healthy agent with no identity.
+func TestClient_WithAPIKey(t *testing.T) {
+	var receivedKey, receivedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedKey = r.Header.Get("X-API-Key")
+		receivedAuth = r.Header.Get("Authorization")
+		resp := RegistrationResponse{
+			Success: true,
+			IdentityPackage: DIDIdentityPackage{
+				AgentDID: DIDIdentity{DID: "did:web:test"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, WithAPIKey("my-api-key"))
+	_, err := c.RegisterAgent(context.Background(), RegistrationRequest{AgentNodeID: "test"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "my-api-key", receivedKey)
+	// The API key is a distinct credential and must not be sent as a bearer token.
+	assert.Empty(t, receivedAuth)
+}
+
 func TestClient_ContextCancellation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Never respond — client should cancel


### PR DESCRIPTION
Found while verifying whether rc.11 is safe to release. The unauthenticated
flow is clean; this is the authenticated one.

## What happens

Point a Go agent at a control plane running with `AGENTFIELD_API_KEY` and it
looks healthy — it registers, it appears in `af nodes`, its reasoner runs. Then
the result never arrives. The status callback is rejected, retried five times
and given up on; the run sits in `running` forever and the caller hangs until
it times out. The only trace is one warning line in the agent's own log.

Reproduced against a control plane built from `main`, one Go agent with the key
and one Python agent beside it on the same server:

```
POST /api/v1/executions/exec_…0thpwnuj/status → 401   (×5, one per retry)

go-auth-agent.greet    → run stuck in "running", caller times out
auth-agent.hello       → succeeds        (Python, same server, same key)
go-unauth-agent.greet  → succeeds        (Go, server without a key)
```

So it is specific to Go + API-key auth.

## Why

`Config.APIKey` was threaded into the shared client, and everything that goes
through it authenticates correctly — which is why registration works and the
agent looks fine. But a handful of paths build their own `*http.Request`, and
each set only `Authorization` from `Config.Token`:

| | |
| --- | --- |
| `agent.go` `postExecutionStatus` | every async execution result |
| `agent.go` `applyCallHeaders` | cross-node call submit **and** poll |
| `agent.go` `sendWorkflowEvent` | the events the DAG view is built from |
| `note.go` | `agent.Note` |
| `discovery.go` | `agent.Discover` |

Two more had the same gap: the local verifier was handed `cfg.Token` for a
parameter its constructor names `apiKey` and sends as `X-API-Key`, and the DID
client had no API-key option at all, so DID registration and VC posts 401'd and
the agent came up without an identity.

## The change

One `applyControlPlaneAuth` helper, used by all five request builders, setting
`Authorization` and `X-API-Key` independently — they are separate credentials
and either may be configured alone. The local verifier now prefers `APIKey` and
falls back to `Token`, since callers used Token as the key before `APIKey`
existed. `did.WithAPIKey` is new and wired from `Config.APIKey`.

With neither credential set nothing is sent, so the default local flow is byte
for byte what it was.

## Verification

Same two agents, after the fix:

| case | before | after |
| --- | --- | --- |
| Go `greet` on the authenticated CP | hangs, run stuck `running` | `succeeded` |
| Go `gochain` (cross-node call) on the authenticated CP | — | `succeeded` |
| Go `greet` on a CP with no key | `succeeded` | `succeeded` |
| Go `gochain` on a CP with no key | `succeeded` | `succeeded` |
| 401s in the control-plane log after the fix | 24 | none new |

Unit tests drive each of the five builders against a recording server and
assert what actually left the process, plus the credential combinations:
key only, token only, both, neither. All six fail if the `X-API-Key` line is
removed from the helper (checked by mutation), and the neither-set case is what
protects the out-of-the-box flow from picking up an empty header.

`go build ./...`, `go mod tidy` and the full `sdk/go` suite are clean; patch
coverage is 100% on the 30 touched lines.

## Note

The Python SDK does not have this gap — it sends the key from its client, the
handler, memory events, the async execution manager, the DID manager, the
verifier and the VC generator. Verified live against the same authenticated
control plane.
