### PR TITLE
fix(go-sdk): allow custom HTTP clients for AI requests

### DIFF
--- a/sdk/go/ai/README.md
+++ b/sdk/go/ai/README.md
@@ -148,8 +148,12 @@ both shapes into `Usage.Cost`, so cost tracking reads the same either way.
 
 ### AI Client
 
-#### `ai.NewClient(config *Config) (*Client, error)`
+#### `ai.NewClient(config *Config, opts ...ClientOption) (*Client, error)`
 Creates a new AI client with the given configuration.
+
+Use `ai.WithHTTPClient` to provide a custom `*http.Client`, or
+`ai.WithTransport` to provide a custom `http.RoundTripper` while retaining the
+default client's timeout.
 
 #### `client.Complete(ctx context.Context, prompt string, opts ...Option) (*Response, error)`
 Makes a chat completion request.

--- a/sdk/go/ai/client.go
+++ b/sdk/go/ai/client.go
@@ -16,8 +16,30 @@ type Client struct {
 	httpClient *http.Client
 }
 
+// ClientOption configures an AI client during construction.
+type ClientOption func(*Client)
+
+// WithHTTPClient uses the supplied HTTP client for AI requests.
+func WithHTTPClient(httpClient *http.Client) ClientOption {
+	return func(c *Client) {
+		if httpClient != nil {
+			c.httpClient = httpClient
+		}
+	}
+}
+
+// WithTransport uses the supplied round tripper while preserving the default
+// HTTP client's timeout and other settings.
+func WithTransport(transport http.RoundTripper) ClientOption {
+	return func(c *Client) {
+		if transport != nil {
+			c.httpClient.Transport = transport
+		}
+	}
+}
+
 // NewClient creates a new AI client with the given configuration.
-func NewClient(config *Config) (*Client, error) {
+func NewClient(config *Config, opts ...ClientOption) (*Client, error) {
 	if config == nil {
 		config = DefaultConfig()
 	}
@@ -26,12 +48,20 @@ func NewClient(config *Config) (*Client, error) {
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 
-	return &Client{
+	client := &Client{
 		config: config,
 		httpClient: &http.Client{
 			Timeout: config.Timeout,
 		},
-	}, nil
+	}
+
+	for _, opt := range opts {
+		if opt != nil {
+			opt(client)
+		}
+	}
+
+	return client, nil
 }
 
 // Model returns the client's configured default model slug.

--- a/sdk/go/ai/client_test.go
+++ b/sdk/go/ai/client_test.go
@@ -71,6 +71,70 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+func TestNewClient_WithHTTPClient(t *testing.T) {
+	var requestSeen bool
+	transport := &roundTripFunc{fn: func(req *http.Request) (*http.Response, error) {
+		requestSeen = true
+		assert.Equal(t, "https://api.example.com/v1/chat/completions", req.URL.String())
+		return testCompletionResponse(), nil
+	}}
+	customHTTPClient := &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: transport,
+	}
+	config := &Config{
+		APIKey:  "test-key",
+		BaseURL: "https://api.example.com/v1",
+		Model:   "gpt-4o",
+	}
+
+	client, err := NewClient(config, WithHTTPClient(customHTTPClient))
+	require.NoError(t, err)
+	require.Same(t, customHTTPClient, client.httpClient)
+
+	response, err := client.Complete(context.Background(), "hello")
+	require.NoError(t, err)
+	assert.Equal(t, "ok", response.Text())
+	assert.True(t, requestSeen)
+}
+
+func TestNewClient_WithTransportPreservesTimeout(t *testing.T) {
+	transport := &roundTripFunc{fn: func(*http.Request) (*http.Response, error) {
+		return testCompletionResponse(), nil
+	}}
+	config := &Config{
+		APIKey:  "test-key",
+		BaseURL: "https://api.example.com/v1",
+		Model:   "gpt-4o",
+		Timeout: 17 * time.Second,
+	}
+
+	client, err := NewClient(config, WithTransport(transport))
+	require.NoError(t, err)
+	require.Same(t, transport, client.httpClient.Transport)
+	assert.Equal(t, config.Timeout, client.httpClient.Timeout)
+
+	response, err := client.Complete(context.Background(), "hello")
+	require.NoError(t, err)
+	assert.Equal(t, "ok", response.Text())
+}
+
+type roundTripFunc struct {
+	fn func(*http.Request) (*http.Response, error)
+}
+
+func (f *roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f.fn(req)
+}
+
+func testCompletionResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(`{"choices":[{"message":{"role":"assistant","content":[{"type":"text","text":"ok"}]}}]}`)),
+	}
+}
+
 func TestComplete(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)


### PR DESCRIPTION
## Summary

- add WithHTTPClient and WithTransport options to the Go AI client
- preserve the configured timeout when only a custom transport is provided
- add offline regression coverage and document the constructor options

Fixes #437

## Validation

- go test ./ai -count=1
- go test ./ai ./client ./did -count=1
- go vet ./ai ./client ./did
- golangci-lint run ./ai --new-from-rev upstream/main
- gofmt and git diff --check

The repository-wide SDK test command still has a pre-existing Windows path assertion failure in sdk/go/agent/agent_trigger_origin_test.go:50; the changed packages pass.