### PR TITLE
Seamless agent use: cloud-aware skill, native Codex install, self-healing skill sync

### DIFF
--- a/control-plane/internal/cli/skill.go
+++ b/control-plane/internal/cli/skill.go
@@ -110,13 +110,16 @@ func newSkillInstallCommand() *cobra.Command {
 			// installs exactly that one skill.
 			if skillName == "" {
 				reports, err := skillkit.InstallAll(installOpts)
-				if err != nil {
-					return err
-				}
+				// Print everything that did happen before failing: a partial
+				// install is still worth showing, and the failures are named
+				// in the error.
 				for _, report := range reports {
 					printInstallReport(report, dryRun)
 				}
-				return nil
+				if err != nil {
+					return err
+				}
+				return skillkit.ReportsError(reports)
 			}
 
 			report, err := skillkit.Install(installOpts)
@@ -124,7 +127,7 @@ func newSkillInstallCommand() *cobra.Command {
 				return err
 			}
 			printInstallReport(report, dryRun)
-			return nil
+			return report.ReportError()
 		},
 	}
 
@@ -174,7 +177,7 @@ func newSkillUpdateCommand() *cobra.Command {
 				return err
 			}
 			printInstallReport(report, false)
-			return nil
+			return report.ReportError()
 		},
 	}
 	cmd.Flags().StringVar(&skillName, "skill", "", "Skill name to update")

--- a/control-plane/internal/cli/skill_additional_test.go
+++ b/control-plane/internal/cli/skill_additional_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -177,6 +178,73 @@ func pickedByIndex(indexes ...int) []string {
 type assertErr string
 
 func (e assertErr) Error() string { return string(e) }
+
+// TestSkillInstallExitsNonZeroWhenATargetFails is the contract that makes an
+// automated `af skill install` (the desktop app runs one at launch) trustworthy:
+// a target that could not be written is a failed command, not a success with a
+// red line buried in the report. The report still prints first.
+func TestSkillInstallExitsNonZeroWhenATargetFails(t *testing.T) {
+	setupFailingClaudeTarget := func(t *testing.T) {
+		t.Helper()
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+		t.Setenv("AGENTFIELD_HOME", filepath.Join(home, ".agentfield"))
+		t.Setenv("AGENTFIELD_SKIP_FURROW", "1")
+		// A regular file where ~/.claude/skills belongs: the target cannot
+		// create its directory, so its install fails while the canonical
+		// store write succeeds.
+		require.NoError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(home, ".claude", "skills"), []byte("blocker"), 0o644))
+	}
+
+	t.Run("named skill", func(t *testing.T) {
+		setupFailingClaudeTarget(t)
+		cmd := newSkillInstallCommand()
+		cmd.SetArgs([]string{"agentfield", "--target", "claude-code"})
+		var err error
+		output := captureOutput(t, func() { err = cmd.Execute() })
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "claude-code")
+		require.Contains(t, output, "af skill list", "the report must print before the command fails")
+	})
+
+	t.Run("whole catalog", func(t *testing.T) {
+		setupFailingClaudeTarget(t)
+		cmd := newSkillInstallCommand()
+		cmd.SetArgs([]string{"--target", "claude-code"})
+		var err error
+		output := captureOutput(t, func() { err = cmd.Execute() })
+		require.Error(t, err)
+		for _, skill := range skillkit.Catalog {
+			require.Contains(t, err.Error(), skill.Name)
+		}
+		require.Contains(t, output, "af skill list")
+	})
+
+	t.Run("update", func(t *testing.T) {
+		setupFailingClaudeTarget(t)
+		// Record claude-code as installed so update has a target to retry.
+		require.NoError(t, skillkit.SaveState(&skillkit.State{
+			Skills: map[string]skillkit.InstalledSkill{
+				"agentfield": {
+					CurrentVersion:    skillkit.Catalog[0].Version,
+					InstalledAt:       time.Now().UTC(),
+					AvailableVersions: []string{skillkit.Catalog[0].Version},
+					Targets: map[string]skillkit.InstalledTarget{
+						"claude-code": {TargetName: "claude-code", Method: "symlink", Version: skillkit.Catalog[0].Version},
+					},
+				},
+			},
+		}))
+		cmd := newSkillUpdateCommand()
+		cmd.SetArgs([]string{"agentfield"})
+		var err error
+		_ = captureOutput(t, func() { err = cmd.Execute() })
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "claude-code")
+	})
+}
 
 // TestSkillInstallExplicitNameDryRun covers the explicit-skill-name install
 // path (`af skill install <name>`), which is unchanged by the no-name

--- a/control-plane/internal/handlers/agentic/agent_summary.go
+++ b/control-plane/internal/handlers/agentic/agent_summary.go
@@ -9,6 +9,20 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+const (
+	// agentSummaryRecentExecutionsLimit caps how many recent executions the
+	// response carries. Unbounded, this endpoint inlines every execution of the
+	// last 24h — a multi-megabyte reply from what callers use as a cheap
+	// orientation call.
+	agentSummaryRecentExecutionsLimit = 20
+
+	// agentSummaryMetricsQueryLimit bounds the query itself. Metrics are computed
+	// over every row it returns, so it sits far above the serialized list; it is
+	// only a guardrail against pathological execution volume in the window.
+	// Payload-free rows are cheap, which is what makes the wide read affordable.
+	agentSummaryMetricsQueryLimit = 500
+)
+
 // AgentSummaryHandler returns agent info plus recent executions and metrics.
 func AgentSummaryHandler(store storage.StorageProvider) gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -31,19 +45,27 @@ func AgentSummaryHandler(store storage.StorageProvider) gin.HandlerFunc {
 			return
 		}
 
-		// Get recent executions (last 24h)
+		// Get executions from the last 24h, newest first. Payloads are dropped:
+		// this is an orientation surface, and the full input/result of a given
+		// execution is one POST /api/v1/agentic/query away. Dropping them is what
+		// lets the window stay wide enough for the metrics below to be exact
+		// while only the newest few rows are serialized.
 		since := time.Now().Add(-24 * time.Hour)
 		filter := types.ExecutionFilter{
-			AgentNodeID: &agentID,
-			StartTime:   &since,
+			AgentNodeID:     &agentID,
+			StartTime:       &since,
+			Limit:           agentSummaryMetricsQueryLimit,
+			SortBy:          "started_at",
+			SortDescending:  true,
+			ExcludePayloads: true,
 		}
-		recentExecs, _ := store.QueryExecutionRecords(ctx, filter)
+		windowExecs, _ := store.QueryExecutionRecords(ctx, filter)
 
-		// Compute metrics
+		// Compute metrics over the whole window, not just the rows we return.
 		statusCounts := make(map[string]int)
 		var totalDurationMs int64
 		completedCount := 0
-		for _, e := range recentExecs {
+		for _, e := range windowExecs {
 			statusCounts[e.Status]++
 			if e.Status == "completed" && e.CompletedAt != nil {
 				if e.DurationMS != nil {
@@ -58,15 +80,41 @@ func AgentSummaryHandler(store storage.StorageProvider) gin.HandlerFunc {
 			avgDurationMs = totalDurationMs / int64(completedCount)
 		}
 
+		// Only the newest few executions are serialized; the metrics above still
+		// describe every row in the window.
+		recentExecs := windowExecs
+		if len(recentExecs) > agentSummaryRecentExecutionsLimit {
+			recentExecs = recentExecs[:agentSummaryRecentExecutionsLimit]
+		}
+
 		respondOK(c, gin.H{
-			"agent":             agent,
+			"agent":             withResolvedReasonerDescriptions(agent),
 			"recent_executions": recentExecs,
 			"metrics_24h": gin.H{
-				"total_executions": len(recentExecs),
+				"total_executions": len(windowExecs),
 				"status_counts":    statusCounts,
 				"avg_duration_ms":  avgDurationMs,
 				"completed_count":  completedCount,
 			},
 		})
 	}
+}
+
+// withResolvedReasonerDescriptions returns a copy of the agent whose reasoners
+// carry a resolved description (registered field, else the legacy agent-metadata
+// map). Serializing the stored record directly skips that fallback, so an agent
+// registered by an older SDK reads as undocumented here while
+// /api/v1/discovery/capabilities shows its descriptions. The copy leaves the
+// stored record — which storage may hand out from a cache — untouched.
+func withResolvedReasonerDescriptions(agent *types.AgentNode) *types.AgentNode {
+	if agent == nil || len(agent.Reasoners) == 0 {
+		return agent
+	}
+	resolved := *agent
+	resolved.Reasoners = make([]types.ReasonerDefinition, len(agent.Reasoners))
+	copy(resolved.Reasoners, agent.Reasoners)
+	for i := range resolved.Reasoners {
+		resolved.Reasoners[i].Description = reasonerDescription(agent, resolved.Reasoners[i])
+	}
+	return &resolved
 }

--- a/control-plane/internal/handlers/agentic/coverage_additional_test.go
+++ b/control-plane/internal/handlers/agentic/coverage_additional_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -217,6 +218,146 @@ func TestAgentSummaryHandler(t *testing.T) {
 		assert.Equal(t, float64(2), metrics["status_counts"].(map[string]interface{})["completed"])
 		assert.Equal(t, float64(1), metrics["status_counts"].(map[string]interface{})["failed"])
 		store.AssertExpectations(t)
+	})
+
+	t.Run("execution query is bounded and payload free", func(t *testing.T) {
+		var captured types.ExecutionFilter
+		store := &handlerTestStorage{
+			mockStatusStorage: &mockStatusStorage{},
+			getAgentFn: func(context.Context, string) (*types.AgentNode, error) {
+				return &types.AgentNode{ID: "agent-1"}, nil
+			},
+		}
+		store.On("QueryExecutionRecords", mock.Anything, mock.MatchedBy(func(filter types.ExecutionFilter) bool {
+			captured = filter
+			return true
+		})).Return([]*types.Execution{}, nil)
+
+		router := gin.New()
+		router.GET("/agents/:agent_id/summary", AgentSummaryHandler(store))
+
+		req := httptest.NewRequest(http.MethodGet, "/agents/agent-1/summary", nil)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		// Without both of these the summary inlines full payloads for every
+		// execution of the last 24h.
+		assert.True(t, captured.ExcludePayloads, "payloads must be excluded")
+		// The query is bounded by the metrics guardrail, not by the much smaller
+		// serialized-list cap — metrics must stay exact over the window.
+		assert.Equal(t, agentSummaryMetricsQueryLimit, captured.Limit)
+		// A limit is only meaningful with a newest-first ordering.
+		assert.Equal(t, "started_at", captured.SortBy)
+		assert.True(t, captured.SortDescending)
+		// The 24h window is preserved.
+		require.NotNil(t, captured.StartTime)
+		assert.WithinDuration(t, time.Now().Add(-24*time.Hour), *captured.StartTime, time.Minute)
+	})
+
+	t.Run("metrics cover the window while the list stays short", func(t *testing.T) {
+		// More executions than the serialized cap, so the two counts diverge.
+		const total = agentSummaryRecentExecutionsLimit + 7
+		duration := int64(100)
+		completedAt := time.Now()
+		execs := make([]*types.Execution, 0, total)
+		for i := 0; i < total; i++ {
+			status := "completed"
+			if i%3 == 0 {
+				status = "failed"
+			}
+			execs = append(execs, &types.Execution{
+				ExecutionID: fmt.Sprintf("exec-%d", i),
+				Status:      status,
+				CompletedAt: &completedAt,
+				DurationMS:  &duration,
+			})
+		}
+
+		store := &handlerTestStorage{
+			mockStatusStorage: &mockStatusStorage{},
+			getAgentFn: func(context.Context, string) (*types.AgentNode, error) {
+				return &types.AgentNode{ID: "agent-1"}, nil
+			},
+		}
+		store.On("QueryExecutionRecords", mock.Anything, mock.Anything).Return(execs, nil)
+
+		router := gin.New()
+		router.GET("/agents/:agent_id/summary", AgentSummaryHandler(store))
+
+		req := httptest.NewRequest(http.MethodGet, "/agents/agent-1/summary", nil)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		resp := decodeEnvelope(t, rec.Body)
+		data := resp.Data.(map[string]interface{})
+
+		// The list is clipped...
+		listed := data["recent_executions"].([]interface{})
+		assert.Len(t, listed, agentSummaryRecentExecutionsLimit)
+		assert.Equal(t, "exec-0", listed[0].(map[string]interface{})["execution_id"], "newest rows are kept")
+
+		// ...but the metrics still describe every row the query returned.
+		metrics := data["metrics_24h"].(map[string]interface{})
+		assert.Equal(t, float64(total), metrics["total_executions"])
+		statusCounts := metrics["status_counts"].(map[string]interface{})
+		assert.Equal(t, float64(9), statusCounts["failed"])
+		assert.Equal(t, float64(total-9), statusCounts["completed"])
+		assert.Equal(t, float64(total-9), metrics["completed_count"])
+		assert.Equal(t, float64(100), metrics["avg_duration_ms"])
+	})
+
+	t.Run("reasoner descriptions use the legacy metadata fallback", func(t *testing.T) {
+		agent := &types.AgentNode{
+			ID: "agent-1",
+			Reasoners: []types.ReasonerDefinition{
+				{ID: "registered", Description: "declared by the SDK"},
+				{ID: "legacy"},
+				{ID: "undocumented"},
+			},
+			Metadata: types.AgentMetadata{
+				Custom: map[string]interface{}{
+					"descriptions": map[string]interface{}{
+						"legacy":     "  carried in agent metadata  ",
+						"registered": "should not win over the registered field",
+					},
+				},
+			},
+		}
+		store := &handlerTestStorage{
+			mockStatusStorage: &mockStatusStorage{},
+			getAgentFn: func(context.Context, string) (*types.AgentNode, error) {
+				return agent, nil
+			},
+		}
+		store.On("QueryExecutionRecords", mock.Anything, mock.Anything).Return([]*types.Execution{}, nil)
+
+		router := gin.New()
+		router.GET("/agents/:agent_id/summary", AgentSummaryHandler(store))
+
+		req := httptest.NewRequest(http.MethodGet, "/agents/agent-1/summary", nil)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		resp := decodeEnvelope(t, rec.Body)
+		data := resp.Data.(map[string]interface{})
+		reasoners := data["agent"].(map[string]interface{})["reasoners"].([]interface{})
+		require.Len(t, reasoners, 3)
+
+		descriptions := map[string]string{}
+		for _, raw := range reasoners {
+			entry := raw.(map[string]interface{})
+			desc, _ := entry["description"].(string)
+			descriptions[entry["id"].(string)] = desc
+		}
+		assert.Equal(t, "declared by the SDK", descriptions["registered"])
+		assert.Equal(t, "carried in agent metadata", descriptions["legacy"])
+		assert.Empty(t, descriptions["undocumented"])
+
+		// The stored record must not be rewritten by the response shaping.
+		assert.Empty(t, agent.Reasoners[1].Description)
 	})
 }
 

--- a/control-plane/internal/handlers/agentic/reasoners.go
+++ b/control-plane/internal/handlers/agentic/reasoners.go
@@ -25,13 +25,20 @@ const (
 	reasonerSearchMaxLimit     = 50
 )
 
+// reasonerSearchMaxDescriptionRunes caps the description carried in a search
+// result. Enough to decide whether a hit is the right reasoner; the full text
+// (and the input schema) comes from the agent summary or discovery surface.
+const reasonerSearchMaxDescriptionRunes = 500
+
 // ReasonerSearchResult is one ranked reasoner. It carries everything the
 // driving agent needs to invoke the reasoner immediately, without a second
