### PR TITLE
fix(install): ignore wedged runs when deciding whether the server is busy

### DIFF
--- a/control-plane/cmd/af-tray/launchd_darwin.go
+++ b/control-plane/cmd/af-tray/launchd_darwin.go
@@ -38,7 +38,7 @@ func installDesktop() error { return installDesktopWith(installOptions{}) }
 func installDesktopWith(opts installOptions) error {
 	// Decide about the server agent BEFORE writing anything: a refusal must
 	// leave the other install's files exactly as they were.
-	decision, plistData := serverAgentDecision(opts)
+	decision, plistData, staleRuns := serverAgentDecision(opts)
 	if decision.Action == launchdsvc.ActionRefuse {
 		existing, _ := launchdsvc.ReadPlistOwner(serverPlistPath())
 		return fmt.Errorf(
@@ -95,7 +95,8 @@ func installDesktopWith(opts installOptions) error {
 	case launchdsvc.ActionSkip:
 		fmt.Println("AgentField server: already up to date; leaving it running.")
 	case launchdsvc.ActionWriteOnly:
-		fmt.Printf("AgentField server: %s — not restarting.\n", decision.Reason)
+		fmt.Printf("AgentField server: %s — not restarting.%s\n",
+			decision.Reason, staleSuffix(staleRuns))
 		fmt.Println("  The new version takes effect on the next restart " +
 			"(menu-bar Restart, or `af service restart`).")
 	default:
@@ -112,7 +113,7 @@ func installDesktopWith(opts installOptions) error {
 // serverAgentDecision probes the current server agent and applies the takeover
 // policy. It returns the decision and the plist bytes the install would write,
 // so the caller can both act on the decision and avoid regenerating the plist.
-func serverAgentDecision(opts installOptions) (launchdsvc.TakeoverDecision, []byte) {
+func serverAgentDecision(opts installOptions) (launchdsvc.TakeoverDecision, []byte, int) {
 	want := []byte(serverPlist())
 
 	existing, plistExists := launchdsvc.ReadPlistOwner(serverPlistPath())
@@ -121,6 +122,7 @@ func serverAgentDecision(opts installOptions) (launchdsvc.TakeoverDecision, []by
 		WorkingDirectory: agentfieldDir(),
 	})
 
+	stale := 0
 	in := launchdsvc.TakeoverInputs{
 		PlistExists:  plistExists,
 		SameOwner:    sameOwner,
@@ -135,8 +137,12 @@ func serverAgentDecision(opts installOptions) (launchdsvc.TakeoverDecision, []by
 			// An unreadable endpoint (auth, older server) reports ok=false and
 			// is treated as not-busy: an install must not be blocked forever by
 			// a probe it cannot interpret.
-			if n, ok := launchdsvc.ActiveExecutions(serverPort(), os.Getenv("AGENTFIELD_API_KEY")); ok {
+			// Only runs that have done something recently block a restart;
+			// a wedged run left in the active list forever must not pin an
+			// install to an old binary. See launchdsvc.ActiveWindow.
+			if n, s, ok := launchdsvc.ActiveExecutions(serverPort(), os.Getenv("AGENTFIELD_API_KEY")); ok {
 				in.ActiveExecutions = n
+				stale = s
 			}
 		}
 	}
@@ -146,7 +152,18 @@ func serverAgentDecision(opts installOptions) (launchdsvc.TakeoverDecision, []by
 		launchdsvc.FileHasContents(serverPlistPath(), want) &&
 		trayBundleUpToDate()
 
-	return launchdsvc.DecideTakeover(in), want
+	return launchdsvc.DecideTakeover(in), want, stale
+}
+
+// staleSuffix names runs the probe deliberately ignored, so a user who reads
+// "1 workflow in flight" against a server they believe is idle can see that the
+// harness already discounted the wedged ones.
+func staleSuffix(stale int) string {
+	if stale <= 0 {
+		return ""
+	}
+	return fmt.Sprintf(" (ignored %d stale run(s) with no activity for over %s)",
+		stale, launchdsvc.ActiveWindow())
 }
 
 // trayBundleUpToDate reports whether the installed tray binary is already the

--- a/control-plane/cmd/af-tray/takeover_darwin_test.go
+++ b/control-plane/cmd/af-tray/takeover_darwin_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Agent-Field/agentfield/control-plane/internal/launchdsvc"
@@ -47,5 +48,23 @@ func TestTrayPlistRoundTrips(t *testing.T) {
 	owner := launchdsvc.ParsePlistOwner([]byte(trayPlist()))
 	if owner.Program != trayBundleBinaryPath() {
 		t.Errorf("tray Program = %q, want %q", owner.Program, trayBundleBinaryPath())
+	}
+}
+
+// TestStaleSuffix: when the probe discounts wedged runs, the install says so —
+// otherwise "1 workflow in flight" on a server the user believes is idle looks
+// like the harness is simply wrong.
+func TestStaleSuffix(t *testing.T) {
+	if got := staleSuffix(0); got != "" {
+		t.Errorf("staleSuffix(0) = %q, want empty", got)
+	}
+	if got := staleSuffix(-1); got != "" {
+		t.Errorf("staleSuffix(-1) = %q, want empty", got)
+	}
+	got := staleSuffix(2)
+	for _, want := range []string{"ignored 2 stale run(s)", "no activity for over"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("staleSuffix(2) = %q, want it to mention %q", got, want)
+		}
 	}
 }

--- a/control-plane/internal/cli/service.go
+++ b/control-plane/internal/cli/service.go
@@ -92,6 +92,7 @@ type serviceStatus struct {
 	Port             int    `json:"port"`
 	Version          string `json:"version,omitempty"`
 	ActiveExecutions int    `json:"active_executions"`
+	StaleExecutions  int    `json:"stale_executions"`
 	ActiveKnown      bool   `json:"active_known"`
 }
 
@@ -111,7 +112,7 @@ func collectServiceStatus() serviceStatus {
 	st.Healthy = launchdsvc.ServerHealthy(port)
 	if st.Healthy {
 		st.Version = serviceServerVersion(port)
-		st.ActiveExecutions, st.ActiveKnown =
+		st.ActiveExecutions, st.StaleExecutions, st.ActiveKnown =
 			launchdsvc.ActiveExecutions(port, os.Getenv("AGENTFIELD_API_KEY"))
 	}
 	return st
@@ -162,7 +163,14 @@ func printServiceStatus(st serviceStatus) {
 	switch {
 	case !st.Healthy:
 	case st.ActiveKnown:
-		fmt.Printf("In flight:     %d workflow(s)\n", st.ActiveExecutions)
+		if st.StaleExecutions > 0 {
+			// Name the wedged runs explicitly: they are why the number here can
+			// look lower than the dashboard's.
+			fmt.Printf("In flight:     %d workflow(s) (plus %d stale, idle >%s)\n",
+				st.ActiveExecutions, st.StaleExecutions, launchdsvc.ActiveWindow())
+		} else {
+			fmt.Printf("In flight:     %d workflow(s)\n", st.ActiveExecutions)
+		}
 	default:
 		fmt.Println("In flight:     unknown (endpoint unreadable — set AGENTFIELD_API_KEY?)")
 	}

--- a/control-plane/internal/cli/service_test.go
+++ b/control-plane/internal/cli/service_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -166,6 +168,14 @@ func TestPrintServiceStatus(t *testing.T) {
 			deny: []string{"version"},
 		},
 		{
+			name: "stale runs are named alongside the live count",
+			st: serviceStatus{
+				Supported: true, Loaded: true, Healthy: true, Port: 8080,
+				ActiveExecutions: 2, StaleExecutions: 1, ActiveKnown: true,
+			},
+			want: []string{"2 workflow(s) (plus 1 stale, idle >"},
+		},
+		{
 			name: "healthy but in-flight count unreadable",
 			st:   serviceStatus{Supported: true, Loaded: true, Healthy: true, Port: 8080},
 			want: []string{"unknown (endpoint unreadable"},
@@ -231,7 +241,15 @@ func TestServiceStatusRunE(t *testing.T) {
 		case "/health":
 			_, _ = w.Write([]byte(`{"status":"healthy","version":"9.9.9"}`))
 		case "/api/v1/executions/active":
-			_, _ = w.Write([]byte(`{"count":4,"runs":[]}`))
+			now := time.Now().UTC().Format(time.RFC3339)
+			old := time.Now().Add(-10 * time.Hour).UTC().Format(time.RFC3339)
+			_, _ = w.Write([]byte(fmt.Sprintf(
+				`{"count":5,"runs":[{"run_id":"a","latest_activity":%q},`+
+					`{"run_id":"b","latest_activity":%q},`+
+					`{"run_id":"c","latest_activity":%q},`+
+					`{"run_id":"d","latest_activity":%q},`+
+					`{"run_id":"zombie","latest_activity":%q}]}`,
+				now, now, now, now, old)))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -262,7 +280,7 @@ func TestServiceStatusRunE(t *testing.T) {
 				t.Fatalf("status: %v", err)
 			}
 		})
-		for _, want := range []string{"version 9.9.9", "4 workflow(s)", "/opt/demo/bin/agentfield"} {
+		for _, want := range []string{"version 9.9.9", "4 workflow(s) (plus 1 stale, idle >30m0s)", "/opt/demo/bin/agentfield"} {
 			if !strings.Contains(out, want) {
 				t.Errorf("status output missing %q:\n%s", want, out)
 			}
@@ -278,7 +296,7 @@ func TestServiceStatusRunE(t *testing.T) {
 			}
 		})
 		for _, want := range []string{`"healthy": true`, `"version": "9.9.9"`,
-			`"active_executions": 4`, `"active_known": true`} {
+			`"active_executions": 4`, `"stale_executions": 1`, `"active_known": true`} {
 			if !strings.Contains(out, want) {
 				t.Errorf("json output missing %q:\n%s", want, out)
 			}

--- a/control-plane/internal/launchdsvc/launchdsvc.go
+++ b/control-plane/internal/launchdsvc/launchdsvc.go
@@ -138,8 +138,11 @@ type TakeoverInputs struct {
 	LabelLoaded bool
 	// ServerHealthy reports that GET /health answered.
 	ServerHealthy bool
-	// ActiveExecutions is the number of in-flight runs reported by
+	// ActiveExecutions is the number of RECENTLY-ACTIVE in-flight runs from
 	// GET /api/v1/executions/active. Only meaningful when ServerHealthy.
+	// Runs that are listed but have gone quiet are excluded by the probe (see
+	// launchdsvc.ActiveWindow), so a wedged run cannot make this permanently
+	// non-zero and defer every future restart.
 	ActiveExecutions int
 	// Identical reports that the plists we would write are byte-identical to
 	// what is on disk AND the target binary already has the new contents.

--- a/control-plane/internal/launchdsvc/probe.go
+++ b/control-plane/internal/launchdsvc/probe.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -14,6 +15,35 @@ import (
 // endpoints are local and answer in milliseconds; a longer wait would only
 // stall `curl … | bash` behind a dead socket.
 const probeTimeout = 1500 * time.Millisecond
+
+// defaultActiveWindow is how recently a run must have done something to count
+// as genuinely in flight.
+//
+// A live workflow touches latest_activity on every reasoner event, so a healthy
+// run refreshes it constantly. A run that has not moved in half an hour is
+// either wedged or was abandoned by a server that died mid-flight — and with
+// execution cleanup disabled it can sit in the active list indefinitely. One
+// such zombie used to make the busy probe permanently true, which meant an
+// upgrade of the SAME install would defer its restart forever and never pick up
+// a new binary.
+const defaultActiveWindow = 30 * time.Minute
+
+// ActiveWindowEnv overrides defaultActiveWindow with a Go duration ("2h").
+const ActiveWindowEnv = "AGENTFIELD_INSTALL_ACTIVE_WINDOW"
+
+// ActiveWindow resolves the freshness window. An unparseable or non-positive
+// value falls back to the default rather than failing an install.
+func ActiveWindow() time.Duration {
+	raw := strings.TrimSpace(os.Getenv(ActiveWindowEnv))
+	if raw == "" {
+		return defaultActiveWindow
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return defaultActiveWindow
+	}
+	return d
+}
 
 // HealthURL / ActiveExecutionsURL address the local control plane.
 func HealthURL(port int) string { return fmt.Sprintf("http://localhost:%d/health", port) }
@@ -39,47 +69,86 @@ func ServerHealthy(port int) bool {
 
 // activeExecutionsResponse is the shape of GET /api/v1/executions/active.
 type activeExecutionsResponse struct {
-	Count int `json:"count"`
-	Runs  []struct {
-		RunID string `json:"run_id"`
-	} `json:"runs"`
+	Count int         `json:"count"`
+	Runs  []activeRun `json:"runs"`
 }
 
-// ActiveExecutions returns the number of in-flight runs, and whether the answer
-// is trustworthy. A server that does not answer, or answers with an auth error,
-// reports ok=false — and the caller then treats the server as not-busy rather
-// than blocking an install forever on an unreadable endpoint.
-func ActiveExecutions(port int, apiKey string) (int, bool) {
+type activeRun struct {
+	RunID          string `json:"run_id"`
+	RootStatus     string `json:"root_status"`
+	StartedAt      string `json:"started_at"`
+	LatestActivity string `json:"latest_activity"`
+}
+
+// fresh reports whether this run has done something inside the window, and is
+// therefore work an install must not interrupt.
+//
+// A missing or unparseable latest_activity counts as FRESH on purpose: the
+// probe exists to protect running work, so an ambiguous timestamp must never be
+// the thing that licenses a restart.
+func (r activeRun) fresh(now time.Time, window time.Duration) bool {
+	stamp := strings.TrimSpace(r.LatestActivity)
+	if stamp == "" {
+		return true
+	}
+	t, err := time.Parse(time.RFC3339, stamp)
+	if err != nil {
+		return true
+	}
+	return now.Sub(t) <= window
+}
+
+// ActiveExecutions reports how many runs are genuinely in flight (fresh), how
+// many are listed but have gone quiet (stale, and therefore ignored), and
+// whether the answer is trustworthy at all. A server that does not answer, or
+// answers with an auth error, reports ok=false — and the caller then treats the
+// server as not-busy rather than blocking an install forever on an unreadable
+// endpoint.
+func ActiveExecutions(port int, apiKey string) (fresh, stale int, ok bool) {
 	client := &http.Client{Timeout: probeTimeout}
 	req, err := http.NewRequest(http.MethodGet, ActiveExecutionsURL(port), nil)
 	if err != nil {
-		return 0, false
+		return 0, 0, false
 	}
 	if apiKey != "" {
 		req.Header.Set("X-API-Key", apiKey)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return 0, false
+		return 0, 0, false
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		_, _ = io.Copy(io.Discard, resp.Body)
-		return 0, false
+		return 0, 0, false
 	}
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return 0, false
+		return 0, 0, false
 	}
 	var parsed activeExecutionsResponse
 	if err := json.Unmarshal(body, &parsed); err != nil {
-		return 0, false
+		return 0, 0, false
 	}
-	// count is authoritative; fall back to the run list when it is absent.
-	if parsed.Count > 0 {
-		return parsed.Count, true
+	return splitActiveRuns(parsed, time.Now(), ActiveWindow())
+}
+
+// splitActiveRuns is the pure half of the probe, so the staleness rules are
+// testable without a clock or a socket.
+func splitActiveRuns(parsed activeExecutionsResponse, now time.Time, window time.Duration) (fresh, stale int, ok bool) {
+	for _, run := range parsed.Runs {
+		if run.fresh(now, window) {
+			fresh++
+			continue
+		}
+		stale++
 	}
-	return len(parsed.Runs), true
+	// An older server may report a count without the run detail needed to age
+	// it. Trust the count and treat it as fresh rather than restarting blind.
+	if len(parsed.Runs) == 0 && parsed.Count > 0 {
+		return parsed.Count, 0, true
+	}
+	return fresh, stale, true
 }
 
 // FileSHA256 hashes a file, reporting ok=false when it cannot be read. Used to

--- a/control-plane/internal/launchdsvc/probe.go
+++ b/control-plane/internal/launchdsvc/probe.go
@@ -83,19 +83,35 @@ type activeRun struct {
 // fresh reports whether this run has done something inside the window, and is
 // therefore work an install must not interrupt.
 //
-// A missing or unparseable latest_activity counts as FRESH on purpose: the
-// probe exists to protect running work, so an ambiguous timestamp must never be
-// the thing that licenses a restart.
+// The rule when evidence is missing runs toward STALE: this fleet has a
+// history of runs wedged in "running" while doing nothing, and a run that
+// cannot demonstrate liveness must not pin upgrades forever — that is the
+// exact bug the staleness split exists to fix. A run with no usable
+// latest_activity gets one fallback, its start time, so a demonstrably young
+// run (an older server that reports no activity stamps) is still protected;
+// with no usable evidence at all it is assumed stale.
 func (r activeRun) fresh(now time.Time, window time.Duration) bool {
-	stamp := strings.TrimSpace(r.LatestActivity)
+	if t, ok := parseStamp(r.LatestActivity); ok {
+		return now.Sub(t) <= window
+	}
+	if t, ok := parseStamp(r.StartedAt); ok {
+		return now.Sub(t) <= window
+	}
+	return false
+}
+
+// parseStamp parses an RFC3339 timestamp, reporting ok=false for the missing
+// and malformed shapes fresh() must fall back on.
+func parseStamp(stamp string) (time.Time, bool) {
+	stamp = strings.TrimSpace(stamp)
 	if stamp == "" {
-		return true
+		return time.Time{}, false
 	}
 	t, err := time.Parse(time.RFC3339, stamp)
 	if err != nil {
-		return true
+		return time.Time{}, false
 	}
-	return now.Sub(t) <= window
+	return t, true
 }
 
 // ActiveExecutions reports how many runs are genuinely in flight (fresh), how
@@ -144,9 +160,11 @@ func splitActiveRuns(parsed activeExecutionsResponse, now time.Time, window time
 		stale++
 	}
 	// An older server may report a count without the run detail needed to age
-	// it. Trust the count and treat it as fresh rather than restarting blind.
+	// it. Unconfirmable liveness counts as stale (the owner's rule): a count
+	// with no evidence behind it must not pin upgrades, and the stale figure
+	// keeps it visible in the install message and `af service status`.
 	if len(parsed.Runs) == 0 && parsed.Count > 0 {
-		return parsed.Count, 0, true
+		return 0, parsed.Count, true
 	}
 	return fresh, stale, true
 }

--- a/control-plane/internal/launchdsvc/probe_test.go
+++ b/control-plane/internal/launchdsvc/probe_test.go
@@ -262,26 +262,43 @@ func TestActiveExecutionsStaleness(t *testing.T) {
 			wantFresh: 1, wantStale: 2,
 		},
 		{
-			// Fail-safe: an unreadable timestamp must never license a restart.
-			name:      "missing latest_activity counts as busy",
-			body:      payload(`{"run_id":"x","root_status":"running"}`),
-			wantFresh: 1, wantStale: 0,
+			// Unconfirmable liveness is stale (the owner's rule): the fixture's
+			// started_at is hours old, so with no activity stamp the run cannot
+			// demonstrate it is alive and must not pin an upgrade.
+			name:      "missing latest_activity with an old start is stale",
+			body:      payload(`{"run_id":"x","root_status":"running","started_at":"2026-08-05T02:29:00Z"}`),
+			wantFresh: 0, wantStale: 1,
 		},
 		{
-			name:      "empty latest_activity counts as busy",
+			name:      "empty latest_activity with an old start is stale",
 			body:      payload(run("x", `""`)),
-			wantFresh: 1, wantStale: 0,
+			wantFresh: 0, wantStale: 1,
 		},
 		{
-			name:      "malformed latest_activity counts as busy",
+			name:      "malformed latest_activity with an old start is stale",
 			body:      payload(run("x", `"not-a-timestamp"`)),
+			wantFresh: 0, wantStale: 1,
+		},
+		{
+			// The one fallback before assuming stale: a demonstrably young run
+			// (older server reporting no activity stamps) is still protected.
+			name: "missing latest_activity with a young start is fresh",
+			body: payload(fmt.Sprintf(
+				`{"run_id":"x","root_status":"running","started_at":%s}`,
+				quoted(now.Add(-2*time.Minute)))),
 			wantFresh: 1, wantStale: 0,
 		},
 		{
-			// An older server may report a count with no run detail to age.
-			name:      "count without runs is trusted as fresh",
+			name:      "no usable timestamps at all is stale",
+			body:      payload(`{"run_id":"x","root_status":"running","started_at":"garbage"}`),
+			wantFresh: 0, wantStale: 1,
+		},
+		{
+			// An older server may report a count with no run detail to age it.
+			// No evidence of liveness → stale, kept visible via the stale count.
+			name:      "count without runs is unconfirmable, so stale",
 			body:      `{"count":2,"runs":[]}`,
-			wantFresh: 2, wantStale: 0,
+			wantFresh: 0, wantStale: 2,
 		},
 		{
 			name:      "idle server",

--- a/control-plane/internal/launchdsvc/probe_test.go
+++ b/control-plane/internal/launchdsvc/probe_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // probeServer starts an httptest server and returns its port. The probes build
@@ -86,11 +87,11 @@ func TestActiveExecutions(t *testing.T) {
 			if r.URL.Path != "/api/v1/executions/active" {
 				t.Errorf("unexpected path %q", r.URL.Path)
 			}
-			_, _ = w.Write([]byte(`{"count":3,"runs":[{"run_id":"a"},{"run_id":"b"},{"run_id":"c"}]}`))
+			_, _ = w.Write([]byte(freshRuns(3)))
 		}))
-		n, ok := ActiveExecutions(port, "")
-		if !ok || n != 3 {
-			t.Fatalf("ActiveExecutions = (%d, %v), want (3, true)", n, ok)
+		n, stale, ok := ActiveExecutions(port, "")
+		if !ok || n != 3 || stale != 0 {
+			t.Fatalf("ActiveExecutions = (%d, %d, %v), want (3, 0, true)", n, stale, ok)
 		}
 	})
 
@@ -98,19 +99,19 @@ func TestActiveExecutions(t *testing.T) {
 		port := probeServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = w.Write([]byte(`{"count":0,"runs":[]}`))
 		}))
-		n, ok := ActiveExecutions(port, "")
-		if !ok || n != 0 {
-			t.Fatalf("ActiveExecutions = (%d, %v), want (0, true)", n, ok)
+		n, stale, ok := ActiveExecutions(port, "")
+		if !ok || n != 0 || stale != 0 {
+			t.Fatalf("ActiveExecutions = (%d, %d, %v), want (0, 0, true)", n, stale, ok)
 		}
 	})
 
-	t.Run("falls back to the run list when count is absent", func(t *testing.T) {
+	t.Run("counts runs when count is absent", func(t *testing.T) {
 		port := probeServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			_, _ = w.Write([]byte(`{"runs":[{"run_id":"a"},{"run_id":"b"}]}`))
+			_, _ = w.Write([]byte(freshRuns(2)))
 		}))
-		n, ok := ActiveExecutions(port, "")
-		if !ok || n != 2 {
-			t.Fatalf("ActiveExecutions = (%d, %v), want (2, true)", n, ok)
+		n, stale, ok := ActiveExecutions(port, "")
+		if !ok || n != 2 || stale != 0 {
+			t.Fatalf("ActiveExecutions = (%d, %d, %v), want (2, 0, true)", n, stale, ok)
 		}
 	})
 
@@ -120,7 +121,7 @@ func TestActiveExecutions(t *testing.T) {
 			seen = r.Header.Get("X-API-Key")
 			_, _ = w.Write([]byte(`{"count":1}`))
 		}))
-		if _, ok := ActiveExecutions(port, "sekret"); !ok {
+		if _, _, ok := ActiveExecutions(port, "sekret"); !ok {
 			t.Fatal("expected a usable answer")
 		}
 		if seen != "sekret" {
@@ -135,7 +136,7 @@ func TestActiveExecutions(t *testing.T) {
 			w.WriteHeader(http.StatusUnauthorized)
 			_, _ = w.Write([]byte(`{"error":"nope"}`))
 		}))
-		if n, ok := ActiveExecutions(port, ""); ok {
+		if n, _, ok := ActiveExecutions(port, ""); ok {
 			t.Fatalf("401 reported as trustworthy (n=%d)", n)
 		}
 	})
@@ -144,13 +145,13 @@ func TestActiveExecutions(t *testing.T) {
 		port := probeServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = w.Write([]byte(`{"count": `))
 		}))
-		if _, ok := ActiveExecutions(port, ""); ok {
+		if _, _, ok := ActiveExecutions(port, ""); ok {
 			t.Fatal("truncated JSON reported as trustworthy")
 		}
 	})
 
 	t.Run("nothing listening is not trustworthy", func(t *testing.T) {
-		if _, ok := ActiveExecutions(freePort(t), ""); ok {
+		if _, _, ok := ActiveExecutions(freePort(t), ""); ok {
 			t.Fatal("a refused connection reported as trustworthy")
 		}
 	})
@@ -199,5 +200,164 @@ func TestFileHasContentsMatrix(t *testing.T) {
 	}
 	if FileHasContents(filepath.Join(dir, "absent"), body) {
 		t.Error("a missing file must not match")
+	}
+}
+
+// freshRuns builds an executions/active payload whose runs all reported
+// activity just now.
+func freshRuns(n int) string {
+	now := time.Now().UTC().Format(time.RFC3339)
+	runs := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		runs = append(runs, fmt.Sprintf(
+			`{"run_id":"r%d","root_status":"running","started_at":%q,"latest_activity":%q}`,
+			i, now, now))
+	}
+	return fmt.Sprintf(`{"count":%d,"runs":[%s]}`, n, strings.Join(runs, ","))
+}
+
+// run builds one entry of the executions/active payload. latest_activity is
+// passed verbatim so tests can supply a missing or malformed value.
+func run(id, latestActivity string) string {
+	return fmt.Sprintf(
+		`{"run_id":%q,"root_status":"running","started_at":"2026-08-05T02:29:00Z","latest_activity":%s}`,
+		id, latestActivity)
+}
+
+func quoted(t time.Time) string { return fmt.Sprintf("%q", t.UTC().Format(time.RFC3339)) }
+
+func payload(runs ...string) string {
+	return fmt.Sprintf(`{"count":%d,"runs":[%s]}`, len(runs), strings.Join(runs, ","))
+}
+
+// TestActiveExecutionsStaleness is the zombie-run regression. Execution cleanup
+// is disabled server-side, so a wedged run sits in the active list forever; if
+// it counted as busy, an upgrade of the same install would defer its restart
+// permanently and never land a new binary.
+func TestActiveExecutionsStaleness(t *testing.T) {
+	now := time.Now()
+	fresh := quoted(now.Add(-2 * time.Minute))
+	// The live example: started 02:29, last touched 03:05, observed >10h later.
+	zombie := quoted(now.Add(-10 * time.Hour))
+
+	cases := []struct {
+		name      string
+		body      string
+		wantFresh int
+		wantStale int
+	}{
+		{
+			name:      "all fresh runs block a restart",
+			body:      payload(run("a", fresh), run("b", fresh)),
+			wantFresh: 2, wantStale: 0,
+		},
+		{
+			name:      "all stale runs are ignored, so the server is not busy",
+			body:      payload(run("zombie", zombie)),
+			wantFresh: 0, wantStale: 1,
+		},
+		{
+			name:      "mixed: only the fresh one blocks",
+			body:      payload(run("live", fresh), run("zombie", zombie), run("zombie2", zombie)),
+			wantFresh: 1, wantStale: 2,
+		},
+		{
+			// Fail-safe: an unreadable timestamp must never license a restart.
+			name:      "missing latest_activity counts as busy",
+			body:      payload(`{"run_id":"x","root_status":"running"}`),
+			wantFresh: 1, wantStale: 0,
+		},
+		{
+			name:      "empty latest_activity counts as busy",
+			body:      payload(run("x", `""`)),
+			wantFresh: 1, wantStale: 0,
+		},
+		{
+			name:      "malformed latest_activity counts as busy",
+			body:      payload(run("x", `"not-a-timestamp"`)),
+			wantFresh: 1, wantStale: 0,
+		},
+		{
+			// An older server may report a count with no run detail to age.
+			name:      "count without runs is trusted as fresh",
+			body:      `{"count":2,"runs":[]}`,
+			wantFresh: 2, wantStale: 0,
+		},
+		{
+			name:      "idle server",
+			body:      `{"count":0,"runs":[]}`,
+			wantFresh: 0, wantStale: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := tc.body
+			port := probeServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(body))
+			}))
+			f, s, ok := ActiveExecutions(port, "")
+			if !ok {
+				t.Fatal("expected a trustworthy answer")
+			}
+			if f != tc.wantFresh || s != tc.wantStale {
+				t.Fatalf("ActiveExecutions = (fresh %d, stale %d), want (%d, %d)",
+					f, s, tc.wantFresh, tc.wantStale)
+			}
+		})
+	}
+}
+
+// TestActiveWindow covers the env override and its failure modes: a bad value
+// must fall back rather than fail an install.
+func TestActiveWindow(t *testing.T) {
+	t.Setenv(ActiveWindowEnv, "")
+	if got := ActiveWindow(); got != defaultActiveWindow {
+		t.Errorf("default = %v, want %v", got, defaultActiveWindow)
+	}
+	t.Setenv(ActiveWindowEnv, "2h")
+	if got := ActiveWindow(); got != 2*time.Hour {
+		t.Errorf("override = %v, want 2h", got)
+	}
+	t.Setenv(ActiveWindowEnv, "  90s  ")
+	if got := ActiveWindow(); got != 90*time.Second {
+		t.Errorf("trimmed override = %v, want 90s", got)
+	}
+	for _, bad := range []string{"soon", "-5m", "0", "12"} {
+		t.Setenv(ActiveWindowEnv, bad)
+		if got := ActiveWindow(); got != defaultActiveWindow {
+			t.Errorf("%q should fall back to %v, got %v", bad, defaultActiveWindow, got)
+		}
+	}
+}
+
+// TestActiveWindowHonouredByProbe: the window is what decides, end to end.
+func TestActiveWindowHonouredByProbe(t *testing.T) {
+	body := payload(run("a", quoted(time.Now().Add(-45*time.Minute))))
+	port := probeServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+
+	t.Setenv(ActiveWindowEnv, "") // default 30m → 45m old is stale
+	if f, s, _ := ActiveExecutions(port, ""); f != 0 || s != 1 {
+		t.Fatalf("default window: fresh=%d stale=%d, want 0/1", f, s)
+	}
+	t.Setenv(ActiveWindowEnv, "2h") // widened → the same run is fresh again
+	if f, s, _ := ActiveExecutions(port, ""); f != 1 || s != 0 {
+		t.Fatalf("2h window: fresh=%d stale=%d, want 1/0", f, s)
+	}
+}
+
+// TestSplitActiveRunsIsPure pins the boundary condition without a socket: a run
+// exactly at the window edge still counts as fresh.
+func TestSplitActiveRunsIsPure(t *testing.T) {
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	parsed := activeExecutionsResponse{Runs: []activeRun{
+		{RunID: "edge", LatestActivity: now.Add(-30 * time.Minute).Format(time.RFC3339)},
+		{RunID: "just-over", LatestActivity: now.Add(-31 * time.Minute).Format(time.RFC3339)},
+	}}
+	f, s, ok := splitActiveRuns(parsed, now, 30*time.Minute)
+	if !ok || f != 1 || s != 1 {
+		t.Fatalf("splitActiveRuns = (%d, %d, %v), want (1, 1, true)", f, s, ok)
 	}
 }


