### PR TITLE
fix(sdk/python): harden cross-loop teardown

### DIFF
--- a/sdk/python/agentfield/async_lifecycle.py
+++ b/sdk/python/agentfield/async_lifecycle.py
@@ -84,9 +84,17 @@ async def cancel_and_await_if_same_loop(
             pass
         except RuntimeError as exc:
             # A loop-association error can still occur if the task's cleanup
-            # awaits a future created by another loop. Other RuntimeErrors
-            # belong to the task's cleanup and must not be hidden by teardown.
-            if "attached to a different loop" not in str(exc):
+            # awaits something owned by another loop. CPython words this two
+            # ways: "attached to a different loop" for a foreign Future
+            # (asyncio/tasks.py) and "bound to a different event loop" for a
+            # foreign Lock/Event/Condition (asyncio/mixins.py). Other
+            # RuntimeErrors belong to the task's cleanup and must not be
+            # hidden by teardown.
+            msg = str(exc)
+            if (
+                "attached to a different loop" not in msg
+                and "bound to a different event loop" not in msg
+            ):
                 raise
             logger.debug(
                 "Awaiting cancelled task raised a cross-loop RuntimeError",

--- a/sdk/python/agentfield/async_lifecycle.py
+++ b/sdk/python/agentfield/async_lifecycle.py
@@ -82,11 +82,14 @@ async def cancel_and_await_if_same_loop(
             await task
         except asyncio.CancelledError:
             pass
-        except RuntimeError:
-            # Defensive: if the loop association is somehow inconsistent,
-            # don't let teardown wedge the caller.
+        except RuntimeError as exc:
+            # A loop-association error can still occur if the task's cleanup
+            # awaits a future created by another loop. Other RuntimeErrors
+            # belong to the task's cleanup and must not be hidden by teardown.
+            if "attached to a different loop" not in str(exc):
+                raise
             logger.debug(
-                "Awaiting cancelled task raised RuntimeError during teardown",
+                "Awaiting cancelled task raised a cross-loop RuntimeError",
                 exc_info=True,
             )
         return

--- a/sdk/python/agentfield/http_connection_manager.py
+++ b/sdk/python/agentfield/http_connection_manager.py
@@ -7,6 +7,7 @@ Supports both single requests and batch operations for the AgentField SDK async 
 """
 
 import asyncio
+import threading
 import time
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
@@ -17,7 +18,6 @@ import aiohttp
 from .async_config import AsyncConfig
 from .async_lifecycle import (
     cancel_and_await_if_same_loop,
-    cancel_task_cross_loop,
     current_running_loop,
 )
 from .exceptions import AgentFieldClientError
@@ -109,6 +109,11 @@ class ConnectionManager:
         self._connector: Optional[aiohttp.TCPConnector] = None
         self._lock = asyncio.Lock()
         self._closed = False
+        # Closing can be requested from a foreign thread. This small,
+        # thread-safe gate prevents a second close() from trying to acquire
+        # the owner loop's asyncio lock while the first teardown is pending.
+        self._close_request_lock = threading.Lock()
+        self._close_requested = False
 
         # Metrics and health monitoring
         self.metrics = ConnectionMetrics()
@@ -142,13 +147,13 @@ class ConnectionManager:
             AgentFieldClientError: If manager is already started or closed
         """
         async with self._lock:
-            if self._session is not None:
-                raise AgentFieldClientError("ConnectionManager is already started")
-
-            if self._closed:
+            if self._close_requested or self._closed:
                 raise AgentFieldClientError(
                     "ConnectionManager is closed and cannot be restarted"
                 )
+
+            if self._session is not None:
+                raise AgentFieldClientError("ConnectionManager is already started")
 
             # Record the loop the session and background tasks are bound to
             # so close() can tell whether it may await them or must tear down
@@ -207,6 +212,9 @@ class ConnectionManager:
         session would raise ``got Future attached to a different loop`` / hang,
         so we schedule the teardown on the owning loop without awaiting.
         """
+        if not self._claim_close_request():
+            return
+
         owning_loop = self._loop
         current_loop = current_running_loop()
 
@@ -215,11 +223,25 @@ class ConnectionManager:
             self._close_cross_loop(owning_loop)
             return
 
-        async with self._lock:
-            if self._closed:
-                return
+        await self._close_on_owner_loop(owning_loop)
 
-            self._closed = True
+    def _claim_close_request(self) -> bool:
+        """Claim the one close transition allowed for this manager."""
+        with self._close_request_lock:
+            if self._close_requested or self._closed:
+                return False
+            self._close_requested = True
+            return True
+
+    async def _close_on_owner_loop(
+        self, owning_loop: Optional[asyncio.AbstractEventLoop]
+    ) -> None:
+        """Perform the complete teardown while holding the owner-loop lock."""
+        async with self._lock:
+            with self._close_request_lock:
+                if self._closed:
+                    return
+                self._closed = True
 
             # Cancel background tasks (same loop — safe to await).
             await cancel_and_await_if_same_loop(self._health_check_task, owning_loop)
@@ -248,57 +270,42 @@ class ConnectionManager:
         serializes the transition so an in-flight get_session() on the owning
         loop never sees half-torn-down state (#623).
         """
-        if self._closed:
-            return
-        self._closed = True
-
-        cancel_task_cross_loop(self._health_check_task, owning_loop)
-        cancel_task_cross_loop(self._cleanup_task, owning_loop)
-        self._health_check_task = None
-        self._cleanup_task = None
-
-        # Schedule the real teardown (lock acquisition + session/connector
-        # close + state nulling) on the owning loop. We don't mutate
-        # _session/_connector here — that happens inside the scheduled
-        # coroutine under the lock so concurrent get_session() callers
-        # on the owning loop see a consistent state.
+        # Schedule the complete teardown (including task cancellation and all
+        # state mutation) on the owning loop. The foreign thread only claims
+        # the close request; it never touches loop-bound state.
         if owning_loop.is_closed():
             # Loop already gone — resources will be GC'd; just drop refs.
+            with self._close_request_lock:
+                self._closed = True
             self._session = None
             self._connector = None
+            self._health_check_task = None
+            self._cleanup_task = None
             self._loop = None
             logger.info("ConnectionManager closed (owning loop already closed)")
             return
 
-        # Capture refs for the closure; clear self._loop so the manager
-        # appears stopped from the outside immediately.
-        mgr_self = self
-        self._loop = None
-
-        async def _close_resources_on_owner() -> None:
+        async def close_on_owner() -> None:
             try:
-                async with mgr_self._lock:
-                    session = mgr_self._session
-                    connector = mgr_self._connector
-                    mgr_self._session = None
-                    mgr_self._connector = None
-                    if session is not None:
-                        await session.close()
-                    if connector is not None:
-                        await connector.close()
+                await self._close_on_owner_loop(owning_loop)
             except Exception:
-                logger.debug(
-                    "Cross-loop session/connector close failed", exc_info=True
-                )
+                # There is no caller on the foreign loop to receive an
+                # exception from this fire-and-forget teardown task.
+                logger.debug("Cross-loop close failed", exc_info=True)
 
         try:
             owning_loop.call_soon_threadsafe(
-                lambda: owning_loop.create_task(_close_resources_on_owner())
+                lambda: owning_loop.create_task(close_on_owner())
             )
         except Exception:
             # Owning loop may be mid-teardown; drop refs so GC can collect.
+            with self._close_request_lock:
+                self._closed = True
             self._session = None
             self._connector = None
+            self._health_check_task = None
+            self._cleanup_task = None
+            self._loop = None
             logger.debug("Could not schedule cross-loop close", exc_info=True)
 
         logger.info("ConnectionManager closed (cross-loop)")
@@ -314,14 +321,17 @@ class ConnectionManager:
         Raises:
             AgentFieldClientError: If manager is not started or is closed
         """
-        if self._session is None:
-            raise AgentFieldClientError("ConnectionManager is not started. Call start() first.")
+        session = self._session
+        if session is None:
+            raise AgentFieldClientError(
+                "ConnectionManager is not started. Call start() first."
+            )
 
-        if self._closed:
+        if self._close_requested or self._closed:
             raise AgentFieldClientError("ConnectionManager is closed")
 
         try:
-            yield self._session
+            yield session
         except Exception as e:
             self.health.mark_unhealthy(str(e))
             raise
@@ -498,12 +508,12 @@ class ConnectionManager:
     @property
     def is_healthy(self) -> bool:
         """Check if connection manager is healthy."""
-        return self.health.is_healthy and not self._closed
+        return self.health.is_healthy and not self.is_closed
 
     @property
     def is_closed(self) -> bool:
         """Check if connection manager is closed."""
-        return self._closed
+        return self._closed or self._close_requested
 
     def __repr__(self) -> str:
         """String representation of the connection manager."""

--- a/sdk/python/tests/test_async_lifecycle_deadlock.py
+++ b/sdk/python/tests/test_async_lifecycle_deadlock.py
@@ -23,8 +23,11 @@ import asyncio
 import threading
 import time
 
+import pytest
+
 from agentfield.async_config import AsyncConfig
 from agentfield.async_execution_manager import AsyncExecutionManager
+from agentfield.async_lifecycle import cancel_and_await_if_same_loop
 from agentfield.http_connection_manager import ConnectionManager
 
 
@@ -62,11 +65,22 @@ def test_connection_manager_cross_loop_close_no_deadlock():
     # something loop-bound to tear down.
     cfg.enable_performance_logging = True
     cm = ConnectionManager(cfg)
+    session_closed = threading.Event()
 
     loop1, thread = _run_loop_in_thread()
     try:
         asyncio.run_coroutine_threadsafe(cm.start(), loop1).result(timeout=5)
         assert cm._session is not None
+
+        original_session_close = cm._session.close
+
+        async def close_session():
+            try:
+                await original_session_close()
+            finally:
+                session_closed.set()
+
+        cm._session.close = close_session
         time.sleep(0.15)
 
         async def close_here():
@@ -74,12 +88,99 @@ def test_connection_manager_cross_loop_close_no_deadlock():
 
         asyncio.run(close_here())
 
-        # Cross-loop close marks the manager closed and drops task refs.
+        assert session_closed.wait(timeout=5)
+        # The owner loop completes the whole teardown before state is cleared.
         assert cm._closed is True
         assert cm._health_check_task is None
         assert cm._cleanup_task is None
+        assert cm._session is None
     finally:
         _shutdown_loop(loop1, thread)
+
+
+def test_connection_manager_cross_loop_close_is_idempotent_while_owner_lock_is_held():
+    """A repeated foreign-loop close must not acquire the owner-loop lock."""
+    cm = ConnectionManager()
+    loop1, thread = _run_loop_in_thread()
+    lock_held = threading.Event()
+    release_lock = asyncio.Event()
+    session_closed = threading.Event()
+    holder = None
+
+    async def hold_owner_lock():
+        async with cm._lock:
+            lock_held.set()
+            await release_lock.wait()
+
+    try:
+        asyncio.run_coroutine_threadsafe(cm.start(), loop1).result(timeout=5)
+        assert cm._session is not None
+        original_session_close = cm._session.close
+
+        async def close_session():
+            try:
+                await original_session_close()
+            finally:
+                session_closed.set()
+
+        cm._session.close = close_session
+        holder = asyncio.run_coroutine_threadsafe(hold_owner_lock(), loop1)
+        assert lock_held.wait(timeout=5)
+
+        asyncio.run(cm.close())
+        # Before the fix this second call fell through to ``async with
+        # self._lock`` after the first cross-loop close cleared ``_loop``.
+        asyncio.run(cm.close())
+
+        loop1.call_soon_threadsafe(release_lock.set)
+        holder.result(timeout=5)
+        assert session_closed.wait(timeout=5)
+        assert cm._session is None
+        assert cm.is_closed is True
+    finally:
+        if not release_lock.is_set():
+            loop1.call_soon_threadsafe(release_lock.set)
+        if holder is not None:
+            holder.result(timeout=5)
+        _shutdown_loop(loop1, thread)
+
+
+@pytest.mark.asyncio
+async def test_cancel_and_await_same_loop_propagates_cleanup_runtime_error():
+    """Teardown must not hide unrelated RuntimeErrors from task cleanup."""
+    started = asyncio.Event()
+
+    async def task_body():
+        try:
+            started.set()
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            raise RuntimeError("cleanup failed")
+
+    task = asyncio.create_task(task_body())
+    await started.wait()
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        await cancel_and_await_if_same_loop(task, asyncio.get_running_loop())
+
+
+@pytest.mark.asyncio
+async def test_cancel_and_await_same_loop_swallows_loop_association_error():
+    """The known cross-loop RuntimeError remains safe to suppress."""
+    started = asyncio.Event()
+
+    async def task_body():
+        try:
+            started.set()
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            raise RuntimeError("got Future attached to a different loop")
+
+    task = asyncio.create_task(task_body())
+    await started.wait()
+
+    await cancel_and_await_if_same_loop(task, asyncio.get_running_loop())
+    assert task.done()
 
 
 def test_connection_manager_same_loop_close_still_works():

--- a/sdk/python/tests/test_async_lifecycle_deadlock.py
+++ b/sdk/python/tests/test_async_lifecycle_deadlock.py
@@ -183,6 +183,47 @@ async def test_cancel_and_await_same_loop_swallows_loop_association_error():
     assert task.done()
 
 
+@pytest.mark.asyncio
+async def test_cancel_and_await_same_loop_swallows_loop_bound_primitive_error():
+    """The asyncio/mixins.py wording of the same error class is absorbed too."""
+    foreign_loop, thread = _run_loop_in_thread()
+    try:
+        foreign_event = asyncio.Event()
+
+        async def bind_to_foreign_loop():
+            # An Event binds to whichever loop first awaits it.
+            try:
+                await asyncio.wait_for(foreign_event.wait(), timeout=0.05)
+            except asyncio.TimeoutError:
+                pass
+
+        asyncio.run_coroutine_threadsafe(bind_to_foreign_loop(), foreign_loop).result(
+            timeout=5
+        )
+
+        # Precondition: this construction really does produce the mixins
+        # wording, so the assertion below can't pass on the other one.
+        with pytest.raises(RuntimeError, match="bound to a different event loop"):
+            await foreign_event.wait()
+
+        started = asyncio.Event()
+
+        async def task_body():
+            try:
+                started.set()
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                await foreign_event.wait()
+
+        task = asyncio.create_task(task_body())
+        await started.wait()
+
+        await cancel_and_await_if_same_loop(task, asyncio.get_running_loop())
+        assert task.done()
+    finally:
+        _shutdown_loop(foreign_loop, thread)
+
+
 def test_connection_manager_same_loop_close_still_works():
     """A same-loop start/close cycle behaves normally."""
     cfg = AsyncConfig()


### PR DESCRIPTION
Fixes #901

## Summary

- Serialize cross-loop `ConnectionManager` teardown on the owning event loop and its async lock, including task/resource state updates.
- Make repeated foreign-loop `close()` calls return safely while teardown is pending, and keep `get_session()` from yielding a torn-down session.
- Only suppress the known cross-loop `RuntimeError`; propagate unrelated task-cleanup failures.

## Tests

- `uv run --frozen --extra dev pytest tests/test_async_lifecycle_deadlock.py tests/test_http_connection_manager.py -q` (21 passed)
- Relevant async execution, result-cache, client lifecycle, HTTP, and lifecycle tests (passed)
- Ruff 0.15.22 check (passed)
- Full local suite reached 100%; 11 unrelated Windows-environment failures remain because the host uses GBK for UTF-8 `pyproject.toml` reads and has no `bash` executable.