### PR TITLE
fix(desktop): agents table '…' dropdown clipped by panel overflow

### DIFF
--- a/desktop/src/renderer/src/components/AgentsPanel.tsx
+++ b/desktop/src/renderer/src/components/AgentsPanel.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from 'react'
 import { AnimatePresence, m, useReducedMotion } from 'motion/react'
 import type { AgentEnvReport, AgentFieldSnapshot, SnapshotAgent } from '../../../shared/types'
 import { EnvEditor } from './EnvEditor'
+import { MenuPopover } from './MenuPopover'
 import { SkeletonRows } from './Skeleton'
 import { EmptyState } from './EmptyMark'
 
@@ -259,49 +260,38 @@ function AgentRow({
                   Keys
                 </button>
               )}
-              <div className="menu-anchor">
+              <MenuPopover
+                open={menuOpen}
+                onToggle={onToggleMenu}
+                disabled={rowBusy}
+                ariaLabel="More actions"
+              >
+                {(running || agent.badge === 'unknown') && (
+                  <button
+                    className="menu-item"
+                    role="menuitem"
+                    onClick={() => onAction('restart')}
+                  >
+                    Restart
+                  </button>
+                )}
                 <button
-                  className="action-button icon"
-                  aria-label="More actions"
-                  aria-expanded={menuOpen}
-                  disabled={rowBusy}
-                  onClick={(event) => {
-                    event.stopPropagation()
-                    onToggleMenu()
+                  className="menu-item"
+                  role="menuitem"
+                  onClick={() => {
+                    void window.agentfield.openWebUI('/ui/')
                   }}
                 >
-                  ⋯
+                  Open in Web UI
                 </button>
-                {menuOpen && (
-                  <div className="menu-popover" role="menu">
-                    {(running || agent.badge === 'unknown') && (
-                      <button
-                        className="menu-item"
-                        role="menuitem"
-                        onClick={() => onAction('restart')}
-                      >
-                        Restart
-                      </button>
-                    )}
-                    <button
-                      className="menu-item"
-                      role="menuitem"
-                      onClick={() => {
-                        void window.agentfield.openWebUI('/ui/')
-                      }}
-                    >
-                      Open in Web UI
-                    </button>
-                    <button
-                      className="menu-item danger"
-                      role="menuitem"
-                      onClick={onConfirmUninstall}
-                    >
-                      Uninstall
-                    </button>
-                  </div>
-                )}
-              </div>
+                <button
+                  className="menu-item danger"
+                  role="menuitem"
+                  onClick={onConfirmUninstall}
+                >
+                  Uninstall
+                </button>
+              </MenuPopover>
             </div>
           )}
         </div>

--- a/desktop/src/renderer/src/components/InstallPanel.tsx
+++ b/desktop/src/renderer/src/components/InstallPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { AnimatePresence, m, useReducedMotion } from 'motion/react'
 import type { CatalogEntry } from '../../../shared/types'
 import { COMMUNITY_LINKS } from './communityLinks'
