### PR TITLE
Make agent installs work on cloud deployments, and make re-run deploy a real upgrade path

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,4 +85,8 @@ jobs:
             echo "Required checks failed"
             exit 1
           fi
+          if [ "${{ needs.control-plane-cloud-image.result }}" != "success" ]; then
+            echo "Required checks failed"
+            exit 1
+          fi
           echo "All required checks passed successfully"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,6 +67,8 @@ jobs:
             node --version
             npm --version
             go version
+            uv --version
+            [ "$(uv python dir)" = /data/uv/python ]
             opencode --version
           '
 

--- a/deployments/docker/Dockerfile.control-plane-cloud
+++ b/deployments/docker/Dockerfile.control-plane-cloud
@@ -77,6 +77,17 @@ RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
 COPY --from=go-dist /usr/local/go /usr/local/go
 ENV PATH=/usr/local/go/bin:$PATH
 
+# uv, so the installer can provision interpreters for nodes whose
+# requires-python the OS python3 (bookworm = 3.11) can't satisfy.
+# Unpinned like opencode below — a frozen minor stops learning about new
+# Python releases; COPY --from is content-addressed, so a new uv release
+# invalidates this layer even under the persistent CI cache.
+# Downloaded interpreters go under /data: venvs on the volume symlink back
+# to them, and an interpreter left in $HOME would vanish with the container
+# on the next deploy, breaking every venv built from it.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+ENV UV_PYTHON_INSTALL_DIR=/data/uv/python
+
 COPY --from=go-builder /app/bin/af /usr/local/bin/af
 COPY --from=go-builder /app/control-plane/config /etc/agentfield/config
 

--- a/desktop/src/main/deployEngine.test.ts
+++ b/desktop/src/main/deployEngine.test.ts
@@ -5,7 +5,7 @@ import { delimiter, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { mkdtempSync } from 'node:fs'
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
-import { generateApiKey, hasDeployment, resolveTofuBinary, runDeploy, runDestroy } from './deployEngine'
+import { generateApiKey, hasDeployment, resolveCloudImage, resolveTofuBinary, runDeploy, runDestroy } from './deployEngine'
 
 type Script = { stdout?: string; stderr?: string; code?: number }
 
@@ -53,9 +53,12 @@ function workspace(mirror = false) {
   return { root, binaryDir, opts: { railwayToken: 'token', workspaceId: 'workspace', workspaceDir: join(root, 'work'), binaryDir } }
 }
 
-function deployedState(apiKey = 'prior-key', subdomain = 'agentfield-dead') {
+function deployedState(apiKey = 'prior-key', subdomain = 'agentfield-dead', sourceImage?: string) {
   return JSON.stringify({
-    resources: [{ type: 'railway_service_domain', name: 'cp', instances: [{ attributes: { subdomain } }] }],
+    resources: [
+      { type: 'railway_service_domain', name: 'cp', instances: [{ attributes: { subdomain } }] },
+      ...(sourceImage ? [{ type: 'railway_service', name: 'cp', instances: [{ attributes: { source_image: sourceImage } }] }] : [])
+    ],
     outputs: { api_key: { value: apiKey } }
   })
 }
@@ -73,7 +76,12 @@ describe('deployment module and execution', () => {
     const module = readFileSync(join(withMirror.opts.workspaceDir, 'main.tf'), 'utf8')
     expect(module).toContain('resource "railway_project" "cp"')
     expect(module).toContain('workspace_id = var.workspace_id')
-    expect(module).toContain('source_image = "agentfield/control-plane-cloud:latest"')
+    expect(module).toContain('source_image = var.image')
+    expect(module).toContain('default = "agentfield/control-plane-cloud:latest"')
+    expect(module).toContain('ignore_changes = [volume]')
+    // The default harness fetch is not Docker Hub shaped, so the resolver
+    // falls back to the floating tag.
+    expect(fake.calls[0].env.TF_VAR_image).toBe('agentfield/control-plane-cloud:latest')
     expect(module).not.toMatch(/\bvolume\s*=/)
     expect(module).toContain('output "project_id"')
     expect(module).toContain('output "environment_id"')
@@ -100,7 +108,7 @@ describe('deployment module and execution', () => {
       ].join('\n') + '\n'
     }, { stdout: outputs({ url: { value: 'https://x' }, api_key: { value: 'k' } }) }])
     expect((await runDeploy({ ...fixture.opts, onLine: (line) => lines.push(line) }, fake.deps)).ok).toBe(true)
-    expect(lines).toEqual(['Creating', 'Created', 'Attaching storage volume…', 'Storage volume ready'])
+    expect(lines).toEqual(['Deploying agentfield/control-plane-cloud:latest', 'Creating', 'Created', 'Attaching storage volume…', 'Storage volume ready'])
   })
 
   it('surfaces diagnostic summaries and preserves state for reconciliation', async () => {
@@ -140,6 +148,10 @@ describe('deployment module and execution', () => {
     const fixture = workspace()
     const lines: string[] = []
     const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ results: [
+        { name: 'latest', digest: 'sha256:abc' },
+        { name: 'v0.1.124', digest: 'sha256:abc' }
+      ] }), { status: 200 }))
       .mockResolvedValueOnce(new Response(JSON.stringify({ data: { project: { volumes: { edges: [] } } } }), { status: 200 }))
       .mockResolvedValueOnce(new Response(JSON.stringify({ data: { volumeCreate: { id: 'volume', name: 'data' } } }), { status: 200 })) as typeof fetch
     const fake = harness([{}, {}, { stdout: outputs() }], fetchImpl)
