### PR TITLE
fix(ui): only prompt for the admin token when the server enforces one

### DIFF
--- a/control-plane/web/client/src/components/AdminTokenPrompt.tsx
+++ b/control-plane/web/client/src/components/AdminTokenPrompt.tsx
@@ -9,8 +9,10 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 
 /**
  * Inline prompt shown on admin pages for managing the admin token.
- * Always visible: shows a form when no token is set, or a compact
- * status bar with change/clear actions when a token is active.
+ * Shows a form when no token is set, or a compact status bar with
+ * change/clear actions when a token is active. Callers decide when to
+ * render it — only when the server actually enforces an admin token
+ * (or one is already stored and should be clearable).
  */
 export function AdminTokenPrompt({ onTokenSet }: { onTokenSet?: () => void }) {
   const { adminToken, setAdminToken } = useAuth();
@@ -42,7 +44,6 @@ export function AdminTokenPrompt({ onTokenSet }: { onTokenSet?: () => void }) {
           Admin token saved in this browser
           <HintIcon label="About the admin token">
             Matches server <code className="font-mono">admin_token</code> or env. Not Settings.
-            Unchanged repo default is often <code className="font-mono">admin-secret</code>.
           </HintIcon>
         </span>
         <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={() => setEditing(true)}>
@@ -67,7 +68,6 @@ export function AdminTokenPrompt({ onTokenSet }: { onTokenSet?: () => void }) {
             <HintIcon label="About the admin token">
               Must match server <code className="font-mono">admin_token</code> or{" "}
               <code className="font-mono">AGENTFIELD_AUTHORIZATION_ADMIN_TOKEN</code>. This browser only.
-              Default YAML is often <code className="font-mono">admin-secret</code>.
             </HintIcon>
           </span>
           <form onSubmit={handleSubmit} className="flex flex-1 flex-wrap items-center gap-2">

--- a/control-plane/web/client/src/components/AuthGuard.tsx
+++ b/control-plane/web/client/src/components/AuthGuard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import type { FormEvent } from "react";
-import { KeyRound, Loader2, ShieldCheck } from "lucide-react";
+import { KeyRound, Loader2 } from "lucide-react";
 import { useAuth } from "../contexts/AuthContext";
 import { setGlobalApiKey } from "../services/api";
 import { Button } from "@/components/ui/button";
@@ -11,9 +11,8 @@ import logoLight from "@/assets/logos/logo-short-light-v2.svg";
 import logoDark from "@/assets/logos/logo-short-dark-v2.svg";
 
 export function AuthGuard({ children }: { children: React.ReactNode }) {
-  const { apiKey, setApiKey, setAdminToken, isAuthenticated, authRequired } = useAuth();
+  const { apiKey, setApiKey, isAuthenticated, authRequired } = useAuth();
   const [inputKey, setInputKey] = useState("");
-  const [inputAdminToken, setInputAdminToken] = useState("");
   const [error, setError] = useState("");
   const [validating, setValidating] = useState(false);
 
@@ -34,9 +33,6 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
       if (response.ok) {
         setApiKey(inputKey);
         setGlobalApiKey(inputKey);
-        if (inputAdminToken.trim()) {
-          setAdminToken(inputAdminToken.trim());
-        }
       } else {
         setError("Invalid API key. Check the key and try again.");
       }
@@ -91,24 +87,6 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
                     className="pl-9"
                     disabled={validating}
                     autoFocus
-                  />
-                </div>
-              </div>
-
-              <div className="space-y-2">
-                <label htmlFor="admin-token" className="text-sm font-medium leading-none text-muted-foreground">
-                  Admin Token <span className="font-normal">(optional)</span>
-                </label>
-                <div className="relative">
-                  <ShieldCheck className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-                  <Input
-                    id="admin-token"
-                    type="password"
-                    value={inputAdminToken}
-                    onChange={(e) => setInputAdminToken(e.target.value)}
-                    placeholder="For permission management"
-                    className="pl-9"
-                    disabled={validating}
                   />
                 </div>
               </div>

--- a/control-plane/web/client/src/hooks/queries/useGovernance.ts
+++ b/control-plane/web/client/src/hooks/queries/useGovernance.ts
@@ -1,15 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
-import { areGovernanceAdminRoutesAvailable } from "@/lib/governanceProbe";
+import { probeGovernanceAdminAccess } from "@/lib/governanceProbe";
 import { listPolicies } from "@/services/accessPoliciesApi";
 import { listAllAgentsWithTags } from "@/services/tagApprovalApi";
 
 /** Shared TanStack Query prefix for access policy + agent tag admin data. */
 export const ACCESS_MANAGEMENT_QUERY_KEY = "access-management";
 
-export function useAccessAdminRoutesProbe(adminToken: string | null) {
+export function useAccessAdminRoutesProbe() {
   return useQuery({
-    queryKey: [ACCESS_MANAGEMENT_QUERY_KEY, "probe", adminToken ?? ""],
-    queryFn: areGovernanceAdminRoutesAvailable,
+    queryKey: [ACCESS_MANAGEMENT_QUERY_KEY, "probe"],
+    queryFn: probeGovernanceAdminAccess,
     staleTime: 60_000,
     retry: 1,
   });

--- a/control-plane/web/client/src/lib/governanceProbe.ts
+++ b/control-plane/web/client/src/lib/governanceProbe.ts
@@ -1,21 +1,44 @@
-import { getGlobalAdminToken, getGlobalApiKey } from "@/services/api";
+import { getGlobalApiKey } from "@/services/api";
 
 const API_BASE = "/api/v1";
 
-function buildHeaders(): HeadersInit {
+/**
+ * What the server's governance admin routes require from this browser.
+ *
+ * - "open": routes exist and no admin token is enforced (AdminTokenAuth is a
+ *   no-op server-side) — admin calls work with the API key alone.
+ * - "token-required": routes exist and a non-empty admin token is enforced.
+ * - "unavailable": authorization feature is disabled — routes not registered.
+ * - "unauthorized": the API key is missing/invalid; says nothing about the
+ *   admin token.
+ */
+export type GovernanceAdminAccess =
+  | "open"
+  | "token-required"
+  | "unavailable"
+  | "unauthorized";
+
+/**
+ * Probe `/api/v1/admin/policies` to learn what admin access requires.
+ *
+ * The request deliberately omits X-Admin-Token even when one is stored: the
+ * tokenless status is what discriminates. AdminTokenAuth wraps the whole
+ * admin group, so a 200 without a token proves no token is enforced for any
+ * admin route, while a 403 proves one is.
+ */
+export async function probeGovernanceAdminAccess(): Promise<GovernanceAdminAccess> {
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   const apiKey = getGlobalApiKey();
   if (apiKey) headers["X-Api-Key"] = apiKey;
-  const admin = getGlobalAdminToken();
-  if (admin) headers["X-Admin-Token"] = admin;
-  return headers;
-}
 
-/** True when `/api/v1/admin/policies` exists (authorization feature enabled on server). */
-export async function areGovernanceAdminRoutesAvailable(): Promise<boolean> {
   const res = await fetch(`${API_BASE}/admin/policies`, {
     method: "GET",
-    headers: buildHeaders(),
+    headers,
   });
-  return res.status !== 404;
+
+  if (res.status === 404) return "unavailable";
+  if (res.status === 401) return "unauthorized";
+  if (res.status === 403) return "token-required";
+  if (res.ok) return "open";
+  throw new Error(`Governance probe failed with status ${res.status}`);
 }

--- a/control-plane/web/client/src/pages/AccessManagementPage.tsx
+++ b/control-plane/web/client/src/pages/AccessManagementPage.tsx
@@ -41,12 +41,15 @@ function AccessManagementPageInner() {
   const queryClient = useQueryClient();
   const { adminToken } = useAuth();
 
-  const probeQuery = useAccessAdminRoutesProbe(adminToken);
-  const adminRoutesAvailable = probeQuery.data === true;
+  const probeQuery = useAccessAdminRoutesProbe();
+  const access = probeQuery.data;
+  const adminRoutesAvailable = access === "open" || access === "token-required";
+  const tokenRequired = access === "token-required";
+  // Admin calls can work right now: routes exist, and either no token is
+  // enforced or the browser has one stored to send.
+  const canAdmin = adminRoutesAvailable && (!tokenRequired || !!adminToken);
 
-  const policiesQuery = useAccessPolicies(
-    probeQuery.isSuccess && adminRoutesAvailable,
-  );
+  const policiesQuery = useAccessPolicies(probeQuery.isSuccess && canAdmin);
 
   const tagsQuery = useAgentTagSummaries();
 
@@ -60,8 +63,7 @@ function AccessManagementPageInner() {
   };
 
   const policiesLoading =
-    probeQuery.isLoading ||
-    (adminRoutesAvailable && policiesQuery.isLoading);
+    probeQuery.isLoading || (canAdmin && policiesQuery.isLoading);
 
   const showProbeSkeleton = probeQuery.isLoading;
 
@@ -73,9 +75,9 @@ function AccessManagementPageInner() {
           <div className="flex items-center gap-1">
             <h1 className="text-2xl font-semibold tracking-tight">Access management</h1>
             <HintIcon label="What this page does">
-              Tag rules for cross-agent calls and registration-tag approvals. When
-              the server expects it, use the browser admin token below—separate from
-              your normal API key.
+              Tag rules for cross-agent calls and registration-tag approvals. If
+              the server enforces an admin token, a prompt for it appears
+              below—separate from your normal API key.
             </HintIcon>
           </div>
           <p className="text-muted-foreground mt-1 text-sm">
@@ -117,6 +119,15 @@ function AccessManagementPageInner() {
               : "Try again after checking your API key and network."}
           </AlertDescription>
         </Alert>
+      ) : access === "unauthorized" ? (
+        <Alert variant="destructive">
+          <AlertTitle>Your API key was rejected</AlertTitle>
+          <AlertDescription>
+            The server requires a valid API key before authorization APIs can
+            be reached. Sign in again with a current key — the admin token is
+            not involved in this error.
+          </AlertDescription>
+        </Alert>
       ) : !adminRoutesAvailable ? (
         <Alert>
           <AlertTitle>Authorization APIs are not enabled on this server</AlertTitle>
@@ -151,22 +162,30 @@ function AccessManagementPageInner() {
         </Alert>
       ) : null}
 
-      <Card className="border-border/80">
-        <CardHeader className="pb-3">
-          <div className="flex items-center gap-1">
-            <CardTitle className="text-sm font-medium">Browser admin token</CardTitle>
-            <HintIcon label="About the admin token">
-              Same secret as server config (<code className="font-mono">admin_token</code> or{" "}
-              <code className="font-mono">AGENTFIELD_AUTHORIZATION_ADMIN_TOKEN</code>). Not in the DB
-              or Settings—only this browser. Sends <code className="font-mono">X-Admin-Token</code> when
-              set.
-            </HintIcon>
-          </div>
-        </CardHeader>
-        <CardContent className="pt-0">
-          <AdminTokenPrompt onTokenSet={() => invalidateAccessQueries()} />
-        </CardContent>
-      </Card>
+      {(tokenRequired || adminToken) && (
+        <Card className="border-border/80">
+          <CardHeader className="pb-3">
+            <div className="flex items-center gap-1">
+              <CardTitle className="text-sm font-medium">Browser admin token</CardTitle>
+              <HintIcon label="About the admin token">
+                Same secret as server config (<code className="font-mono">admin_token</code> or{" "}
+                <code className="font-mono">AGENTFIELD_AUTHORIZATION_ADMIN_TOKEN</code>). Not in the DB
+                or Settings—only this browser. Sends <code className="font-mono">X-Admin-Token</code> when
+                set.
+              </HintIcon>
+            </div>
+          </CardHeader>
+          <CardContent className="pt-0 space-y-2">
+            {access === "open" && adminToken && (
+              <p className="text-xs text-muted-foreground">
+                This server doesn&apos;t enforce an admin token — the saved token
+                isn&apos;t needed and can be cleared.
+              </p>
+            )}
+            <AdminTokenPrompt onTokenSet={() => invalidateAccessQueries()} />
+          </CardContent>
+        </Card>
+      )}
 
       <Tabs defaultValue="access-rules" className="flex flex-col gap-0">
         <TabsList variant="underline" className="w-full justify-start">
@@ -201,7 +220,7 @@ function AccessManagementPageInner() {
                 policies={policiesQuery.data ?? []}
                 loading={policiesLoading}
                 onRefresh={() => void policiesQuery.refetch()}
-                canMutate={adminRoutesAvailable}
+                canMutate={canAdmin}
                 fetchError={
                   policiesQuery.isError
                     ? policiesQuery.error instanceof Error
@@ -239,7 +258,7 @@ function AccessManagementPageInner() {
                       : new Error(String(tagsQuery.error))
                     : null
                 }
-                canMutate={adminRoutesAvailable}
+                canMutate={canAdmin}
                 onRefresh={() => invalidateAccessQueries()}
               />
             </CardContent>

--- a/control-plane/web/client/src/test/components/AuthGuard.test.tsx
+++ b/control-plane/web/client/src/test/components/AuthGuard.test.tsx
@@ -94,7 +94,7 @@ describe("AuthGuard", () => {
     expect(apiFns.setGlobalApiKey).toHaveBeenCalledWith("stored-key");
   });
 
-  it("submits credentials, persists the admin token, and shows validation state", async () => {
+  it("submits the API key and shows validation state", async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
     } as Response);
@@ -105,8 +105,11 @@ describe("AuthGuard", () => {
       </AuthGuard>,
     );
 
+    // The login screen only asks for the API key; the admin token is prompted
+    // for on Access management, and only when the server enforces one.
+    expect(screen.queryByLabelText(/Admin Token/i)).not.toBeInTheDocument();
+
     fireEvent.change(screen.getByLabelText("API Key"), { target: { value: "hax_live_123" } });
-    fireEvent.change(screen.getByLabelText(/Admin Token/i), { target: { value: "  root-token  " } });
     fireEvent.click(screen.getByRole("button", { name: "Connect" }));
 
     expect(screen.getByRole("button", { name: /Validating/i })).toBeDisabled();
@@ -118,7 +121,6 @@ describe("AuthGuard", () => {
     });
 
     expect(authState.setApiKey).toHaveBeenCalledWith("hax_live_123");
-    expect(authState.setAdminToken).toHaveBeenCalledWith("root-token");
     expect(apiFns.setGlobalApiKey).toHaveBeenCalledWith("hax_live_123");
   });
 

--- a/control-plane/web/client/src/test/lib/libUtils.test.ts
+++ b/control-plane/web/client/src/test/lib/libUtils.test.ts
@@ -7,7 +7,7 @@ vi.mock("@/services/api", () => ({
 
 import { getGlobalAdminToken, getGlobalApiKey } from "@/services/api";
 import { countPendingAgentTags, getAgentTagRowStatus } from "@/lib/governanceUtils";
-import { areGovernanceAdminRoutesAvailable } from "@/lib/governanceProbe";
+import { probeGovernanceAdminAccess } from "@/lib/governanceProbe";
 import { queryClient } from "@/lib/query-client";
 import { getStatusBadgeClasses, getStatusTone, statusTone } from "@/lib/theme";
 import { getNextTimeRange, TIME_RANGE_OPTIONS } from "@/lib/timeRanges";
@@ -91,28 +91,40 @@ describe("lib helpers", () => {
     ).toBe(1);
   });
 
-  it("uses auth headers when probing governance admin routes", async () => {
+  it("probes governance admin routes with the API key but never the admin token", async () => {
     vi.mocked(getGlobalApiKey).mockReturnValue("api-key");
+    // Even with a token stored, the probe must omit it: the tokenless status
+    // is what discriminates "open" (200) from "token-required" (403).
     vi.mocked(getGlobalAdminToken).mockReturnValue("admin-token");
-    globalThis.fetch = vi.fn().mockResolvedValue({ status: 200 });
+    globalThis.fetch = vi.fn().mockResolvedValue({ status: 200, ok: true });
 
-    await expect(areGovernanceAdminRoutesAvailable()).resolves.toBe(true);
+    await expect(probeGovernanceAdminAccess()).resolves.toBe("open");
     expect(globalThis.fetch).toHaveBeenCalledWith("/api/v1/admin/policies", {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
         "X-Api-Key": "api-key",
-        "X-Admin-Token": "admin-token",
       },
     });
   });
 
-  it("treats a 404 governance probe as unavailable", async () => {
+  it("maps each governance probe status to an access state", async () => {
     vi.mocked(getGlobalApiKey).mockReturnValue(null);
     vi.mocked(getGlobalAdminToken).mockReturnValue(null);
-    globalThis.fetch = vi.fn().mockResolvedValue({ status: 404 });
 
-    await expect(areGovernanceAdminRoutesAvailable()).resolves.toBe(false);
+    globalThis.fetch = vi.fn().mockResolvedValue({ status: 403, ok: false });
+    await expect(probeGovernanceAdminAccess()).resolves.toBe("token-required");
+
+    globalThis.fetch = vi.fn().mockResolvedValue({ status: 404, ok: false });
+    await expect(probeGovernanceAdminAccess()).resolves.toBe("unavailable");
+
+    globalThis.fetch = vi.fn().mockResolvedValue({ status: 401, ok: false });
+    await expect(probeGovernanceAdminAccess()).resolves.toBe("unauthorized");
+
+    globalThis.fetch = vi.fn().mockResolvedValue({ status: 500, ok: false });
+    await expect(probeGovernanceAdminAccess()).rejects.toThrow(
+      "Governance probe failed with status 500",
+    );
   });
 
   it("configures the shared query client defaults", () => {

--- a/control-plane/web/client/src/test/pages/AccessManagementPage.test.tsx
+++ b/control-plane/web/client/src/test/pages/AccessManagementPage.test.tsx
@@ -8,7 +8,7 @@ const pageState = vi.hoisted(() => ({
   adminToken: "admin-token" as string | null,
   invalidateQueries: vi.fn(),
   probeQuery: {
-    data: true,
+    data: "token-required" as string | undefined,
     isLoading: false,
     isSuccess: true,
     isError: false,
@@ -208,7 +208,7 @@ describe("AccessManagementPage", () => {
     pageState.invalidateQueries.mockReset();
     pageState.policiesQuery.refetch.mockReset();
     pageState.probeQuery = {
-      data: true,
+      data: "token-required",
       isLoading: false,
       isSuccess: true,
       isError: false,
@@ -242,7 +242,7 @@ describe("AccessManagementPage", () => {
 
   it("shows the disabled-server guidance when admin routes are unavailable", () => {
     pageState.probeQuery = {
-      data: false,
+      data: "unavailable",
       isLoading: false,
       isSuccess: true,
       isError: false,
@@ -283,5 +283,49 @@ describe("AccessManagementPage", () => {
       queryKey: ["access-management"],
     });
     expect(pageState.policiesQuery.refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the admin token card when the server enforces no token", () => {
+    pageState.probeQuery.data = "open";
+    pageState.adminToken = null;
+
+    render(<AccessManagementPage />);
+
+    expect(screen.queryByRole("button", { name: "Save token" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Browser admin token")).not.toBeInTheDocument();
+    expect(screen.getByText("Rules can mutate: true")).toBeInTheDocument();
+  });
+
+  it("offers cleanup when a token is stored but the server enforces none", () => {
+    pageState.probeQuery.data = "open";
+    pageState.adminToken = "stale-token";
+
+    render(<AccessManagementPage />);
+
+    expect(screen.getByText(/doesn't enforce an admin token/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save token" })).toBeInTheDocument();
+  });
+
+  it("prompts for the admin token and gates mutations when the server enforces one", () => {
+    pageState.probeQuery.data = "token-required";
+    pageState.adminToken = null;
+
+    render(<AccessManagementPage />);
+
+    expect(screen.getByRole("button", { name: "Save token" })).toBeInTheDocument();
+    expect(screen.getByText("Rules can mutate: false")).toBeInTheDocument();
+  });
+
+  it("surfaces an API key problem instead of claiming routes are available", () => {
+    pageState.probeQuery.data = "unauthorized";
+    pageState.adminToken = null;
+
+    render(<AccessManagementPage />);
+
+    expect(screen.getByText("Your API key was rejected")).toBeInTheDocument();
+    expect(screen.getByText("Rules can mutate: false")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Authorization APIs are not enabled on this server"),
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Deployments that never set `AGENTFIELD_AUTHORIZATION_ADMIN_TOKEN` were still asked for an admin token by the UI — on the Access management page *and* on the login screen — even though the server never reads `X-Admin-Token` when no token is configured (`AdminTokenAuth` is a no-op for an empty token). Operators ended up pasting whatever they had (usually the API key) into a field that does nothing.

The client already had the discriminating signal and discarded it: the governance probe collapsed the status of `GET /api/v1/admin/policies` into `status !== 404`, which also misclassified 401 (API-key problem) as "admin routes available".

## Changes

- **Tri-state probe** (`governanceProbe.ts`): probe `GET /api/v1/admin/policies` with the API key but deliberately **without** `X-Admin-Token`. Because `AdminTokenAuth` wraps the whole admin group, the tokenless status is authoritative for every admin route:
  - `404` → authorization feature disabled → existing "not enabled" banner, no prompt
  - `403` → admin token enforced → the **only** state that shows the prompt; policy/tag queries and mutations are gated until a token is stored
  - `200` → no token enforced → prompt hidden, admin APIs just work; a leftover stored token gets a "not needed, can be cleared" hint
  - `401` → surfaced as an API-key error instead of "routes available"
- **Login screen**: the "Admin Token (optional)" field is removed. At sign-in the client can't know whether a token is enforced (an unauthenticated probe always 401s); Access management now asks in the one state where it's actually required.
- **Hint copy**: dropped "Unchanged repo default is often `admin-secret`" — that's only true for a source checkout run from `control-plane/` (or a deploy pointing `AGENTFIELD_CONFIG_FILE` at the bundled YAML) and misled operators of env-configured deployments.

## Validation contract → tests

| Behavior | Test |
| --- | --- |
| Probe never sends `X-Admin-Token`, even when one is stored | `libUtils.test.ts` "probes governance admin routes with the API key but never the admin token" |
| 200/403/404/401 map to open / token-required / unavailable / unauthorized; 5xx throws | `libUtils.test.ts` "maps each governance probe status to an access state" |
| No token enforced → no prompt, policies usable | `AccessManagementPage.test.tsx` "hides the admin token card when the server enforces no token" |
| Token enforced → prompt shown, mutations gated until stored | "prompts for the admin token and gates mutations…" |
| Stale stored token on an open server → clearable with a hint | "offers cleanup when a token is stored but the server enforces none" |
| 401 → API-key error, not "routes available" | "surfaces an API key problem instead of claiming routes are available" |
| Login screen asks only for the API key | `AuthGuard.test.tsx` "submits the API key and shows validation state" |

## Test plan

- [x] `npm ci && npm run build` (tsc + vite, the control-plane workflow's UI steps) — clean
- [x] `CI=1 npm run test:coverage` — 131 files, 687 tests passed
- [x] `npx eslint` on all changed files — clean (repo-wide `npm run lint` failures are pre-existing in untouched files)

Server behavior was verified against a locally built `agentfield-server`: with authorization enabled and no admin token, tokenless GET returns 200 and a POST carrying a wrong `X-Admin-Token` returns 201; with a token configured, tokenless/wrong-token requests return 403; with the feature disabled, 404 (or 401 when an API key is configured and missing/invalid) — the exact matrix the probe now consumes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)