### PR TITLE
fix(sdk): preserve multimodal args with user prompt

### DIFF
--- a/sdk/python/agentfield/agent_ai.py
+++ b/sdk/python/agentfield/agent_ai.py
@@ -655,13 +655,34 @@ class AgentAI:
             if system:
                 messages.append({"role": "system", "content": system})
 
-        # Handle flexible user input with intelligent processing
-        if user:
-            messages.append({"role": "user", "content": user})
-        elif args:
-            processed_content = self._process_multimodal_args(args)
-            if processed_content:
-                messages.extend(processed_content)
+        # Handle flexible user input with intelligent processing. When both
+        # input styles are used, keep the positional multimodal content and
+        # append the keyword prompt to the final user message.
+        processed_content = self._process_multimodal_args(args) if args else []
+        if user and processed_content:
+            user_message = next(
+                (
+                    message
+                    for message in reversed(processed_content)
+                    if message.get("role") == "user"
+                ),
+                None,
+            )
+            if user_message is not None:
+                content = user_message.get("content")
+                if isinstance(content, list):
+                    content.append({"type": "text", "text": user})
+                else:
+                    user_message["content"] = [
+                        {"type": "text", "text": content},
+                        {"type": "text", "text": user},
+                    ]
+            else:
+                processed_content.append({"role": "user", "content": user})
+        elif user:
+            processed_content.append({"role": "user", "content": user})
+
+        messages.extend(processed_content)
 
         litellm_module = litellm if hasattr(litellm, "acompletion") else None
 

--- a/sdk/python/tests/test_agent_ai_comprehensive.py
+++ b/sdk/python/tests/test_agent_ai_comprehensive.py
@@ -173,6 +173,39 @@ async def test_ai_multimodal_input_processing(monkeypatch, agent_with_ai):
 
 
 @pytest.mark.asyncio
+async def test_ai_merges_user_keyword_with_positional_multimodal_args(
+    monkeypatch, agent_with_ai
+):
+    """Keep positional media and text when a keyword user prompt is supplied."""
+    from agentfield.multimodal import Image, Text
+
+    litellm_module = setup_litellm_stub(monkeypatch)
+    litellm_module.acompletion.return_value = make_chat_response("image analyzed")
+
+    ai = AgentAI(agent_with_ai)
+    await ai.ai(
+        Image.from_url("https://example.com/image.jpg"),
+        Text(text="Positional context"),
+        user="Describe the image.",
+    )
+
+    messages = litellm_module.acompletion.call_args[1]["messages"]
+    user_messages = [message for message in messages if message["role"] == "user"]
+    assert len(user_messages) == 1
+    assert user_messages[0]["content"] == [
+        {
+            "type": "image_url",
+            "image_url": {
+                "url": "https://example.com/image.jpg",
+                "detail": "high",
+            },
+        },
+        {"type": "text", "text": "Positional context"},
+        {"type": "text", "text": "Describe the image."},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_ai_error_recovery_and_retry(monkeypatch, agent_with_ai):
     """Test error recovery and retry logic."""
     litellm_module = setup_litellm_stub(monkeypatch)


### PR DESCRIPTION
## Summary

Fixes #911 by preserving positional multimodal arguments when `user=` is also provided. Positional media/text is merged into the final user message, with the keyword prompt appended as a text content part.

## Tests

- `python -m pytest tests/test_agent_ai.py tests/test_agent_ai_comprehensive.py --no-cov -q` (30 passed)
- `python -m ruff check agentfield/agent_ai.py tests/test_agent_ai_comprehensive.py`
- `python -m ruff format --check agentfield/agent_ai.py tests/test_agent_ai_comprehensive.py`

The default SDK suite also ran; its 11 failures are unrelated Windows environment/encoding and shell-subprocess tests.