-// lookup: the invocation target and the owning agent's current health.
+// lookup: the invocation target, what the reasoner does, and the owning agent's
+// current health.
 type ReasonerSearchResult struct {
 	ReasonerID       string   `json:"reasoner_id"`
 	AgentID          string   `json:"agent_id"`
 	InvocationTarget string   `json:"invocation_target"`
+	Description      string   `json:"description,omitempty"`
 	Tags             []string `json:"tags,omitempty"`
 	Score            float64  `json:"score"`
 	AgentHealth      string   `json:"agent_health"`
@@ -122,8 +129,11 @@ func buildReasonerCorpus(agents []*types.AgentNode, agentFilter string) ([]searc
 				{boost: reasonerFieldBoostTags, text: strings.Join(reasoner.Tags, " ")},
 				{boost: reasonerFieldBoostAgentID, text: agent.ID},
 			}
-			if desc := reasonerDescription(agent, reasoner.ID); desc != "" {
-				fields = append(fields, searchField{boost: reasonerFieldBoostDescription, text: desc})
+			// The whole description is indexed; only the returned copy is
+			// truncated, so a match on a late word still ranks.
+			description := reasonerDescription(agent, reasoner)
+			if description != "" {
+				fields = append(fields, searchField{boost: reasonerFieldBoostDescription, text: description})
 			}
 
 			docs = append(docs, searchDoc{id: target, fields: fields})
@@ -131,6 +141,7 @@ func buildReasonerCorpus(agents []*types.AgentNode, agentFilter string) ([]searc
 				ReasonerID:       reasoner.ID,
 				AgentID:          agent.ID,
 				InvocationTarget: target,
+				Description:      truncateRunes(description, reasonerSearchMaxDescriptionRunes),
 				Tags:             reasoner.Tags,
 				AgentHealth:      string(agent.HealthStatus),
 			}
@@ -139,12 +150,23 @@ func buildReasonerCorpus(agents []*types.AgentNode, agentFilter string) ([]searc
 	return docs, meta
 }
 
-// reasonerDescription pulls an optional human description for a reasoner from
-// agent metadata (metadata.custom.descriptions[<reasoner id>]) — the same
-// side-channel the discovery handler reads. ReasonerDefinition itself carries no
-// description field, so absence is normal and returns an empty string.
-func reasonerDescription(agent *types.AgentNode, reasonerID string) string {
-	if agent.Metadata.Custom == nil {
+// reasonerDescription resolves a reasoner's human description with the same
+// precedence as the discovery surface: the field the SDK registered on the
+// reasoner record wins, and the legacy agent-level
+// metadata.custom.descriptions[<reasoner id>] map is the fallback for agents
+// registered by older SDKs. Absence is normal and returns an empty string.
+//
+// This is the package-local twin of handlers.reasonerDescription
+// (internal/handlers/discovery.go); the agentic surface deliberately does not
+// import the parent handlers package, so the small lookup is duplicated rather
+// than exported. Keep the two in step.
+//
+// Used by the search corpus below and by the agent-summary handler.
+func reasonerDescription(agent *types.AgentNode, reasoner types.ReasonerDefinition) string {
+	if desc := strings.TrimSpace(reasoner.Description); desc != "" {
+		return desc
+	}
+	if agent == nil || agent.Metadata.Custom == nil {
 		return ""
 	}
 	raw, ok := agent.Metadata.Custom["descriptions"]
@@ -155,7 +177,7 @@ func reasonerDescription(agent *types.AgentNode, reasonerID string) string {
 	if !ok {
 		return ""
 	}
-	desc, ok := m[reasonerID]
+	desc, ok := m[reasoner.ID]
 	if !ok {
 		return ""
 	}
@@ -164,6 +186,16 @@ func reasonerDescription(agent *types.AgentNode, reasonerID string) string {
 		return ""
 	}
 	return strings.TrimSpace(text)
+}
+
+// truncateRunes clips text to at most limit runes (rune-wise so multi-byte
+// characters are never cut in half), marking the clip with an ellipsis.
+func truncateRunes(text string, limit int) string {
+	runes := []rune(text)
+	if len(runes) <= limit {
+		return text
+	}
+	return strings.TrimRight(string(runes[:limit]), " \t\n") + "..."
 }
 
 // roundScore trims BM25 scores to six decimals so the JSON is tidy and stable

--- a/control-plane/internal/handlers/agentic/reasoners_test.go
+++ b/control-plane/internal/handlers/agentic/reasoners_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
@@ -171,5 +172,100 @@ func TestReasonersHandler_DescriptionIndexed(t *testing.T) {
 	data := resp.Data.(map[string]interface{})
 	results := data["results"].([]interface{})
 	require.Len(t, results, 1)
-	assert.Equal(t, "handler_a", results[0].(map[string]interface{})["reasoner_id"])
+	first := results[0].(map[string]interface{})
+	assert.Equal(t, "handler_a", first["reasoner_id"])
+	// The hit must say what the reasoner does — otherwise the caller needs a
+	// second round trip before it can decide to invoke it.
+	assert.Equal(t, "generates quarterly compliance paperwork", first["description"])
+}
+
+func TestReasonersHandler_RegisteredDescriptionWins(t *testing.T) {
+	// The description the SDK registered on the reasoner takes precedence over
+	// the legacy agent-metadata map, and is searchable.
+	agents := []*types.AgentNode{
+		{
+			ID:           "docs",
+			HealthStatus: types.HealthStatusActive,
+			Reasoners: []types.ReasonerDefinition{
+				{ID: "handler_a", Description: "files quarterly compliance paperwork"},
+			},
+			Metadata: types.AgentMetadata{
+				Custom: map[string]interface{}{
+					"descriptions": map[string]interface{}{
+						"handler_a": "stale legacy text",
+					},
+				},
+			},
+		},
+	}
+	store := new(mockStatusStorage)
+	store.On("ListAgents", mock.Anything, mock.Anything).Return(agents, nil)
+
+	rec, resp := serveReasoners(t, store, "q=compliance")
+	require.Equal(t, http.StatusOK, rec.Code)
+	data := resp.Data.(map[string]interface{})
+	results := data["results"].([]interface{})
+	require.Len(t, results, 1)
+	assert.Equal(t, "files quarterly compliance paperwork", results[0].(map[string]interface{})["description"])
+}
+
+func TestReasonersHandler_DescriptionOmittedWhenAbsent(t *testing.T) {
+	store := new(mockStatusStorage)
+	store.On("ListAgents", mock.Anything, mock.Anything).Return(reasonerTestAgents(), nil)
+
+	rec, resp := serveReasoners(t, store, "q=forecast&agent=weather")
+	require.Equal(t, http.StatusOK, rec.Code)
+	data := resp.Data.(map[string]interface{})
+	results := data["results"].([]interface{})
+	require.Len(t, results, 1)
+	_, present := results[0].(map[string]interface{})["description"]
+	assert.False(t, present, "undescribed reasoners must not carry an empty description key")
+}
+
+func TestReasonersHandler_DescriptionTruncated(t *testing.T) {
+	// Long descriptions are clipped in the result but indexed whole, so a term
+	// past the cap still matches.
+	long := strings.Repeat("a", reasonerSearchMaxDescriptionRunes) + " zebra"
+	agents := []*types.AgentNode{
+		{
+			ID:           "verbose",
+			HealthStatus: types.HealthStatusActive,
+			Reasoners:    []types.ReasonerDefinition{{ID: "handler_a", Description: long}},
+		},
+	}
+	store := new(mockStatusStorage)
+	store.On("ListAgents", mock.Anything, mock.Anything).Return(agents, nil)
+
+	rec, resp := serveReasoners(t, store, "q=zebra")
+	require.Equal(t, http.StatusOK, rec.Code)
+	data := resp.Data.(map[string]interface{})
+	results := data["results"].([]interface{})
+	require.Len(t, results, 1)
+
+	desc := results[0].(map[string]interface{})["description"].(string)
+	assert.Equal(t, reasonerSearchMaxDescriptionRunes+len("..."), len([]rune(desc)))
+	assert.True(t, strings.HasSuffix(desc, "..."))
+	assert.NotContains(t, desc, "zebra")
+}
+
+func TestTruncateRunes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		limit int
+		want  string
+	}{
+		{name: "under limit is untouched", input: "short", limit: 10, want: "short"},
+		{name: "exactly at limit is untouched", input: "abcde", limit: 5, want: "abcde"},
+		{name: "over limit gets an ellipsis", input: "abcdef", limit: 5, want: "abcde..."},
+		{name: "trailing space is dropped before the ellipsis", input: "abcd ef", limit: 5, want: "abcd..."},
+		// Rune-wise, so multi-byte characters are never split.
+		{name: "multi byte counted by rune", input: "héllo wörld", limit: 5, want: "héllo..."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, truncateRunes(tt.input, tt.limit))
+		})
+	}
 }

--- a/control-plane/internal/skillkit/catalog.go
+++ b/control-plane/internal/skillkit/catalog.go
@@ -52,13 +52,16 @@ read this skill first`,
 	},
 	{
 		Name:        "agentfield-use",
-		Version:     "0.5.0",
-		Description: "Discover and call agents already running on a local AgentField control plane. Zero-setup MCP endpoint at <server>/mcp, health check, capability discovery, ranked reasoner search (af agent search), concurrent sync/async execution, load-aware pacing (meta.load), in-flight visibility (af ps / executions/active), wedged-run triage (cancel-tree), sessions, and the af CLI ops (run/stop/logs/secrets) that keep installed agents answering.",
+		Version:     "0.6.0",
+		Description: "Discover and call agents already running on a local or cloud AgentField control plane. Resolves the target server first (a desktop-configured cloud beats the local default, and an unreachable one is a stop-and-report, never a silent fallback), zero-setup MCP endpoint at <server>/mcp, health check, capability discovery, ranked reasoner search (af agent search), the reasoner's exact contract fetched before the first dispatch, entry-point-only targeting, concurrent sync/async execution, load-aware pacing (meta.load), in-flight visibility (af ps / executions/active), wedged-run triage (cancel-tree), sessions, and the af CLI ops (run/stop/logs/secrets) that keep installed agents answering.",
 		EmbedRoot:   "skill_data/agentfield-use",
 		EntryFile:   "SKILL.md",
 		Trigger: `When the user asks you to use, call, query, or delegate work to an
 installed AgentField agent, to list available agents or reasoners, or to
-check on a running execution, you MUST read this skill first`,
+check on a running execution, you MUST read this skill first — it resolves
+which control plane the work goes to (local or the desktop-configured
+cloud) and requires fetching a reasoner's contract, and confirming it is an
+entry point, before dispatching to it`,
 	},
 }
 

--- a/control-plane/internal/skillkit/catalog_agentfield_use_test.go
+++ b/control-plane/internal/skillkit/catalog_agentfield_use_test.go
@@ -89,8 +89,8 @@ func TestAgentfieldUseSourceFallbackContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse source frontmatter: %v", err)
 	}
