### PR TITLE
Don't reap executions that are waiting on a child

### DIFF
--- a/control-plane/internal/storage/execution_records.go
+++ b/control-plane/internal/storage/execution_records.go
@@ -1102,6 +1102,16 @@ func parseTimeString(value string) (time.Time, error) {
 // INVARIANT: callers must ensure updated_at is bumped on every meaningful execution activity.
 // If updated_at is not maintained, active executions may be incorrectly reaped.
 // Uses COALESCE(updated_at, created_at, started_at) to handle rows where updated_at may be NULL.
+//
+// An execution that is merely BLOCKED ON A CHILD is not stale, so rows with a
+// non-terminal child are skipped. A parent's own updated_at stops moving while
+// it waits, so without this a long child call — one agent doing many minutes of
+// work in a single request — reaps its whole ancestor chain even though real
+// work is happening. Deliberately no recency test on the child: the chain
+// unwinds bottom-up instead. If work genuinely stops, the leaf goes stale and
+// is reaped first, which makes its parent childless and eligible on the next
+// sweep, and so on up. Nothing is stuck forever; it just takes one sweep per
+// level.
 func (ls *LocalStorage) MarkStaleExecutions(ctx context.Context, staleAfter time.Duration, limit int) (int, error) {
 	if limit <= 0 {
 		return 0, nil
@@ -1115,9 +1125,14 @@ func (ls *LocalStorage) MarkStaleExecutions(ctx context.Context, staleAfter time
 	db := ls.requireSQLDB()
 	rows, err := db.QueryContext(ctx, `
 		SELECT execution_id, started_at
-		FROM executions
+		FROM executions e
 		WHERE status IN ('running', 'pending', 'queued')
 		  AND COALESCE(updated_at, created_at, started_at) <= ?
+		  AND NOT EXISTS (
+		      SELECT 1 FROM executions c
+		      WHERE c.parent_execution_id = e.execution_id
+		        AND c.status IN ('running', 'pending', 'queued')
+		  )
 		ORDER BY COALESCE(updated_at, created_at, started_at) ASC
 		LIMIT ?`, cutoff, limit)
 	if err != nil {
@@ -1208,7 +1223,8 @@ func (ls *LocalStorage) MarkStaleExecutions(ctx context.Context, staleAfter time
 // when their updated_at timestamp exceeds the staleAfter threshold. This catches orphaned
 // child executions whose parent failed without cascading cancellation.
 //
-// See MarkStaleExecutions for the updated_at invariant and COALESCE fallback rationale.
+// See MarkStaleExecutions for the updated_at invariant, the COALESCE fallback
+// rationale, and why a row with a non-terminal child is skipped rather than reaped.
 func (ls *LocalStorage) MarkStaleWorkflowExecutions(ctx context.Context, staleAfter time.Duration, limit int) (int, error) {
 	if limit <= 0 {
 		return 0, nil
@@ -1222,10 +1238,15 @@ func (ls *LocalStorage) MarkStaleWorkflowExecutions(ctx context.Context, staleAf
 	db := ls.requireSQLDB()
 	rows, err := db.QueryContext(ctx, `
 		SELECT execution_id, started_at
-		FROM workflow_executions
+		FROM workflow_executions w
 		WHERE status IN ('running', 'pending', 'queued', 'waiting')
 		  AND COALESCE(updated_at, created_at, started_at) <= ?
 		  AND COALESCE(approval_status, '') != 'pending'
+		  AND NOT EXISTS (
+		      SELECT 1 FROM workflow_executions c
+		      WHERE c.parent_execution_id = w.execution_id
+		        AND c.status IN ('running', 'pending', 'queued', 'waiting')
+		  )
 		ORDER BY COALESCE(updated_at, created_at, started_at) ASC
 		LIMIT ?`, cutoff, limit)
 	if err != nil {

--- a/control-plane/internal/storage/stale_execution_parent_test.go
+++ b/control-plane/internal/storage/stale_execution_parent_test.go
@@ -1,0 +1,141 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newRunningExecution inserts a running execution, optionally parented, whose
+// updated_at is backdated by the given age. A zero age leaves updated_at at
+// "now", i.e. actively progressing.
+func newRunningExecution(t *testing.T, ls *LocalStorage, id, parent string, age time.Duration) {
+	t.Helper()
+	ctx := t.Context()
+	now := time.Now().UTC()
+
+	exec := &types.Execution{
+		ExecutionID: id,
+		RunID:       "run-parented",
+		AgentNodeID: "agent-1",
+		ReasonerID:  "reasoner-1",
+		NodeID:      "node-1",
+		Status:      "running",
+		StartedAt:   now.Add(-2 * time.Hour),
+	}
+	if parent != "" {
+		exec.ParentExecutionID = strPtr(parent)
+	}
+	require.NoError(t, ls.CreateExecutionRecord(ctx, exec))
+	if age > 0 {
+		backdateExecutionUpdatedAt(t, ls, "executions", id, now.Add(-age))
+	}
+}
+
+func executionStatus(t *testing.T, ls *LocalStorage, id string) string {
+	t.Helper()
+	rec, err := ls.GetExecutionRecord(t.Context(), id)
+	require.NoError(t, err)
+	return rec.Status
+}
+
+// TestMarkStaleExecutions_KeepsParentBlockedOnActiveChild is the regression
+// this guards: a parent's own updated_at stops moving while it waits on a
+// child, so an agent doing many minutes of work inside one request used to get
+// its whole ancestor chain reaped mid-flight — reported to the caller as
+// "execution timed out (no activity)" while the work was still running.
+func TestMarkStaleExecutions_KeepsParentBlockedOnActiveChild(t *testing.T) {
+	ls, ctx := setupTestLocalStorage(t)
+
+	// build (idle 1h, waiting) -> adapter (idle 1h, waiting) -> engine (working now)
+	newRunningExecution(t, ls, "exec-build", "", time.Hour)
+	newRunningExecution(t, ls, "exec-adapter", "exec-build", time.Hour)
+	newRunningExecution(t, ls, "exec-engine", "exec-adapter", 0)
+
+	reaped, err := ls.MarkStaleExecutions(ctx, 30*time.Minute, 100)
+	require.NoError(t, err)
+	require.Equal(t, 0, reaped, "nothing may be reaped while a descendant is still working")
+
+	for _, id := range []string{"exec-build", "exec-adapter", "exec-engine"} {
+		require.Equal(t, "running", executionStatus(t, ls, id), "%s must survive", id)
+	}
+}
+
+// TestMarkStaleExecutions_UnwindsChainBottomUp: when work genuinely stops, the
+// chain still drains — one level per sweep, leaf first — so skipping parents
+// cannot strand executions in `running` forever.
+func TestMarkStaleExecutions_UnwindsChainBottomUp(t *testing.T) {
+	ls, ctx := setupTestLocalStorage(t)
+
+	newRunningExecution(t, ls, "exec-build", "", time.Hour)
+	newRunningExecution(t, ls, "exec-adapter", "exec-build", time.Hour)
+	newRunningExecution(t, ls, "exec-engine", "exec-adapter", time.Hour)
+
+	// Sweep 1: only the leaf is childless.
+	reaped, err := ls.MarkStaleExecutions(ctx, 30*time.Minute, 100)
+	require.NoError(t, err)
+	require.Equal(t, 1, reaped)
+	require.Equal(t, "timeout", executionStatus(t, ls, "exec-engine"))
+	require.Equal(t, "running", executionStatus(t, ls, "exec-adapter"))
+	require.Equal(t, "running", executionStatus(t, ls, "exec-build"))
+
+	// Sweep 2: the adapter is now childless.
+	reaped, err = ls.MarkStaleExecutions(ctx, 30*time.Minute, 100)
+	require.NoError(t, err)
+	require.Equal(t, 1, reaped)
+	require.Equal(t, "timeout", executionStatus(t, ls, "exec-adapter"))
+	require.Equal(t, "running", executionStatus(t, ls, "exec-build"))
+
+	// Sweep 3: the root drains last.
+	reaped, err = ls.MarkStaleExecutions(ctx, 30*time.Minute, 100)
+	require.NoError(t, err)
+	require.Equal(t, 1, reaped)
+	require.Equal(t, "timeout", executionStatus(t, ls, "exec-build"))
+}
+
+// TestMarkStaleExecutions_TerminalChildDoesNotShieldParent: only a
+// *non-terminal* child protects a parent. A finished child must not keep a
+// genuinely stuck parent alive.
+func TestMarkStaleExecutions_TerminalChildDoesNotShieldParent(t *testing.T) {
+	ls, ctx := setupTestLocalStorage(t)
+	now := time.Now().UTC()
+
+	newRunningExecution(t, ls, "exec-build", "", time.Hour)
+	done := &types.Execution{
+		ExecutionID:       "exec-done",
+		RunID:             "run-parented",
+		AgentNodeID:       "agent-1",
+		ReasonerID:        "reasoner-1",
+		NodeID:            "node-1",
+		Status:            "succeeded",
+		StartedAt:         now.Add(-2 * time.Hour),
+		ParentExecutionID: strPtr("exec-build"),
+	}
+	require.NoError(t, ls.CreateExecutionRecord(ctx, done))
+
+	reaped, err := ls.MarkStaleExecutions(ctx, 30*time.Minute, 100)
+	require.NoError(t, err)
+	require.Equal(t, 1, reaped)
+	require.Equal(t, "timeout", executionStatus(t, ls, "exec-build"))
+	require.Equal(t, "succeeded", executionStatus(t, ls, "exec-done"), "terminal child untouched")
+}
+
+// TestMarkStaleExecutions_UnrelatedStuckExecutionStillReaped: the new skip is
+// scoped to actual parents — an unrelated stuck execution is still collected in
+// the same sweep as a protected chain.
+func TestMarkStaleExecutions_UnrelatedStuckExecutionStillReaped(t *testing.T) {
+	ls, ctx := setupTestLocalStorage(t)
+
+	newRunningExecution(t, ls, "exec-build", "", time.Hour)
+	newRunningExecution(t, ls, "exec-engine", "exec-build", 0) // working
+	newRunningExecution(t, ls, "exec-orphan", "", time.Hour)   // genuinely stuck
+
+	reaped, err := ls.MarkStaleExecutions(ctx, 30*time.Minute, 100)
+	require.NoError(t, err)
+	require.Equal(t, 1, reaped)
+	require.Equal(t, "timeout", executionStatus(t, ls, "exec-orphan"))
+	require.Equal(t, "running", executionStatus(t, ls, "exec-build"))
+}


### PR DESCRIPTION
An execution's `updated_at` stops moving while it waits for a child to return, so the staleness sweep read "blocked on a child" as "stuck". Any agent that does many minutes of work inside a single request had its whole ancestor chain marked timed out mid-flight — the caller got `execution timed out (no activity)` while the work was still running, and the agent went on to finish normally against a run already reported as failed.

Observed on a real build: the root execution was marked failed at `20:15:46`, and the agent doing the work kept emitting progress until `20:46` and beyond. A comparable build whose work was split across many short reasoner calls succeeded in the same window — each call bumped `updated_at`, so it never looked idle.

This is the invariant the code already documents (*"callers must ensure updated_at is bumped on every meaningful execution activity"*) meeting a caller that legitimately cannot bump it, because it is blocked.

## Change

Rows with a **non-terminal child** are skipped by both sweeps (`MarkStaleExecutions` and `MarkStaleWorkflowExecutions` had the same shape). `parent_execution_id` already exists and is indexed on both tables.

There is deliberately **no recency test on the child**, which is what makes the rule safe for arbitrary nesting depth: the chain drains bottom-up. If work genuinely stops, the leaf goes stale and is reaped first, which makes its parent childless and eligible on the next sweep, and so on up to the root. One sweep per level, and nothing is stranded in `running`. Requiring the child to be *recently active* instead would only protect one level and would still reap grandparents.

## Tests

`internal/storage/stale_execution_parent_test.go` covers:

- a three-level chain where only the leaf is working — nothing is reaped
- the same chain fully idle — drains one level per sweep, leaf first
- a **terminal** child does not shield a genuinely stuck parent
- an unrelated stuck execution is still reaped in the same sweep as a protected chain

Both new behavioural tests were confirmed to **fail** with the fix reverted, so they pin the behaviour rather than the implementation.

`go build ./...` and the full `./internal/storage/...` suite pass, existing reaper tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)