### PR TITLE
Stop probing for a Python venv when starting a Go node

### DIFF
--- a/control-plane/internal/core/services/agent_service.go
+++ b/control-plane/internal/core/services/agent_service.go
@@ -649,74 +649,79 @@ func (as *DefaultAgentService) buildProcessConfig(agentNode packages.InstalledPa
 		env = append(env, fmt.Sprintf("%s=%s", key, value))
 	}
 
-	// Determine Python path - use virtual environment if available
-	var pythonPath string
-	venvPath := filepath.Join(agentNode.Path, "venv")
-
-	// Check if virtual environment exists (Unix/Linux/macOS)
-	if _, err := os.Stat(filepath.Join(venvPath, "bin", "python")); err == nil {
-		pythonPath = filepath.Join(venvPath, "bin", "python")
-		fmt.Printf("🐍 Using virtual environment: %s\n", venvPath)
-
-		// Complete virtual environment activation for Unix/Linux/macOS
-		venvBinPath := filepath.Join(venvPath, "bin")
-
-		// Set VIRTUAL_ENV first (required for proper activation)
-		env = append(env, fmt.Sprintf("VIRTUAL_ENV=%s", venvPath))
-
-		// Prepend virtual environment bin to PATH (critical for package resolution)
-		currentPath := os.Getenv("PATH")
-		env = append(env, fmt.Sprintf("PATH=%s:%s", venvBinPath, currentPath))
-
-		// Unset PYTHONHOME to avoid conflicts with virtual environment
-		env = append(env, "PYTHONHOME=")
-
-		// Set PYTHONPATH to ensure proper module resolution
-		env = append(env, fmt.Sprintf("PYTHONPATH=%s", filepath.Join(venvPath, "lib")))
-
-		fmt.Printf("✅ Virtual environment fully activated with PATH=%s\n", venvBinPath)
-
-	} else if _, err := os.Stat(filepath.Join(venvPath, "Scripts", "python.exe")); err == nil {
-		pythonPath = filepath.Join(venvPath, "Scripts", "python.exe") // Windows
-		fmt.Printf("🐍 Using virtual environment: %s\n", venvPath)
-
-		// Complete virtual environment activation for Windows
-		venvScriptsPath := filepath.Join(venvPath, "Scripts")
-
-		// Set VIRTUAL_ENV first (required for proper activation)
-		env = append(env, fmt.Sprintf("VIRTUAL_ENV=%s", venvPath))
-
-		// Prepend virtual environment Scripts to PATH (critical for package resolution)
-		currentPath := os.Getenv("PATH")
-		env = append(env, fmt.Sprintf("PATH=%s;%s", venvScriptsPath, currentPath))
-
-		// Unset PYTHONHOME to avoid conflicts with virtual environment
-		env = append(env, "PYTHONHOME=")
-
-		// Set PYTHONPATH to ensure proper module resolution
-		env = append(env, fmt.Sprintf("PYTHONPATH=%s", filepath.Join(venvPath, "Lib", "site-packages")))
-
-		fmt.Printf("✅ Virtual environment fully activated with PATH=%s\n", venvScriptsPath)
-
-	} else {
-		// Try to find python3 or python
-		if pythonPath = as.findPythonExecutable(); pythonPath == "" {
-			pythonPath = "python" // Final fallback
-		}
-		fmt.Printf("⚠️  Virtual environment not found at %s, using system Python: %s\n", venvPath, pythonPath)
-	}
-
-	// Launch via the manifest entrypoint (e.g. "python -m pr_af.app"). When the
-	// program token is python/python3, substitute the resolved interpreter. A Go
-	// node launches its install-time-built binary; a package-relative binary path
-	// is resolved against the install dir so exec finds it regardless of cwd.
+	// Launch via the manifest entrypoint (e.g. "python -m pr_af.app"), resolving
+	// the launcher for the node's language. A Go node launches its
+	// install-time-built binary; a package-relative binary path is resolved
+	// against the install dir so exec finds it regardless of cwd. Interpreter
+	// resolution lives inside the non-Go branch so a Go node never probes for a
+	// venv it does not have, nor warns about a Python it never runs.
 	startArgs := metadata.StartCommand()
 	command := startArgs[0]
 	args := startArgs[1:]