-	if frontmatter.Name != "agentfield-use" || frontmatter.Version != "0.5.0" {
-		t.Fatalf("source frontmatter = %+v, want name=agentfield-use version=0.5.0", frontmatter)
+	if frontmatter.Name != "agentfield-use" || frontmatter.Version != "0.6.0" {
+		t.Fatalf("source frontmatter = %+v, want name=agentfield-use version=0.6.0", frontmatter)
 	}
 
 	// The offer is available only after coverage is conclusively checked, it
@@ -118,6 +118,54 @@ func TestAgentfieldUseSourceFallbackContract(t *testing.T) {
 	// the builder skills are reachable only through a plain offer.
 	if strings.Contains(content, "coverage_precheck_complete") {
 		t.Fatal("agentfield-use must not carry the retired coverage_precheck_complete marker")
+	}
+}
+
+// Contract for 0.6.0: the three preconditions the skill put in front of every
+// dispatch. Each one exists because skipping it sends work somewhere wrong —
+// the other fleet, a reasoner whose inputs were guessed, or an internal
+// pipeline stage — so each must survive edits to the skill.
+func TestAgentfieldUseDispatchPreconditions(t *testing.T) {
+	content := string(skillSource(t, "agentfield-use"))
+	for _, needle := range []string{
+		// Resolve the control plane first: cloud config beats the local
+		// default, and an unreachable configured cloud stops the work.
+		"## 0. Resolve the server first (local vs cloud)",
+		"agentfield-desktop/settings.json",
+		"Do NOT silently fall back to local",
+		// Fetch the contract before the first call.
+		"### Fetch the exact contract before you dispatch — never guess inputs",
+		"Search and discovery tell you a reasoner exists; they do not license a call.",
+		"entire contract**",
+		// Entry points only.
+		"### Entry points only — undescribed reasoners are internal",
+		"Dispatch ONLY to reasoners that carry the",
+	} {
+		if !strings.Contains(content, needle) {
+			t.Fatalf("agentfield-use SKILL.md is missing dispatch-precondition text %q", needle)
+		}
+	}
+}
+
+// Contract: the catalog entry is what a rules file and `af skill catalog` show
+// — it must advertise the same preconditions the skill body enforces, or an
+// agent choosing skills by description never learns they exist.
+func TestAgentfieldUseCatalogEntryAdvertisesPreconditions(t *testing.T) {
+	skill, err := CatalogByName("agentfield-use")
+	if err != nil {
+		t.Fatalf("CatalogByName(agentfield-use): %v", err)
+	}
+	description := strings.ToLower(skill.Description)
+	for _, needle := range []string{"local or cloud", "contract", "entry-point"} {
+		if !strings.Contains(description, needle) {
+			t.Fatalf("catalog description does not mention %q: %q", needle, skill.Description)
+		}
+	}
+	trigger := strings.ToLower(skill.Trigger)
+	for _, needle := range []string{"delegate work", "control plane", "contract", "entry point"} {
+		if !strings.Contains(trigger, needle) {
+			t.Fatalf("catalog trigger does not mention %q: %q", needle, skill.Trigger)
+		}
 	}
 }
 

--- a/control-plane/internal/skillkit/install.go
+++ b/control-plane/internal/skillkit/install.go
@@ -1,6 +1,7 @@
 package skillkit
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -126,9 +127,13 @@ func install(opts InstallOptions, reconcile bool) (*InstallReport, error) {
 	}
 
 	for _, t := range selected {
-		// Skip if already at this version and not forced.
+		// Skip if already at this version and not forced — but only when the
+		// recorded integration is really there. A matching version over a
+		// missing, stale, or legacy-method artifact is exactly the case that
+		// leaves a machine permanently broken, so it reinstalls instead.
 		if !opts.Force {
-			if existing, ok := skillState.Targets[t.Name()]; ok && existing.Version == skill.Version {
+			if existing, ok := skillState.Targets[t.Name()]; ok && existing.Version == skill.Version &&
+				installedArtifactValid(skill, t, existing) {
 				report.TargetsSkipped = append(report.TargetsSkipped, SkipReason{
 					TargetName: t.Name(),
 					Reason:     fmt.Sprintf("already installed at v%s (use --force to reinstall)", existing.Version),
@@ -182,16 +187,46 @@ func InstallAll(opts InstallOptions) ([]*InstallReport, error) {
 		}
 	}
 	reports := make([]*InstallReport, 0, len(Catalog))
+	var failures []error
 	for _, s := range Catalog {
 		o := opts
 		o.SkillName = s.Name
 		report, err := install(o, false)
 		if err != nil {
-			return reports, err
+			// One broken skill must not cost the user every skill after it in
+			// the catalog: record the failure and keep going, then return them
+			// all together so the caller can still exit non-zero.
+			failures = append(failures, fmt.Errorf("skill %q: %w", s.Name, err))
+			continue
 		}
 		reports = append(reports, report)
 	}
-	return reports, nil
+	return reports, errors.Join(failures...)
+}
+
+// ReportError returns a non-nil error when any target in the report failed to
+// install, so callers (the CLI) can exit non-zero after printing the report
+// rather than reporting success over a pile of failures.
+func (r *InstallReport) ReportError() error {
+	if r == nil || len(r.TargetsFailed) == 0 {
+		return nil
+	}
+	errs := make([]error, 0, len(r.TargetsFailed))
+	for _, failed := range r.TargetsFailed {
+		errs = append(errs, fmt.Errorf("%s: %s: %w", r.Skill.Name, failed.TargetName, failed.Err))
+	}
+	return errors.Join(errs...)
+}
+
+// ReportsError aggregates ReportError across a batch of reports (InstallAll).
+func ReportsError(reports []*InstallReport) error {
+	errs := make([]error, 0, len(reports))
+	for _, report := range reports {
+		if err := report.ReportError(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // Uninstall removes a skill from the named targets (or all if empty), and

--- a/control-plane/internal/skillkit/install_all_test.go
+++ b/control-plane/internal/skillkit/install_all_test.go
@@ -1,6 +1,10 @@
 package skillkit
 
-import "testing"
+import (
+	"errors"
+	"strings"
+	"testing"
+)
 
 // TestInstallAllInstallsEveryCatalogSkill is the contract for `af skill install`
 // with no skill name: it must install every catalog skill — both the build
@@ -37,6 +41,98 @@ func TestInstallAllInstallsEveryCatalogSkill(t *testing.T) {
 		if _, ok := installed.Targets["codex"]; !ok {
 			t.Errorf("skill %q was not installed into the codex target", want)
 		}
+	}
+}
+
+// Contract: one unusable skill must not cost the user every skill after it in
+// the catalog. InstallAll keeps going and returns the failures together.
+func TestInstallAllContinuesPastAFailingSkill(t *testing.T) {
+	t.Setenv("AGENTFIELD_SKIP_FURROW", "1")
+	withTempHome(t)
+
+	origCatalog := Catalog
+	t.Cleanup(func() { Catalog = origCatalog })
+	// A skill whose embedded files are missing fails at the canonical write —
+	// the first thing install does — so nothing downstream of it can run.
+	broken := Skill{
+		Name:      "broken-skill",
+		Version:   "1.0.0",
+		EmbedRoot: "skill_data/missing",
+		EntryFile: "SKILL.md",
+	}
+	Catalog = append([]Skill{broken}, origCatalog...)
+
+	origTargets := allTargets
+	t.Cleanup(func() { allTargets = origTargets })
+	success := &fakeTarget{name: "success", displayName: "Success", method: "marker-block", detected: true, path: fakeTargetPath(t, "success")}
+	allTargets = []Target{success}
+
+	reports, err := InstallAll(InstallOptions{Targets: []string{"success"}, Force: true})
+	if err == nil {
+		t.Fatal("InstallAll must report the failing skill")
+	}
+	if !strings.Contains(err.Error(), "broken-skill") {
+		t.Fatalf("error does not name the failing skill: %v", err)
+	}
+	if len(reports) != len(Catalog)-1 {
+		t.Fatalf("got %d reports, want one for every skill except the broken one (%d)", len(reports), len(Catalog)-1)
+	}
+	for i, report := range reports {
+		if want := Catalog[i+1].Name; report.Skill.Name != want {
+			t.Fatalf("report %d is for %q, want %q — the remaining skills must still install in catalog order", i, report.Skill.Name, want)
+		}
+	}
+}
+
+// Contract: `af skill install` exits non-zero when a target fails. The report
+// is the user-facing detail; the error is what makes a launch-time install in
+// the desktop app (or CI) notice that nothing landed.
+func TestInstallReportsSurfaceTargetFailuresAsErrors(t *testing.T) {
+	t.Setenv("AGENTFIELD_SKIP_FURROW", "1")
+	withTempHome(t)
+
+	origTargets := allTargets
+	t.Cleanup(func() { allTargets = origTargets })
+	failing := &fakeTarget{
+		name: "failing", displayName: "Failing", method: "marker-block", detected: true,
+		path: fakeTargetPath(t, "failing"), installErr: errors.New("disk on fire"),
+	}
+	allTargets = []Target{failing}
+
+	report, err := Install(InstallOptions{SkillName: "agentfield", Targets: []string{"failing"}, Force: true})
+	if err != nil {
+		t.Fatalf("Install returned a hard error: %v", err)
+	}
+	reportErr := report.ReportError()
+	if reportErr == nil {
+		t.Fatal("a report with a failed target must produce an error")
+	}
+	for _, needle := range []string{"agentfield", "failing", "disk on fire"} {
+		if !strings.Contains(reportErr.Error(), needle) {
+			t.Fatalf("report error %q does not mention %q", reportErr, needle)
+		}
+	}
+
+	reports, err := InstallAll(InstallOptions{Targets: []string{"failing"}, Force: true})
+	if err != nil {
+		t.Fatalf("InstallAll returned a hard error: %v", err)
+	}
+	batchErr := ReportsError(reports)
+	if batchErr == nil {
+		t.Fatal("ReportsError must surface per-target failures across the catalog")
+	}
+	for _, skill := range Catalog {
+		if !strings.Contains(batchErr.Error(), skill.Name) {
+			t.Fatalf("batch error %q does not mention failed skill %q", batchErr, skill.Name)
+		}
+	}
+
+	// A clean report is not an error.
+	if err := (&InstallReport{}).ReportError(); err != nil {
+		t.Fatalf("clean report produced an error: %v", err)
+	}
+	if err := ReportsError(nil); err != nil {
+		t.Fatalf("empty batch produced an error: %v", err)
 	}
 }
 

--- a/control-plane/internal/skillkit/installed_artifact.go
+++ b/control-plane/internal/skillkit/installed_artifact.go
@@ -1,0 +1,143 @@
+package skillkit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// installedArtifactValid reports whether the integration recorded in state for
+// (skill, target) is actually present and usable on disk.
+//
+// The install flow skips a target whose recorded version already matches the
+// binary's. That skip is only safe when the recorded artifact is real: state
+// files outlive the things they describe. Machines in the wild carry entries
+// pointing at deleted temp directories (a test suite that resolved targets
+// against the real home), at rules files the user has since cleaned out, and
+// at integrations written by an install method this binary no longer uses
+// (Codex moved from a rules-file marker block to a native skills symlink).
+// Every one of those is a target that would never be repaired, because the
+// version matched. Invalid here means the caller reinstalls — the same code
+// path --force takes for that one target.
+//
+// Validation is keyed on the RECORDED method, not the target's current one:
+// what is on disk was written by whatever method was in use then. A recorded
+// method that no longer matches how this binary installs the target is invalid
+// by definition, which is what migrates legacy Codex marker-block entries onto
+// the native skills directory.
+func installedArtifactValid(skill Skill, target Target, recorded InstalledTarget) bool {
+	if recorded.Method != target.Method() {
+		return false
+	}
+	switch recorded.Method {
+	case "symlink":
+		return symlinkArtifactValid(skill, recorded.Path)
+	case "marker-block":
+		return markerBlockArtifactValid(skill, recorded.Path)
+	case "manual":
+		// Nothing was ever written to disk — the user pasted the rules into
+		// the agent's own settings UI (Cursor, legacy Windsurf). There is no
+		// artifact to inspect, and reinstalling only reprints instructions.
+		return true
+	default:
+		// Unknown method: assume the recording predates this binary and repair.
+		return false
+	}
+}
+
+// symlinkArtifactValid checks that the recorded path is a symlink that
+// resolves to something that exists inside this skill's canonical store.
+// A link into another skill's store, into a stale temp directory, or a
+// dangling link all fail.
+func symlinkArtifactValid(skill Skill, path string) bool {
+	if path == "" {
+		return false
+	}
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode()&os.ModeSymlink == 0 {
+		return false
+	}
+	dest, err := os.Readlink(path)
+	if err != nil {
+		return false
+	}
+	if !filepath.IsAbs(dest) {
+		dest = filepath.Join(filepath.Dir(path), dest)
+	}
+	root, err := CanonicalRoot()
+	if err != nil {
+		return false
+	}
+	if !pathWithin(filepath.Join(root, skill.Name), dest) {
+		return false
+	}
+	// Following the link must land on something real (the canonical version
+	// directory can be deleted out from under an intact link).
+	_, err = os.Stat(path)
+	return err == nil
+}
+
+// markerBlockArtifactValid checks that the recorded rules file still exists,
+// still carries this skill's marker block, and that the SKILL.md path the
+// block points the agent at is really on disk. A block whose pointer target
+// has been deleted teaches the agent to read a file that is not there, which
+// is worse than no block at all.
+func markerBlockArtifactValid(skill Skill, path string) bool {
+	if path == "" {
+		return false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	block, ok := findMarkerBlock(string(data), skill)
+	if !ok {
+		return false
+	}
+	pointer := markerBlockPointerPath(block, skill)
+	if pointer == "" {
+		return false
+	}
+	_, err = os.Stat(pointer)
+	return err == nil
+}
+
+// findMarkerBlock returns the text of this skill's marker block, from the
+// opening marker through the closing one.
+func findMarkerBlock(content string, skill Skill) (string, bool) {
+	start := strings.Index(content, markerStartPattern(skill))
+	if start < 0 {
+		return "", false
+	}
+	end := strings.Index(content[start:], markerEnd(skill))
+	if end < 0 {
+		return "", false
+	}
+	return content[start : start+end+len(markerEnd(skill))], true
+}
+
+// markerBlockPointerPath extracts the canonical SKILL.md path a rendered
+// pointer block sends the agent to (see renderPointerBlock, which writes it
+// as its own indented line). Empty when the block carries no such line.
+func markerBlockPointerPath(block string, skill Skill) string {
+	for _, line := range strings.Split(block, "\n") {
+		candidate := strings.TrimSpace(line)
+		if candidate == "" || filepath.Base(candidate) != skill.EntryFile {
+			continue
+		}
+		return candidate
+	}
+	return ""
+}
+
+// pathWithin reports whether path is root itself or lives beneath it. The
+// comparison is lexical on purpose: both sides are built from the same home
+// directory string, and resolving symlinks would make a macOS /var vs
+// /private/var difference look like an escape.
+func pathWithin(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}

--- a/control-plane/internal/skillkit/installed_artifact_test.go
+++ b/control-plane/internal/skillkit/installed_artifact_test.go
@@ -1,0 +1,275 @@
+package skillkit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubTarget is a Target that exists only to report a Method() for the
+// validity check.
+type stubTarget struct {
+	name   string
+	method string
+}
+
+func (s stubTarget) Name() string                { return s.name }
+func (s stubTarget) DisplayName() string         { return s.name }
+func (s stubTarget) Detected() bool              { return true }
+func (s stubTarget) Method() string              { return s.method }
+func (s stubTarget) TargetPath() (string, error) { return "", nil }
+func (s stubTarget) Install(Skill, string) (InstalledTarget, error) {
+	return InstalledTarget{}, nil
+}
+func (s stubTarget) Uninstall() error              { return nil }
+func (s stubTarget) Status() (bool, string, error) { return false, "", nil }
+
+func TestInstalledArtifactValidSymlinkCases(t *testing.T) {
+	home := withTempHome(t)
+	root, err := CanonicalRoot()
+	if err != nil {
+		t.Fatalf("CanonicalRoot: %v", err)
+	}
+	skill := Catalog[0]
+	version := filepath.Join(root, skill.Name, skill.Version)
+	if err := os.MkdirAll(version, 0o755); err != nil {
+		t.Fatalf("mkdir version: %v", err)
+	}
+	current := filepath.Join(root, skill.Name, "current")
+	if err := os.Symlink(version, current); err != nil {
+		t.Fatalf("symlink current: %v", err)
+	}
+	links := filepath.Join(home, "links")
+	if err := os.MkdirAll(links, 0o755); err != nil {
+		t.Fatalf("mkdir links: %v", err)
+	}
+	link := func(name, dest string) string {
+		path := filepath.Join(links, name)
+		if err := os.Symlink(dest, path); err != nil {
+			t.Fatalf("symlink %s: %v", name, err)
+		}
+		return path
+	}
+
+	otherSkill := filepath.Join(root, "some-other-skill", "current")
+	if err := os.MkdirAll(otherSkill, 0o755); err != nil {
+		t.Fatalf("mkdir other skill: %v", err)
+	}
+	regular := filepath.Join(links, "regular-dir")
+	if err := os.MkdirAll(regular, 0o755); err != nil {
+		t.Fatalf("mkdir regular: %v", err)
+	}
+
+	target := stubTarget{name: "stub", method: "symlink"}
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "link into the skill's store", path: link("good", current), want: true},
+		{name: "empty path", path: "", want: false},
+		{name: "missing path", path: filepath.Join(links, "nope"), want: false},
+		{name: "regular directory instead of a link", path: regular, want: false},
+		{name: "dangling link inside the store", path: link("dangling", filepath.Join(root, skill.Name, "9.9.9")), want: false},
+		{name: "link to another skill's store", path: link("foreign", otherSkill), want: false},
+		{name: "link outside the canonical store", path: link("escaped", home), want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			recorded := InstalledTarget{Method: "symlink", Path: tc.path, Version: skill.Version}
+			if got := installedArtifactValid(skill, target, recorded); got != tc.want {
+				t.Fatalf("installedArtifactValid(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInstalledArtifactValidMarkerBlockCases(t *testing.T) {
+	base := t.TempDir()
+	skill := Catalog[0]
+	target := stubTarget{name: "stub", method: "marker-block"}
+
+	livePointer := filepath.Join(base, "canonical", "current")
+	if err := os.MkdirAll(livePointer, 0o755); err != nil {
+		t.Fatalf("mkdir pointer dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(livePointer, skill.EntryFile), []byte("# skill"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+
+	write := func(name, content string) string {
+		path := filepath.Join(base, name)
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		return path
+	}
+
+	valid := write("valid.md", "notes\n"+renderPointerBlock(skill, livePointer)+"\n")
+	deletedPointer := write("deleted.md", "notes\n"+renderPointerBlock(skill, filepath.Join(base, "gone", "current"))+"\n")
+	noBlock := write("plain.md", "just the user's own rules\n")
+	otherSkillBlock := write("other.md", renderPointerBlock(Catalog[len(Catalog)-1], livePointer)+"\n")
+	truncated := write("truncated.md", strings.Split(renderPointerBlock(skill, livePointer), markerEnd(skill))[0])
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "block pointing at a live SKILL.md", path: valid, want: true},
+		{name: "block pointing at a deleted SKILL.md", path: deletedPointer, want: false},
+		{name: "rules file without our block", path: noBlock, want: false},
+		{name: "only another skill's block", path: otherSkillBlock, want: false},
+		{name: "block missing its closing marker", path: truncated, want: false},
+		{name: "missing rules file", path: filepath.Join(base, "absent.md"), want: false},
+		{name: "empty path", path: "", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			recorded := InstalledTarget{Method: "marker-block", Path: tc.path, Version: skill.Version}
+			if got := installedArtifactValid(skill, target, recorded); got != tc.want {
+				t.Fatalf("installedArtifactValid(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// Contract: what the artifact was installed WITH decides how it is checked,
+// and a method this binary no longer uses for that target is never valid —
+// that is what migrates legacy Codex marker-block records onto the native
+// skills symlink instead of skipping them forever at a matching version.
+func TestInstalledArtifactValidMethodChanges(t *testing.T) {
+	base := t.TempDir()
+	skill := Catalog[0]
+	rules := filepath.Join(base, "AGENTS.override.md")
+	if err := os.MkdirAll(filepath.Join(base, "current"), 0o755); err != nil {
+		t.Fatalf("mkdir current: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(base, "current", skill.EntryFile), []byte("# skill"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	if err := os.WriteFile(rules, []byte(renderPointerBlock(skill, filepath.Join(base, "current"))), 0o644); err != nil {
+		t.Fatalf("write rules: %v", err)
+	}
+
+	legacy := InstalledTarget{Method: "marker-block", Path: rules, Version: skill.Version}
+	if installedArtifactValid(skill, codexTarget{}, legacy) {
+		t.Fatal("a legacy codex marker-block record must be invalid now that codex installs by symlink")
+	}
+	if !installedArtifactValid(skill, stubTarget{name: "legacy", method: "marker-block"}, legacy) {
+		t.Fatal("a marker-block record must stay valid for a target that still installs marker blocks")
+	}
+
+	manual := InstalledTarget{Method: "manual", Path: "Cursor Settings → Rules for AI (manual)", Version: skill.Version}
+	if !installedArtifactValid(skill, cursorTarget{}, manual) {
+		t.Fatal("manual targets write nothing to disk; there is no artifact to invalidate")
+	}
+	unknown := InstalledTarget{Method: "carrier-pigeon", Path: rules, Version: skill.Version}
+	if installedArtifactValid(skill, stubTarget{name: "stub", method: "carrier-pigeon"}, unknown) {
+		t.Fatal("an unrecognized install method must be treated as needing repair")
+	}
+}
+
+// Contract: this is the self-healing property the desktop's launch-time
+// `af skill install` relies on. State says the target is current; the artifact
+// is gone. The install must repair it instead of skipping it, without --force.
+func TestInstallRepairsRecordedTargetWhoseArtifactVanished(t *testing.T) {
+	home := codexHome(t)
+
+	first, err := Install(InstallOptions{SkillName: "agentfield", Targets: []string{"codex"}})
+	if err != nil {
+		t.Fatalf("first Install: %v", err)
+	}
+	if len(first.TargetsInstalled) != 1 {
+		t.Fatalf("first install did not install codex: %+v", first)
+	}
+	link := filepath.Join(home, ".codex", "skills", "agentfield")
+
+	// A second run with the artifact intact is a no-op skip.
+	second, err := Install(InstallOptions{SkillName: "agentfield", Targets: []string{"codex"}})
+	if err != nil {
+		t.Fatalf("second Install: %v", err)
+	}
+	if len(second.TargetsInstalled) != 0 || len(second.TargetsSkipped) != 1 ||
+		!strings.Contains(second.TargetsSkipped[0].Reason, "already installed") {
+		t.Fatalf("intact artifact should be skipped: %+v", second)
+	}
+
+	// Now the artifact disappears (an uninstall of the agent, a cleaned home,
+	// a link into a deleted temp dir) while state still says v<current>.
+	if err := os.RemoveAll(link); err != nil {
+		t.Fatalf("remove link: %v", err)
+	}
+	third, err := Install(InstallOptions{SkillName: "agentfield", Targets: []string{"codex"}})
+	if err != nil {
+		t.Fatalf("third Install: %v", err)
+	}
+	if len(third.TargetsInstalled) != 1 || third.TargetsInstalled[0].TargetName != "codex" {
+		t.Fatalf("missing artifact was not repaired: %+v", third)
+	}
+	if _, err := os.Stat(link); err != nil {
+		t.Fatalf("repaired link missing: %v", err)
+	}
+}
+
+// Contract: the machines already in the wild. State records codex at the
+// current version through the old marker-block method, and the block sits in
+// a file Codex never reads. A plain `af skill install` must repair that.
+func TestInstallMigratesLegacyCodexMarkerBlockInstallation(t *testing.T) {
+	home := codexHome(t)
+	skill := Catalog[0]
+	legacyPath := filepath.Join(home, ".codex", "AGENTS.override.md")
+	if err := os.WriteFile(legacyPath, []byte("keep me\n\n"+renderPointerBlock(skill, "/deleted/canonical/current")+"\n"), 0o644); err != nil {
+		t.Fatalf("seed legacy rules file: %v", err)
+	}
+	if err := SaveState(&State{Skills: map[string]InstalledSkill{
+		skill.Name: {
+			CurrentVersion:    skill.Version,
+			InstalledAt:       time.Now().UTC(),
+			AvailableVersions: []string{skill.Version},
+			Targets: map[string]InstalledTarget{
+				"codex": {
+					TargetName:  "codex",
+					Method:      "marker-block",
+					Path:        legacyPath,
+					Version:     skill.Version,
+					InstalledAt: time.Now().UTC(),
+				},
+			},
+		},
+	}}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	report, err := Install(InstallOptions{SkillName: skill.Name, Targets: []string{"codex"}})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if len(report.TargetsInstalled) != 1 || report.TargetsInstalled[0].Method != "symlink" {
+		t.Fatalf("legacy marker-block install was not migrated: %+v", report)
+	}
+	link := filepath.Join(home, ".codex", "skills", skill.Name)
+	if _, err := os.Stat(filepath.Join(link, skill.EntryFile)); err != nil {
+		t.Fatalf("SKILL.md not readable through the native skills dir: %v", err)
+	}
+	data, err := os.ReadFile(legacyPath)
+	if err != nil {
+		t.Fatalf("read legacy rules file: %v", err)
+	}
+	if strings.Contains(string(data), markerStartPattern(skill)) {
+		t.Fatalf("legacy block survived the migration:\n%s", data)
+	}
+	if !strings.Contains(string(data), "keep me") {
+		t.Fatalf("migration destroyed user content:\n%s", data)
+	}
+
+	state, err := LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if got := state.Skills[skill.Name].Targets["codex"]; got.Method != "symlink" || got.Path != link {
+		t.Fatalf("state still records the legacy integration: %+v", got)
+	}
+}

--- a/control-plane/internal/skillkit/reconcile_test.go
+++ b/control-plane/internal/skillkit/reconcile_test.go
@@ -24,6 +24,12 @@ func setupReconciliation(t *testing.T, state *State) string {
 	t.Helper()
 	home := t.TempDir()
 	t.Setenv("AGENTFIELD_HOME", home)
+	// Targets resolve their install paths through os.UserHomeDir(), which
+	// AGENTFIELD_HOME does not cover: every one of these must be set or a
+	// reconcile test that installs into a real target writes into the running
+	// user's home. (TestMain already redirects it package-wide; this narrows
+	// it to one test.)
+	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	if err := SaveState(state); err != nil {
 		t.Fatal(err)

--- a/control-plane/internal/skillkit/skill_data/agentfield-use/SKILL.md
+++ b/control-plane/internal/skillkit/skill_data/agentfield-use/SKILL.md
@@ -27,13 +27,22 @@ Resolution order — stop at the first match:
 
 1. **Explicit wins.** The user named a server, or `AGENTFIELD_SERVER` is set in
    the environment → use that.
-2. **Read the desktop cloud config** (first file that exists):
+2. **Read the desktop cloud config.** Check every path that applies to this
+   machine — a file that exists but declares no enabled cloud does NOT end
+   the search:
    - macOS: `~/Library/Application Support/agentfield-desktop/settings.json`
    - Windows: `%APPDATA%/agentfield-desktop/settings.json`
    - Linux: `~/.config/agentfield-desktop/settings.json`
-   If `cloud.enabled` is `true` and `cloud.serverUrl` is non-empty, the cloud
-   is the target: strip any trailing slash from the URL and take `cloud.apiKey`
-   as the key. Health-check it (`GET <url>/health` with `X-API-Key`).
+   - WSL (detect: `grep -qi microsoft /proc/version`): the Linux path above
+     first, then the Windows side, where the desktop app usually lives:
+     `/mnt/c/Users/*/AppData/Roaming/agentfield-desktop/settings.json`.
+     A Linux-side file with no `cloud` key shadowing a Windows file that
+     holds the real cloud config is the common split-brain — the enabled
+     cloud wins, whichever side declares it.
+   The first file declaring `cloud.enabled: true` with a non-empty
+   `cloud.serverUrl` makes the cloud the target: strip any trailing slash
+   from the URL and take `cloud.apiKey` as the key. Health-check it
+   (`GET <url>/health` with `X-API-Key`).
    - Healthy → use the cloud for everything below.
    - Unreachable → **stop and tell the user their cloud control plane is
      configured but not responding.** Do NOT silently fall back to local:

--- a/control-plane/internal/skillkit/skill_data/agentfield-use/SKILL.md
+++ b/control-plane/internal/skillkit/skill_data/agentfield-use/SKILL.md
@@ -1,19 +1,53 @@
 ---
 name: agentfield-use
-version: 0.5.0
-description: "Discover and call agents already running on a local AgentField control plane. Use when the user asks to use, call, query, run, or delegate work to an installed AgentField agent (swe-planner, pr-af, sec-af, …), to list what agents or reasoners are available, or to check on an execution. Not for building new agents — that is the agentfield skill."
+version: 0.6.0
+description: "Discover and call agents already running on a local or cloud AgentField control plane. Use when the user asks to use, call, query, run, or delegate work to an installed AgentField agent (swe-planner, pr-af, sec-af, …), to list what agents or reasoners are available, or to check on an execution. Resolves the right control plane (desktop-configured cloud first), fetches the reasoner's exact contract before dispatching, and only calls entry-point reasoners. Not for building new agents — that is the agentfield skill."
 ---
 
 # Using AgentField agents
 
-A machine with AgentField has a **control plane** (default `http://localhost:8080`,
-override via `AGENTFIELD_SERVER`) and **agent nodes** installed under
-`~/.agentfield`. Each node exposes **reasoners** — typed functions you call over
-HTTP. You never talk to an agent's own port: every call goes through the control
-plane, which routes it, records the workflow, and returns the result.
+A machine with AgentField has one or more **control planes** — a local one
+(default `http://localhost:8080`) and possibly a **cloud deployment**
+configured in AgentField Desktop — plus **agent nodes** installed under
+`~/.agentfield`. Each node exposes **reasoners** — typed functions you call
+over HTTP. You never talk to an agent's own port: every call goes through the
+control plane, which routes it, records the workflow, and returns the result.
 
-In local mode there is no auth. If the server has an API key configured, send it
-as `X-API-Key: <key>` on every request.
+**Resolve which control plane you are targeting before anything else (§0).**
+The local and cloud fleets are disjoint: different agents, different versions,
+different filesystems, different run history. Nothing ever falls back from one
+to the other on its own.
+
+A local server in local mode has no auth. A cloud deployment (and any server
+with an API key configured) requires `X-API-Key: <key>` on every request.
+
+## 0. Resolve the server first (local vs cloud)
+
+Resolution order — stop at the first match:
+
+1. **Explicit wins.** The user named a server, or `AGENTFIELD_SERVER` is set in
+   the environment → use that.
+2. **Read the desktop cloud config** (first file that exists):
+   - macOS: `~/Library/Application Support/agentfield-desktop/settings.json`
+   - Windows: `%APPDATA%/agentfield-desktop/settings.json`
+   - Linux: `~/.config/agentfield-desktop/settings.json`
+   If `cloud.enabled` is `true` and `cloud.serverUrl` is non-empty, the cloud
+   is the target: strip any trailing slash from the URL and take `cloud.apiKey`
+   as the key. Health-check it (`GET <url>/health` with `X-API-Key`).
+   - Healthy → use the cloud for everything below.
+   - Unreachable → **stop and tell the user their cloud control plane is
+     configured but not responding.** Do NOT silently fall back to local:
+     work dispatched there lands on a different fleet with different
+     filesystems, which is worse than no dispatch.
+3. **Otherwise use local:** `http://localhost:8080`.
+
+Then pass the target **explicitly on every call**: `af --server <url> -k <key>`
+(every `af` command accepts `-s/--server` and `-k/--api-key`), or the URL plus
+`-H 'X-API-Key: <key>'` for curl. Do not export `AGENTFIELD_SERVER` yourself to
+switch targets — a global default leaks into other processes and outlives the
+task; explicit per-call flags are the contract. If you'd rather not pass `-k`
+each time, `af auth login --server <url>` stores a key per server in
+`~/.agentfield/credentials.json`.
 
 ## MCP (zero-setup)
 
@@ -25,6 +59,8 @@ Claude Code:
 
 ```bash
 claude mcp add --transport http agentfield http://localhost:8080/mcp
+# cloud target (§0):
+claude mcp add --transport http agentfield https://<cloud-host>/mcp --header "X-API-Key: <key>"
 ```
 
 Other MCP clients: point them at the same streamable-HTTP URL
@@ -43,8 +79,11 @@ than the five tools give you.
 
 ## The flow
 
+0. Resolve the server (§0) — desktop-configured cloud first, explicit
+   `--server`/URL on every call.
 1. Health-check the control plane.
-2. Discover what agents and reasoners exist.
+2. Discover what agents and reasoners exist, and fetch the target reasoner's
+   exact contract before the first call.
 3. Execute — async for anything nontrivial. Fire independent calls concurrently.
 4. Poll (or stream) until the execution finishes — and watch for wedged runs.
 
@@ -54,10 +93,12 @@ than the five tools give you.
 curl -s http://localhost:8080/health
 ```
 
-Healthy: `200` with `{"status":"healthy", ...}`. Connection refused means no
-control plane is running — the user can open the AgentField desktop app, or you
-can start one in the background (`af server` blocks, so background it and poll
-`/health` until healthy).
+Healthy: `200` with `{"status":"healthy", ...}`. Connection refused on the
+**local** target means no control plane is running — the user can open the
+AgentField desktop app, or you can start one in the background (`af server`
+blocks, so background it and poll `/health` until healthy). If the resolved
+target is the desktop-configured **cloud** and this check fails, stop and
+report it (§0) — do not retarget local.
 
 ## 2. Discover agents and reasoners
 
@@ -105,6 +146,38 @@ Each hit carries `reasoner_id`, `agent_id`, `invocation_target`, `tags`,
 `score`, and `agent_health` — everything you need to dispatch with no second
 lookup. Build the execute target straight from `invocation_target` (colon → dot)
 and only dispatch to hits whose `agent_health` is `"active"`.
+
+### Fetch the exact contract before you dispatch — never guess inputs
+
+Search and discovery tell you a reasoner exists; they do not license a call.
+Before the first call to any reasoner, read its contract:
+
+```bash
+af agent agent-summary --id <agent_id> -s <server>   # all of an agent's reasoners: descriptions + input/output schemas + health + 24h metrics
+# single reasoner via MCP: get_reasoner_schema
+# or the fleet at once: curl -s "<server>/api/v1/discovery/capabilities?include_input_schema=true"
+```
+
+Read BOTH the description and the input schema, and follow them literally:
+
+- A schema of `{"type":"object"}` with no properties is NOT "anything goes" —
+  it means the agent registered no schema and **the description text is the
+  entire contract**. Field names, required-ness, and types stated there are
+  binding (e.g. swe-pro's `code_task`: `goal` and an **absolute** `dir` are
+  required; model pools are comma-separated strings, not arrays).
+- Result semantics live in the description too. Some agents report a failed
+  job in the RESULT (`status: "fail"`) while the execution itself reads
+  `succeeded` — check the result's own status field, not just the execution's.
+
+### Entry points only — undescribed reasoners are internal
+
+Agents register their internal pipeline stages alongside their public flows,
+and discovery lists all of them. Dispatch ONLY to reasoners that carry the
+`entrypoint` tag or a description. A reasoner with no description (e.g.
+swe-planner's `run_*` stages) or tagged `internal` is plumbing invoked by an
+orchestrator — calling it directly fails or corrupts a run. `af ls -e` lists
+tagged entry points; when in doubt, pick the described reasoner whose
+description names your use case.
 
 ### No coverage: offer to build it
 
@@ -161,7 +234,10 @@ batch now and poll as a group — not one-at-a-time. What to know:
 - Concurrent calls to the **same reasoner** are safe when the agent is (e.g.
   pr-af isolates concurrent reviews per PR). If an agent's docs don't say it's
   parallel-safe, assume same-target calls may contend on shared state and
-  stagger them; different agents never contend.
+  stagger them; different agents never contend. Some agents serialize ALL
+  executions process-wide (swe-pro queues concurrent `code_task` calls behind
+  one lock) — the reasoner description says so when known; dispatching more
+  than one heavy call to such a node just builds a queue.
 - Each call fans out inside the agent (one review ≈ dozens of sub-executions,
   several LLM CLI processes). 3–4 heavy runs per node is a sensible ceiling
   unless the agent documents otherwise.
@@ -267,7 +343,10 @@ so change files between issues or on a fork rather than while the agent writes.
 
 `get_workspace_handle` re-fetches a handle mid-run:
 `POST /api/v1/execute/<agent>.get_workspace_handle` with `{"input":{"run_id":"..."}}`.
-`{"available": false}` means no mirror — carry on without it.
+`{"available": false}` means no mirror — carry on without it. Not every build
+ships this reasoner: check the agent's reasoner list (discovery or
+`agent-summary`) before calling it; if it's absent, the node predates the
+mirror feature and results simply never carry a handle.
 
 **Several at once:** `POST /api/v1/executions/batch-status` with
 `{"execution_ids": [...]}`. Terminal entries embed the FULL result payload —
@@ -309,7 +388,9 @@ resolve from the `X-Workflow-ID` / `X-Session-ID` / `X-Actor-ID` headers).
 
 | Symptom | Meaning | Fix |
 |---|---|---|
-| connection refused on :8080 | control plane not running | desktop app, or background `af server` and poll `/health` |
+| connection refused on :8080 | local control plane not running | desktop app, or background `af server` and poll `/health` |
+| desktop-configured cloud unreachable | cloud deployment down, or URL/key stale | stop and tell the user (§0) — never silently retarget local |
+| 401/403 from a cloud target | missing or wrong `X-API-Key` | key from desktop `settings.json` `cloud.apiKey`, or `af auth login --server <url>` |
 | agent `inactive` in discovery / missing | node installed but not running (or not installed) | `af list`, then `af run <name>` — or `af install <source>` |
 | `missing required environment variables: X` from `af run` | required key not configured | `af secrets set X` (value via stdin/arg; `--node <name>` for node-scoped) — or desktop app → Agents → Keys |
 | HTTP 502 with `error_message` | the agent itself errored | read `af logs <name>`, fix, retry |
@@ -318,9 +399,14 @@ resolve from the `X-Workflow-ID` / `X-Session-ID` / `X-Actor-ID` headers).
 
 ## Local ops cheat sheet (af CLI)
 
+All commands accept `-s/--server <url>` and `-k/--api-key <key>` — required on
+every invocation when the resolved target is the cloud (§0).
+
 ```bash
 af list                    # installed agents + status
 af ls [query]              # search reasoners across running agents (NOT the install registry)
+af ls -e                   # only entry-point reasoners — the callable surface
+af agent agent-summary --id <name>   # full contract: reasoners, schemas, health, 24h metrics
 af ps                      # in-flight runs across all agents (af ps --agent <name>)
 af run <name>              # start (detached); af stop <name>
 af logs <name>             # agent logs (-f follows; no per-run filter — grep by run_id)
@@ -338,6 +424,13 @@ is enabled), and verify offline with `af verify audit.json`.
 
 ## Hard rules
 
+- Resolve the server per §0 and pass it explicitly (`--server` / full URL) on
+  every call. A desktop-configured cloud beats the local default; an
+  unreachable configured cloud is a stop-and-report, never a silent fallback.
+- Fetch the reasoner's contract before the first call. A vacuous schema means
+  the description is the contract — follow it literally.
+- Dispatch only to `entrypoint`-tagged or described reasoners. Undescribed or
+  `internal`-tagged reasoners are pipeline stages — never call them directly.
 - Every call goes through the control plane — never POST to an agent's own port.
   The one exception is a `workspace_handle`: its `ssh://` endpoint is a furrow
   transport, not the agent's HTTP port, and the per-run token in the handle is

--- a/control-plane/internal/skillkit/skill_mirror_test.go
+++ b/control-plane/internal/skillkit/skill_mirror_test.go
@@ -21,7 +21,7 @@ func TestSkillCatalogAndEmbeddedMirrorsStayAligned(t *testing.T) {
 	}{
 		{name: "agentfield", version: "0.5.2"},
 		{name: "agentfield-personal", version: "0.1.0"},
-		{name: "agentfield-use", version: "0.5.0"},
+		{name: "agentfield-use", version: "0.6.0"},
 	}
 
 	for _, tt := range tests {

--- a/control-plane/internal/skillkit/skillkit_edge_test.go
+++ b/control-plane/internal/skillkit/skillkit_edge_test.go
@@ -156,8 +156,8 @@ func TestInstallAndUninstallBranches(t *testing.T) {
 	origTargets := allTargets
 	t.Cleanup(func() { allTargets = origTargets })
 
-	success := &fakeTarget{name: "success", displayName: "Success", method: "marker-block", detected: true, path: "/tmp/success"}
-	broken := &fakeTarget{name: "broken", displayName: "Broken", method: "marker-block", detected: true, path: "/tmp/broken", uninstallErr: errors.New("nope")}
+	success := &fakeTarget{name: "success", displayName: "Success", method: "marker-block", detected: true, path: fakeTargetPath(t, "success")}
+	broken := &fakeTarget{name: "broken", displayName: "Broken", method: "marker-block", detected: true, path: fakeTargetPath(t, "broken"), uninstallErr: errors.New("nope")}
 	allTargets = []Target{success, broken}
 
 	report, err := Install(InstallOptions{SkillName: Catalog[0].Name, AllRegistered: true})
@@ -205,8 +205,8 @@ func TestInstallAndUninstallBranches(t *testing.T) {
 		origTargets := allTargets
 		t.Cleanup(func() { allTargets = origTargets })
 
-		first := &fakeTarget{name: "alpha", displayName: "Alpha", method: "marker-block", detected: true, path: "/tmp/alpha"}
-		second := &fakeTarget{name: "beta", displayName: "Beta", method: "marker-block", detected: true, path: "/tmp/beta"}
+		first := &fakeTarget{name: "alpha", displayName: "Alpha", method: "marker-block", detected: true, path: fakeTargetPath(t, "alpha")}
+		second := &fakeTarget{name: "beta", displayName: "Beta", method: "marker-block", detected: true, path: fakeTargetPath(t, "beta")}
 		allTargets = []Target{first, second}
 
 		if _, err := Install(InstallOptions{SkillName: Catalog[0].Name, AllRegistered: true}); err != nil {
@@ -233,7 +233,7 @@ func TestInstallExistingStateAndCanonicalFailures(t *testing.T) {
 		origTargets := allTargets
 		t.Cleanup(func() { allTargets = origTargets })
 
-		success := &fakeTarget{name: "success", displayName: "Success", method: "marker-block", detected: true, path: "/tmp/success"}
+		success := &fakeTarget{name: "success", displayName: "Success", method: "marker-block", detected: true, path: fakeTargetPath(t, "success")}
 		allTargets = []Target{success}
 
 		// Seed the state with two historical versions that are definitely
@@ -271,9 +271,9 @@ func TestInstallExistingStateAndCanonicalFailures(t *testing.T) {
 		// Expect: the two seeded versions are still there and the catalog's
 		// current version got merged in.
 		wantContains := map[string]bool{
-			"0.1.0":              false,
-			"9.9.9":              false,
-			Catalog[0].Version:   false,
+			"0.1.0":            false,
+			"9.9.9":            false,
+			Catalog[0].Version: false,
 		}
 		for _, v := range got {
 			if _, ok := wantContains[v]; ok {
@@ -333,7 +333,7 @@ func TestInstallExistingStateAndCanonicalFailures(t *testing.T) {
 		origTargets := allTargets
 		t.Cleanup(func() { allTargets = origTargets })
 
-		success := &fakeTarget{name: "success", displayName: "Success", method: "marker-block", detected: true, path: "/tmp/success"}
+		success := &fakeTarget{name: "success", displayName: "Success", method: "marker-block", detected: true, path: fakeTargetPath(t, "success")}
 		allTargets = []Target{success}
 
 		if _, err := Install(InstallOptions{AllRegistered: true}); err != nil {
@@ -783,6 +783,9 @@ func TestTargetSpecificEdgeCases(t *testing.T) {
 		}
 		cases := []targetCase{
 			{name: "aider", target: aiderTarget{}, path: filepath.Join(home, ".aider.conventions.md")},
+			// Codex installs by symlink now; it stays in this table because its
+			// uninstall still visits the legacy rules file and must tolerate one
+			// holding nothing but the user's own text.
 			{name: "codex", target: codexTarget{}, dir: filepath.Join(home, ".codex"), path: filepath.Join(home, ".codex", "AGENTS.override.md")},
 			{name: "gemini", target: geminiTarget{}, dir: filepath.Join(home, ".gemini"), path: filepath.Join(home, ".gemini", "GEMINI.md")},
 			{name: "opencode", target: opencodeTarget{}, dir: filepath.Join(home, ".config", "opencode"), path: filepath.Join(home, ".config", "opencode", "AGENTS.md")},

--- a/control-plane/internal/skillkit/skillkit_test.go
+++ b/control-plane/internal/skillkit/skillkit_test.go
@@ -22,20 +22,32 @@ type fakeTarget struct {
 	installCalls int
 }
 
-func (f *fakeTarget) Name() string       { return f.name }
+func (f *fakeTarget) Name() string        { return f.name }
 func (f *fakeTarget) DisplayName() string { return f.displayName }
-func (f *fakeTarget) Method() string     { return f.method }
-func (f *fakeTarget) Detected() bool     { return f.detected }
+func (f *fakeTarget) Method() string      { return f.method }
+func (f *fakeTarget) Detected() bool      { return f.detected }
 func (f *fakeTarget) TargetPath() (string, error) {
 	if f.path == "" {
 		return "", errors.New("missing path")
 	}
 	return f.path, nil
 }
-func (f *fakeTarget) Install(skill Skill, _ string) (InstalledTarget, error) {
+func (f *fakeTarget) Install(skill Skill, canonicalCurrentDir string) (InstalledTarget, error) {
 	f.installCalls++
 	if f.installErr != nil {
 		return InstalledTarget{}, f.installErr
+	}
+	// Write the artifact the recorded method claims exists. The installer only
+	// skips an already-current target when its artifact really is on disk, so a
+	// fake that records a marker-block install without writing one would be
+	// permanently "invalid" and never exercise the skip path.
+	if f.method == "marker-block" {
+		inst, err := installMarkerBlock(skill, canonicalCurrentDir, f.path)
+		if err != nil {
+			return InstalledTarget{}, err
+		}
+		inst.TargetName = f.name
+		return inst, nil
 	}
 	return InstalledTarget{
 		TargetName:  f.name,
@@ -59,9 +71,20 @@ func withTempHome(t *testing.T) string {
 	t.Helper()
 	home := t.TempDir()
 	withEnv(t, "HOME", home)
+	// os.UserHomeDir reads USERPROFILE on Windows; without it the package-wide
+	// isolated home from TestMain would leak across this narrower one there.
+	withEnv(t, "USERPROFILE", home)
 	withEnv(t, "AGENTFIELD_HOME", filepath.Join(home, ".agentfield-home"))
 	withEnv(t, "PATH", filepath.Join(home, "bin"))
 	return home
+}
+
+// fakeTargetPath returns a writable temp path for a fake target's artifact.
+// Fakes must never point at a shared location like /tmp/<name>: their installs
+// are real file writes now.
+func fakeTargetPath(t *testing.T, name string) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), name+".md")
 }
 
 func captureStdout(t *testing.T, fn func()) string {
@@ -152,7 +175,7 @@ func TestStateFunctions(t *testing.T) {
 				InstalledAt:       time.Now().UTC(),
 				AvailableVersions: []string{Catalog[0].Version},
 				Targets: map[string]InstalledTarget{
-					"zeta": {TargetName: "zeta"},
+					"zeta":  {TargetName: "zeta"},
 					"alpha": {TargetName: "alpha"},
 				},
 			},
@@ -328,17 +351,26 @@ func TestHelpersAndTargets(t *testing.T) {
 		t.Fatalf("mkdir codex dir: %v", err)
 	}
 	codex := codexTarget{}
-	if codex.DisplayName() != "Codex (OpenAI)" || codex.Method() != "marker-block" {
+	// Codex reads ~/.codex/skills/<name>/SKILL.md natively (the cross-tool
+	// skills standard), so it installs by symlink like Claude Code.
+	if codex.DisplayName() != "Codex (OpenAI)" || codex.Method() != "symlink" {
 		t.Fatalf("unexpected codex metadata: %q %q", codex.DisplayName(), codex.Method())
 	}
 	if !codex.Detected() {
 		t.Fatal("codex target should be detected")
 	}
 	codexPath, _ := codex.TargetPath()
-	if _, err := codex.Install(skill, filepath.Join(home, "canonical", "current")); err != nil {
+	codexInst, err := codex.Install(skill, filepath.Join(home, "canonical", "current"))
+	if err != nil {
 		t.Fatalf("codex install: %v", err)
 	}
-	if installed, version, err := codex.Status(); err != nil || !installed || version != skill.Version {
+	if codexInst.Method != "symlink" || codexInst.Path != filepath.Join(home, ".codex", "skills", skill.Name) {
+		t.Fatalf("unexpected codex install result: %+v", codexInst)
+	}
+	if dest, err := os.Readlink(codexInst.Path); err != nil || dest != filepath.Join(home, "canonical", "current") {
+		t.Fatalf("codex link dest = %q err=%v", dest, err)
+	}
+	if installed, version, err := codex.Status(); err != nil || !installed || version != "current" {
 		t.Fatalf("codex status = %v %q %v", installed, version, err)
 	}
 	if err := codex.Uninstall(); err != nil {
@@ -347,7 +379,7 @@ func TestHelpersAndTargets(t *testing.T) {
 	if installed, _, _ := codex.Status(); installed {
 		t.Fatal("codex should not be installed after uninstall")
 	}
-	if !strings.HasSuffix(codexPath, filepath.Join(".codex", "AGENTS.override.md")) {
+	if !strings.HasSuffix(codexPath, filepath.Join(".codex", "skills")) {
 		t.Fatalf("unexpected codex path: %q", codexPath)
 	}
 
@@ -513,9 +545,9 @@ func TestResolveTargetsAndInstallLifecycle(t *testing.T) {
 	origTargets := allTargets
 	t.Cleanup(func() { allTargets = origTargets })
 
-	success := &fakeTarget{name: "success", displayName: "Success", method: "marker-block", detected: true, path: "/tmp/success"}
-	failing := &fakeTarget{name: "failing", displayName: "Failing", method: "marker-block", detected: true, path: "/tmp/failing", installErr: errors.New("boom")}
-	skippedTarget := &fakeTarget{name: "skipped", displayName: "Skipped", method: "marker-block", detected: false, path: "/tmp/skipped"}
+	success := &fakeTarget{name: "success", displayName: "Success", method: "marker-block", detected: true, path: fakeTargetPath(t, "success")}
+	failing := &fakeTarget{name: "failing", displayName: "Failing", method: "marker-block", detected: true, path: fakeTargetPath(t, "failing"), installErr: errors.New("boom")}
+	skippedTarget := &fakeTarget{name: "skipped", displayName: "Skipped", method: "marker-block", detected: false, path: fakeTargetPath(t, "skipped")}
 	allTargets = []Target{success, failing, skippedTarget}
 
 	selected, skipped, err := resolveTargets(InstallOptions{AllDetected: true})

--- a/control-plane/internal/skillkit/state.go
+++ b/control-plane/internal/skillkit/state.go
@@ -13,24 +13,24 @@ import (
 // and which target integrations are active. Persisted at
 // ~/.agentfield/skills/.state.json.
 type State struct {
-	Version string                       `json:"state_version"`
-	Skills  map[string]InstalledSkill    `json:"skills"`
+	Version string                    `json:"state_version"`
+	Skills  map[string]InstalledSkill `json:"skills"`
 }
 
 // InstalledSkill records the installed-version state of a single skill.
 type InstalledSkill struct {
-	CurrentVersion    string                       `json:"current_version"`
-	InstalledAt       time.Time                    `json:"installed_at"`
-	AvailableVersions []string                     `json:"available_versions"`
-	Targets           map[string]InstalledTarget   `json:"targets"`
+	CurrentVersion    string                     `json:"current_version"`
+	InstalledAt       time.Time                  `json:"installed_at"`
+	AvailableVersions []string                   `json:"available_versions"`
+	Targets           map[string]InstalledTarget `json:"targets"`
 }
 
 // InstalledTarget records one target integration for one skill.
 type InstalledTarget struct {
-	TargetName  string    `json:"target_name"`  // "claude-code", "codex", ...
-	Method      string    `json:"method"`       // "symlink", "marker-block", "manual"
-	Path        string    `json:"path"`         // file or directory the integration writes to
-	Version     string    `json:"version"`      // version installed at this target
+	TargetName  string    `json:"target_name"` // "claude-code", "codex", ...
+	Method      string    `json:"method"`      // "symlink", "marker-block", "manual"
+	Path        string    `json:"path"`        // file or directory the integration writes to
+	Version     string    `json:"version"`     // version installed at this target
 	InstalledAt time.Time `json:"installed_at"`
 }
 

--- a/control-plane/internal/skillkit/target_codex.go
+++ b/control-plane/internal/skillkit/target_codex.go
@@ -2,19 +2,32 @@ package skillkit
 
 import (
 	"errors"
+	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
+	"time"
 )
 
-// codexTarget installs the skill into Codex (OpenAI's coding agent CLI) by
-// appending a marker block to ~/.codex/AGENTS.override.md. The block points
-// at the canonical SKILL.md so updates flow through automatically.
+// codexTarget installs the skill into Codex (OpenAI's coding agent CLI) via
+// the cross-tool skills standard Codex adopted in late 2025: a personal skill
+// is a directory at ~/.codex/skills/<name>/ containing SKILL.md, discovered at
+// startup and auto-activated from its description (Codex's own bundled skills
+// live alongside them in ~/.codex/skills/.system/). We symlink that directory
+// at the canonical versioned store — exactly like the Claude Code target — so
+// updates to the store flow through without rewriting anything Codex owns.
+//
+// Older af binaries appended a marker block to ~/.codex/AGENTS.override.md, a
+// file Codex never reads, so the skill was effectively never installed. Every
+// install/update/uninstall now strips that block and removes the file when our
+// block was the only thing in it.
 type codexTarget struct{}
 
 func init() { RegisterTarget(codexTarget{}) }
 
 func (codexTarget) Name() string        { return "codex" }
 func (codexTarget) DisplayName() string { return "Codex (OpenAI)" }
-func (codexTarget) Method() string      { return "marker-block" }
+func (codexTarget) Method() string      { return "symlink" }
 
 func (codexTarget) Detected() bool {
 	return commandAvailable("codex") || dirExists(filepath.Join(homeDir(), ".codex"))
@@ -25,29 +38,83 @@ func (codexTarget) TargetPath() (string, error) {
 	if h == "" {
 		return "", errors.New("could not resolve home directory")
 	}
+	return filepath.Join(h, ".codex", "skills"), nil
+}
+
+// legacyRulesPath is the file older af binaries appended marker blocks to.
+// Kept only so the blocks can be cleaned up; nothing is ever written there.
+func (codexTarget) legacyRulesPath() (string, error) {
+	h := homeDir()
+	if h == "" {
+		return "", errors.New("could not resolve home directory")
+	}
 	return filepath.Join(h, ".codex", "AGENTS.override.md"), nil
 }
 
+func (t codexTarget) skillLink(skill Skill) (string, error) {
+	root, err := t.TargetPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, skill.Name), nil
+}
+
 func (t codexTarget) Install(skill Skill, canonicalCurrentDir string) (InstalledTarget, error) {
-	path, err := t.TargetPath()
+	root, err := t.TargetPath()
 	if err != nil {
 		return InstalledTarget{}, err
 	}
-	inst, err := installMarkerBlock(skill, canonicalCurrentDir, path)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return InstalledTarget{}, fmt.Errorf("create %s: %w", root, err)
+	}
+	link, err := t.skillLink(skill)
 	if err != nil {
 		return InstalledTarget{}, err
 	}
-	inst.TargetName = t.Name()
-	return inst, nil
+
+	// Replace whatever is there (stale symlink, copied directory, plain file)
+	// with a fresh link at the canonical current/ directory.
+	if info, err := os.Lstat(link); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || info.IsDir() || info.Mode().IsRegular() {
+			if err := os.RemoveAll(link); err != nil {
+				return InstalledTarget{}, fmt.Errorf("remove existing %s: %w", link, err)
+			}
+		}
+	}
+	if err := os.Symlink(canonicalCurrentDir, link); err != nil {
+		return InstalledTarget{}, fmt.Errorf("symlink %s -> %s: %w", link, canonicalCurrentDir, err)
+	}
+
+	// Codex has no ~/.claude/commands equivalent — skills are the whole
+	// integration surface, so there is nothing else to link.
+	if err := t.removeLegacyMarkerBlock(skill); err != nil {
+		return InstalledTarget{}, err
+	}
+
+	return InstalledTarget{
+		TargetName:  t.Name(),
+		Method:      t.Method(),
+		Path:        link,
+		Version:     skill.Version,
+		InstalledAt: time.Now().UTC(),
+	}, nil
 }
 
 func (t codexTarget) Uninstall() error {
-	path, err := t.TargetPath()
+	root, err := t.TargetPath()
 	if err != nil {
 		return err
 	}
 	for _, s := range Catalog {
-		if err := uninstallMarkerBlock(s, path); err != nil {
+		link := filepath.Join(root, s.Name)
+		if info, lstatErr := os.Lstat(link); lstatErr == nil {
+			if info.Mode()&os.ModeSymlink != 0 || info.IsDir() || info.Mode().IsRegular() {
+				if err := os.RemoveAll(link); err != nil {
+					return fmt.Errorf("remove %s: %w", link, err)
+				}
+			}
+		}
+		if err := t.removeLegacyMarkerBlock(s); err != nil {
 			return err
 		}
 	}
@@ -55,13 +122,49 @@ func (t codexTarget) Uninstall() error {
 }
 
 func (t codexTarget) Status() (bool, string, error) {
-	path, err := t.TargetPath()
+	link, err := t.skillLink(Catalog[0])
 	if err != nil {
 		return false, "", err
 	}
-	v := readMarkerVersion(Catalog[0], path)
-	if v == "" {
+	info, err := os.Lstat(link)
+	if err != nil {
 		return false, "", nil
 	}
-	return true, v, nil
+	if info.Mode()&os.ModeSymlink == 0 {
+		return true, "manual", nil // a real dir/file lives there — not ours
+	}
+	dest, err := os.Readlink(link)
+	if err != nil {
+		return false, "", nil
+	}
+	// dest looks like .../.agentfield/skills/<name>/<version>
+	return true, filepath.Base(dest), nil
+}
+
+// removeLegacyMarkerBlock strips this skill's marker block from
+// ~/.codex/AGENTS.override.md, the rules file older af binaries wrote into.
+// The file is deleted when nothing but whitespace survives the strip, so a
+// file created solely for our block does not linger. Other tools' blocks and
+// any user prose are preserved.
+func (t codexTarget) removeLegacyMarkerBlock(skill Skill) error {
+	path, err := t.legacyRulesPath()
+	if err != nil {
+		return err
+	}
+	if err := uninstallMarkerBlock(skill, path); err != nil {
+		return fmt.Errorf("remove legacy Codex rules block from %s: %w", path, err)
+	}
+	// uninstallMarkerBlock drops a file left completely empty; a file left
+	// holding only whitespace was equally ours alone.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil // already gone, or not ours to interpret
+	}
+	if strings.TrimSpace(string(data)) != "" {
+		return nil
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove empty %s: %w", path, err)
+	}
+	return nil
 }

--- a/control-plane/internal/skillkit/target_codex_test.go
+++ b/control-plane/internal/skillkit/target_codex_test.go
@@ -1,0 +1,212 @@
+package skillkit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// codexHome prepares an isolated home with a ~/.codex directory, the shape a
+// machine with Codex installed has.
+func codexHome(t *testing.T) string {
+	t.Helper()
+	home := withTempHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatalf("mkdir .codex: %v", err)
+	}
+	return home
+}
+
+// Contract: Codex loads personal skills from ~/.codex/skills/<name>/SKILL.md.
+// Installing must put a symlink to the canonical store there — the old
+// marker block in ~/.codex/AGENTS.override.md went into a file Codex never
+// reads, so the skill was never actually installed.
+func TestCodexInstallLinksNativeSkillsDirectory(t *testing.T) {
+	home := codexHome(t)
+	current := filepath.Join(t.TempDir(), "current")
+	if err := os.MkdirAll(current, 0o755); err != nil {
+		t.Fatalf("mkdir current: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(current, "SKILL.md"), []byte("# skill\n"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+
+	inst, err := codexTarget{}.Install(Catalog[0], current)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	link := filepath.Join(home, ".codex", "skills", Catalog[0].Name)
+	if inst.Path != link || inst.Method != "symlink" {
+		t.Fatalf("install result = %+v, want symlink at %q", inst, link)
+	}
+	if dest, err := os.Readlink(link); err != nil || dest != current {
+		t.Fatalf("readlink = %q err=%v, want %q", dest, err, current)
+	}
+	// The skill's own SKILL.md must be reachable through the link — that is
+	// the whole contract with Codex.
+	if _, err := os.Stat(filepath.Join(link, "SKILL.md")); err != nil {
+		t.Fatalf("SKILL.md not reachable through the link: %v", err)
+	}
+	// Codex has no ~/.claude/commands analogue; nothing else may be created.
+	entries, err := os.ReadDir(filepath.Join(home, ".codex"))
+	if err != nil {
+		t.Fatalf("read .codex: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != "skills" {
+			t.Fatalf("install created unexpected entry in ~/.codex: %q", entry.Name())
+		}
+	}
+}
+
+// Contract: installing replaces whatever occupies the skill directory —
+// including a real directory a user (or an older tool) copied in.
+func TestCodexInstallReplacesExistingDirectoryAndStaleLink(t *testing.T) {
+	home := codexHome(t)
+	link := filepath.Join(home, ".codex", "skills", Catalog[0].Name)
+	if err := os.MkdirAll(link, 0o755); err != nil {
+		t.Fatalf("seed directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(link, "SKILL.md"), []byte("stale copy"), 0o644); err != nil {
+		t.Fatalf("seed stale copy: %v", err)
+	}
+
+	first := filepath.Join(t.TempDir(), "v1")
+	second := filepath.Join(t.TempDir(), "v2")
+	for _, dir := range []string{first, second} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	target := codexTarget{}
+	if _, err := target.Install(Catalog[0], first); err != nil {
+		t.Fatalf("Install over directory: %v", err)
+	}
+	if dest, err := os.Readlink(link); err != nil || dest != first {
+		t.Fatalf("readlink = %q err=%v, want %q", dest, err, first)
+	}
+	if _, err := target.Install(Catalog[0], second); err != nil {
+		t.Fatalf("Install over stale link: %v", err)
+	}
+	if dest, err := os.Readlink(link); err != nil || dest != second {
+		t.Fatalf("readlink = %q err=%v, want %q", dest, err, second)
+	}
+}
+
+// Contract: the migration off the old integration. Every install/update/
+// uninstall strips this skill's marker block from ~/.codex/AGENTS.override.md
+// while leaving the user's own prose and other tools' blocks alone.
+func TestCodexInstallStripsLegacyMarkerBlockAndKeepsForeignContent(t *testing.T) {
+	home := codexHome(t)
+	legacy := filepath.Join(home, ".codex", "AGENTS.override.md")
+	foreign := "<!-- plandb-skill:plandb v1 -->\nplandb rules\n<!-- /plandb-skill:plandb -->"
+	content := "# my own notes\n\n" +
+		renderPointerBlock(Catalog[0], "/gone/canonical/current") + "\n\n" + foreign + "\n"
+	if err := os.WriteFile(legacy, []byte(content), 0o644); err != nil {
+		t.Fatalf("seed legacy rules file: %v", err)
+	}
+
+	current := filepath.Join(t.TempDir(), "current")
+	if err := os.MkdirAll(current, 0o755); err != nil {
+		t.Fatalf("mkdir current: %v", err)
+	}
+	if _, err := (codexTarget{}).Install(Catalog[0], current); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	data, err := os.ReadFile(legacy)
+	if err != nil {
+		t.Fatalf("read legacy rules file: %v", err)
+	}
+	got := string(data)
+	if strings.Contains(got, markerStartPattern(Catalog[0])) {
+		t.Fatalf("legacy marker block survived the install:\n%s", got)
+	}
+	if !strings.Contains(got, "# my own notes") || !strings.Contains(got, foreign) {
+		t.Fatalf("migration destroyed content it does not own:\n%s", got)
+	}
+}
+
+// Contract: a rules file that held nothing but our block is deleted rather
+// than left behind as an empty (or whitespace-only) file Codex would keep
+// listing forever.
+func TestCodexInstallDeletesLegacyRulesFileItOwnedAlone(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+	}{
+		{name: "block only", content: renderPointerBlock(Catalog[0], "/gone/current") + "\n"},
+		{name: "block and whitespace", content: "\n  \n" + renderPointerBlock(Catalog[0], "/gone/current") + "\n \n\t\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := codexHome(t)
+			legacy := filepath.Join(home, ".codex", "AGENTS.override.md")
+			if err := os.WriteFile(legacy, []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("seed legacy rules file: %v", err)
+			}
+			current := filepath.Join(t.TempDir(), "current")
+			if err := os.MkdirAll(current, 0o755); err != nil {
+				t.Fatalf("mkdir current: %v", err)
+			}
+			if _, err := (codexTarget{}).Install(Catalog[0], current); err != nil {
+				t.Fatalf("Install: %v", err)
+			}
+			if _, err := os.Lstat(legacy); !os.IsNotExist(err) {
+				data, _ := os.ReadFile(legacy)
+				t.Fatalf("legacy rules file should be removed, lstat err=%v content=%q", err, data)
+			}
+		})
+	}
+}
+
+// Contract: uninstall removes every catalog skill's link and finishes the
+// legacy migration for machines that never ran an install in between.
+func TestCodexUninstallRemovesLinksAndLegacyBlocks(t *testing.T) {
+	home := codexHome(t)
+	legacy := filepath.Join(home, ".codex", "AGENTS.override.md")
+	var content strings.Builder
+	content.WriteString("user prose\n\n")
+	for _, s := range Catalog {
+		content.WriteString(renderPointerBlock(s, "/gone/current"))
+		content.WriteString("\n\n")
+	}
+	if err := os.WriteFile(legacy, []byte(content.String()), 0o644); err != nil {
+		t.Fatalf("seed legacy rules file: %v", err)
+	}
+
+	current := filepath.Join(t.TempDir(), "current")
+	if err := os.MkdirAll(current, 0o755); err != nil {
+		t.Fatalf("mkdir current: %v", err)
+	}
+	target := codexTarget{}
+	for _, s := range Catalog {
+		if _, err := target.Install(s, current); err != nil {
+			t.Fatalf("Install(%s): %v", s.Name, err)
+		}
+	}
+
+	if err := target.Uninstall(); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+	for _, s := range Catalog {
+		if _, err := os.Lstat(filepath.Join(home, ".codex", "skills", s.Name)); !os.IsNotExist(err) {
+			t.Fatalf("link for %s remains: %v", s.Name, err)
+		}
+	}
+	data, err := os.ReadFile(legacy)
+	if err != nil {
+		t.Fatalf("read legacy rules file: %v", err)
+	}
+	if strings.Contains(string(data), "agentfield-skill:") {
+		t.Fatalf("legacy blocks remain after uninstall:\n%s", data)
+	}
+	if !strings.Contains(string(data), "user prose") {
+		t.Fatalf("uninstall destroyed user content:\n%s", data)
+	}
+	// Uninstalling twice is a no-op, not an error.
+	if err := target.Uninstall(); err != nil {
+		t.Fatalf("second Uninstall: %v", err)
+	}
+}

--- a/control-plane/internal/skillkit/targets.go
+++ b/control-plane/internal/skillkit/targets.go
@@ -12,14 +12,14 @@ import (
 // Each target knows how to detect itself, install, uninstall, and report
 // its current installed version (if any).
 type Target interface {
-	Name() string                                                              // canonical short name, e.g. "claude-code"
-	DisplayName() string                                                       // pretty name for UI, e.g. "Claude Code"
-	Detected() bool                                                            // is this target installed on the user's machine?
-	Method() string                                                            // "symlink", "marker-block", "manual"
-	TargetPath() (string, error)                                               // canonical path the target writes to
-	Install(skill Skill, canonicalCurrentDir string) (InstalledTarget, error)  // performs the install (idempotent)
-	Uninstall() error                                                          // removes the integration
-	Status() (installed bool, version string, err error)                       // currently installed?
+	Name() string                                                             // canonical short name, e.g. "claude-code"
+	DisplayName() string                                                      // pretty name for UI, e.g. "Claude Code"
+	Detected() bool                                                           // is this target installed on the user's machine?
+	Method() string                                                           // "symlink", "marker-block", "manual"
+	TargetPath() (string, error)                                              // canonical path the target writes to
+	Install(skill Skill, canonicalCurrentDir string) (InstalledTarget, error) // performs the install (idempotent)
+	Uninstall() error                                                         // removes the integration
+	Status() (installed bool, version string, err error)                      // currently installed?
 }
 
 // AllTargets returns the registered list of targets in stable order. New

--- a/control-plane/internal/skillkit/testmain_test.go
+++ b/control-plane/internal/skillkit/testmain_test.go
@@ -1,0 +1,165 @@
+package skillkit
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// realHomeBeforeIsolation is the user's actual home directory, captured once
+// before TestMain redirects every home lookup into a temp tree. Tests use it
+// only to assert that nothing was written there.
+var realHomeBeforeIsolation string
+
+// isolatedHome is the package-wide fake home every test inherits.
+var isolatedHome string
+
+// TestMain redirects the home directory for the whole package before any test
+// runs.
+//
+// The canonical store honors AGENTFIELD_HOME, so tests that set it were
+// isolated for state — but every target resolves its install path through
+// os.UserHomeDir(), which AGENTFIELD_HOME does not touch. Tests that installed
+// into real targets therefore wrote into the developer's actual home: a real
+// ~/.codex/AGENTS.override.md was found in the wild holding marker blocks
+// written by the reconcile suite, pointing at /var/folders temp paths that had
+// been deleted with the test run. Setting HOME (and USERPROFILE, which
+// os.UserHomeDir uses on Windows) here makes that structurally impossible —
+// individual tests can still narrow it further with t.Setenv, and the value is
+// restored to this temp tree after each one.
+func TestMain(m *testing.M) {
+	if home, err := os.UserHomeDir(); err == nil {
+		realHomeBeforeIsolation = home
+	}
+
+	dir, err := os.MkdirTemp("", "skillkit-home-")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "skillkit tests: create isolated home: %v\n", err)
+		os.Exit(1)
+	}
+	// Resolve symlinks (macOS hands out /var/... for /private/var/...) so the
+	// path a test compares against is the one the OS reports back.
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
+	isolatedHome = dir
+
+	for key, value := range map[string]string{
+		"HOME":            dir,
+		"USERPROFILE":     dir,
+		"AGENTFIELD_HOME": filepath.Join(dir, ".agentfield"),
+	} {
+		if err := os.Setenv(key, value); err != nil {
+			fmt.Fprintf(os.Stderr, "skillkit tests: set %s: %v\n", key, err)
+			os.Exit(1)
+		}
+	}
+
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
+
+// TestPackageHomeIsIsolated is the guard for the guard: if TestMain ever stops
+// redirecting the home directory, this fails before any test can write into
+// the developer's real one.
+func TestPackageHomeIsIsolated(t *testing.T) {
+	if isolatedHome == "" {
+		t.Fatal("TestMain did not create an isolated home")
+	}
+	if got := homeDir(); got != isolatedHome {
+		t.Fatalf("homeDir() = %q, want the isolated temp home %q", got, isolatedHome)
+	}
+	if realHomeBeforeIsolation != "" && homeDir() == realHomeBeforeIsolation {
+		t.Fatalf("homeDir() still resolves to the real home %q", realHomeBeforeIsolation)
+	}
+	root, err := CanonicalRoot()
+	if err != nil {
+		t.Fatalf("CanonicalRoot: %v", err)
+	}
+	if !pathWithin(isolatedHome, root) {
+		t.Fatalf("CanonicalRoot() = %q, want inside the isolated home %q", root, isolatedHome)
+	}
+}
+
+// TestInstallAllWritesNothingIntoTheRealHome is the regression test for the
+// pollution that motivated TestMain: a full catalog install into every
+// registered target must land entirely inside the fake home and leave the
+// user's real home byte-for-byte untouched.
+func TestInstallAllWritesNothingIntoTheRealHome(t *testing.T) {
+	if realHomeBeforeIsolation == "" {
+		t.Skip("real home directory could not be resolved")
+	}
+	t.Setenv("AGENTFIELD_SKIP_FURROW", "1")
+	home := withTempHome(t)
+
+	before := realHomeSnapshot(t)
+
+	reports, err := InstallAll(InstallOptions{AllRegistered: true, Force: true})
+	if err != nil {
+		t.Fatalf("InstallAll: %v", err)
+	}
+	if len(reports) != len(Catalog) {
+		t.Fatalf("got %d reports, want one per catalog skill (%d)", len(reports), len(Catalog))
+	}
+
+	root, err := CanonicalRoot()
+	if err != nil {
+		t.Fatalf("CanonicalRoot: %v", err)
+	}
+	installedSomewhere := false
+	for _, report := range reports {
+		if !pathWithin(root, report.CanonicalDir) {
+			t.Fatalf("canonical dir %q escaped the fake store %q", report.CanonicalDir, root)
+		}
+		for _, installed := range report.TargetsInstalled {
+			if installed.Path == "" || installed.Method == "manual" {
+				continue // cursor prints instructions; it writes nothing
+			}
+			installedSomewhere = true
+			if !pathWithin(home, installed.Path) && !pathWithin(root, installed.Path) {
+				t.Fatalf("target %q wrote to %q, outside the fake home %q",
+					installed.TargetName, installed.Path, home)
+			}
+			if pathWithin(realHomeBeforeIsolation, installed.Path) {
+				t.Fatalf("target %q wrote into the real home: %q", installed.TargetName, installed.Path)
+			}
+		}
+	}
+	if !installedSomewhere {
+		t.Fatal("no target reported an installed path; the assertion above proved nothing")
+	}
+
+	if after := realHomeSnapshot(t); after != before {
+		t.Fatalf("InstallAll changed the real home:\nbefore: %s\nafter:  %s", before, after)
+	}
+}
+
+// realHomeSnapshot fingerprints every path in the real home that a skill
+// install would touch, so the test can prove none of them moved.
+func realHomeSnapshot(t *testing.T) string {
+	t.Helper()
+	paths := []string{
+		filepath.Join(realHomeBeforeIsolation, ".agentfield", "skills"),
+		filepath.Join(realHomeBeforeIsolation, ".claude", "skills"),
+		filepath.Join(realHomeBeforeIsolation, ".claude", "commands"),
+		filepath.Join(realHomeBeforeIsolation, ".codex", "skills"),
+		filepath.Join(realHomeBeforeIsolation, ".codex", "AGENTS.override.md"),
+		filepath.Join(realHomeBeforeIsolation, ".gemini", "GEMINI.md"),
+		filepath.Join(realHomeBeforeIsolation, ".config", "opencode", "AGENTS.md"),
+		filepath.Join(realHomeBeforeIsolation, ".aider.conventions.md"),
+		filepath.Join(realHomeBeforeIsolation, ".aider.conf.yml"),
+		filepath.Join(realHomeBeforeIsolation, ".codeium", "windsurf", "memories", "global_rules.md"),
+	}
+	snapshot := ""
+	for _, path := range paths {
+		info, err := os.Lstat(path)
+		if err != nil {
+			snapshot += fmt.Sprintf("%s=absent\n", path)
+			continue
+		}
+		snapshot += fmt.Sprintf("%s=%d/%d/%s\n", path, info.Size(), info.Mode(), info.ModTime().UTC())
+	}
+	return snapshot
+}

--- a/desktop/src/main/agentfield.ts
+++ b/desktop/src/main/agentfield.ts
@@ -14,6 +14,7 @@ import type {
   ExecutionSummary,
   InstalledAgent,
   RegistryResult,
+  SkillSyncRecord,
   UsageGroup,
   UsageStats
 } from '../shared/types'
@@ -354,6 +355,12 @@ export interface SnapshotOptions {
   baseUrl?: string
   fetchImpl?: FetchLike
   cpClient?: CpClient
+  /**
+   * Last skill-sync result, passed through onto the snapshot. It is main-
+   * process state (main/skills.ts), not something this module can read, so the
+   * IPC handler supplies it; callers that don't care (autostart) leave it out.
+   */
+  skillSync?: SkillSyncRecord | null
 }
 
 /**
@@ -396,6 +403,7 @@ export async function getSnapshot(options: SnapshotOptions = {}): Promise<AgentF
     executions,
     metrics,
     usage,
+    skillSync: options.skillSync ?? null,
     fetchedAt: new Date().toISOString()
   }
 }

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -5,14 +5,13 @@ import { CATALOG } from '../shared/catalog'
 import { RAILWAY_TEMPLATE_URL } from '../shared/cloudLinks'
 import { DEEP_LINK_SCHEME, type View, deepLinkFromArgv, parseDeepLink } from '../shared/deeplink'
 import type { DesktopSettings } from '../shared/types'
-import { spawn } from 'node:child_process'
 import { getBaseUrl, getSnapshot, setActiveControlPlanePort } from './agentfield'
 import { type AgentAction, runAgentAction, startControlPlane, uninstallAgent } from './agents'
 import { runAutostart } from './autostart'
 import { testCloudConnection, applyConnectionProfile } from './cloud'
 import { isCloudActive } from './connection'
-import { getCliCommand, initializeCli, installBundledCli, refreshCliStatus } from './cli'
-import { childEnv, initUserPath } from './env'
+import { initializeCli, installBundledCli, refreshCliStatus } from './cli'
+import { initUserPath } from './env'
 import { installAgent, installFromSource, updateAgent } from './installer'
 import {
   getEnvReports,
@@ -22,6 +21,13 @@ import {
   setAgentSecret
 } from './secrets'
 import { loadSettings, mergeSettings, saveSettings } from './settings'
+import {
+  SkillSync,
+  defaultSkillSyncDeps,
+  shouldSyncOnCliUpdate,
+  shouldSyncOnLaunch,
+  shouldSyncOnSettingsChange
+} from './skills'
 import { pickFreePort } from './ports'
 import { setupTray } from './tray'
 import { syncTrayCompanion } from './tray-companion'
@@ -254,20 +260,34 @@ function syncTray(enabled: boolean): void {
     .catch((err) => console.error('tray companion failed:', err))
 }
 
-// Keep the AgentField skills present in detected coding agents (Claude Code,
-// Codex, Gemini, …). A no-name `af skill install` installs the CLI's ENTIRE
-// skill catalog (builder, personal-agent, consumer, and whatever ships next),
-// so new catalog skills reach existing installs without a desktop release —
-// hardcoding names here is how agentfield-personal was silently missed. One
-// process, so concurrent runs never race on skillkit's state file. Idempotent
-// — skillkit tracks versions in ~/.agentfield/skills/.state.json — and pure
-// best-effort: failures are ignored.
-function syncSkills(): void {
-  spawn(getCliCommand(), ['skill', 'install', '--non-interactive'], {
-    windowsHide: true,
-    stdio: 'ignore',
-    env: childEnv()
-  }).on('error', () => {})
+// Where per-run skill-sync lines land: ~/Library/Logs/AgentField/skill-sync.log
+// on macOS, the platform equivalent elsewhere. app.getPath('logs') is the
+// Electron-blessed spot; fall back under userData if the platform has no logs
+// path so a sync is never lost for want of a directory.
+function skillSyncLogFile(): string {
+  try {
+    return join(app.getPath('logs'), 'skill-sync.log')
+  } catch {
+    return join(app.getPath('userData'), 'logs', 'skill-sync.log')
+  }
+}
+
+/**
+ * Keeps the AgentField skill catalog installed in detected coding agents (see
+ * main/skills.ts) and remembers how the last run went. Built once app is
+ * ready — skillSyncLogFile() needs the app paths.
+ */
+let skillSync: SkillSync
+
+/**
+ * Fire-and-forget wrapper for the three triggers (launch, the settings toggle
+ * flipping on, a successful CLI update). SkillSync never rejects and
+ * serializes overlapping calls, so this is safe to call from anywhere.
+ */
+function syncSkills(reason: string): void {
+  void skillSync.sync().then((record) => {
+    console.log(`skill sync (${reason}): ${record.ok ? 'ok' : 'FAILED'} — ${record.message}`)
+  })
 }
 
 // Register (or clear) the OS login item. Dev builds skip it — registering
@@ -331,14 +351,18 @@ function main(): void {
     await initializeCli(bundledCliPath())
     // Skills and the furrow client belong to local coding agents even when
     // their control plane and workspaces are remote.
-    if (settings.installSkills) syncSkills()
+    skillSync = new SkillSync(defaultSkillSyncDeps(skillSyncLogFile()))
+    if (shouldSyncOnLaunch(settings)) syncSkills('launch')
 
     // macOS only: provision + install the af-tray menu-bar companion so a
     // desktop-app-only install gets the menu-bar icon. Runs after initializeCli
     // (it needs the managed bin dir to exist) and non-blocking, like syncSkills.
     syncTray(settings.trayCompanion)
 
-    ipcMain.handle('agentfield:snapshot', () => getSnapshot())
+    // The snapshot carries the last skill-sync result along with the control-
+    // plane view, so the renderer's existing 5s poll keeps the dashboard's
+    // skill state honest without a channel (or a loop) of its own.
+    ipcMain.handle('agentfield:snapshot', () => getSnapshot({ skillSync: skillSync.last() }))
     ipcMain.handle('agentfield:catalog', () => CATALOG)
     ipcMain.handle('agentfield:install', async (event, name: unknown) => {
       if (typeof name !== 'string') {
@@ -478,6 +502,9 @@ function main(): void {
     ipcMain.handle('agentfield:cli-update', async () => {
       const result = await installBundledCli(bundledCliPath())
       if (!result.ok) console.error(result.message)
+      // A newer af ships a newer skill catalog: re-sync so the skills the
+      // coding agents see match the CLI that just landed.
+      if (shouldSyncOnCliUpdate(result.ok, settings)) syncSkills('cli update')
       return refreshCliStatus(bundledCliPath())
     })
 
@@ -596,6 +623,10 @@ function main(): void {
       }
       // macOS: reflect a flipped tray toggle (install ↔ uninstall) right away.
       if (settings.trayCompanion !== prev.trayCompanion) syncTray(settings.trayCompanion)
+      // Skills toggled on: install them now instead of at the next launch.
+      // (Off is not a trigger — `af skill install` has no uninstall side, and
+      // the dashboard reports the setting itself as off.)
+      if (shouldSyncOnSettingsChange(prev, settings)) syncSkills('settings')
       await saveSettings(settingsFile(), settings)
       applyConnectionProfile(settings)
       return settings

--- a/desktop/src/main/skills.test.ts
+++ b/desktop/src/main/skills.test.ts
@@ -1,0 +1,348 @@
+import { EventEmitter } from 'node:events'
+import { spawn } from 'node:child_process'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DesktopSettings, SkillSyncRecord } from '../shared/types'
+import {
+  SKILL_SYNC_ARGS,
+  SkillSync,
+  buildSkillSyncRecord,
+  defaultSkillSyncDeps,
+  formatSkillSyncLogLine,
+  lastLine,
+  shouldSyncOnCliUpdate,
+  shouldSyncOnLaunch,
+  shouldSyncOnSettingsChange,
+  type SkillSyncDeps,
+  type SkillSyncOutcome
+} from './skills'
+
+// The default runner is the one seam DI can't cover — it IS the spawn. vi.mock
+// is hoisted above the imports, so `spawn` above is the mock.
+vi.mock('node:child_process', () => ({ spawn: vi.fn() }))
+
+// ---- test doubles ------------------------------------------------------------
+
+interface Harness {
+  deps: SkillSyncDeps
+  /** Every (command, args) pair the sync ran. */
+  runs: Array<{ command: string; args: readonly string[] }>
+  /** Every line appended to the log. */
+  logged: string[]
+}
+
+function harness(
+  outcomes: SkillSyncOutcome | SkillSyncOutcome[],
+  overrides: Partial<SkillSyncDeps> = {}
+): Harness {
+  const queue = Array.isArray(outcomes) ? [...outcomes] : [outcomes]
+  const runs: Harness['runs'] = []
+  const logged: string[] = []
+  let tick = 0
+  return {
+    runs,
+    logged,
+    deps: {
+      command: () => 'af',
+      run: async (command, args) => {
+        runs.push({ command, args })
+        return queue.length > 1 ? queue.shift()! : queue[0]
+      },
+      appendLog: async (line) => {
+        logged.push(line)
+      },
+      now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+      ...overrides
+    }
+  }
+}
+
+function ok(output = 'installed 3 skills'): SkillSyncOutcome {
+  return { code: 0, output, error: null }
+}
+
+// ---- pure helpers ------------------------------------------------------------
+
+describe('lastLine', () => {
+  it('takes the last non-empty line, trimmed', () => {
+    expect(lastLine('checking targets\n  installed 3 skills  \n\n')).toBe('installed 3 skills')
+  })
+
+  it('handles CRLF output and blank input', () => {
+    expect(lastLine('a\r\nb\r\n')).toBe('b')
+    expect(lastLine('   \n\n')).toBe('')
+  })
+
+  it('caps a runaway line with an ellipsis', () => {
+    expect(lastLine('x'.repeat(50), 10)).toBe(`${'x'.repeat(9)}…`)
+  })
+})
+
+describe('buildSkillSyncRecord', () => {
+  const at = '2026-01-01T00:00:00.000Z'
+
+  it('exit 0 is a successful sync summarized by the CLI last line', () => {
+    expect(buildSkillSyncRecord(at, ok('installed 3 skills for claude-code'))).toEqual({
+      at,
+      ok: true,
+      exitCode: 0,
+      message: 'installed 3 skills for claude-code'
+    })
+  })
+
+  it('exit 0 with no output still reads as up to date', () => {
+    expect(buildSkillSyncRecord(at, ok(''))).toEqual({
+      at,
+      ok: true,
+      exitCode: 0,
+      message: 'skills up to date'
+    })
+  })
+
+  it('a non-zero exit is a FAILED sync carrying the code and the CLI message', () => {
+    const record = buildSkillSyncRecord(at, {
+      code: 1,
+      output: 'installing…\nerror: codex target not writable',
+      error: null
+    })
+    expect(record.ok).toBe(false)
+    expect(record.exitCode).toBe(1)
+    expect(record.message).toBe('af skill install exited 1 — error: codex target not writable')
+  })
+
+  it('a spawn error is a failed sync with no exit code', () => {
+    const record = buildSkillSyncRecord(at, {
+      code: null,
+      output: '',
+      error: 'spawn af ENOENT'
+    })
+    expect(record).toEqual({
+      at,
+      ok: false,
+      exitCode: null,
+      message: 'could not run af skill install: spawn af ENOENT'
+    })
+  })
+})
+
+describe('formatSkillSyncLogLine', () => {
+  it('flattens the run onto one line with timestamp and exit code', () => {
+    const record: SkillSyncRecord = {
+      at: '2026-01-01T00:00:00.000Z',
+      ok: false,
+      exitCode: 1,
+      message: 'af skill install exited 1 — boom'
+    }
+    expect(formatSkillSyncLogLine(record, 'starting\n\nboom\n')).toBe(
+      '2026-01-01T00:00:00.000Z exit=1 ok=false starting | boom'
+    )
+  })
+
+  it('falls back to the summary when the run printed nothing', () => {
+    const record: SkillSyncRecord = {
+      at: '2026-01-01T00:00:00.000Z',
+      ok: false,
+      exitCode: null,
+      message: 'could not run af skill install: spawn af ENOENT'
+    }
+    expect(formatSkillSyncLogLine(record, '')).toBe(
+      '2026-01-01T00:00:00.000Z exit=none ok=false could not run af skill install: spawn af ENOENT'
+    )
+  })
+})
+
+// ---- SkillSync ---------------------------------------------------------------
+
+describe('SkillSync', () => {
+  it('reports no sync before the first run', () => {
+    expect(new SkillSync(harness(ok()).deps).last()).toBeNull()
+  })
+
+  it('runs the non-interactive catalog install and records the success', async () => {
+    const h = harness(ok('installed 3 skills'))
+    const sync = new SkillSync(h.deps)
+
+    const record = await sync.sync()
+
+    expect(h.runs).toEqual([{ command: 'af', args: SKILL_SYNC_ARGS }])
+    expect(record.ok).toBe(true)
+    expect(sync.last()).toEqual(record)
+    expect(h.logged).toEqual(['2026-01-01T00:00:00.000Z exit=0 ok=true installed 3 skills'])
+  })
+
+  it('records a non-zero exit as a failed sync instead of swallowing it', async () => {
+    const h = harness({ code: 2, output: 'error: no writable target', error: null })
+    const sync = new SkillSync(h.deps)
+
+    const record = await sync.sync()
+
+    expect(record.ok).toBe(false)
+    expect(record.exitCode).toBe(2)
+    expect(record.message).toContain('error: no writable target')
+    expect(sync.last()).toEqual(record)
+    expect(h.logged[0]).toContain('exit=2 ok=false')
+  })
+
+  it('records a spawn error as a failed sync and never throws', async () => {
+    const h = harness({ code: null, output: '', error: 'spawn af ENOENT' })
+    const sync = new SkillSync(h.deps)
+
+    const record = await sync.sync()
+
+    expect(record).toMatchObject({ ok: false, exitCode: null })
+    expect(record.message).toContain('spawn af ENOENT')
+  })
+
+  it('captures a rejecting runner rather than leaking the rejection', async () => {
+    const h = harness(ok(), {
+      run: async () => {
+        throw new Error('runner blew up')
+      }
+    })
+
+    const record = await new SkillSync(h.deps).sync()
+
+    expect(record.ok).toBe(false)
+    expect(record.message).toContain('runner blew up')
+  })
+
+  it('still records the sync when the log file cannot be written', async () => {
+    const h = harness(ok(), {
+      appendLog: async () => {
+        throw new Error('EACCES')
+      }
+    })
+    const sync = new SkillSync(h.deps)
+
+    await expect(sync.sync()).resolves.toMatchObject({ ok: true })
+    expect(sync.last()?.ok).toBe(true)
+  })
+
+  it('serializes concurrent triggers onto a single run', async () => {
+    let release: (() => void) | null = null
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const h = harness(ok(), {
+      run: async (command, args) => {
+        h.runs.push({ command, args })
+        await gate
+        return ok()
+      }
+    })
+    const sync = new SkillSync(h.deps)
+
+    const first = sync.sync()
+    const second = sync.sync()
+    expect(sync.isRunning()).toBe(true)
+    release!()
+    const [a, b] = await Promise.all([first, second])
+
+    expect(h.runs).toHaveLength(1)
+    expect(a).toBe(b)
+    expect(sync.isRunning()).toBe(false)
+  })
+
+  it('runs again once the previous sync finished', async () => {
+    const h = harness([ok('first'), ok('second')])
+    const sync = new SkillSync(h.deps)
+
+    await sync.sync()
+    const record = await sync.sync()
+
+    expect(h.runs).toHaveLength(2)
+    expect(record.message).toBe('second')
+    expect(sync.last()?.message).toBe('second')
+  })
+
+  it('resolves the af command per run, so CLI updates are picked up', async () => {
+    let command = 'af'
+    const h = harness(ok(), { command: () => command })
+    const sync = new SkillSync(h.deps)
+
+    await sync.sync()
+    command = '/Users/x/.agentfield/bin/af'
+    await sync.sync()
+
+    expect(h.runs.map((r) => r.command)).toEqual(['af', '/Users/x/.agentfield/bin/af'])
+  })
+})
+
+// ---- default runner (the real spawn seam) ------------------------------------
+
+/** Minimal ChildProcess stand-in: emits on stdout/stderr, then close/error. */
+function fakeChild(): EventEmitter & {
+  stdout: EventEmitter
+  stderr: EventEmitter
+  kill: () => void
+} {
+  const child = Object.assign(new EventEmitter(), {
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    kill: vi.fn()
+  })
+  return child
+}
+
+describe('defaultSkillSyncDeps().run', () => {
+  beforeEach(() => {
+    vi.mocked(spawn).mockReset()
+  })
+  afterEach(() => {
+    vi.mocked(spawn).mockReset()
+  })
+
+  it('pipes stdio and captures stdout, stderr and the exit code', async () => {
+    const child = fakeChild()
+    vi.mocked(spawn).mockReturnValue(child as never)
+
+    const pending = defaultSkillSyncDeps('/tmp/does-not-matter.log').run('af', SKILL_SYNC_ARGS)
+    child.stdout.emit('data', Buffer.from('installing\n'))
+    child.stderr.emit('data', Buffer.from('warn: codex not found\n'))
+    child.emit('close', 1)
+
+    await expect(pending).resolves.toEqual({
+      code: 1,
+      output: 'installing\nwarn: codex not found',
+      error: null
+    })
+    const [, args, options] = vi.mocked(spawn).mock.calls[0]
+    expect(args).toEqual([...SKILL_SYNC_ARGS])
+    expect(options).toMatchObject({ windowsHide: true, stdio: ['ignore', 'pipe', 'pipe'] })
+  })
+
+  it('turns a spawn error into an outcome instead of an unhandled event', async () => {
+    const child = fakeChild()
+    vi.mocked(spawn).mockReturnValue(child as never)
+
+    const pending = defaultSkillSyncDeps('/tmp/does-not-matter.log').run('af', SKILL_SYNC_ARGS)
+    child.emit('error', new Error('spawn af ENOENT'))
+
+    await expect(pending).resolves.toEqual({ code: null, output: '', error: 'spawn af ENOENT' })
+  })
+})
+
+// ---- trigger conditions ------------------------------------------------------
+
+function settings(installSkills: boolean): Pick<DesktopSettings, 'installSkills'> {
+  return { installSkills }
+}
+
+describe('sync triggers', () => {
+  it('launch syncs only when skills are enabled', () => {
+    expect(shouldSyncOnLaunch(settings(true))).toBe(true)
+    expect(shouldSyncOnLaunch(settings(false))).toBe(false)
+  })
+
+  it('a settings update syncs only on the off → on transition', () => {
+    expect(shouldSyncOnSettingsChange(settings(false), settings(true))).toBe(true)
+    expect(shouldSyncOnSettingsChange(settings(true), settings(true))).toBe(false)
+    expect(shouldSyncOnSettingsChange(settings(true), settings(false))).toBe(false)
+    expect(shouldSyncOnSettingsChange(settings(false), settings(false))).toBe(false)
+  })
+
+  it('a CLI update syncs only after a successful install with skills enabled', () => {
+    expect(shouldSyncOnCliUpdate(true, settings(true))).toBe(true)
+    expect(shouldSyncOnCliUpdate(false, settings(true))).toBe(false)
+    expect(shouldSyncOnCliUpdate(true, settings(false))).toBe(false)
+  })
+})

--- a/desktop/src/main/skills.ts
+++ b/desktop/src/main/skills.ts
@@ -1,0 +1,261 @@
+// Keep the AgentField skills present in detected coding agents (Claude Code,
+// Codex, Gemini, …) by running `af skill install --non-interactive`, and — the
+// point of this module — remember whether that actually worked.
+//
+// A no-name `af skill install` installs the CLI's ENTIRE skill catalog
+// (builder, personal-agent, consumer, and whatever ships next), so new catalog
+// skills reach existing installs without a desktop release — hardcoding names
+// here is how agentfield-personal was silently missed. It is idempotent
+// (skillkit tracks versions in ~/.agentfield/skills/.state.json), so re-running
+// it on settings changes and CLI updates is cheap.
+//
+// It used to be fire-and-forget with stdio:'ignore' and a swallowed 'error'
+// handler: a failed sync was indistinguishable from a successful one, and the
+// dashboard cheerfully claimed "Installed for coding agents" from a settings
+// boolean. Now the run is captured (stdout+stderr, exit code), summarized into
+// a SkillSyncRecord the renderer can render honestly, and appended to a log
+// file for the times the one-line summary is not enough. `af skill install`
+// exits non-zero when any skill/target fails, so a non-zero exit is a failed
+// sync, full stop.
+//
+// One sync at a time (skillkit's state file is not concurrency-safe), enforced
+// by an in-flight promise: overlapping triggers all await the same run.
+//
+// No electron imports — the log-file path is injected by index.ts — so this
+// stays unit-testable under plain vitest.
+
+import { spawn } from 'node:child_process'
+import { promises as fs } from 'node:fs'
+import { dirname } from 'node:path'
+import type { DesktopSettings, SkillSyncRecord } from '../shared/types'
+import { getCliCommand } from './cli'
+import { childEnv } from './env'
+
+/** The slice of settings the triggers below care about. */
+type SkillSettings = Pick<DesktopSettings, 'installSkills'>
+
+/** App launch: sync whenever the user wants skills kept installed. */
+export function shouldSyncOnLaunch(settings: SkillSettings): boolean {
+  return settings.installSkills
+}
+
+/**
+ * A settings update: only the off → on transition. Staying on needs no sync
+ * (launch already did one, and every other settings edit would re-trigger it);
+ * turning off is not a sync at all — `af skill install` has no uninstall side.
+ */
+export function shouldSyncOnSettingsChange(prev: SkillSettings, next: SkillSettings): boolean {
+  return next.installSkills && !prev.installSkills
+}
+
+/**
+ * A CLI update: only when the install succeeded and skills are wanted. A newer
+ * `af` carries a newer skill catalog, so the skills the coding agents see would
+ * otherwise stay a release behind until the next launch.
+ */
+export function shouldSyncOnCliUpdate(cliUpdateOk: boolean, settings: SkillSettings): boolean {
+  return cliUpdateOk && settings.installSkills
+}
+
+/** The one command this module runs. Exported so tests assert on it. */
+export const SKILL_SYNC_ARGS = ['skill', 'install', '--non-interactive'] as const
+
+/** A sync that hasn't finished by now is hung; kill it and record a failure. */
+const SKILL_SYNC_TIMEOUT_MS = 120_000
+
+/** Keep only the tail of a chatty run — the failure is always at the end. */
+const MAX_OUTPUT_CHARS = 64 * 1024
+
+/** How much of the output the one-line summary may carry. */
+const MAX_SUMMARY_CHARS = 240
+
+/** What one `af skill install` run produced. Never a thrown error. */
+export interface SkillSyncOutcome {
+  /** Exit code, or null when the process never ran (spawn error / timeout). */
+  code: number | null
+  /** stdout and stderr interleaved in arrival order. */
+  output: string
+  /** Spawn-level failure message (missing CLI, timeout), else null. */
+  error: string | null
+}
+
+/**
+ * Last non-empty line of the captured output, collapsed and capped. The CLI's
+ * final line is the verdict ("installed 3 skills", "failed for codex: …"), so
+ * it makes the most useful one-line summary.
+ */
+export function lastLine(output: string, max = MAX_SUMMARY_CHARS): string {
+  const lines = output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line !== '')
+  const line = lines.length > 0 ? lines[lines.length - 1] : ''
+  return line.length > max ? `${line.slice(0, max - 1)}…` : line
+}
+
+/**
+ * Turn a run into the record the renderer shows. ok is exit code 0 and nothing
+ * else: `af skill install` exits non-zero when any skill or target fails, and a
+ * spawn error (no usable `af`) is a failed sync, not a missing one.
+ */
+export function buildSkillSyncRecord(at: string, outcome: SkillSyncOutcome): SkillSyncRecord {
+  if (outcome.error !== null) {
+    return {
+      at,
+      ok: false,
+      exitCode: outcome.code,
+      message: `could not run af skill install: ${outcome.error}`
+    }
+  }
+  const tail = lastLine(outcome.output)
+  if (outcome.code === 0) {
+    return { at, ok: true, exitCode: 0, message: tail === '' ? 'skills up to date' : tail }
+  }
+  const suffix = tail === '' ? '' : ` — ${tail}`
+  return {
+    at,
+    ok: false,
+    exitCode: outcome.code,
+    message: `af skill install exited ${outcome.code ?? 'without a code'}${suffix}`
+  }
+}
+
+/**
+ * One log line per sync: timestamp, exit code, and the run's output flattened
+ * onto that line (newlines become " | " so a grep for a failing run returns
+ * the whole run).
+ */
+export function formatSkillSyncLogLine(record: SkillSyncRecord, output: string): string {
+  const flattened = output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line !== '')
+    .join(' | ')
+  const exit = record.exitCode === null ? 'none' : String(record.exitCode)
+  const body = flattened === '' ? record.message : flattened
+  return `${record.at} exit=${exit} ok=${record.ok} ${body}`
+}
+
+/** Everything a SkillSync needs from the outside world. */
+export interface SkillSyncDeps {
+  /** Spawnable af command — read late, so CLI resolution can finish first. */
+  command: () => string
+  /** Run the sync to completion, capturing output; must never reject. */
+  run: (command: string, args: readonly string[]) => Promise<SkillSyncOutcome>
+  /** Append one line to the skill-sync log. Best-effort; may reject. */
+  appendLog: (line: string) => Promise<void>
+  now: () => Date
+}
+
+/** Default runner: piped stdio, the app's resolved child env; never rejects. */
+function realRun(command: string, args: readonly string[]): Promise<SkillSyncOutcome> {
+  return new Promise((resolve) => {
+    let output = ''
+    let settled = false
+    const done = (code: number | null, error: string | null): void => {
+      if (settled) return
+      settled = true
+      resolve({ code, output: output.trim(), error })
+    }
+    const child = spawn(command, [...args], {
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: childEnv()
+    })
+    const timer = setTimeout(() => {
+      child.kill()
+      done(null, `timed out after ${SKILL_SYNC_TIMEOUT_MS}ms`)
+    }, SKILL_SYNC_TIMEOUT_MS)
+    const capture = (chunk: Buffer): void => {
+      output += chunk.toString('utf8')
+      if (output.length > MAX_OUTPUT_CHARS) output = output.slice(-MAX_OUTPUT_CHARS)
+    }
+    child.stdout?.on('data', capture)
+    child.stderr?.on('data', capture)
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      done(null, err.message)
+    })
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      done(code ?? null, null)
+    })
+  })
+}
+
+/** Append one line to `file`, creating its directory on first write. */
+export async function appendLogLine(file: string, line: string): Promise<void> {
+  await fs.mkdir(dirname(file), { recursive: true })
+  await fs.appendFile(file, `${line}\n`, 'utf8')
+}
+
+/**
+ * Production deps. `logFile` comes from index.ts (app.getPath('logs')), the
+ * only place that may touch electron.
+ */
+export function defaultSkillSyncDeps(logFile: string): SkillSyncDeps {
+  return {
+    command: () => getCliCommand(),
+    run: realRun,
+    appendLog: (line) => appendLogLine(logFile, line),
+    now: () => new Date()
+  }
+}
+
+/**
+ * Owns the skill-sync state for the app's lifetime: the last result (served to
+ * the renderer inside the snapshot) and the in-flight guard that keeps two
+ * triggers from racing on skillkit's state file.
+ */
+export class SkillSync {
+  private readonly deps: SkillSyncDeps
+  private lastRecord: SkillSyncRecord | null = null
+  private inFlight: Promise<SkillSyncRecord> | null = null
+
+  constructor(deps: SkillSyncDeps) {
+    this.deps = deps
+  }
+
+  /** The last sync's result, or null when none has finished this session. */
+  last(): SkillSyncRecord | null {
+    return this.lastRecord
+  }
+
+  /** True while a sync is running (a second sync() would join it). */
+  isRunning(): boolean {
+    return this.inFlight !== null
+  }
+
+  /**
+   * Run a sync, or join the one already running. Never rejects — every failure
+   * mode ends as a recorded, failed SkillSyncRecord.
+   */
+  sync(): Promise<SkillSyncRecord> {
+    if (this.inFlight) return this.inFlight
+    const started = this.execute()
+    this.inFlight = started
+    void started.finally(() => {
+      if (this.inFlight === started) this.inFlight = null
+    })
+    return started
+  }
+
+  private async execute(): Promise<SkillSyncRecord> {
+    let outcome: SkillSyncOutcome
+    try {
+      outcome = await this.deps.run(this.deps.command(), SKILL_SYNC_ARGS)
+    } catch (err) {
+      // A deps.run that rejects is a bug, not a CLI failure — record it anyway
+      // rather than letting it escape into an unhandled rejection.
+      outcome = { code: null, output: '', error: err instanceof Error ? err.message : String(err) }
+    }
+    const record = buildSkillSyncRecord(this.deps.now().toISOString(), outcome)
+    this.lastRecord = record
+    try {
+      await this.deps.appendLog(formatSkillSyncLogLine(record, outcome.output))
+    } catch {
+      // Logging is best-effort: an unwritable log must not fail the sync.
+    }
+    return record
+  }
+}

--- a/desktop/src/renderer/src/components/DashboardView.tsx
+++ b/desktop/src/renderer/src/components/DashboardView.tsx
@@ -4,6 +4,7 @@ import type {
   AgentEnvReport,
   AgentFieldSnapshot,
   ExecutionSummary,
+  SkillSyncRecord,
   UsageGroup
 } from '../../../shared/types'
 import type { View } from './Sidebar'
@@ -149,6 +150,33 @@ function formatHarnessSpend(entry: UsageGroup): string {
   return `${entry.key} ${formatTokens(entry.totalTokens)} tok`
 }
 
+/** What the Skills row says, from the setting AND the last sync's outcome. */
+export interface SkillRowState {
+  /** 'off' renders the enable-in-Settings link; the rest are plain values. */
+  tone: 'loading' | 'off' | 'pending' | 'ok' | 'failed'
+  label: string
+  /** Full failure text for the title attribute (the label is elided). */
+  detail?: string
+}
+
+/**
+ * The row used to claim "Installed for coding agents" from the settings
+ * boolean alone, which said nothing about whether `af skill install` had ever
+ * run, let alone succeeded. Report what actually happened: installed only
+ * after a sync that exited 0, a warning (with the CLI's message) after one
+ * that didn't, and a neutral pending state until a sync has finished.
+ */
+export function skillRowState(
+  installSkills: boolean | null,
+  sync: SkillSyncRecord | null | undefined
+): SkillRowState {
+  if (installSkills === null) return { tone: 'loading', label: '…' }
+  if (!installSkills) return { tone: 'off', label: 'Off — enable in Settings' }
+  if (!sync) return { tone: 'pending', label: 'Installing…' }
+  if (sync.ok) return { tone: 'ok', label: 'Installed for coding agents' }
+  return { tone: 'failed', label: `Install failed — ${sync.message}`, detail: sync.message }
+}
+
 function pickRecentRows(
   executions: AgentFieldSnapshot['executions']
 ): Array<{ run: ExecutionSummary; live: boolean }> {
@@ -231,6 +259,9 @@ export function DashboardView({ snapshot, onNavigate }: DashboardViewProps): Rea
       : null
 
   const recentRows = pickRecentRows(executions)
+  // Skills state rides the snapshot (main/skills.ts records every sync), so
+  // the existing poll refreshes it — no extra loop, no settings-only guess.
+  const skillRow = skillRowState(installSkills, snapshot?.skillSync)
 
   const attentionChips: Array<{ key: string; label: string; view: View }> = []
   if (cp && !cp.healthy) {
@@ -404,17 +435,22 @@ export function DashboardView({ snapshot, onNavigate }: DashboardViewProps): Rea
             </div>
             <div className="connect-row">
               <span className="connect-label">Skills</span>
-              {installSkills === false ? (
+              {skillRow.tone === 'off' ? (
                 <button
                   type="button"
                   className="link-button"
                   onClick={() => onNavigate('settings')}
                 >
-                  Off — enable in Settings
+                  {skillRow.label}
                 </button>
               ) : (
-                <span className="connect-value">
-                  {installSkills === null ? '…' : 'Installed for coding agents'}
+                <span
+                  className={
+                    skillRow.tone === 'failed' ? 'connect-value warn-text' : 'connect-value'
+                  }
+                  title={skillRow.detail}
+                >
+                  {skillRow.label}
                 </span>
               )}
             </div>

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -286,6 +286,22 @@ export interface AppUpdateStatus {
   error: string | null
 }
 
+/**
+ * Result of the last `af skill install --non-interactive` this app ran (see
+ * main/skills.ts). In-memory, per session: null means no sync has finished
+ * since launch, which the UI must show as pending rather than as installed.
+ */
+export interface SkillSyncRecord {
+  /** ISO timestamp of when the sync finished. */
+  at: string
+  /** The CLI exited 0 — every skill reached every detected coding agent. */
+  ok: boolean
+  /** Exit code, or null when the CLI never ran (spawn error / timeout). */
+  exitCode: number | null
+  /** One line: what the sync reported, or why it failed. */
+  message: string
+}
+
 /** Headline numbers from GET /api/ui/v1/dashboard/summary. */
 export interface DashboardMetrics {
   agentsRunning: number
@@ -333,6 +349,12 @@ export interface AgentFieldSnapshot {
    * response could not be parsed — UI hides Spend/Usage entirely.
    */
   usage: UsageStats | null
+  /**
+   * Last coding-agent skill sync, or null when none has finished this session.
+   * Main-process state, not control-plane data — it rides the snapshot so the
+   * existing poll delivers it without a second polling loop in the renderer.
+   */
+  skillSync: SkillSyncRecord | null
   /** ISO timestamp of when this snapshot was assembled. */
   fetchedAt: string
 }

--- a/scripts/sync-embedded-skills.sh
+++ b/scripts/sync-embedded-skills.sh
@@ -25,6 +25,7 @@ EMBED_DIR="${REPO_ROOT}/control-plane/internal/skillkit/skill_data"
 # Skills to mirror. Add new skills here when they're added to the catalog.
 SKILLS=(
   "agentfield"
+  "agentfield-personal"
   "agentfield-use"
 )
 

--- a/skills/agentfield-use/SKILL.md
+++ b/skills/agentfield-use/SKILL.md
@@ -27,13 +27,22 @@ Resolution order — stop at the first match:
 
 1. **Explicit wins.** The user named a server, or `AGENTFIELD_SERVER` is set in
    the environment → use that.
-2. **Read the desktop cloud config** (first file that exists):
+2. **Read the desktop cloud config.** Check every path that applies to this
+   machine — a file that exists but declares no enabled cloud does NOT end
+   the search:
    - macOS: `~/Library/Application Support/agentfield-desktop/settings.json`
    - Windows: `%APPDATA%/agentfield-desktop/settings.json`
    - Linux: `~/.config/agentfield-desktop/settings.json`
-   If `cloud.enabled` is `true` and `cloud.serverUrl` is non-empty, the cloud
-   is the target: strip any trailing slash from the URL and take `cloud.apiKey`
-   as the key. Health-check it (`GET <url>/health` with `X-API-Key`).
+   - WSL (detect: `grep -qi microsoft /proc/version`): the Linux path above
+     first, then the Windows side, where the desktop app usually lives:
+     `/mnt/c/Users/*/AppData/Roaming/agentfield-desktop/settings.json`.
+     A Linux-side file with no `cloud` key shadowing a Windows file that
+     holds the real cloud config is the common split-brain — the enabled
+     cloud wins, whichever side declares it.
+   The first file declaring `cloud.enabled: true` with a non-empty
+   `cloud.serverUrl` makes the cloud the target: strip any trailing slash
+   from the URL and take `cloud.apiKey` as the key. Health-check it
+   (`GET <url>/health` with `X-API-Key`).
    - Healthy → use the cloud for everything below.
    - Unreachable → **stop and tell the user their cloud control plane is
      configured but not responding.** Do NOT silently fall back to local:

--- a/skills/agentfield-use/SKILL.md
+++ b/skills/agentfield-use/SKILL.md
@@ -1,19 +1,53 @@
 ---
 name: agentfield-use
-version: 0.5.0
-description: "Discover and call agents already running on a local AgentField control plane. Use when the user asks to use, call, query, run, or delegate work to an installed AgentField agent (swe-planner, pr-af, sec-af, …), to list what agents or reasoners are available, or to check on an execution. Not for building new agents — that is the agentfield skill."
+version: 0.6.0
+description: "Discover and call agents already running on a local or cloud AgentField control plane. Use when the user asks to use, call, query, run, or delegate work to an installed AgentField agent (swe-planner, pr-af, sec-af, …), to list what agents or reasoners are available, or to check on an execution. Resolves the right control plane (desktop-configured cloud first), fetches the reasoner's exact contract before dispatching, and only calls entry-point reasoners. Not for building new agents — that is the agentfield skill."
 ---
 
 # Using AgentField agents
 
-A machine with AgentField has a **control plane** (default `http://localhost:8080`,
-override via `AGENTFIELD_SERVER`) and **agent nodes** installed under
-`~/.agentfield`. Each node exposes **reasoners** — typed functions you call over
-HTTP. You never talk to an agent's own port: every call goes through the control
-plane, which routes it, records the workflow, and returns the result.
+A machine with AgentField has one or more **control planes** — a local one
+(default `http://localhost:8080`) and possibly a **cloud deployment**
+configured in AgentField Desktop — plus **agent nodes** installed under
+`~/.agentfield`. Each node exposes **reasoners** — typed functions you call
+over HTTP. You never talk to an agent's own port: every call goes through the
+control plane, which routes it, records the workflow, and returns the result.
 
-In local mode there is no auth. If the server has an API key configured, send it
-as `X-API-Key: <key>` on every request.
+**Resolve which control plane you are targeting before anything else (§0).**
+The local and cloud fleets are disjoint: different agents, different versions,
+different filesystems, different run history. Nothing ever falls back from one
+to the other on its own.
+
+A local server in local mode has no auth. A cloud deployment (and any server
+with an API key configured) requires `X-API-Key: <key>` on every request.
+
+## 0. Resolve the server first (local vs cloud)
+
+Resolution order — stop at the first match:
+
+1. **Explicit wins.** The user named a server, or `AGENTFIELD_SERVER` is set in
+   the environment → use that.
+2. **Read the desktop cloud config** (first file that exists):
+   - macOS: `~/Library/Application Support/agentfield-desktop/settings.json`
+   - Windows: `%APPDATA%/agentfield-desktop/settings.json`
+   - Linux: `~/.config/agentfield-desktop/settings.json`
+   If `cloud.enabled` is `true` and `cloud.serverUrl` is non-empty, the cloud
+   is the target: strip any trailing slash from the URL and take `cloud.apiKey`
+   as the key. Health-check it (`GET <url>/health` with `X-API-Key`).
+   - Healthy → use the cloud for everything below.
+   - Unreachable → **stop and tell the user their cloud control plane is
+     configured but not responding.** Do NOT silently fall back to local:
+     work dispatched there lands on a different fleet with different
+     filesystems, which is worse than no dispatch.
+3. **Otherwise use local:** `http://localhost:8080`.
+
+Then pass the target **explicitly on every call**: `af --server <url> -k <key>`
+(every `af` command accepts `-s/--server` and `-k/--api-key`), or the URL plus
+`-H 'X-API-Key: <key>'` for curl. Do not export `AGENTFIELD_SERVER` yourself to
+switch targets — a global default leaks into other processes and outlives the
+task; explicit per-call flags are the contract. If you'd rather not pass `-k`
+each time, `af auth login --server <url>` stores a key per server in
+`~/.agentfield/credentials.json`.
 
 ## MCP (zero-setup)
 
@@ -25,6 +59,8 @@ Claude Code:
 
 ```bash
 claude mcp add --transport http agentfield http://localhost:8080/mcp
+# cloud target (§0):
+claude mcp add --transport http agentfield https://<cloud-host>/mcp --header "X-API-Key: <key>"
 ```
 
 Other MCP clients: point them at the same streamable-HTTP URL
@@ -43,8 +79,11 @@ than the five tools give you.
 
 ## The flow
 
+0. Resolve the server (§0) — desktop-configured cloud first, explicit
+   `--server`/URL on every call.
 1. Health-check the control plane.
-2. Discover what agents and reasoners exist.
+2. Discover what agents and reasoners exist, and fetch the target reasoner's
+   exact contract before the first call.
 3. Execute — async for anything nontrivial. Fire independent calls concurrently.
 4. Poll (or stream) until the execution finishes — and watch for wedged runs.
 
@@ -54,10 +93,12 @@ than the five tools give you.
 curl -s http://localhost:8080/health
 ```
 
-Healthy: `200` with `{"status":"healthy", ...}`. Connection refused means no
-control plane is running — the user can open the AgentField desktop app, or you
-can start one in the background (`af server` blocks, so background it and poll
-`/health` until healthy).
+Healthy: `200` with `{"status":"healthy", ...}`. Connection refused on the
+**local** target means no control plane is running — the user can open the
+AgentField desktop app, or you can start one in the background (`af server`
+blocks, so background it and poll `/health` until healthy). If the resolved
+target is the desktop-configured **cloud** and this check fails, stop and
+report it (§0) — do not retarget local.
 
 ## 2. Discover agents and reasoners
 
@@ -105,6 +146,38 @@ Each hit carries `reasoner_id`, `agent_id`, `invocation_target`, `tags`,
 `score`, and `agent_health` — everything you need to dispatch with no second
 lookup. Build the execute target straight from `invocation_target` (colon → dot)
 and only dispatch to hits whose `agent_health` is `"active"`.
+
+### Fetch the exact contract before you dispatch — never guess inputs
+
+Search and discovery tell you a reasoner exists; they do not license a call.
+Before the first call to any reasoner, read its contract:
+
+```bash
+af agent agent-summary --id <agent_id> -s <server>   # all of an agent's reasoners: descriptions + input/output schemas + health + 24h metrics
+# single reasoner via MCP: get_reasoner_schema
+# or the fleet at once: curl -s "<server>/api/v1/discovery/capabilities?include_input_schema=true"
+```
+
+Read BOTH the description and the input schema, and follow them literally:
+
+- A schema of `{"type":"object"}` with no properties is NOT "anything goes" —
+  it means the agent registered no schema and **the description text is the
+  entire contract**. Field names, required-ness, and types stated there are
+  binding (e.g. swe-pro's `code_task`: `goal` and an **absolute** `dir` are
+  required; model pools are comma-separated strings, not arrays).
+- Result semantics live in the description too. Some agents report a failed
+  job in the RESULT (`status: "fail"`) while the execution itself reads
+  `succeeded` — check the result's own status field, not just the execution's.
+
+### Entry points only — undescribed reasoners are internal
+
+Agents register their internal pipeline stages alongside their public flows,
+and discovery lists all of them. Dispatch ONLY to reasoners that carry the
+`entrypoint` tag or a description. A reasoner with no description (e.g.
+swe-planner's `run_*` stages) or tagged `internal` is plumbing invoked by an
+orchestrator — calling it directly fails or corrupts a run. `af ls -e` lists
+tagged entry points; when in doubt, pick the described reasoner whose
+description names your use case.
 
 ### No coverage: offer to build it
 
@@ -161,7 +234,10 @@ batch now and poll as a group — not one-at-a-time. What to know:
 - Concurrent calls to the **same reasoner** are safe when the agent is (e.g.
   pr-af isolates concurrent reviews per PR). If an agent's docs don't say it's
   parallel-safe, assume same-target calls may contend on shared state and
-  stagger them; different agents never contend.
+  stagger them; different agents never contend. Some agents serialize ALL
+  executions process-wide (swe-pro queues concurrent `code_task` calls behind
+  one lock) — the reasoner description says so when known; dispatching more
+  than one heavy call to such a node just builds a queue.
 - Each call fans out inside the agent (one review ≈ dozens of sub-executions,
   several LLM CLI processes). 3–4 heavy runs per node is a sensible ceiling
   unless the agent documents otherwise.
@@ -267,7 +343,10 @@ so change files between issues or on a fork rather than while the agent writes.
 
 `get_workspace_handle` re-fetches a handle mid-run:
 `POST /api/v1/execute/<agent>.get_workspace_handle` with `{"input":{"run_id":"..."}}`.
-`{"available": false}` means no mirror — carry on without it.
+`{"available": false}` means no mirror — carry on without it. Not every build
+ships this reasoner: check the agent's reasoner list (discovery or
+`agent-summary`) before calling it; if it's absent, the node predates the
+mirror feature and results simply never carry a handle.
 
 **Several at once:** `POST /api/v1/executions/batch-status` with
 `{"execution_ids": [...]}`. Terminal entries embed the FULL result payload —
@@ -309,7 +388,9 @@ resolve from the `X-Workflow-ID` / `X-Session-ID` / `X-Actor-ID` headers).
 
 | Symptom | Meaning | Fix |
 |---|---|---|
-| connection refused on :8080 | control plane not running | desktop app, or background `af server` and poll `/health` |
+| connection refused on :8080 | local control plane not running | desktop app, or background `af server` and poll `/health` |
+| desktop-configured cloud unreachable | cloud deployment down, or URL/key stale | stop and tell the user (§0) — never silently retarget local |
+| 401/403 from a cloud target | missing or wrong `X-API-Key` | key from desktop `settings.json` `cloud.apiKey`, or `af auth login --server <url>` |
 | agent `inactive` in discovery / missing | node installed but not running (or not installed) | `af list`, then `af run <name>` — or `af install <source>` |
 | `missing required environment variables: X` from `af run` | required key not configured | `af secrets set X` (value via stdin/arg; `--node <name>` for node-scoped) — or desktop app → Agents → Keys |
 | HTTP 502 with `error_message` | the agent itself errored | read `af logs <name>`, fix, retry |
@@ -318,9 +399,14 @@ resolve from the `X-Workflow-ID` / `X-Session-ID` / `X-Actor-ID` headers).
 
 ## Local ops cheat sheet (af CLI)
 
+All commands accept `-s/--server <url>` and `-k/--api-key <key>` — required on
+every invocation when the resolved target is the cloud (§0).
+
 ```bash
 af list                    # installed agents + status
 af ls [query]              # search reasoners across running agents (NOT the install registry)
+af ls -e                   # only entry-point reasoners — the callable surface
+af agent agent-summary --id <name>   # full contract: reasoners, schemas, health, 24h metrics
 af ps                      # in-flight runs across all agents (af ps --agent <name>)
 af run <name>              # start (detached); af stop <name>
 af logs <name>             # agent logs (-f follows; no per-run filter — grep by run_id)
@@ -338,6 +424,13 @@ is enabled), and verify offline with `af verify audit.json`.
 
 ## Hard rules
 
+- Resolve the server per §0 and pass it explicitly (`--server` / full URL) on
+  every call. A desktop-configured cloud beats the local default; an
+  unreachable configured cloud is a stop-and-report, never a silent fallback.
+- Fetch the reasoner's contract before the first call. A vacuous schema means
+  the description is the contract — follow it literally.
+- Dispatch only to `entrypoint`-tagged or described reasoners. Undescribed or
+  `internal`-tagged reasoners are pipeline stages — never call them directly.
 - Every call goes through the control plane — never POST to an agent's own port.
   The one exception is a `workspace_handle`: its `ssh://` endpoint is a furrow
   transport, not the agent's HTTP port, and the per-run token in the handle is


### PR DESCRIPTION
## Problem

A machine with both a local control plane and a Desktop-configured cloud deployment routed every CLI/skill call to local — the cloud config lives in Electron settings nothing else reads, and nothing ever falls back in either direction. Separately, coding agents dispatched to reasoners by guessing inputs (the best contract surface inlined 24h of full execution payloads), swe-planner's 25 undescribed internal stages were callable and got called, and skills were invisible to Codex: the codex target wrote a marker block into `~/.codex/AGENTS.override.md`, a file Codex doesn't read — while skillkit's own tests polluted that real file with temp-dir paths that the version-match skip then preserved forever.

## Changes

**agentfield-use v0.6.0** — resolves the server before anything else (explicit > Desktop cloud config > local; a configured-but-unreachable cloud is a stop-and-report, never a silent fallback; explicit `--server`/`-k` per call, no env exports); mandates fetching the reasoner contract before first dispatch (vacuous schema ⇒ the description is the contract); restricts dispatch to entrypoint-tagged/described reasoners; capability-gates the workspace-handle flow; documents process-wide serialization. Also adds `agentfield-personal` to the embed sync script (drift bug).

**skillkit** — Codex target now installs the native skills standard (`~/.codex/skills/<name>` symlink) and strips legacy marker blocks; installs self-heal (version match no longer skips a broken/stale/legacy-method artifact); package `TestMain` pins HOME so tests can never write into the real home again (regression test fingerprints the real home across a full `InstallAll`); `af skill install/update` exit non-zero on failure and continue past a failing skill.

**agentic API** — `agent-summary` excludes payloads, caps the query (metrics stay exact over the 24h window; serialized list capped at 20), and applies the description fallback; reasoner search returns descriptions (and indexes registered ones).

**desktop** — `SkillSync` module: captured output logged to `<logs>/skill-sync.log`, failure recorded as failure, re-sync on launch / `installSkills` enable / CLI update, dashboard renders from the recorded result instead of the settings boolean.

## Verification

`go build ./...`; `go test ./internal/skillkit/... ./internal/cli/... ./internal/handlers/agentic/...` green; desktop `tsc --noEmit` + 425 vitest tests green; `sync-embedded-skills.sh --check` green. The codex migration + self-heal path was reproduced end-to-end in a sandbox against a copy of a really-polluted machine state.

Companion PRs: swe-pro-go (contract validation + schemas + entrypoint tags) and SWE-AF (entrypoint/internal surface, Go + Python).

🤖 Generated with [Claude Code](https://claude.com/claude-code)