### PR TITLE
chore(deps): bump js-yaml to 4.3.1

### DIFF
--- a/control-plane/web/client/package-lock.json
+++ b/control-plane/web/client/package-lock.json
@@ -6610,9 +6610,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "dev": true,
             "funding": [
                 {

--- a/control-plane/web/client/package.json
+++ b/control-plane/web/client/package.json
@@ -85,7 +85,7 @@
         "vitest": "^4.1.8"
     },
     "overrides": {
-        "js-yaml": "4.3.0",
+        "js-yaml": "4.3.1",
         "esbuild": "0.28.1",
         "ws": "8.21.0",
         "brace-expansion@1": "1.1.18",
@@ -94,7 +94,7 @@
     },
     "pnpm": {
         "overrides": {
-            "js-yaml": "4.3.0",
+            "js-yaml": "4.3.1",
             "esbuild": "0.28.1",
             "ws": "8.21.0",
             "brace-expansion@1": "1.1.18",

--- a/control-plane/web/client/pnpm-lock.yaml
+++ b/control-plane/web/client/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
   esbuild: 0.28.1
   ws: 8.21.0
   brace-expansion@1: 1.1.18
@@ -2490,8 +2490,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@26.1.0:
@@ -4066,7 +4066,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5986,7 +5986,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/examples/benchmarks/100k-scale/mastra-bench/package-lock.json
+++ b/examples/benchmarks/100k-scale/mastra-bench/package-lock.json
@@ -1801,9 +1801,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/examples/benchmarks/100k-scale/mastra-bench/package.json
+++ b/examples/benchmarks/100k-scale/mastra-bench/package.json
@@ -15,7 +15,7 @@
     "@types/node": "^20.0.0"
   },
   "overrides": {
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "fast-uri": "3.1.5",
     "body-parser": "2.3.0",
     "@ai-sdk/provider-utils": "^4.0.27",


### PR DESCRIPTION
## Summary
- bump the control-plane client `js-yaml` override and both client lockfiles to `4.3.1`
- bump the benchmark example override and lockfile to `4.3.1`
- clear the three open Dependabot alerts tied to `GHSA-5p4m-2wfm-xmqj`

## Validation
- `npm audit --json` in `examples/benchmarks/100k-scale/mastra-bench` reports 0 vulnerabilities after the bump
- `npm audit --json` in `control-plane/web/client` no longer reports `js-yaml`; remaining findings are unrelated `@eslint/plugin-kit`, `ajv`, and `nanoid`
- `pnpm build` on this branch still fails in `control-plane/web/client`, but the same failure reproduces on clean `origin/main`: missing `react-hook-form` and `date-fns` imports
- `pnpm test` on this branch still fails in `control-plane/web/client`, but the same two failing suites reproduce on clean `origin/main` because `date-fns` is missing there too

## Notes
This keeps the remediation isolated to the alert paths instead of mixing in the pre-existing client manifest/toolchain cleanup.