### PR TITLE
fix(release): bundle the OpenTofu deploy engine into desktop installers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -598,6 +598,25 @@ jobs:
           AF_CLI_VERSION: ${{ needs.prepare.outputs.tag_name }}
         run: npm run bundle-cli -- full
 
+      # One-click Railway deploy needs OpenTofu + the Railway provider in
+      # vendor/deploy-engine so extraResources can pack them into the app.
+      - name: Fetch deploy engine (OpenTofu + Railway provider)
+        working-directory: desktop
+        run: npm run fetch:deploy-engine
+
+      # electron-builder silently skips a missing extraResources source, so a
+      # broken or removed fetch would ship installers whose Remote tab says
+      # "one-click deploy isn't bundled" (every build up to v0.1.118 did).
+      # Fail the release here instead of degrading the artifact.
+      - name: Assert deploy engine is bundled
+        working-directory: desktop
+        shell: bash
+        run: |
+          ls vendor/deploy-engine/tofu vendor/deploy-engine/tofu.exe 2>/dev/null | grep -q . \
+            || { echo "::error::vendor/deploy-engine has no tofu binary; run fetch:deploy-engine"; exit 1; }
+          test -d vendor/deploy-engine/providers \
+            || { echo "::error::vendor/deploy-engine/providers mirror is missing; offline provider install would fail"; exit 1; }
+
       # electron-builder signs every Mach-O in the bundle (including the
       # bundled af/af-tray) with the Developer ID cert + hardened runtime,
       # then notarizes and staples the .app before packing DMG/zip from it.


### PR DESCRIPTION
## Summary

The `desktop-installers` job never runs `npm run fetch:deploy-engine`, so `desktop/vendor/deploy-engine` (populated only at build time, not in git) is always absent in CI. electron-builder **silently skips** a missing `extraResources` source, so every released installer shipped without the OpenTofu binary and the Railway provider mirror — the desktop Remote tab degrades to "One-click deploy isn't bundled in this build" on every install (#847 shipped the feature, the fetch script, and the `extraResources` wiring, but never wired the fetch into the release workflow).

## Changes

- Run `npm run fetch:deploy-engine` in the `desktop-installers` job (both matrix legs) after `bundle-cli`, before `npm run dist`, so OpenTofu + the Railway provider land in `vendor/deploy-engine` for `extraResources` to pack.
- Add an assert step that fails the release if the `tofu` binary or the `providers` filesystem mirror is missing — electron-builder's silent skip is exactly what let this ship broken, so a regression must fail loudly here instead of degrading the artifact.

## Validation Contract

- A released installer must contain `resources/bin/deploy-engine/tofu(.exe)` and the `providers` mirror, so `resolveTofuBinary()` resolves the bundled binary and the Remote tab shows the one-click deploy flow instead of the template fallback.
- If the deploy engine is missing at pack time (fetch step removed, script broken, layout drift vs. the `extraResources` mapping), the release run must fail at the assert step — never produce a green release with a degraded installer.

## Testing

- `actionlint` clean on the modified workflow; YAML parses.
- Assert snippet smoke-tested under `bash -e` for both paths: exits 1 with an empty `vendor/deploy-engine`, exits 0 with `tofu.exe` + `providers/` present.
- Full proof needs a release run: after the next tag, the Windows/macOS installers should show the Railway login button in the Remote tab instead of the fallback link.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)