### PR TITLE
fix(control-plane): make the execution cleanup initial delay testable

### DIFF
--- a/control-plane/internal/handlers/execution_cleanup.go
+++ b/control-plane/internal/handlers/execution_cleanup.go
@@ -10,6 +10,11 @@ import (
 	"github.com/Agent-Field/agentfield/control-plane/internal/storage"
 )
 
+// defaultInitialCleanupDelay is how long cleanupLoop waits before its first
+// cleanup pass, giving the server time to finish starting up before the
+// cleanup service touches the database.
+const defaultInitialCleanupDelay = 30 * time.Second
+
 // ExecutionCleanupService manages the background cleanup of old executions
 type ExecutionCleanupService struct {
 	storage   storage.StorageProvider
@@ -18,6 +23,11 @@ type ExecutionCleanupService struct {
 	wg        sync.WaitGroup
 	isRunning bool
 	mu        sync.RWMutex
+
+	// initialDelay is the wait before the first cleanup pass. It is always
+	// defaultInitialCleanupDelay in production; tests shorten it so the
+	// first-pass branch of cleanupLoop is reachable without a 30s sleep.
+	initialDelay time.Duration
 
 	// Metrics
 	totalCleaned    int64
@@ -28,9 +38,10 @@ type ExecutionCleanupService struct {
 // NewExecutionCleanupService creates a new execution cleanup service
 func NewExecutionCleanupService(storage storage.StorageProvider, config config.ExecutionCleanupConfig) *ExecutionCleanupService {
 	return &ExecutionCleanupService{
-		storage:  storage,
-		config:   config,
-		stopChan: make(chan struct{}),
+		storage:      storage,
+		config:       config,
+		stopChan:     make(chan struct{}),
+		initialDelay: defaultInitialCleanupDelay,
 	}
 }
 
@@ -97,7 +108,7 @@ func (ecs *ExecutionCleanupService) cleanupLoop(ctx context.Context) {
 	defer ticker.Stop()
 
 	// Run initial cleanup after a short delay
-	initialDelay := time.NewTimer(30 * time.Second)
+	initialDelay := time.NewTimer(ecs.initialDelay)
 	defer initialDelay.Stop()
 
 	for {

--- a/control-plane/internal/handlers/execution_cleanup_loop_test.go
+++ b/control-plane/internal/handlers/execution_cleanup_loop_test.go
@@ -1,0 +1,108 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// waitForCleanupCalls polls until the loop has issued at least n cleanup calls.
+func waitForCleanupCalls(t *testing.T, store *cleanupStoreMock, n int) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(store.getCleanupCalls()) >= n {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("expected at least %d cleanup calls, got %d", n, len(store.getCleanupCalls()))
+}
+
+// The constructor must keep production on the 30s delay.
+func TestExecutionCleanupService_DefaultsToProductionInitialDelay(t *testing.T) {
+	svc := NewExecutionCleanupService(&cleanupStoreMock{}, testExecutionCleanupConfig(10))
+
+	if svc.initialDelay != defaultInitialCleanupDelay {
+		t.Fatalf("expected initial delay %v, got %v", defaultInitialCleanupDelay, svc.initialDelay)
+	}
+	if defaultInitialCleanupDelay != 30*time.Second {
+		t.Fatalf("production initial delay changed: got %v", defaultInitialCleanupDelay)
+	}
+}
+
+// cleanupLoop's first pass fires off initialDelay, not the ticker.
+func TestExecutionCleanupService_CleanupLoop_RunsInitialCleanup(t *testing.T) {
+	setupExecutionCleanupTestLogger(t)
+
+	store := &cleanupStoreMock{}
+	cfg := testExecutionCleanupConfig(10)
+	cfg.CleanupInterval = time.Hour // ticker must not be what fires
+
+	svc := NewExecutionCleanupService(store, cfg)
+	svc.initialDelay = 5 * time.Millisecond
+
+	if err := svc.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitForCleanupCalls(t, store, 1)
+	if err := svc.Stop(); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+}
+
+// cleanupLoop keeps running on the ticker after the initial pass.
+func TestExecutionCleanupService_CleanupLoop_RunsOnTicker(t *testing.T) {
+	setupExecutionCleanupTestLogger(t)
+
+	store := &cleanupStoreMock{}
+	cfg := testExecutionCleanupConfig(10)
+	cfg.CleanupInterval = 5 * time.Millisecond
+
+	svc := NewExecutionCleanupService(store, cfg)
+	svc.initialDelay = time.Hour // initial timer must not be what fires
+
+	if err := svc.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitForCleanupCalls(t, store, 2)
+	if err := svc.Stop(); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+}
+
+// A failing retry pass is logged and does not abort the cleanup.
+func TestExecutionCleanupService_PerformCleanup_ContinuesWhenRetryStaleFails(t *testing.T) {
+	logBuffer := setupExecutionCleanupTestLogger(t)
+
+	store := &cleanupStoreMock{
+		retryStaleErrs:   []error{errors.New("retry boom")},
+		cleanupResponses: []cleanupResponse{{count: 2}},
+	}
+	cfg := testExecutionCleanupConfig(10)
+	cfg.MaxRetries = 3
+
+	svc := NewExecutionCleanupService(store, cfg)
+	svc.performCleanup(context.Background())
+
+	if got := len(store.getRetryStaleCalls()); got != 1 {
+		t.Fatalf("expected 1 retry call, got %d", got)
+	}
+	if got := len(store.getCleanupCalls()); got != 1 {
+		t.Fatalf("retry failure should not stop the delete pass, got %d cleanup calls", got)
+	}
+
+	totalCleaned, _, lastErr := svc.GetMetrics()
+	if totalCleaned != 2 {
+		t.Fatalf("expected 2 cleaned, got %d", totalCleaned)
+	}
+	if lastErr != nil {
+		t.Fatalf("retry failure must not be recorded as a cleanup error, got %v", lastErr)
+	}
+	if logs := logBuffer.String(); !strings.Contains(logs, "failed to retry stale workflow executions") {
+		t.Fatalf("expected retry failure log, got: %s", logs)
+	}
+}


### PR DESCRIPTION
Found while looking at #118. That issue turns out to be already satisfied by #195, which I have noted there. Separately, one real gap did surface, which this PR addresses.

## Problem

`cleanupLoop` waits on a hardcoded 30 second timer before its first cleanup pass:

```go
initialDelay := time.NewTimer(30 * time.Second)
```

That branch cannot be reached by a test without actually sleeping for 30 seconds, so the first cleanup pass after startup has never been exercised by anything. It is the path that runs on every server boot.

## Change

Move the value to a named constant and hold it in an unexported field the constructor always populates.

**Production timing is unchanged.** `NewExecutionCleanupService` is the only construction site in the repo (there are no struct literals elsewhere), so every instance still gets 30 seconds. Nothing is added to `ExecutionCleanupConfig`, so no new YAML key, no new env var, and no exported API change. Operators cannot alter it. Tests in this package shorten the field directly.

A guard test asserts the default is still 30 seconds, so the value is now pinned by an assertion instead of sitting as an implicit assumption inside a loop.

## Tests

Three previously unreachable branches now have coverage:

- the initial-cleanup branch of `cleanupLoop`
- the ticker branch of `cleanupLoop`
- the `RetryStaleWorkflowExecutions` error path in `performCleanup`

Each loop test neutralises the other timer, setting `CleanupInterval` to an hour when testing the initial pass and `initialDelay` to an hour when testing the ticker, so neither can pass for the wrong reason.

## Result

`execution_cleanup.go` is now at 100% across all seven functions.

| Function | Before | After |
| --- | --- | --- |
| `cleanupLoop` | 84.6% | 100% |
| `performCleanup` | 97.9% | 100% |

All 18 tests touching the cleanup service pass. No existing tests were modified.