### PR TITLE
Fix macOS Go scaffold happy path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
             version="${EXISTING_VERSION}"
             tag="v${version}"
             git fetch --tags origin "refs/tags/${tag}:refs/tags/${tag}" --depth=1
-            release_sha="$(git rev-parse "${tag}")"
+            release_sha="$(git rev-list -n 1 "${tag}")"
           else
             if [ "${ENVIRONMENT}" = "staging" ]; then
               # Staging: Always create prerelease version
@@ -182,6 +182,23 @@ jobs:
             git push origin "HEAD:${REF_NAME}"
             git push origin "${tag}"
             release_sha="$(git rev-parse HEAD)"
+          fi
+
+          # sdk/go is a nested Go module. Go resolves its versions from tags
+          # prefixed with the module subdirectory, not from the repository's
+          # root vX.Y.Z tag. The generated Go scaffold pins this exact version,
+          # so publish the matching nested tag before release artifacts are
+          # built and users can run `af init`.
+          sdk_go_tag="sdk/go/${tag}"
+          if git show-ref --verify --quiet "refs/tags/${sdk_go_tag}"; then
+            sdk_go_sha="$(git rev-list -n 1 "${sdk_go_tag}")"
+            if [ "${sdk_go_sha}" != "${release_sha}" ]; then
+              echo "${sdk_go_tag} already points to ${sdk_go_sha}, expected ${release_sha}" >&2
+              exit 1
+            fi
+          else
+            git tag -a "${sdk_go_tag}" "${release_sha}" -m "Go SDK ${tag}"
+            git push origin "${sdk_go_tag}"
           fi
 
           echo "version=${version}" >> "$GITHUB_OUTPUT"
@@ -217,6 +234,15 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
           cache-dependency-path: control-plane/go.sum
+
+      - name: Verify Go SDK module release
+        if: matrix.label == 'linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="v${{ needs.prepare.outputs.version }}"
+          resolved="$(GOPROXY=direct GONOSUMDB=github.com/Agent-Field/agentfield/sdk/go go list -m -f '{{.Version}}' "github.com/Agent-Field/agentfield/sdk/go@${version}")"
+          test "${resolved}" = "${version}"
 
       - name: Install cross-compilers
         if: matrix.label == 'linux'

--- a/control-plane/internal/cli/generated_scaffold_test.go
+++ b/control-plane/internal/cli/generated_scaffold_test.go
@@ -24,7 +24,7 @@ func TestGeneratedScaffoldsHaveInstallableV1Manifests(t *testing.T) {
 	}
 	wantStarts := map[string]string{
 		"python":     "python main.py",
-		"go":         "go run .",
+		"go":         "bin/representative-node",
 		"typescript": "npm run start",
 	}
 
