### PR TITLE
fix(sdk/python): exclude litellm 1.97.0 (crashes app.ai() on Python 3.10)

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "uvicorn",
     "requests>=2.28",
     "pydantic>=2.0",
-    "litellm",
+    "litellm!=1.97.0",  # 1.97.0 crashes on Python 3.10 building ModelResponse (BerriAI/litellm#36384)
     "psutil",
     "PyYAML>=6.0",
     "aiohttp>=3.8",


### PR DESCRIPTION
## Summary
`litellm==1.97.0` (published to PyPI 2026-08-16) crashes on **Python 3.10** while constructing `ModelResponse` (BerriAI/litellm#36384):

```
PydanticUserError: `Message` is not fully defined; you should define all referenced types, then call `Message.model_rebuild()`
```

The SDK declares a bare `litellm` dependency, so a fresh `pip install agentfield` on 3.10 (a version we support and test in CI) resolves to 1.97.0 and **every `app.ai()` call fails** before reaching any provider — the docs quickstart `summarize` reasoner and the `af init` scaffold's "Enable AI" path are both dead on a clean install. This is not new code in agentfield: it also affects 0.1.129 installed today. CI didn't catch it because `uv.lock` pins litellm 1.87.0 for tests.

## Changes Made
- `sdk/python/pyproject.toml`: `litellm` → `litellm!=1.97.0`. Excludes only the broken release, so pip resolves 1.96.2 today and any fixed 1.97.x+/1.98 later.

## Verification (live, pre-release regression sweep of v0.1.130-rc.5)
- Standalone repro, bare venv, py3.10: `litellm==1.97.0` → `ModelResponse()` raises; `litellm==1.96.2` → OK. Same 1.97.0 on py3.11 and py3.12 → OK (3.10-only).
- Fresh `pip install agentfield==0.1.130rc5` on py3.10 → docs `summarize` execution fails with the trace above; pinning litellm 1.96.2 in the same venv → `{"title":"AgentField Overview","key_points":[...]}` returned via OpenRouter.
- `pip install .` from this branch on py3.10 resolves litellm 1.96.2 and `ModelResponse()` constructs.
- `ruff check .` clean.

## Test Plan
- [x] Bare-venv repro on py3.10 / py3.11 / py3.12
- [x] Live `app.ai()` before/after on a fresh py3.10 install
- [ ] CI

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)