### PR DESCRIPTION
Follow-up to #879, closing a hole the owner spotted post-merge: the busy probe counted every run the active-executions endpoint reports, but runs can wedge — `root_status: running` with no activity for hours (execution cleanup is disabled, so they never age out). One zombie made the busy check permanently true, so every future same-owner upgrade deferred its restart forever and the new binary never took effect. A real example was live during development: a run whose `latest_activity` was >10 hours old.

Busy now means **recently active**: a run blocks a restart only when its `latest_activity` falls within a freshness window (default 30m; `AGENTFIELD_INSTALL_ACTIVE_WINDOW` accepts a Go duration to widen/narrow it, invalid values fall back safely). Per the owner's call, unconfirmable liveness counts as STALE: a run with a missing or malformed activity stamp gets one fallback (its start time — a demonstrably young run stays protected, covering older servers that report no activity stamps), and with no usable evidence at all it is assumed stale rather than allowed to pin upgrades forever. The count-without-run-detail shape from older servers follows the same rule and stays visible in the stale figure. `DecideTakeover` stays pure and unchanged; its `ActiveExecutions` input just gains the "recently-active" meaning.

Stuck runs also become visible instead of silently haunting the machine: the installer's deferral line reports what it ignored ("2 workflow(s) in flight — not restarting. (ignored 1 stale run(s) with no activity for over 30m0s)"), and `af service status` shows "In flight: 2 workflow(s) (plus 1 stale, idle >30m0s)" with a matching `stale_executions` JSON field.

With the zombie observed live: before, `WriteOnly` forever; after, it ages out and the installer restarts normally.

Tests cover all-fresh / all-stale / mixed / missing / empty / malformed timestamps, the env override incl. 4 invalid shapes, the exact window boundary (at the edge = fresh, one minute over = stale), and the status text + JSON in both branches. New lines sit at 93–97% coverage on the linux gate surface. Full suite matches the clean-main baseline (same pre-existing failures, none new); vet clean on darwin and linux.

The underlying disease — wedged executions accumulating because cleanup is disabled — deserves its own server-side TTL reaper; this PR treats the install-layer symptom correctly regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)