+import { MenuPopover } from './MenuPopover'
 import { SkeletonRows } from './Skeleton'
 
 /**
@@ -514,35 +515,24 @@ function FeaturedCard({
           ) : (
             <div className="row-actions">
               <span className="market-installed">✓ Installed</span>
-              <div className="menu-anchor">
+              <MenuPopover
+                open={menuOpen}
+                onToggle={onToggleMenu}
+                disabled={installing}
+                ariaLabel={`More actions for ${entry.name}`}
+              >
                 <button
-                  className="action-button icon"
-                  aria-label={`More actions for ${entry.name}`}
-                  aria-expanded={menuOpen}
-                  disabled={installing}
-                  onClick={(event) => {
-                    event.stopPropagation()
-                    onToggleMenu()
-                  }}
+                  className="menu-item"
+                  role="menuitem"
+                  title="Reinstall the latest version; a running agent restarts after the update"
+                  onClick={onUpdate}
                 >
-                  ⋯
+                  {busy ? 'Updating…' : 'Update'}
                 </button>
-                {menuOpen && (
-                  <div className="menu-popover" role="menu">
-                    <button
-                      className="menu-item"
-                      role="menuitem"
-                      title="Reinstall the latest version; a running agent restarts after the update"
-                      onClick={onUpdate}
-                    >
-                      {busy ? 'Updating…' : 'Update'}
-                    </button>
-                    <button className="menu-item danger" role="menuitem" onClick={onConfirmUninstall}>
-                      Uninstall
-                    </button>
-                  </div>
-                )}
-              </div>
+                <button className="menu-item danger" role="menuitem" onClick={onConfirmUninstall}>
+                  Uninstall
+                </button>
+              </MenuPopover>
             </div>
           )
         ) : (

--- a/desktop/src/renderer/src/components/MenuPopover.tsx
+++ b/desktop/src/renderer/src/components/MenuPopover.tsx
@@ -1,0 +1,75 @@
+import { useLayoutEffect, useRef, useState } from 'react'
+import type { ReactElement, ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+
+/**
+ * Overflow ("⋯") trigger + menu. The popover is portaled to <body> with
+ * fixed coordinates because in-place absolute positioning gets clipped by
+ * `.panel`'s rounded-corner `overflow: hidden` and re-anchored by
+ * `.market-card`'s hover transform. Same escape hatch as `.af-tooltip`.
+ */
+export function MenuPopover({
+  open,
+  onToggle,
+  disabled,
+  ariaLabel,
+  children
+}: {
+  open: boolean
+  onToggle: () => void
+  disabled?: boolean
+  ariaLabel: string
+  children: ReactNode
+}): ReactElement {
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null)
+
+  // Fixed positioning doesn't follow the trigger, so re-place on any
+  // scroll (capture: the scrolling container isn't the window) or resize.
+  useLayoutEffect(() => {
+    if (!open) {
+      setPos(null)
+      return
+    }
+    const button = buttonRef.current
+    if (!button) return
+    const place = () => {
+      const rect = button.getBoundingClientRect()
+      setPos({ left: rect.right, top: rect.bottom + 4 })
+    }
+    place()
+    window.addEventListener('scroll', place, true)
+    window.addEventListener('resize', place)
+    return () => {
+      window.removeEventListener('scroll', place, true)
+      window.removeEventListener('resize', place)
+    }
+  }, [open])
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        className="action-button icon"
+        aria-label={ariaLabel}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        disabled={disabled}
+        onClick={(event) => {
+          event.stopPropagation()
+          onToggle()
+        }}
+      >
+        ⋯
+      </button>
+      {open &&
+        pos &&
+        createPortal(
+          <div className="menu-popover" role="menu" style={{ left: pos.left, top: pos.top }}>
+            {children}
+          </div>,
+          document.body
+        )}
+    </>
+  )
+}

--- a/desktop/src/renderer/src/styles.css
+++ b/desktop/src/renderer/src/styles.css
@@ -1012,16 +1012,14 @@ section > .section-title {
   cursor: default;
 }
 
-/* Overflow menu */
-.menu-anchor {
-  position: relative;
-}
-
+/* Overflow menu (MenuPopover.tsx). Portaled to body — not clipped by
+   .panel's overflow or re-anchored by .market-card's hover transform.
+   left/top come inline from the trigger rect; the translate keeps the
+   menu's right edge on the trigger's right edge. */
 .menu-popover {
-  position: absolute;
-  right: 0;
-  top: calc(100% + 4px);
-  z-index: 40;
+  position: fixed;
+  transform: translateX(-100%);
+  z-index: 100;
   min-width: 160px;
   padding: 4px;
   background: var(--bg-elevated);


### PR DESCRIPTION
## Problem

Clicking the `⋯` button on an agent row opened a dropdown that got cut off at the bottom edge of the Agents card — with two agents installed, the **Uninstall** item was completely invisible on the first row and the whole menu unreachable on the last.

## Root cause

`.menu-popover` was `position: absolute` inside `.menu-anchor`, which lives inside `.panel`. `.panel` sets `overflow: hidden` for rounded-corner clipping, so any part of the menu extending past the card's bounds was clipped.

## Fix

- New shared `MenuPopover` component: renders the `⋯` trigger and portals the menu to `<body>` with `position: fixed` coordinates taken from the trigger's `getBoundingClientRect()` (right-aligned, 4px below). Same escape-hatch pattern already used by `.af-tooltip` in `ActivityPanel`.
- Repositions on scroll (capture phase — the scroll container isn't the window) and resize while open; outside-click close keeps working since the existing handler listens on `window`.
- Migrated both call sites: `AgentsPanel` (the reported bug) and `InstallPanel`, which duplicated the same markup — its `.market-card` hover `transform` would have re-anchored a fixed-position descendant, so the portal matters there too.
- Dropped the now-unused `.menu-anchor` class.

## Testing

- `npm run typecheck` — clean
- `npm test` — 393/393 pass
- Manual: menu opens fully past the card edge on both first and last rows; closes on outside click; tracks the row while scrolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)