### PR TITLE
feat(control-plane): expose furrow_public_addr in health

### DIFF
--- a/control-plane/internal/server/routes_core.go
+++ b/control-plane/internal/server/routes_core.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/Agent-Field/agentfield/control-plane/internal/config"
@@ -215,6 +216,9 @@ func (s *AgentFieldServer) healthCheckHandler(c *gin.Context) {
 		"timestamp": time.Now().UTC().Format(time.RFC3339),
 		"version":   "1.0.0", // TODO: Get from build info
 		"checks":    gin.H{},
+	}
+	if furrowPublicAddr := os.Getenv("FURROW_PUBLIC_ADDR"); furrowPublicAddr != "" {
+		healthStatus["furrow_public_addr"] = furrowPublicAddr
 	}
 
 	allHealthy := true

--- a/control-plane/internal/server/server_test.go
+++ b/control-plane/internal/server/server_test.go
@@ -165,6 +165,47 @@ func TestHealthCheckHandlerHealthy(t *testing.T) {
 	}
 }
 
+func TestHealthCheckHandlerFurrowPublicAddr(t *testing.T) {
+	tests := []struct {
+		name      string
+		address   string
+		wantValue bool
+	}{
+		{name: "set", address: "furrow.example.com:7443", wantValue: true},
+		{name: "empty", address: "", wantValue: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("FURROW_PUBLIC_ADDR", tt.address)
+			gin.SetMode(gin.TestMode)
+			srv := &AgentFieldServer{
+				storageHealthOverride: func(context.Context) gin.H { return gin.H{"status": "healthy"} },
+				cacheHealthOverride:   func(context.Context) gin.H { return gin.H{"status": "healthy"} },
+			}
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			req, _ := http.NewRequest(http.MethodGet, "/health", nil)
+			c.Request = req
+
+			srv.healthCheckHandler(c)
+
+			var payload map[string]any
+			if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			got, present := payload["furrow_public_addr"]
+			if present != tt.wantValue {
+				t.Fatalf("furrow_public_addr presence = %v, want %v; payload: %+v", present, tt.wantValue, payload)
+			}
+			if tt.wantValue && got != tt.address {
+				t.Fatalf("furrow_public_addr = %v, want %q", got, tt.address)
+			}
+		})
+	}
+}
+
 func TestHealthCheckHandlerCacheOptional(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	srv := &AgentFieldServer{


### PR DESCRIPTION
## Summary
The desktop's workspace-sync probe (merged in #885, `furrowAddressFrom` in `desktop/src/main/cloud.ts`) reads a `furrow_public_addr` field from the control plane's health response — but no control-plane version emits that field, so `furrowAvailable` can never be true, even on a deployment where workspace sync is fully provisioned and reachable. Found while e2e-testing #885 + Agent-Field/SWE-AF#130 against a live cloud deployment.

## Changes Made
- The shared health handler (`GET /health` and `GET /api/v1/health`) now includes top-level `furrow_public_addr` when the `FURROW_PUBLIC_ADDR` env var is non-empty — the var the deploy engine already sets on provisioned services. When unset, the key is absent (not empty), matching what the desktop probe expects.
- Handler test covering both cases (`TestHealthCheckHandlerFurrowPublicAddr`).

## Test Plan
- [x] `go test ./internal/server` (new subtests `set` / `empty` pass)
- [x] `go build ./...`, `go vet ./...`, gofmt clean
- [x] Desktop-side consumer verified separately against a live cloud deployment (probe TLS-connects once this field is present)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)