### PR TITLE
fix(sdk/python): forward MiniMax v1 video optional fields regressed by #854

### DIFF
--- a/sdk/python/agentfield/media_providers.py
+++ b/sdk/python/agentfield/media_providers.py
@@ -1813,10 +1813,10 @@ class MiniMaxProvider(MediaProvider):
                 timeout=timeout,
                 kwargs=kwargs,
             )
-        if content is not None or any(
-            value is not None for value in (ratio, callback_url, aigc_watermark)
-        ):
-            raise ValueError("MiniMax v2 request fields require the MiniMax-H3 model")
+        if content is not None:
+            raise ValueError(
+                "MiniMax v2 structured content requires the MiniMax-H3 model"
+            )
 
         body: Dict[str, Any] = {"model": send_model, "prompt": prompt}
         if image_url:
@@ -1827,6 +1827,15 @@ class MiniMaxProvider(MediaProvider):
             body["duration"] = int(duration)
         if resolution:
             body["resolution"] = resolution.upper()
+        # Unlike the H3 path, these are forwarded unvalidated: the v1 API
+        # accepts them directly and pre-H3 releases passed them through
+        # **kwargs verbatim.
+        if ratio is not None:
+            body["ratio"] = ratio
+        if callback_url is not None:
+            body["callback_url"] = callback_url
+        if aigc_watermark is not None:
+            body["aigc_watermark"] = aigc_watermark
         overrides = {**(extra or {}), **kwargs}
         # Validated/normalized above — merging them from extra/kwargs would
         # bypass those checks (e.g. a fractional duration or lowercase

--- a/sdk/python/tests/test_minimax_video.py
+++ b/sdk/python/tests/test_minimax_video.py
@@ -234,6 +234,65 @@ async def test_minimax_video_validates_credentials_and_duration(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_minimax_video_legacy_forwards_v1_optional_fields(monkeypatch):
+    session = CaptureSession(
+        FakeResponse({"task_id": "task-123", "base_resp": {"status_code": 0}}),
+        [
+            FakeResponse(
+                {
+                    "status": "Success",
+                    "file_id": "file-123",
+                    "base_resp": {"status_code": 0},
+                }
+            ),
+            FakeResponse(
+                {
+                    "file": {
+                        "filename": "result.mp4",
+                        "download_url": "https://cdn.example.com/result.mp4",
+                    },
+                    "base_resp": {"status_code": 0},
+                }
+            ),
+        ],
+    )
+    monkeypatch.setattr("aiohttp.ClientSession", lambda **kwargs: session)
+
+    provider = MiniMaxProvider(api_key="unit-value")
+    await provider.generate_video(
+        prompt="A landscape",
+        model="minimax/MiniMax-Hailuo-02",
+        duration=6.0,
+        ratio="16:9",
+        callback_url="https://hook.example/cb",
+        aigc_watermark=True,
+        poll_interval=0,
+    )
+
+    assert session.calls[0][2]["json"] == {
+        "model": "MiniMax-Hailuo-02",
+        "prompt": "A landscape",
+        "duration": 6,
+        "ratio": "16:9",
+        "callback_url": "https://hook.example/cb",
+        "aigc_watermark": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_minimax_video_legacy_rejects_h3_structured_content():
+    provider = MiniMaxProvider(api_key="unit-value")
+
+    with pytest.raises(ValueError, match="structured content requires the MiniMax-H3"):
+        await provider.generate_video(
+            "A landscape",
+            model="minimax/MiniMax-Hailuo-02",
+            duration=6.0,
+            content=[{"type": "text", "text": "A landscape"}],
+        )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("resolution", "normalized_resolution", "expected_cost"),
     [("2k", "2K", 0.95), ("768p", "768P", 0.6)],


### PR DESCRIPTION
## Summary

PR #854 (MiniMax H3 video v2) promoted `content`, `ratio`, `callback_url`, and `aigc_watermark` from `**kwargs` to named parameters on `MiniMaxProvider.generate_video`, then added a guard rejecting all four for any non-H3 model. In v0.1.123 the last three fell through `**kwargs` → `overrides` → the v1 `/video_generation` request body and were forwarded verbatim (`callback_url` and `aigc_watermark` are documented v1 fields), so existing Hailuo callers like

```python
await provider.generate_video(prompt, model="minimax/MiniMax-Hailuo-02", duration=6, callback_url="https://hook.example/cb")
```

now raise `ValueError("MiniMax v2 request fields require the MiniMax-H3 model")` instead of submitting the job.

## Changes Made

- Forward `ratio`, `callback_url`, and `aigc_watermark` verbatim into the v1 request body when provided, restoring v0.1.123 behavior byte-for-byte.
- Keep the client-side guard for `content` only: structured content is a v2 request shape that never worked against v1, so the clear error is strictly better than the old server-side rejection.
- No new names in the `reserved` override check, so the `extra={"callback_url": ...}` path (which kept working throughout) is unchanged.

## Validation Contract

1. A v1 (non-H3) call passing `ratio` / `callback_url` / `aigc_watermark` as named kwargs submits them verbatim in the v1 POST body with no exception — covered by `test_minimax_video_legacy_forwards_v1_optional_fields`.
2. `content=[...]` with a non-H3 model still raises a clear `ValueError` — covered by `test_minimax_video_legacy_rejects_h3_structured_content`.
3. H3 path behavior is untouched (existing H3 tests unchanged and passing).

## Test Plan

- [x] Differential probe against a v0.1.123 checkout (captured submit bodies): all five scenarios — each named field, plain control, and the `extra=` path — are byte-identical between v0.1.123 and this branch.
- [x] `ruff check .` clean at CI's pinned 0.15.22; `ruff format --check` clean on touched files.
- [x] Full sdk/python suite: 1872 passed, 4 skipped (includes the 2 new tests).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)