### PR TITLE
Preserve file modes when installing a package

### DIFF
--- a/control-plane/internal/core/services/package_service.go
+++ b/control-plane/internal/core/services/package_service.go
@@ -3,7 +3,6 @@ package services
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -545,22 +544,11 @@ func (ps *DefaultPackageService) copyPackage(sourcePath, destPath string) error 
 	})
 }
 
-// copyFile copies a single file from src to dst
+// copyFile copies a single file from src to dst, preserving its mode. Shared
+// with the CLI installer so an executable a node ships stays executable on
+// both install paths.
 func (ps *DefaultPackageService) copyFile(src, dst string) error {
-	sourceFile, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer sourceFile.Close()
-
-	destFile, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer destFile.Close()
-
-	_, err = io.Copy(destFile, sourceFile)
-	return err
+	return packages.CopyFile(src, dst)
 }
 
 // installDependencies installs package dependencies for the node's language

--- a/control-plane/internal/packages/copyfile_test.go
+++ b/control-plane/internal/packages/copyfile_test.go
@@ -1,0 +1,122 @@
+package packages
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCopyFilePreservesExecutableBit guards the property a node relies on when
+// it ships an executable: a helper binary or hook script that is 0755 in the
+// repo must still be runnable after an install. os.Create would have produced
+// 0666&^umask, leaving it non-executable and failing at spawn time with
+// "permission denied".
+func TestCopyFilePreservesExecutableBit(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "helper")
+	if err := os.WriteFile(src, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(dir, "copied-helper")
+	if err := CopyFile(src, dst); err != nil {
+		t.Fatalf("CopyFile: %v", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o755 {
+		t.Errorf("copied mode = %o, want 755 — an executable a node ships must stay executable", got)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Error("copied file is not executable")
+	}
+}
+
+// TestCopyFilePreservesNonExecutableMode: the mode is copied, not forced — a
+// plain data file must not gain an execute bit.
+func TestCopyFilePreservesNonExecutableMode(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(src, []byte("name: demo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(dir, "copied.yaml")
+	if err := CopyFile(src, dst); err != nil {
+		t.Fatalf("CopyFile: %v", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o644 {
+		t.Errorf("copied mode = %o, want 644", got)
+	}
+}
+
+// TestCopyFileOverwritesModeOfExistingDest: reinstalling over an existing file
+// must correct its mode, not inherit the stale one (O_CREATE alone would leave
+// an existing destination's permissions untouched).
+func TestCopyFileOverwritesModeOfExistingDest(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "bin")
+	if err := os.WriteFile(src, []byte("payload"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "stale")
+	if err := os.WriteFile(dst, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyFile(src, dst); err != nil {
+		t.Fatalf("CopyFile: %v", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o755 {
+		t.Errorf("mode after overwrite = %o, want 755", got)
+	}
+	content, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "payload" {
+		t.Errorf("content = %q, want the source content", content)
+	}
+}
+
+// TestCopyPackagePreservesExecutableBit exercises the property through the
+// real install entry point rather than the helper alone.
+func TestCopyPackagePreservesExecutableBit(t *testing.T) {
+	src := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(src, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "bin", "engine"), []byte("ELF"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "agentfield-package.yaml"), []byte("name: demo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(t.TempDir(), "installed")
+	pi := &PackageInstaller{}
+	if err := pi.copyPackage(src, dst); err != nil {
+		t.Fatalf("copyPackage: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dst, "bin", "engine"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Errorf("installed binary mode = %o — a shipped executable must stay executable", info.Mode().Perm())
+	}
+}

--- a/control-plane/internal/packages/installer.go
+++ b/control-plane/internal/packages/installer.go
@@ -816,22 +816,44 @@ func shouldSkipCopy(relPath string, info os.FileInfo) bool {
 	return false
 }
 
-// copyFile copies a single file from src to dst
-func (pi *PackageInstaller) copyFile(src, dst string) error {
+// CopyFile copies a single file from src to dst, preserving its permission
+// bits. Preserving the mode matters because a node may ship an executable it
+// expects to run — a helper binary or a hook script. os.Create would produce
+// 0666&^umask, so such a file would arrive on disk non-executable and fail at
+// spawn time with "permission denied".
+//
+// This is the one implementation: the package installer and the package
+// service both route their file copies through it so the two cannot drift.
+func CopyFile(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	perm := info.Mode().Perm()
+
 	sourceFile, err := os.Open(src)
 	if err != nil {
 		return err
 	}
 	defer sourceFile.Close()
 
-	destFile, err := os.Create(dst)
+	destFile, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
 	if err != nil {
 		return err
 	}
 	defer destFile.Close()
 
-	_, err = io.Copy(destFile, sourceFile)
-	return err
+	if _, err := io.Copy(destFile, sourceFile); err != nil {
+		return err
+	}
+	// O_CREATE applies the umask to perm, and an existing dst keeps its old
+	// mode entirely, so set it explicitly.
+	return os.Chmod(dst, perm)
+}
+
+// copyFile copies a single file from src to dst, preserving its mode.
+func (pi *PackageInstaller) copyFile(src, dst string) error {
+	return CopyFile(src, dst)
 }
 
 // installDependencies installs package dependencies


### PR DESCRIPTION
`copyFile` created every destination with `os.Create`, whose mode is `0666&^umask`, and never read the source's mode. Any executable a node ships — a helper binary, a hook, a shell script — therefore arrived on disk at `0644` and failed at spawn time with "permission denied".

Measured against a node that vendors a `0755` binary: it is `100755` in git and installs non-executable, on both the local-directory and git-clone paths. Directories were unaffected (`copyPackage` already passes `info.Mode()`); only regular files lost their bits.

## Changes

The two byte-identical copies of this function — `packages.PackageInstaller` (used by `af install <git-url>`) and `services.DefaultPackageService` (used by `af install <local-dir>`) — are now one shared `packages.CopyFile`, so a fix to one can't leave the other broken. It stats the source, creates with those permission bits, and chmods explicitly afterwards, since `O_CREATE` applies the umask and an existing destination would otherwise keep its old mode.

Regression tests cover the executable bit, that a plain data file does *not* gain one, reinstalling over an existing file with a stale mode, and a full `copyPackage` walk.

## Context

Found while verifying that a node which vendors a binary works after `af install`. You mentioned you wanted to take the install flow yourself — this is split out from the catalog PR so it's easy to close if you'd rather do your own.

## Validation

`gofmt`, `go build ./...`, and `go test ./internal/packages/... ./internal/core/services/...` all clean. Verified end to end with a real `af install`: the vendored binary now lands `0755` and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)