+
 	if metadata.IsGo() {
 		command = packages.GoBinaryProgram(agentNode.Path, command)
-	} else if command == "python" || command == "python3" {
-		command = pythonPath
+	} else {
+		// Determine Python path - use virtual environment if available
+		var pythonPath string
+		venvPath := filepath.Join(agentNode.Path, "venv")
+
+		// Check if virtual environment exists (Unix/Linux/macOS)
+		if _, err := os.Stat(filepath.Join(venvPath, "bin", "python")); err == nil {
+			pythonPath = filepath.Join(venvPath, "bin", "python")
+			fmt.Printf("🐍 Using virtual environment: %s\n", venvPath)
+
+			// Complete virtual environment activation for Unix/Linux/macOS
+			venvBinPath := filepath.Join(venvPath, "bin")
+
+			// Set VIRTUAL_ENV first (required for proper activation)
+			env = append(env, fmt.Sprintf("VIRTUAL_ENV=%s", venvPath))
+
+			// Prepend virtual environment bin to PATH (critical for package resolution)
+			currentPath := os.Getenv("PATH")
+			env = append(env, fmt.Sprintf("PATH=%s:%s", venvBinPath, currentPath))
+
+			// Unset PYTHONHOME to avoid conflicts with virtual environment
+			env = append(env, "PYTHONHOME=")
+
+			// Set PYTHONPATH to ensure proper module resolution
+			env = append(env, fmt.Sprintf("PYTHONPATH=%s", filepath.Join(venvPath, "lib")))
+
+			fmt.Printf("✅ Virtual environment fully activated with PATH=%s\n", venvBinPath)
+
+		} else if _, err := os.Stat(filepath.Join(venvPath, "Scripts", "python.exe")); err == nil {
+			pythonPath = filepath.Join(venvPath, "Scripts", "python.exe") // Windows
+			fmt.Printf("🐍 Using virtual environment: %s\n", venvPath)
+
+			// Complete virtual environment activation for Windows
+			venvScriptsPath := filepath.Join(venvPath, "Scripts")
+
+			// Set VIRTUAL_ENV first (required for proper activation)
+			env = append(env, fmt.Sprintf("VIRTUAL_ENV=%s", venvPath))
+
+			// Prepend virtual environment Scripts to PATH (critical for package resolution)
+			currentPath := os.Getenv("PATH")
+			env = append(env, fmt.Sprintf("PATH=%s;%s", venvScriptsPath, currentPath))
+
+			// Unset PYTHONHOME to avoid conflicts with virtual environment
+			env = append(env, "PYTHONHOME=")
+
+			// Set PYTHONPATH to ensure proper module resolution
+			env = append(env, fmt.Sprintf("PYTHONPATH=%s", filepath.Join(venvPath, "Lib", "site-packages")))
+
+			fmt.Printf("✅ Virtual environment fully activated with PATH=%s\n", venvScriptsPath)
+
+		} else {
+			// Try to find python3 or python
+			if pythonPath = as.findPythonExecutable(); pythonPath == "" {
+				pythonPath = "python" // Final fallback
+			}
+			fmt.Printf("⚠️  Virtual environment not found at %s, using system Python: %s\n", venvPath, pythonPath)
+		}
+
+		if command == "python" || command == "python3" {
+			command = pythonPath
+		}
 	}
 
 	return interfaces.ProcessConfig{

--- a/control-plane/internal/core/services/agent_service_language_test.go
+++ b/control-plane/internal/core/services/agent_service_language_test.go
@@ -1,0 +1,172 @@
+package services
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Agent-Field/agentfield/control-plane/internal/core/interfaces"
+	"github.com/Agent-Field/agentfield/control-plane/internal/packages"
+)
+
+// writeVenv materializes a Unix-style virtualenv under dir and returns its root
+// and bin directory. A Go-node test that plants one exercises the venv-found
+// branches; one that does not exercises the system-Python fallback, which is the
+// branch a real Go install reaches (installing a Go node never builds a venv).
+func writeVenv(t *testing.T, dir string) (venvPath, venvBin, python string) {
+	t.Helper()
+	venvPath = filepath.Join(dir, "venv")
+	venvBin = filepath.Join(venvPath, "bin")
+	require.NoError(t, os.MkdirAll(venvBin, 0o755))
+	python = filepath.Join(venvBin, "python")
+	require.NoError(t, os.WriteFile(python, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	return venvPath, venvBin, python
+}
+
+func buildConfigCapturingStdout(t *testing.T, dir, name string, port int) (interfaces.ProcessConfig, string) {
+	t.Helper()
+	service := &DefaultAgentService{}
+	var (
+		cfg interfaces.ProcessConfig
+		err error
+	)
+	out := captureStdout(t, func() {
+		cfg, err = service.buildProcessConfig(packages.InstalledPackage{
+			Name:    name,
+			Path:    dir,
+			Runtime: packages.RuntimeInfo{LogFile: filepath.Join(dir, name+".log")},
+		}, port)
+	})
+	require.NoError(t, err)
+	return cfg, out
+}
+
+// Contract: starting a Go node says nothing about Python, injects no Python env,
+// and still launches the resolved Go binary. Covers a manifest that declares
+// `language: go` and one that omits it but ships a go.mod (parse-time detection).
+func TestBuildProcessConfigGoNodeSkipsPythonResolution(t *testing.T) {
+	cases := []struct {
+		name     string
+		manifest string
+		goMod    bool
+		venv     bool
+	}{
+		{
+			name:     "explicit language go",
+			manifest: "name: go-node\nversion: 0.1.0\nlanguage: go\nentrypoint:\n  start: bin/node\n",
+			venv:     true,
+		},
+		{
+			name:     "language omitted with go.mod",
+			manifest: "name: go-node\nversion: 0.1.0\nentrypoint:\n  start: bin/node\n",
+			goMod:    true,
+			venv:     true,
+		},
+		{
+			// The shape `af install` actually produces: a Go node has no venv, so
+			// the unguarded code fell through to the system-Python fallback. This
+			// is the case that reported the bug, and the only one that can fail on
+			// the "not found"/"system Python" assertions below.
+			name:     "no venv, as a real Go install leaves it",
+			manifest: "name: go-node\nversion: 0.1.0\nlanguage: go\nentrypoint:\n  start: bin/node\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// A non-empty PYTHONHOME in the inherited environment keeps the
+			// "PYTHONHOME=" assertion below about what the venv block appends.
+			t.Setenv("PYTHONHOME", "inherited")
+
+			dir := t.TempDir()
+			writeManifest(t, dir, tc.manifest)
+			if tc.goMod {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+					[]byte("module example.com/node\n\ngo 1.21\n"), 0o644))
+			}
+			venvPath := filepath.Join(dir, "venv")
+			venvBin := filepath.Join(venvPath, "bin")
+			if tc.venv {
+				venvPath, venvBin, _ = writeVenv(t, dir)
+			}
+			require.NoError(t, os.MkdirAll(filepath.Join(dir, "bin"), 0o755))
+			binary := filepath.Join(dir, "bin", "node")
+			require.NoError(t, os.WriteFile(binary, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+
+			cfg, out := buildConfigCapturingStdout(t, dir, "go-node", 8201)
+
+			// Contract 1: no Python/venv chatter.
+			for _, phrase := range []string{
+				"Using virtual environment",
+				"Virtual environment not found",
+				"Virtual environment fully activated",
+				"system Python",
+			} {
+				assert.NotContains(t, out, phrase, "Go node printed a Python message")
+			}
+
+			// Contract 2: no Python env injected as a side effect. Collected rather
+			// than asserted entry-by-entry so a failure names the offender instead
+			// of dumping the inherited environment.
+			var injected []string
+			for _, entry := range cfg.Env {
+				switch {
+				case entry == "VIRTUAL_ENV="+venvPath,
+					entry == "PYTHONHOME=",
+					entry == "PYTHONPATH="+filepath.Join(venvPath, "lib"),
+					strings.HasPrefix(entry, "PATH="+venvBin):
+					injected = append(injected, entry)
+				}
+			}
+			assert.Empty(t, injected, "Go node had Python env injected")
+
+			// Contract 5: the launch command is the resolved Go binary.
+			assert.Equal(t, binary, cfg.Command)
+			assert.Empty(t, cfg.Args)
+		})
+	}
+}
+
+// Contract: a Python node keeps its interpreter resolution — venv activation
+// when one exists, system-Python fallback plus the warning when it does not.
+func TestBuildProcessConfigPythonNodeKeepsInterpreterResolution(t *testing.T) {
+	const manifest = "name: py-node\nversion: 0.1.0\nlanguage: python\nentrypoint:\n  start: python main.py\n"
+
+	t.Run("with venv", func(t *testing.T) {
+		t.Setenv("PYTHONHOME", "inherited")
+
+		dir := t.TempDir()
+		writeManifest(t, dir, manifest)
+		venvPath, venvBin, python := writeVenv(t, dir)
+
+		cfg, out := buildConfigCapturingStdout(t, dir, "py-node", 8202)
+
+		assert.Contains(t, out, "Using virtual environment: "+venvPath)
+		assert.Equal(t, python, cfg.Command)
+		assert.Equal(t, []string{"main.py"}, cfg.Args)
+		assert.Contains(t, cfg.Env, "VIRTUAL_ENV="+venvPath)
+		assertEnvWithPrefix(t, cfg.Env, "PATH=", venvBin)
+		assert.Contains(t, cfg.Env, "PYTHONHOME=")
+		assert.Contains(t, cfg.Env, "PYTHONPATH="+filepath.Join(venvPath, "lib"))
+	})
+
+	t.Run("without venv", func(t *testing.T) {
+		dir := t.TempDir()
+		writeManifest(t, dir, manifest)
+
+		stubBin := filepath.Join(dir, "stub")
+		require.NoError(t, os.MkdirAll(stubBin, 0o755))
+		stubPython := filepath.Join(stubBin, "python3")
+		require.NoError(t, os.WriteFile(stubPython, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+		t.Setenv("PATH", stubBin)
+
+		cfg, out := buildConfigCapturingStdout(t, dir, "py-node", 8203)
+
+		assert.Contains(t, out, "Virtual environment not found")
+		assert.Equal(t, stubPython, cfg.Command)
+	})
+}


### PR DESCRIPTION
## What

Starting a Go agent node printed a Python warning:

```
⚠️  Virtual environment not found at /home/…/.agentfield/packages/pr-af/venv, using system Python: /usr/bin/python3
```

Caught while sanity-checking a fresh `pr-af` install on v0.1.121. `buildProcessConfig` resolved a Python interpreter unconditionally — probing `venv/bin/python`, then `venv/Scripts/python.exe`, then scanning `PATH` — printed a message either way, and only *afterwards* checked `metadata.IsGo()` to override the command. The interpreter it found was discarded. A Go install never builds a venv, so Go nodes always hit the "not found" branch.

## How

Move the interpreter resolution inside the non-Go branch, matching the shape [`packages/runner.go`](https://github.com/Agent-Field/agentfield/blob/main/control-plane/internal/packages/runner.go) already uses:

```go
if metadata.IsGo() {
    command = packages.GoBinaryProgram(agentNode.Path, command)
} else {
    // …venv resolution, unchanged…
}
```

The venv block is byte-identical, only re-indented. For a Go node the stat probes, the `LookPath` scan, the prints and the four env appends now don't execute at all, rather than executing and being thrown away.

Two deliberate non-changes to keep this surgical:
- Did **not** adopt runner.go's extra `if program == "python"` guard around the whole block. `agent_service.go` also injects `VIRTUAL_ENV`/`PATH`/`PYTHONHOME`/`PYTHONPATH`, which non-Go nodes with a non-python entrypoint (`node dist/index.js`, `gunicorn …`) get today. Nesting would silently strip that.
- `PythonUTF8Env(env)` stays unconditional, for parity with runner.go.

## Validation contract

| # | Behaviour | Test |
|---|---|---|
| 1 | Go node prints no Python/venv message | `TestBuildProcessConfigGoNodeSkipsPythonResolution` |
| 2 | Go node gets no `VIRTUAL_ENV`/`PYTHONHOME`/`PYTHONPATH`/venv-`PATH` injected | same |
| 3 | Python node **with** venv activates identically, same message | `…PythonNodeKeepsInterpreterResolution/with_venv` |
| 4 | Python node **without** venv falls back to system Python and still warns | `…/without_venv` |
| 5 | Go launch command unchanged (`GoBinaryProgram`-resolved) | Go test |
| 6 | `language` omitted + `go.mod` ⇒ Go (same `IsGo()`, no re-detect) | Go test, case 2 |

The Go test runs three cases: explicit `language: go`, `language` omitted with a `go.mod`, and **no venv** — the shape `af install` actually produces. That third case is the one that reproduces the reported message; without it the `"Virtual environment not found"` / `"system Python"` assertions can never fail. Verified by reverting the fix:

```
--- FAIL: …/no_venv,_as_a_real_Go_install_leaves_it
    "⚠️  Virtual environment not found at …/venv, using system Python: …/python3"
      should not contain "Virtual environment not found"
```

The two venv-planted cases fail on the `"Using virtual environment"` / `"fully activated"` phrases plus the env-injection assertion.

## Gates

- `gofmt` clean on both files
- `go build ./...`, `go vet` clean
- `internal/core/services` and `internal/packages` suites green
- `buildProcessConfig` at **94.1%** coverage (gate is 80% on changed lines); the single uncovered line inside the diff is `findPythonExecutable()`'s "no python on the machine at all" inner fallback, equally uncovered before
- `golangci-lint run` reports 97 issues, all pre-existing, none in these two files (that step is `continue-on-error` in CI)
- `internal/server`'s `TestStartAndStopCoverAdditionalBranches` fails — **confirmed pre-existing**, fails identically on a pristine `origin/main` worktree

## Out of scope, found while here

- `dev_service.go` never reads the manifest at all — it hardcodes `exec.Command(pythonPath, "main.py")`. Since `af init` scaffolds Go (`main.go`) and TypeScript (`main.ts`) projects too, `af dev` only works for the Python scaffold. Separate fix.
- TypeScript nodes still take the non-Go branch and still print the venv warning. Unchanged here; same root cause as the above.