@@ -147,8 +159,9 @@ describe('deployment module and execution', () => {
     expect(await runDeploy({ ...fixture.opts, onLine: (line) => lines.push(line) }, fake.deps)).toEqual({
       ok: true, url: 'https://cp.test', apiKey: 'key', message: 'AgentField deployed to Railway.'
     })
-    expect(fetchImpl).toHaveBeenCalledTimes(2)
-    const requests = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls as unknown as Array<[string, RequestInit]>
+    expect(fetchImpl).toHaveBeenCalledTimes(3)
+    expect(fake.calls[0].env.TF_VAR_image).toBe('agentfield/control-plane-cloud:v0.1.124')
+    const requests = ((fetchImpl as ReturnType<typeof vi.fn>).mock.calls as unknown as Array<[string, RequestInit]>).slice(1)
     for (const [url, init] of requests) {
       expect(url).toBe('https://backboard.railway.com/graphql/v2')
       expect(init.headers).toMatchObject({ Authorization: 'Bearer token', 'Content-Type': 'application/json', 'User-Agent': 'agentfield-desktop' })
@@ -158,7 +171,7 @@ describe('deployment module and execution', () => {
       variables: { projectId: 'project', environmentId: 'environment', serviceId: 'service', mountPath: '/data' }
     })
     expect(JSON.parse(String(requests[1][1].body)).query).toContain('mutation VolumeCreate')
-    expect(lines).toEqual(['Attaching storage volume…', 'Storage volume ready'])
+    expect(lines).toEqual(['Deploying agentfield/control-plane-cloud:v0.1.124', 'Attaching storage volume…', 'Storage volume ready'])
   })
 
   it('does not create a volume when one already exists', async () => {
@@ -168,13 +181,15 @@ describe('deployment module and execution', () => {
     }), { status: 200 })) as typeof fetch
     const fake = harness([{}, {}, { stdout: outputs() }], fetchImpl)
     expect((await runDeploy(fixture.opts, fake.deps)).ok).toBe(true)
-    expect(fetchImpl).toHaveBeenCalledOnce()
-    expect(JSON.parse(String((fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0][1].body)).query).not.toContain('mutation VolumeCreate')
+    // First call resolves the image from Docker Hub; the volume query is the only other one.
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(JSON.parse(String((fetchImpl as ReturnType<typeof vi.fn>).mock.calls[1][1].body)).query).not.toContain('mutation VolumeCreate')
   })
 
   it('keeps parsed outputs internal and reports a retryable volume creation failure', async () => {
     const fixture = workspace()
     const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ results: [] }), { status: 200 }))
       .mockResolvedValueOnce(new Response(JSON.stringify({ data: { project: { volumes: { edges: [] } } } }), { status: 200 }))
       .mockResolvedValueOnce(new Response(JSON.stringify({ errors: [{ message: 'volume denied' }] }), { status: 200 })) as typeof fetch
     const fake = harness([{}, {}, { stdout: outputs() }], fetchImpl)
@@ -182,6 +197,53 @@ describe('deployment module and execution', () => {
       ok: false,
       message: 'Deployed, but attaching the storage volume failed: volume denied. Re-run deploy to retry.'
     })
