### PR TITLE
fix(release): deploy-engine assert false-positives under pipefail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -611,11 +611,19 @@ jobs:
       - name: Assert deploy engine is bundled
         working-directory: desktop
         shell: bash
+        # Plain file tests only: this step runs under bash -e -o pipefail,
+        # where an `ls existing missing | grep` pipeline reports the missing
+        # arg's exit status even when the other file exists (the v0.1.119
+        # false positive that blocked the macOS DMG).
         run: |
-          ls vendor/deploy-engine/tofu vendor/deploy-engine/tofu.exe 2>/dev/null | grep -q . \
-            || { echo "::error::vendor/deploy-engine has no tofu binary; run fetch:deploy-engine"; exit 1; }
-          test -d vendor/deploy-engine/providers \
-            || { echo "::error::vendor/deploy-engine/providers mirror is missing; offline provider install would fail"; exit 1; }
+          if [ ! -f vendor/deploy-engine/tofu ] && [ ! -f vendor/deploy-engine/tofu.exe ]; then
+            echo "::error::vendor/deploy-engine has no tofu binary; run fetch:deploy-engine"
+            exit 1
+          fi
+          if [ ! -d vendor/deploy-engine/providers ]; then
+            echo "::error::vendor/deploy-engine/providers mirror is missing; offline provider install would fail"
+            exit 1
+          fi
 
       # electron-builder signs every Mach-O in the bundle (including the
       # bundled af/af-tray) with the Developer ID cert + hardened runtime,


### PR DESCRIPTION
## Summary

The v0.1.119 release failed on the macOS `desktop-installers` leg **after a successful deploy-engine fetch** — the assert step from #859 false-positived. GitHub runs `shell: bash` steps as `bash --noprofile --norc -e -o pipefail`, and the check was a pipeline: `ls tofu tofu.exe 2>/dev/null | grep -q .`. On macOS only `tofu` exists, so `ls` exits nonzero for the missing `tofu.exe` argument even while printing the real binary, and `pipefail` surfaces that status despite `grep` matching. The Windows leg passed only by accident (MSYS `.exe` transparency makes `ls tofu` resolve `tofu.exe`).

## Changes

- Replace the `ls | grep` pipeline with plain `[ -f ]` / `[ -d ]` tests inside `if` blocks — no pipeline, so `pipefail` has nothing to poison, and `-e` is guarded by the conditional.
- Comment on the step records why a pipeline must not be reintroduced.

## Validation Contract

- With `tofu` present (macOS layout) or `tofu.exe` present (Windows layout) plus the `providers` mirror, the assert must pass.
- With no tofu binary, or no `providers` mirror, the assert must fail the release with the matching `::error::` annotation.

## Testing

Ran the exact step body under GitHub's shell invocation (`bash --noprofile --norc -e -o pipefail`) in all four layouts: macOS shape → exit 0, Windows shape → exit 0, missing binary → exit 1 with the tofu error, missing mirror → exit 1 with the providers error. `actionlint` clean. (The original change was smoke-tested with `bash -e` only — the missing `-o pipefail` is exactly how the false positive slipped through.)

After merge, re-running the release should let the macOS leg proceed to the signed/notarized DMG + zip; the fetch step itself already proved out on both platforms in run 30719194262.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)