### PR TITLE
Let a manifest declare itself superseded by another package

### DIFF
--- a/control-plane/internal/packages/git.go
+++ b/control-plane/internal/packages/git.go
@@ -392,6 +392,24 @@ func (gi *GitInstaller) parsePackageMetadata(packagePath string) (*PackageMetada
 }
 
 // updateRegistryWithGit updates the installation registry with Git source info
+// appendSubdirSelector rewrites "https://host/owner/repo[@ref]" into
+// "https://host/owner/repo//subdir[@ref]" so a recorded source round-trips
+// through ParseGitURL. It is needed whenever the subdirectory arrived by the
+// --path flag (or the install API, which splits the selector off before
+// calling): without it the registry records the REPO ROOT, and the next update
+// installs whatever lives there instead of the package that is installed.
+func appendSubdirSelector(url, subdir string) string {
+	subdir = strings.Trim(strings.TrimSpace(subdir), "/")
+	if subdir == "" {
+		return url
+	}
+	base, ref := url, ""
+	if at := strings.LastIndex(url, "@"); at > strings.LastIndex(url, "/") {
+		base, ref = url[:at], url[at:]
+	}
+	return base + "//" + subdir + ref
+}
+
 func (gi *GitInstaller) updateRegistryWithGit(metadata *PackageMetadata, info *GitPackageInfo, sourcePath, destPath string) error {
 	registryPath := filepath.Join(gi.AgentFieldHome, "installed.yaml")
 
@@ -422,6 +440,13 @@ func (gi *GitInstaller) updateRegistryWithGit(metadata *PackageMetadata, info *G
 	// any @ref and //subdir the user gave. (Appending the ref again used to
 	// produce doubled "…@main@main" entries.)
 	sourcePathStr := info.URL
+	// …except when the subdirectory came from --path (or the install API, which
+	// splits `//subdir` off the URL before calling). Then info.URL is the bare
+	// repo and the selector has to be put back, or this records a source that
+	// resolves to the repo root and the next update installs a different package.
+	if strings.TrimSpace(info.Subdir) == "" && strings.TrimSpace(gi.Subdir) != "" {
+		sourcePathStr = appendSubdirSelector(sourcePathStr, gi.Subdir)
+	}
 
 	// Add/update package entry with Git information
 	registry.Installed[metadata.Name] = InstalledPackage{

--- a/control-plane/internal/packages/git.go
+++ b/control-plane/internal/packages/git.go
@@ -38,7 +38,19 @@ type GitInstaller struct {
 	// subdirectory becomes the package root that is copied and installed. It
 	// composes with an @ref pin on the URL, which is parsed independently.
 	Subdir string
+
+	// redirects counts how many superseded_by hops led here, bounding a cycle
+	// (A superseded by B, B superseded by A) instead of cloning forever.
+	redirects int
+	// installedName records the package name this installer actually installed.
+	// A superseded_by redirect needs it to hand the old package's node-scoped
+	// secrets to the successor, whose name it cannot know in advance.
+	installedName string
 }
+
+// maxSupersedeRedirects bounds a superseded_by chain. Three is generous for the
+// real case (one hop) and still fails fast on a manifest cycle.
+const maxSupersedeRedirects = 3
 
 // newSpinner creates a new spinner with the given message
 func (gi *GitInstaller) newSpinner(message string) *Spinner {
@@ -202,7 +214,15 @@ func (gi *GitInstaller) InstallFromGit(gitURL string, force bool) error {
 		return fmt.Errorf("failed to parse package metadata: %w", err)
 	}
 
-	// 4. Use existing installer for the rest
+	// 4. A superseded package installs its successor instead. This runs before
+	// the force check and before anything is copied, so a redirect never
+	// half-installs the package it is redirecting away from.
+	if target := strings.TrimSpace(metadata.SupersededBy); target != "" {
+		return gi.followSupersededBy(metadata.Name, target, force)
+	}
+	gi.installedName = metadata.Name
+
+	// 5. Use existing installer for the rest
 	installer := &PackageInstaller{
 		AgentFieldHome: gi.AgentFieldHome,
 		Verbose:        gi.Verbose,
@@ -392,6 +412,94 @@ func (gi *GitInstaller) parsePackageMetadata(packagePath string) (*PackageMetada
 }
 
 // updateRegistryWithGit updates the installation registry with Git source info
+// followSupersededBy installs the successor a manifest points at, then retires
+// the superseded package when it was already installed. Order matters: the
+// successor is installed FIRST, so a failure leaves the user's existing node
+// exactly as it was rather than with nothing.
+func (gi *GitInstaller) followSupersededBy(fromName, target string, force bool) error {
+	if gi.redirects >= maxSupersedeRedirects {
+		return fmt.Errorf(
+			"superseded_by chain longer than %d hops (at %q → %q) — the manifests most likely point at each other",
+			maxSupersedeRedirects, fromName, target)
+	}
+
+	installer := &PackageInstaller{AgentFieldHome: gi.AgentFieldHome}
+	replacing := installer.isPackageInstalled(fromName)
+
+	fmt.Println()
+	fmt.Printf("⚠️  %s has been superseded by %s\n", fromName, target)
+	if replacing {
+		fmt.Printf("⚠️  %s is currently installed and WILL BE REPLACED: the successor is installed first,\n", fromName)
+		fmt.Printf("    then %s is stopped and removed. Its node-scoped secrets move to the successor.\n", fromName)
+	}
+	fmt.Println(ui.Muted("  installing the successor instead"))
+	fmt.Println()
+
+	successor := &GitInstaller{
+		AgentFieldHome: gi.AgentFieldHome,
+		Verbose:        gi.Verbose,
+		redirects:      gi.redirects + 1,
+	}
+	if err := successor.InstallFromGit(target, force); err != nil {
+		return fmt.Errorf("installing %s, the successor of %s: %w", target, fromName, err)
+	}
+	gi.installedName = successor.installedName
+
+	if !replacing || successor.installedName == fromName {
+		return nil
+	}
+	gi.retireSuperseded(fromName, successor.installedName)
+	return nil
+}
+
+// retireSuperseded removes the old package once its successor is in place. It
+// never fails the install: the successor is already working, so a stubborn
+// leftover is a cleanup chore, not a reason to report failure.
+func (gi *GitInstaller) retireSuperseded(oldName, newName string) {
+	if store, err := NewSecretStore(gi.AgentFieldHome); err == nil {
+		migrateNodeScopedSecrets(store, oldName, newName)
+	}
+	uninstaller := &PackageUninstaller{AgentFieldHome: gi.AgentFieldHome}
+	if err := uninstaller.UninstallPackage(oldName); err != nil {
+		fmt.Printf("⚠️  Could not remove the superseded %s: %v\n", oldName, err)
+		fmt.Printf("    %s is installed and usable; remove the old one with: af uninstall %s\n", newName, oldName)
+		return
+	}
+	fmt.Printf("✓ Replaced %s with %s\n", oldName, newName)
+}
+
+// migrateNodeScopedSecrets hands node-scoped secrets to the successor before
+// the old package is uninstalled, which deletes that scope outright. Without
+// this every `af secrets set KEY --node <old>` value is silently lost in the
+// swap. Global secrets are shared and untouched. A value already set on the
+// successor wins: the user set that one deliberately, and later.
+func migrateNodeScopedSecrets(store *SecretStore, oldName, newName string) {
+	// Read the scope directly rather than via Get, which falls back to the
+	// global scope and would copy shared secrets into the node scope.
+	oldValues, err := store.load(oldName)
+	if err != nil || len(oldValues) == 0 {
+		return
+	}
+	newValues, err := store.load(newName)
+	if err != nil {
+		newValues = map[string]string{}
+	}
+	moved := 0
+	for key, value := range oldValues {
+		if _, exists := newValues[key]; exists {
+			continue
+		}
+		if err := store.Set(newName, key, value); err != nil {
+			fmt.Printf("⚠️  Could not move secret %s to %s: %v\n", key, newName, err)
+			continue
+		}
+		moved++
+	}
+	if moved > 0 {
+		fmt.Printf("  moved %d node-scoped secret(s) from %s to %s\n", moved, oldName, newName)
+	}
+}
+
 // appendSubdirSelector rewrites "https://host/owner/repo[@ref]" into
 // "https://host/owner/repo//subdir[@ref]" so a recorded source round-trips
 // through ParseGitURL. It is needed whenever the subdirectory arrived by the

--- a/control-plane/internal/packages/git_supersede_test.go
+++ b/control-plane/internal/packages/git_supersede_test.go
@@ -1,0 +1,256 @@
+package packages
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These cover the shape a real repo uses to retire a node: the root manifest
+// declares itself superseded by a package in a subdirectory of the same repo,
+// so `af install <repo>` lands on the successor.
+
+const supersededRoot = "name: dual-node\nversion: 1.0.0\n" +
+	"superseded_by: https://gitlab.com/acme/dual//go\n"
+
+func seedInstalled(t *testing.T, home, name string) string {
+	t.Helper()
+	pkgDir := filepath.Join(home, "packages", name)
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pu := &PackageUninstaller{AgentFieldHome: home}
+	registry, err := pu.loadRegistry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry.Installed[name] = InstalledPackage{Name: name, Path: pkgDir, Status: "stopped"}
+	if err := pu.saveRegistry(registry); err != nil {
+		t.Fatal(err)
+	}
+	return pkgDir
+}
+
+// Contract: installing a superseded package installs its successor instead,
+// and the superseded name never reaches the registry.
+func TestInstallFromGit_SupersededRedirectsToSuccessor(t *testing.T) {
+	home := t.TempDir()
+	repo := filepath.Join(t.TempDir(), "repo")
+	writeTestPackage(t, repo, supersededRoot)
+	writeSubdirManifest(t, filepath.Join(repo, "go"), "dual-node-go")
+	setupFakeGit(t, "copy", repo, false)
+
+	if err := (&GitInstaller{AgentFieldHome: home}).
+		InstallFromGit("https://gitlab.com/acme/dual", false); err != nil {
+		t.Fatalf("InstallFromGit: %v", err)
+	}
+
+	registry := readRegistryFile(t, filepath.Join(home, "installed.yaml"))
+	if _, ok := registry.Installed["dual-node-go"]; !ok {
+		t.Fatalf("successor missing from registry, got %v", registry.Installed)
+	}
+	if _, ok := registry.Installed["dual-node"]; ok {
+		t.Fatal("the superseded package must not be installed")
+	}
+	if _, err := os.Stat(filepath.Join(home, "packages", "dual-node-go", "agentfield-package.yaml")); err != nil {
+		t.Fatalf("successor not on disk: %v", err)
+	}
+}
+
+// Contract: when the superseded package is already installed it is replaced —
+// the successor lands first, then the old package is stopped and removed.
+func TestInstallFromGit_SupersededReplacesExistingInstall(t *testing.T) {
+	home := t.TempDir()
+	repo := filepath.Join(t.TempDir(), "repo")
+	writeTestPackage(t, repo, supersededRoot)
+	writeSubdirManifest(t, filepath.Join(repo, "go"), "dual-node-go")
+	setupFakeGit(t, "copy", repo, false)
+
+	oldDir := seedInstalled(t, home, "dual-node")
+
+	if err := (&GitInstaller{AgentFieldHome: home}).
+		InstallFromGit("https://gitlab.com/acme/dual", false); err != nil {
+		t.Fatalf("InstallFromGit: %v", err)
+	}
+
+	registry := readRegistryFile(t, filepath.Join(home, "installed.yaml"))
+	if _, ok := registry.Installed["dual-node-go"]; !ok {
+		t.Fatalf("successor missing, got %v", registry.Installed)
+	}
+	if _, ok := registry.Installed["dual-node"]; ok {
+		t.Fatal("superseded package should have been retired from the registry")
+	}
+	if _, err := os.Stat(oldDir); !os.IsNotExist(err) {
+		t.Fatalf("superseded package dir should be gone, stat err = %v", err)
+	}
+}
+
+// Contract: node-scoped secrets follow the user across the swap, because
+// uninstalling the old package deletes that scope outright. A value already
+// set on the successor wins, and global secrets are untouched.
+func TestInstallFromGit_SupersededMigratesNodeScopedSecrets(t *testing.T) {
+	home := t.TempDir()
+	repo := filepath.Join(t.TempDir(), "repo")
+	writeTestPackage(t, repo, supersededRoot)
+	writeSubdirManifest(t, filepath.Join(repo, "go"), "dual-node-go")
+	setupFakeGit(t, "copy", repo, false)
+
+	seedInstalled(t, home, "dual-node")
+	store, err := NewSecretStore(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("dual-node", "CARRIED", "from-old"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("dual-node", "KEPT", "old-value"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("dual-node-go", "KEPT", "new-value"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("global", "SHARED", "shared-value"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := (&GitInstaller{AgentFieldHome: home}).
+		InstallFromGit("https://gitlab.com/acme/dual", false); err != nil {
+		t.Fatalf("InstallFromGit: %v", err)
+	}
+
+	after, err := NewSecretStore(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	values, err := after.load("dual-node-go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if values["CARRIED"] != "from-old" {
+		t.Fatalf("secret did not follow the swap: %v", values)
+	}
+	if values["KEPT"] != "new-value" {
+		t.Fatalf("successor's own value must win, got %q", values["KEPT"])
+	}
+	globals, err := after.load("global")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if globals["SHARED"] != "shared-value" {
+		t.Fatal("global secrets must survive the swap")
+	}
+}
+
+// Contract: with nothing to replace, the redirect is a plain install — no
+// error, and no attempt to retire a package that was never there.
+func TestInstallFromGit_SupersededWithoutPriorInstall(t *testing.T) {
+	home := t.TempDir()
+	repo := filepath.Join(t.TempDir(), "repo")
+	writeTestPackage(t, repo, supersededRoot)
+	writeSubdirManifest(t, filepath.Join(repo, "go"), "dual-node-go")
+	setupFakeGit(t, "copy", repo, false)
+
+	if err := (&GitInstaller{AgentFieldHome: home}).
+		InstallFromGit("https://gitlab.com/acme/dual", false); err != nil {
+		t.Fatalf("InstallFromGit: %v", err)
+	}
+	registry := readRegistryFile(t, filepath.Join(home, "installed.yaml"))
+	if len(registry.Installed) != 1 {
+		t.Fatalf("expected exactly the successor installed, got %v", registry.Installed)
+	}
+}
+
+// Contract: two manifests pointing at each other fail loudly instead of
+// redirecting forever.
+func TestInstallFromGit_SupersededCycleIsBounded(t *testing.T) {
+	home := t.TempDir()
+	repo := filepath.Join(t.TempDir(), "repo")
+	writeTestPackage(t, repo, supersededRoot)
+	// The successor points straight back at the root: A → B → A → …
+	if err := os.MkdirAll(filepath.Join(repo, "go"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := "name: dual-node-go\nversion: 1.0.0\n" +
+		"entrypoint:\n  start: python -m dual-node-go\n" +
+		"superseded_by: https://gitlab.com/acme/dual\n"
+	if err := os.WriteFile(
+		filepath.Join(repo, "go", "agentfield-package.yaml"), []byte(manifest), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	setupFakeGit(t, "copy", repo, false)
+
+	err := (&GitInstaller{AgentFieldHome: home}).
+		InstallFromGit("https://gitlab.com/acme/dual", false)
+	if err == nil || !strings.Contains(err.Error(), "superseded_by chain longer than") {
+		t.Fatalf("expected a bounded-chain error, got %v", err)
+	}
+	// Nothing was installed, so the registry was never even created.
+	if _, statErr := os.Stat(filepath.Join(home, "installed.yaml")); !os.IsNotExist(statErr) {
+		registry := readRegistryFile(t, filepath.Join(home, "installed.yaml"))
+		if len(registry.Installed) != 0 {
+			t.Fatalf("a cycle must install nothing, got %v", registry.Installed)
+		}
+	}
+}
+
+// Contract: a source recorded for a --path install round-trips through
+// ParseGitURL back to the same repo AND subdir, so the next update resolves
+// the package that is actually installed rather than the repo root.
+func TestAppendSubdirSelectorRoundTrips(t *testing.T) {
+	cases := []struct {
+		url, subdir, want, wantRef string
+	}{
+		{"https://github.com/acme/repo", "go", "https://github.com/acme/repo//go", ""},
+		{"https://github.com/acme/repo@main", "go", "https://github.com/acme/repo//go@main", "main"},
+		{"https://github.com/acme/repo", "nested/dir", "https://github.com/acme/repo//nested/dir", ""},
+		{"https://github.com/acme/repo", "", "https://github.com/acme/repo", ""},
+	}
+	for _, c := range cases {
+		got := appendSubdirSelector(c.url, c.subdir)
+		if got != c.want {
+			t.Errorf("appendSubdirSelector(%q, %q) = %q, want %q", c.url, c.subdir, got, c.want)
+			continue
+		}
+		info, err := ParseGitURL(got)
+		if err != nil {
+			t.Errorf("ParseGitURL(%q): %v", got, err)
+			continue
+		}
+		wantSubdir := strings.Trim(c.subdir, "/")
+		if info.Subdir != wantSubdir || info.Ref != c.wantRef {
+			t.Errorf("round-trip of %q = subdir %q ref %q, want %q %q",
+				got, info.Subdir, info.Ref, wantSubdir, c.wantRef)
+		}
+	}
+}
+
+// Contract: the registry records the subdirectory even when it arrived by the
+// --path flag rather than the URL selector. Without this the stored source
+// resolves to the repo root and the next update installs a different package.
+func TestInstallFromGit_PathFlagRecordsSubdirInSource(t *testing.T) {
+	home := t.TempDir()
+	repo := filepath.Join(t.TempDir(), "repo")
+	writeTestPackage(t, repo, "name: dual-node\nversion: 1.0.0\n")
+	writeSubdirManifest(t, filepath.Join(repo, "go"), "dual-node-go")
+	setupFakeGit(t, "copy", repo, false)
+
+	gi := &GitInstaller{AgentFieldHome: home, Subdir: "go"}
+	if err := gi.InstallFromGit("https://gitlab.com/acme/dual", false); err != nil {
+		t.Fatalf("InstallFromGit: %v", err)
+	}
+
+	registry := readRegistryFile(t, filepath.Join(home, "installed.yaml"))
+	pkg, ok := registry.Installed["dual-node-go"]
+	if !ok {
+		t.Fatalf("expected dual-node-go installed, got %v", registry.Installed)
+	}
+	if pkg.SourcePath != "https://gitlab.com/acme/dual//go" {
+		t.Fatalf("source path = %q, want the //go selector recorded", pkg.SourcePath)
+	}
+	info, err := ParseGitURL(pkg.SourcePath)
+	if err != nil || info.Subdir != "go" {
+		t.Fatalf("recorded source must resolve back to the subdir: %v / %+v", err, info)
+	}
+}

--- a/control-plane/internal/packages/installer.go
+++ b/control-plane/internal/packages/installer.go
@@ -115,7 +115,17 @@ type PackageMetadata struct {
 	// at parse time by detection (a go.mod at the package root => "go", otherwise
 	// "python"), so existing Python manifests keep working with no new field. This
 	// is an *additive* optional key: it does NOT bump config_version.
-	Language        string                 `yaml:"language"`
+	Language string `yaml:"language"`
+	// SupersededBy retires this package in favour of another one, named by an
+	// installable source (any string `af install` accepts, including a `//subdir`
+	// selector and an @ref). Installing a superseded package installs the
+	// successor instead, and replaces the old one when it is already present.
+	//
+	// This is how a node author renames or replaces their own node without the
+	// control plane knowing anything about them: the redirect lives in the
+	// package's manifest, not in a table here. Absent means "not superseded",
+	// so this is an *additive* optional key: it does NOT bump config_version.
+	SupersededBy    string                 `yaml:"superseded_by"`
 	Main            string                 `yaml:"main"`
 	Entrypoint      EntrypointConfig       `yaml:"entrypoint"`
 	AgentNode       AgentNodeConfig        `yaml:"agent_node"`


### PR DESCRIPTION
## Why

A node author who renames or replaces their own node has no way to carry
existing users across. `af install <their url>` keeps installing the old
package forever, because the manifest at that source is the only thing the
installer looks at — and the update path just replays the recorded source.

This adds a generic mechanism for that. **No node is named anywhere in the
control plane**: the redirect lives in the package's own manifest, so any
author gets it and this repo stays agnostic about what people install.

## What

An optional manifest key:

```yaml
name: my-node
superseded_by: https://github.com/me/my-repo//v2
```

Installing a superseded package installs the successor instead, and replaces
the old one when it is already present. The value is anything `af install`
accepts, including a `//subdir` selector and an `@ref`.

Ordering and safety, all covered by tests:

- The successor is installed **first**; only then is the old package retired,
  so a failed install leaves the existing node exactly as it was.
- The redirect is taken before the force check and before anything is copied,
  so it never half-installs the package it is redirecting away from.
- **Node-scoped secrets move to the successor** before the old package is
  uninstalled, which would otherwise delete that scope outright. A value
  already set on the successor wins. Global secrets are shared and untouched.
- Retiring never fails the install — the successor is already working, so a
  leftover is a cleanup chore, not a failure.
- A chain is bounded at 3 hops, so two manifests pointing at each other fail
  loudly instead of cloning forever.

The user is warned before the swap, naming exactly what will be replaced.

## Also: a subdir bug this depends on

A subdirectory reaches the installer two ways — the `//subdir` selector on the
URL, or the `--path` flag. The install API takes the second route, so
`info.URL` arrives bare and the registry recorded the **repo root** as the
source. The next update then resolved that bare source and installed whatever
manifest lives at the root — a *different package* than the one installed.

For a repo shipping a Python root and a Go port side by side, updating the Go
node silently replaced it with the Python one. Fixed in its own commit.

## Validation

Seven tests, one per behaviour, driven through the real `InstallFromGit`
against the existing fake-git harness rather than against internals: redirect,
replace-existing, secret migration (including that the successor's own value
wins and globals survive), the no-prior-install case, the bounded cycle, and
the `--path` source round-tripping back through `ParseGitURL`.

Verified end to end against a real repo with a root manifest and a `go/`
subdirectory: installing the bare repo URL installs the subdirectory's node,
records `//go` in the source, migrates a node-scoped secret, removes the old
package and its directory, and leaves global secrets intact.

`go build`, `go vet`, `gofmt` and the full `go test ./...` are clean (51
packages, 0 failures). `golangci-lint` reports no new issues in the changed
files.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)