@@ -69,6 +69,9 @@ func TestGeneratedScaffoldsHaveInstallableV1Manifests(t *testing.T) {
 			}
 			if metadata.AgentNode.NodeID != data.NodeID || metadata.AgentNode.DefaultPort != data.AgentPort || metadata.Entrypoint.Start != wantStart || metadata.HealthcheckPath() != "/health" {
 				t.Fatalf("unexpected executable metadata: %#v", metadata)
+			}
+			if language == "go" && metadata.Entrypoint.Build != "." {
+				t.Fatalf("Go build target = %q, want .", metadata.Entrypoint.Build)
 			}
 			if len(metadata.UserEnvironment.Required) != 0 {
 				t.Fatalf("required environment = %#v, want empty", metadata.UserEnvironment.Required)

--- a/control-plane/internal/cli/init.go
+++ b/control-plane/internal/cli/init.go
@@ -446,7 +446,11 @@ Example:
 
 			fmt.Println()
 			fmt.Println("Test it:")
-			fmt.Printf("  curl -X POST http://localhost:8080/api/v1/execute/%s.demo_echo \\\n", nodeID)
+			reasonerName := "demo_echo"
+			if language == "go" {
+				reasonerName = "echo"
+			}
+			fmt.Printf("  curl -X POST http://localhost:8080/api/v1/execute/%s.%s \\\n", nodeID, reasonerName)
 			fmt.Println("    -H \"Content-Type: application/json\" \\")
 			fmt.Println("    -d '{\"input\": {\"message\": \"Hello!\"}}'")
 			fmt.Println()

--- a/control-plane/internal/cli/stop.go
+++ b/control-plane/internal/cli/stop.go
@@ -186,8 +186,14 @@ func (as *AgentNodeStopper) StopAgentNode(agentNodeName string) error {
 	// query since the control plane keys executions by node_id, which may differ
 	// from the registry install name.
 	queryID := agentNodeName
-	if md, err := packages.ParsePackageMetadata(agentNode.Path); err == nil && md.AgentNode.NodeID != "" {
-		queryID = md.AgentNode.NodeID
+	httpShutdownSupported := true
+	if md, err := packages.ParsePackageMetadata(agentNode.Path); err == nil {
+		if md.AgentNode.NodeID != "" {
+			queryID = md.AgentNode.NodeID
+		}
+		// The Go SDK shuts down cleanly on SIGINT/SIGTERM and does not expose
+		// the legacy Python /shutdown route. Skip a guaranteed 404.
+		httpShutdownSupported = !md.IsGo()
 	}
 	if !as.confirmStopWithRunningExecutions(queryID) {
 		as.Outcome = "aborted"
@@ -197,7 +203,7 @@ func (as *AgentNodeStopper) StopAgentNode(agentNodeName string) error {
 
 	// Try HTTP shutdown first if port is available
 	httpShutdownSuccess := false
-	if agentNode.Runtime.Port != nil {
+	if httpShutdownSupported && agentNode.Runtime.Port != nil {
 		as.printf("🛑 Attempting graceful HTTP shutdown for agent %s on port %d\n", agentNodeName, *agentNode.Runtime.Port)
 
 		// Construct agent base URL
@@ -239,7 +245,11 @@ func (as *AgentNodeStopper) StopAgentNode(agentNodeName string) error {
 
 	// If HTTP shutdown failed or not available, fall back to process signals
 	if !httpShutdownSuccess {
-		as.printf("🔄 Falling back to process signal shutdown for agent %s\n", agentNodeName)
+		if httpShutdownSupported {
+			as.printf("🔄 Falling back to process signal shutdown for agent %s\n", agentNodeName)
+		} else {
+			as.printf("🛑 Sending graceful process signal to agent %s\n", agentNodeName)
+		}
 
 		// Ask for graceful shutdown (SIGINT on Unix, taskkill on Windows).
 		// A process that exits between the aliveness check above and the

--- a/control-plane/internal/core/services/agent_service.go
+++ b/control-plane/internal/core/services/agent_service.go
@@ -3,7 +3,6 @@ package services
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -832,65 +831,8 @@ func (as *DefaultAgentService) updateRuntimeInfo(agentNodeName string, port, pid
 }
 
 // displayCapabilities fetches and displays agent node capabilities
-func (as *DefaultAgentService) displayCapabilities(agentNode packages.InstalledPackage, port int) error {
-	client := &http.Client{Timeout: 5 * time.Second}
-
-	// Get reasoners
-	reasonersResp, err := client.Get(fmt.Sprintf("http://localhost:%d/reasoners", port))
-	if err != nil {
-		return err
-	}
-	defer reasonersResp.Body.Close()
-
-	var reasonersData map[string]interface{}
-	if err := json.NewDecoder(reasonersResp.Body).Decode(&reasonersData); err != nil {
-		return err
-	}
-
-	// Get skills
-	skillsResp, err := client.Get(fmt.Sprintf("http://localhost:%d/skills", port))
-	if err != nil {
-		return err
-	}
-	defer skillsResp.Body.Close()
-
-	var skillsData map[string]interface{}
-	if err := json.NewDecoder(skillsResp.Body).Decode(&skillsData); err != nil {
-		return err
-	}
-
-	fmt.Printf("\n🌐 Access locally at: http://localhost:%d\n", port)
-	fmt.Printf("📖 Available functions:\n")
-
-	// Display reasoners
-	if reasoners, ok := reasonersData["reasoners"].([]interface{}); ok && len(reasoners) > 0 {
-		fmt.Printf("  🧠 Reasoners: ")
-		var reasonerNames []string
-		for _, reasoner := range reasoners {
-			if r, ok := reasoner.(map[string]interface{}); ok {
-				if id, ok := r["id"].(string); ok {
-					reasonerNames = append(reasonerNames, id)
-				}
-			}
-		}
-		fmt.Printf("%s\n", strings.Join(reasonerNames, ", "))
-	}
-
-	// Display skills
-	if skills, ok := skillsData["skills"].([]interface{}); ok && len(skills) > 0 {
-		fmt.Printf("  🛠️  Skills:    ")
-		var skillNames []string
-		for _, skill := range skills {
-			if s, ok := skill.(map[string]interface{}); ok {
-				if id, ok := s["id"].(string); ok {
-					skillNames = append(skillNames, id)
-				}
-			}
-		}
-		fmt.Printf("%s\n", strings.Join(skillNames, ", "))
-	}
-
-	return nil
+func (as *DefaultAgentService) displayCapabilities(_ packages.InstalledPackage, port int) error {
+	return packages.DisplayCapabilities(port)
 }
 
 // findAgentInRegistry finds an agent in the registry by name, handling name normalization

--- a/control-plane/internal/packages/gointerp.go
+++ b/control-plane/internal/packages/gointerp.go
@@ -230,6 +230,12 @@ func InstallGoDependencies(packagePath string, metadata *PackageMetadata) error 
 	args := []string{"build"}
 	if hasVendorDir(packagePath) {
 		args = append(args, "-mod=vendor")
+	} else {
+		// Freshly generated Go scaffolds intentionally omit go.sum. Let the Go
+		// tool resolve transitive module requirements and write go.mod/go.sum in
+		// the installed package copy before compiling it. Without -mod=mod,
+		// modern Go versions reject the fresh package as needing `go mod tidy`.
+		args = append(args, "-mod=mod")
 	}
 	if outBin != "" {
 		outAbs := filepath.Join(packagePath, outBin)

--- a/control-plane/internal/packages/runner.go
+++ b/control-plane/internal/packages/runner.go
@@ -336,31 +336,32 @@ func (ar *AgentNodeRunner) waitForAgentNode(port int, healthPath, expectedNodeID
 }
 
 // displayCapabilities fetches and displays agent node capabilities
-func (ar *AgentNodeRunner) displayCapabilities(agentNode InstalledPackage, port int) error {
+func (ar *AgentNodeRunner) displayCapabilities(_ InstalledPackage, port int) error {
+	return DisplayCapabilities(port)
+}
+
+// DisplayCapabilities prints the reasoners and skills served by a running node.
+// It understands both the current /discover contract and legacy split endpoints.
+func DisplayCapabilities(port int) error {
 	client := &http.Client{Timeout: 5 * time.Second}
 
-	// Get reasoners
-	reasonersResp, err := client.Get(fmt.Sprintf("http://localhost:%d/reasoners", port))
-	if err != nil {
-		return err
-	}
-	defer reasonersResp.Body.Close()
-
-	var reasonersData map[string]interface{}
-	if err := json.NewDecoder(reasonersResp.Body).Decode(&reasonersData); err != nil {
-		return err
-	}
-
-	// Get skills
-	skillsResp, err := client.Get(fmt.Sprintf("http://localhost:%d/skills", port))
-	if err != nil {
-		return err
-	}
-	defer skillsResp.Body.Close()
-
-	var skillsData map[string]interface{}
-	if err := json.NewDecoder(skillsResp.Body).Decode(&skillsData); err != nil {
-		return err
+	// Current SDKs expose one discovery document. Older Python nodes expose
+	// separate /reasoners and /skills collections, so fall back to those when
+	// /discover is absent or not JSON.
+	discovery, discoverErr := fetchCapabilityDocument(client, port, "/discover")
+	var reasonersData, skillsData map[string]interface{}
+	if discoverErr == nil {
+		reasonersData, skillsData = discovery, discovery
+	} else {
+		var err error
+		reasonersData, err = fetchCapabilityDocument(client, port, "/reasoners")
+		if err != nil {
+			return fmt.Errorf("discover capabilities: %v; legacy reasoners: %w", discoverErr, err)
+		}
+		skillsData, err = fetchCapabilityDocument(client, port, "/skills")
+		if err != nil {
+			return fmt.Errorf("legacy skills: %w", err)
+		}
 	}
 
 	fmt.Printf("\n🌐 Access locally at: http://localhost:%d\n", port)
@@ -395,6 +396,22 @@ func (ar *AgentNodeRunner) displayCapabilities(agentNode InstalledPackage, port 
 	}
 
 	return nil
+}
+
+func fetchCapabilityDocument(client *http.Client, port int, path string) (map[string]interface{}, error) {
+	resp, err := client.Get(fmt.Sprintf("http://localhost:%d%s", port, path))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("GET %s returned %s", path, resp.Status)
+	}
+	var data map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, fmt.Errorf("decode GET %s: %w", path, err)
+	}
+	return data, nil
 }
 
 // updateRuntimeInfo updates the registry with runtime information

--- a/control-plane/internal/packages/runner_test.go
+++ b/control-plane/internal/packages/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -194,6 +195,25 @@ func TestAgentNodeRunnerWaitDisplayAndStartProcess(t *testing.T) {
 	}
 	if err == nil || !strings.Contains(err.Error(), "failed to open log file") {
 		t.Fatalf("expected log file error, got %v", err)
+	}
+}
+
+func TestDisplayCapabilitiesUsesDiscoveryDocument(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/discover" {
+			t.Errorf("unexpected legacy capability request: %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"reasoners":[{"id":"echo"}],"skills":[]}`))
+	}))
+	defer server.Close()
+
+	port := server.Listener.Addr().(*net.TCPAddr).Port
+	runner := &AgentNodeRunner{}
+	if err := runner.displayCapabilities(InstalledPackage{Name: "go-demo"}, port); err != nil {
+		t.Fatalf("displayCapabilities: %v", err)
 	}
 }
 

--- a/control-plane/internal/templates/go/README.md.tmpl
+++ b/control-plane/internal/templates/go/README.md.tmpl
@@ -19,7 +19,8 @@ A AgentField agent created with `af init`.
    go run .
    ```
 
-   The agent will auto-discover an available port and register with AgentField.
+   The agent listens on port {{.AgentPort}} by default. `af run` assigns an
+   available `PORT` automatically, and the agent registers with AgentField.
 
 ## Test the Agent
 

--- a/control-plane/internal/templates/go/agentfield-package.yaml.tmpl
+++ b/control-plane/internal/templates/go/agentfield-package.yaml.tmpl
@@ -5,7 +5,8 @@ description: {{yamlQuote (printf "Run the %s Go AgentField scaffold locally." .P
 author: {{yamlQuote .AuthorName}}
 language: go
 entrypoint:
-  start: go run .
+  build: .
+  start: bin/{{.NodeID}}
   healthcheck: /health
 agent_node:
   node_id: {{yamlQuote .NodeID}}

--- a/control-plane/internal/templates/go/main.go.tmpl
+++ b/control-plane/internal/templates/go/main.go.tmpl
@@ -6,15 +6,22 @@ import (
 	"os"
 
 	"github.com/Agent-Field/agentfield/sdk/go/agent"
-	"github.com/Agent-Field/agentfield/sdk/go/ai"
+	// "github.com/Agent-Field/agentfield/sdk/go/ai" // Uncomment with AIConfig below.
 )
+
+func envOrDefault(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
 
 func main() {
 	cfg := agent.Config{
 		NodeID:        "{{.NodeID}}",
 		Version:       "1.0.0",
-		AgentFieldURL:      "http://localhost:8080",
-		ListenAddress: ":0", // Auto-discover available port
+		AgentFieldURL: envOrDefault("AGENTFIELD_SERVER", "http://localhost:8080"),
+		ListenAddress: ":" + envOrDefault("PORT", "{{.AgentPort}}"),
 
 		// 🔧 Uncomment to enable AI features:
 		// AIConfig: &ai.Config{

--- a/control-plane/internal/templates/go/reasoners.go.tmpl
+++ b/control-plane/internal/templates/go/reasoners.go.tmpl
@@ -2,10 +2,10 @@ package main
 
 import (
 	"context"
-	"fmt"
+	// "fmt" // Uncomment with analyze_sentiment below.
 
 	"github.com/Agent-Field/agentfield/sdk/go/agent"
-	"github.com/Agent-Field/agentfield/sdk/go/ai"
+	// "github.com/Agent-Field/agentfield/sdk/go/ai" // Uncomment with analyze_sentiment below.
 )
 
 func registerReasoners(app *agent.Agent) {
@@ -24,7 +24,7 @@ func registerReasoners(app *agent.Agent) {
 		}, nil
 	})
 
-	// 🔧 Uncomment when AI is configured in main.go:
+	// 🔧 Uncomment the AI imports and this block when AI is configured in main.go:
 	//
 	// AI-powered sentiment analysis
 	//

--- a/control-plane/internal/templates/rendered_manifest_test.go
+++ b/control-plane/internal/templates/rendered_manifest_test.go
@@ -22,9 +22,10 @@ func TestRenderedScaffoldManifestIsInstallable(t *testing.T) {
 	tests := []struct {
 		language string
 		start    string
+		build    string
 	}{
 		{language: "python", start: "python main.py"},
-		{language: "go", start: "go run ."},
+		{language: "go", start: "bin/representative-node", build: "."},
 		{language: "typescript", start: "npm run start"},
 	}
 
@@ -77,6 +78,9 @@ func TestRenderedScaffoldManifestIsInstallable(t *testing.T) {
 			}
 			if metadata.HealthcheckPath() != "/health" || metadata.Entrypoint.Start != tt.start {
 				t.Errorf("healthcheck/start = %q/%q, want /health/%q", metadata.HealthcheckPath(), metadata.Entrypoint.Start, tt.start)
+			}
+			if metadata.Entrypoint.Build != tt.build {
+				t.Errorf("build = %q, want %q", metadata.Entrypoint.Build, tt.build)
 			}
 			if len(metadata.UserEnvironment.Required) != 0 {
 				t.Errorf("required environment = %#v, want explicit empty list", metadata.UserEnvironment.Required)

--- a/control-plane/internal/templates/templates_test.go
+++ b/control-plane/internal/templates/templates_test.go
@@ -2,6 +2,9 @@ package templates
 
 import (
 	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -161,6 +164,64 @@ func TestGetTemplateFiles(t *testing.T) {
 				t.Fatalf("GetTemplateFiles(%q) mapped %d manifests to the scaffold root, want 1", tt.language, manifestCount)
 			}
 		})
+	}
+}
+
+func TestRenderedGoScaffoldBuilds(t *testing.T) {
+	root := t.TempDir()
+	data := TemplateData{
+		ProjectName: "Buildable Go scaffold",
+		GoModule:    "example.com/buildable-go-scaffold",
+		NodeID:      "buildable-go-scaffold",
+		AuthorName:  "AgentField",
+		AgentPort:   8001,
+	}
+
+	files, err := GetTemplateFiles("go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for templatePath, destination := range files {
+		tmpl, err := GetTemplate(templatePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var rendered bytes.Buffer
+		if err := tmpl.Execute(&rendered, data); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, destination), rendered.Bytes(), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mainContents, err := os.ReadFile(filepath.Join(root, "main.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`envOrDefault("AGENTFIELD_SERVER", "http://localhost:8080")`,
+		`envOrDefault("PORT", "8001")`,
+	} {
+		if !strings.Contains(string(mainContents), want) {
+			t.Fatalf("rendered main.go missing %q:\n%s", want, mainContents)
+		}
+	}
+
+	sdkRoot, err := filepath.Abs("../../../sdk/go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	commands := [][]string{
+		{"mod", "edit", "-replace=github.com/Agent-Field/agentfield/sdk/go=" + sdkRoot},
+		{"build", "-mod=mod", "./..."},
+	}
+	for _, args := range commands {
+		cmd := exec.Command("go", args...)
+		cmd.Dir = root
+		cmd.Env = append(os.Environ(), "GOWORK=off")
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("go %s failed: %v\n%s", strings.Join(args, " "), err, output)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- make generated Go agents compile and honor the control-plane URL and assigned port
- build Go agents during install, use the prebuilt binary at runtime, and support current capability discovery and clean shutdown
- publish the nested Go SDK module tag during releases and verify it resolves before shipping
- add rendered-scaffold compilation and lifecycle regression coverage

## Why

A clean macOS smoke test against the public v0.1.125 release reproduced several real failures in the documented happy path:

1. `af init --language go` pinned `github.com/Agent-Field/agentfield/sdk/go@v0.1.125`, but releases only published the root `v0.1.125` tag. Go therefore requested the absent nested-module tag `sdk/go/v0.1.125`.
2. The generated source had active unused imports, so it still failed to compile after a local module replacement.
3. Fresh generated modules needed dependency resolution during install, but the build did not use module-update mode.
4. The scaffold ignored `AGENTFIELD_SERVER` and the assigned `PORT`, then listened on a random port, causing `af run` readiness to time out.
5. Capability display and shutdown assumed legacy Python-only HTTP routes.

## User impact

The production curl installer itself works on Apple Silicon, and the Python scaffold path works. The released Go happy path did not: a new scaffold could not install, and after working around compilation it could not become ready under `af run`.

## Validation

Public-release reproduction on macOS arm64:

- installed v0.1.125 using `curl -fsSL https://agentfield.ai/install.sh | bash` with isolated install/state directories
- verified the downloaded binary checksum, Mach-O arm64 architecture, symlink, version, and health endpoint
- reproduced `unknown revision sdk/go/v0.1.125`, unused-import build errors, and the runtime readiness timeout
- verified the patched end-to-end flow: `af init` → `af install` → `af run` → live reasoner call → `af stop`
- live call returned: `{"echoed":"macOS happy path: PASS","length":22,"original":"macOS happy path: PASS"}`

Automated checks:

- `bash -n scripts/install.sh`
- parsed `.github/workflows/release.yml` with Ruby YAML
- `go test ./internal/templates`
- `go test ./internal/cli`
- `go test ./internal/core/services -run 'TestAgentServiceDisplayCapabilities' -count=1`
- `go test ./internal/packages -run 'TestInstallGoDependencies|TestGoBuildTarget|TestGoReplace|TestInstallDependencies_DispatchesGo|TestAgentNodeRunnerWaitDisplayAndStartProcess|TestDisplayCapabilitiesUsesDiscoveryDocument' -count=1`
- `git diff --check`

## Note

The broader `go test ./internal/packages` suite still has existing macOS path expectation failures caused by `/var/...` versus `/private/var/...`; those are outside this patch. The focused package tests covering this change pass.