+  })
+})
+
+describe('cloud image resolution', () => {
+  const hub = (results: Array<{ name: string; digest?: string }>, status = 200) =>
+    vi.fn(async () => new Response(JSON.stringify({ results }), { status })) as typeof fetch
+
+  it('pins the release tag sharing a digest with latest, ignoring staging tags', async () => {
+    const fetchImpl = hub([
+      { name: 'latest', digest: 'sha256:abc' },
+      { name: 'staging-0.1.125-rc.1', digest: 'sha256:abc' },
+      { name: 'v0.1.124', digest: 'sha256:abc' },
+      { name: 'v0.1.123', digest: 'sha256:old' }
+    ])
+    expect(await resolveCloudImage(fetchImpl)).toBe('agentfield/control-plane-cloud:v0.1.124')
+    expect((fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0][0]).toContain('hub.docker.com/v2/repositories/agentfield/control-plane-cloud/tags')
+  })
+
+  it('returns null when the lookup fails or nothing matches', async () => {
+    expect(await resolveCloudImage(vi.fn(async () => { throw new Error('offline') }) as unknown as typeof fetch)).toBeNull()
+    expect(await resolveCloudImage(hub([], 500))).toBeNull()
+    expect(await resolveCloudImage(hub([{ name: 'v0.1.124', digest: 'sha256:abc' }]))).toBeNull()
+    expect(await resolveCloudImage(hub([{ name: 'latest', digest: 'sha256:abc' }, { name: 'staging-0.1.124-rc.9', digest: 'sha256:abc' }]))).toBeNull()
+  })
+
+  it('a failed lookup keeps an existing deployment on its recorded pin instead of de-pinning to latest', async () => {
+    const fixture = workspace()
+    mkdirSync(fixture.opts.workspaceDir, { recursive: true })
+    writeFileSync(join(fixture.opts.workspaceDir, 'terraform.tfstate'), deployedState('prior-key', 'agentfield-dead', 'agentfield/control-plane-cloud:v0.1.124'))
+    const offline = harness([{}, {}, { stdout: outputs() }], vi.fn(async () => { throw new Error('offline') }) as unknown as typeof fetch)
+    // The volume step also uses the failing fetch, so the deploy reports the
+    // retryable volume error — the apply itself, and its pin, still ran.
+    await runDeploy(fixture.opts, offline.deps)
+    expect(offline.calls[0].env.TF_VAR_image).toBe('agentfield/control-plane-cloud:v0.1.124')
+
+    // A successful lookup still upgrades the same deployment.
+    writeFileSync(join(fixture.opts.workspaceDir, 'terraform.tfstate'), deployedState('prior-key', 'agentfield-dead', 'agentfield/control-plane-cloud:v0.1.124'))
+    const online = harness([{}, {}, { stdout: outputs() }], vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ results: [
+        { name: 'latest', digest: 'sha256:new' },
+        { name: 'v0.1.125', digest: 'sha256:new' }
+      ] }), { status: 200 }))
+      .mockResolvedValue(new Response(JSON.stringify({
+        data: { project: { volumes: { edges: [{ node: { id: 'volume', name: 'data' } }] } } }
+      }), { status: 200 })) as typeof fetch)
+    expect((await runDeploy(fixture.opts, online.deps)).ok).toBe(true)
+    expect(online.calls[0].env.TF_VAR_image).toBe('agentfield/control-plane-cloud:v0.1.125')
   })
 })
 

--- a/desktop/src/main/deployEngine.ts
+++ b/desktop/src/main/deployEngine.ts
@@ -42,6 +42,12 @@ variable "api_key" {
   type      = string
   sensitive = true
 }
+variable "image" {
+  type = string
+  # Floating fallback for when the release lookup fails; a fresh deploy still
+  # lands on the newest production release at create time.
+  default = "agentfield/control-plane-cloud:latest"
+}
 resource "railway_project" "cp" {
   name         = var.project_name
   workspace_id = var.workspace_id
@@ -49,10 +55,24 @@ resource "railway_project" "cp" {
 resource "railway_service" "cp" {
   name         = "control-plane"
   project_id   = railway_project.cp.id
-  # Tracks the newest production release at deploy time. Railway resolves the
-  # tag once per deploy and never auto-repulls, so existing deployments stay
-  # on whatever "latest" meant when they were created.
-  source_image = "agentfield/control-plane-cloud:latest"
+  # Pinned to the concrete release tag resolved at deploy time. Railway
+  # resolves a floating tag once per deploy and never auto-repulls, and an
+  # unchanged image string is a no-op apply — a ":latest" pin here froze
+  # existing deployments on whatever "latest" meant the day they were
+  # created. With a concrete tag, each new release changes the string, the
+  # change is a diff, and the diff is what redeploys the service: re-running
+  # deploy IS the upgrade path.
+  source_image = var.image
+  # The /data volume is created out-of-band (Railway GraphQL, ensureVolume) so
+  # this module never declares one — but the provider refreshes it into state,
+  # plans the undeclared attribute back to null, and its Update handler treats
+  # that as "delete the volume" (volumeDelete — the data, not a detach). Every
+  # re-apply would silently wipe the control plane's SQLite/BoltDB, secrets,
+  # and installed agents. Ignoring the attribute keeps the refreshed value in
+  # the plan so the delete branch can never fire.
+  lifecycle {
+    ignore_changes = [volume]
+  }
 }
 resource "railway_variable" "api_key" {
   name           = "AGENTFIELD_API_KEY"
@@ -82,6 +102,32 @@ output "api_key" {
 `
 
 const NO_ENGINE = 'Deploy engine not bundled. Install OpenTofu or rebuild AgentField Desktop with the deploy engine.'
+
+const CLOUD_IMAGE_REPO = 'agentfield/control-plane-cloud'
+const CLOUD_IMAGE_LATEST = `${CLOUD_IMAGE_REPO}:latest`
+const DOCKER_HUB_TAGS = `https://hub.docker.com/v2/repositories/${CLOUD_IMAGE_REPO}/tags?page_size=100`
+
+/**
+ * Resolve the concrete release tag "latest" currently points at (release.yml
+ * pushes both on every production release, so they share a digest). Returns
+ * null when Docker Hub is unreachable or the digests don't line up — the
+ * caller falls back to the pin already recorded in state (so a lookup outage
+ * never rewrites a working deployment's image) or, for a fresh deployment,
+ * to the floating tag.
+ */
+export async function resolveCloudImage(fetchImpl: typeof fetch = fetch): Promise<string | null> {
+  try {
+    const response = await fetchImpl(DOCKER_HUB_TAGS, { signal: AbortSignal.timeout(5000) })
+    if (!response.ok) return null
+    const payload = (await response.json()) as { results?: Array<{ name?: string; digest?: string }> }
+    const tags = payload.results ?? []
+    const digest = tags.find((tag) => tag.name === 'latest')?.digest
+    const release = digest ? tags.find((tag) => tag.digest === digest && /^v\d+\.\d+\.\d+$/.test(tag.name ?? '')) : undefined
+    return release?.name ? `${CLOUD_IMAGE_REPO}:${release.name}` : null
+  } catch {
+    return null
+  }
+}
 
 function executableName(): string {
   return process.platform === 'win32' ? 'tofu.exe' : 'tofu'
@@ -157,6 +203,12 @@ function stateWorkspaceId(state: TfState | null): string | null {
   return typeof value === 'string' && value.length > 0 ? value : null
 }
 
+function stateSourceImage(state: TfState | null): string | null {
+  const resource = state?.resources?.find((item) => item.type === 'railway_service' && item.name === 'cp')
+  const value = resource?.instances?.[0]?.attributes?.source_image
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
 function writeConfig(workspaceDir: string, binaryDir?: string | null): string | null {
   if (!binaryDir) return null
   const mirror = join(binaryDir, 'providers')
@@ -226,7 +278,7 @@ function runCommand(
   })
 }
 
-function deployEnv(opts: DeployEngineOptions, apiKey: string, subdomain: string, cliConfig: string | null, deps: DeploySpawnDeps): NodeJS.ProcessEnv {
+function deployEnv(opts: DeployEngineOptions, apiKey: string, subdomain: string, cliConfig: string | null, deps: DeploySpawnDeps, image?: string): NodeJS.ProcessEnv {
   return {
     ...process.env,
     ...deps.env,
@@ -236,6 +288,7 @@ function deployEnv(opts: DeployEngineOptions, apiKey: string, subdomain: string,
     TF_VAR_subdomain: subdomain,
     TF_VAR_api_key: apiKey,
     TF_IN_AUTOMATION: '1',
+    ...(image ? { TF_VAR_image: image } : {}),
     ...(cliConfig ? { TF_CLI_CONFIG_FILE: cliConfig } : {})
   }
 }
@@ -303,7 +356,12 @@ export async function runDeploy(opts: DeployEngineOptions, deps: DeploySpawnDeps
   const subdomain = existing ? stateSubdomain(state) : `${projectName}-${randomBytes(2).toString('hex')}`
   if (!subdomain) return { ok: false, message: 'Existing deployment is missing its Railway subdomain.' }
   const cliConfig = writeConfig(opts.workspaceDir, opts.binaryDir)
-  const env = deployEnv(opts, apiKey, subdomain, cliConfig, deps)
+  // Newest release when the lookup succeeds; the deployment's recorded pin
+  // when it doesn't (so an outage never rewrites a working image and forces
+  // a pointless redeploy); the floating tag only for a brand-new deployment.
+  const image = (await resolveCloudImage(deps.fetchImpl ?? fetch)) ?? stateSourceImage(state) ?? CLOUD_IMAGE_LATEST
+  opts.onLine?.(`Deploying ${image}`)
+  const env = deployEnv(opts, apiKey, subdomain, cliConfig, deps, image)
 
   if (!providerReady(opts.workspaceDir)) {
     const init = await runCommand(binary, ['init', '-input=false'], opts.workspaceDir, env, deps, false)


### PR DESCRIPTION
## Summary

Deploying swe-planner from AgentField Desktop onto a Remote (BETA) deployment failed with `failed to install dependencies: this agent node requires Python >=3.12, but no compatible interpreter is available (found python3 (Python 3.11.2))` — even though SWE-AF is Go-based now and its root manifest redirects to the Go node via `superseded_by`.

Root cause: the remote control plane was frozen on a pre-`superseded_by` image. The deploy module pinned `source_image` to the floating `:latest`, Railway resolves a floating tag once at service creation and never re-pulls, and re-applying an unchanged string is a Terraform no-op — so existing remote deployments could never be upgraded, and one created before v0.1.121 kept parsing SWE-AF as the root Python node forever. The same staleness silently installs the *wrong* (Python) node for pr-af, whose root satisfies 3.11.

## Changes

**`fix(desktop)` — re-run deploy becomes a safe, actual upgrade path**
- `source_image` is a Terraform variable resolved per deploy by `resolveCloudImage()`: it pins the concrete release tag sharing `latest`'s digest on Docker Hub. A new release changes the string → the diff redeploys the service (the Railway provider calls `redeployAllInstances` on update).
- A failed lookup (offline, Hub outage — bounded by a 5s timeout) falls back to the pin recorded in Terraform state, never rewriting a working deployment's image to `:latest`; only a brand-new deployment falls back to the floating tag.
- `lifecycle { ignore_changes = [volume] }` on the service: the `/data` volume is created out-of-band, the provider refreshes it into state, and any re-apply planned the undeclared attribute to null — which the provider turns into `volumeDelete`, silently destroying the databases, secrets keyring, and every installed agent. Pre-existing hazard, but promoting re-runs to the routine upgrade action made closing it a prerequisite.

**`fix(deploy)` — cloud image can install `requires-python >=3.12` nodes**
- Ships `uv` (the installer's `provisionViaUv` path already uses it when on PATH) with `UV_PYTHON_INSTALL_DIR=/data/uv/python`, so provisioned interpreters live on the persistent volume — a venv symlinking into `$HOME` would break on the next container replacement.
- CI smoke test asserts both the binary and the install dir.

**`fix(ci)` — `required-checks` now actually gates the cloud image job** (it listed the job in `needs` but never inspected its result).

## Validation

- Fixture node declaring `requires-python = ">=3.12"`: reproduces the exact production error on the published image; installs cleanly on the patched image (uv provisions CPython 3.12 under `/data/uv/python`, venv survives container replacement).
- Full catalog sweep inside the current image: SWE-AF resolves the `superseded_by` redirect and installs the **Go** node; pr-af, sec-af, cloudsecurity-af all install cleanly.
- End-to-end on a real Railway deployment: after moving it to v0.1.124, `POST /api/ui/v1/agents/packages/install` for SWE-AF succeeds and registers the Go `swe-planner`.
- Desktop gates: `npm ci`, `tsc --noEmit`, 396/396 vitest tests (incl. new de-pinning regression test over existing state), `npm run build`.
- Docker gates: full image build + the workflow's smoke test including the new assertions.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)