### PR TITLE
fix(install): make --no-aforge actually skip the aforge download

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -48,6 +48,9 @@ TRAY_MODE="${TRAY_MODE:-auto}"
 # spawn it for LLM work, so a machine with af but no aforge fails at the first
 # harness call. The download/verify/upgrade rules live in Go, so this installer
 # only decides WHETHER to ask for it. Opt out with --no-aforge or AFORGE_MODE=none.
+# Opting out also exports AGENTFIELD_SKIP_AFORGE=1 for every `af` call this
+# script makes: `af skill install` runs the same best-effort aforge hook, so
+# without the env gate the binary would be downloaded anyway.
 AFORGE_MODE="${AFORGE_MODE:-auto}"
 
 # Extra flags forwarded to `af-tray install` (see --defer-restart / --take-over).
@@ -817,6 +820,14 @@ print_success_message() {
 main() {
   # Parse command line arguments
   parse_args "$@"
+
+  # --no-aforge / AFORGE_MODE=none must hold for the whole install, not just
+  # the explicit `af aforge ensure` step: `af skill install` (and af-tray) run
+  # the same provisioning hook, and AGENTFIELD_SKIP_AFORGE=1 is the one switch
+  # the Go side honours (control-plane/internal/aforge).
+  if [[ "$AFORGE_MODE" == "none" ]]; then
+    export AGENTFIELD_SKIP_AFORGE=1
+  fi
 
   # Set install directory based on channel
   set_install_dir


### PR DESCRIPTION
## Summary
`scripts/install.sh --no-aforge` (and `AFORGE_MODE=none`) did not prevent the aforge download. The script only skipped its own explicit `af aforge ensure` step, but `af skill install --all` — which runs earlier in the same install — fires the same best-effort provisioning hook (`control-plane/internal/skillkit/install.go` → `aforge.EnsureBestEffort`), so opted-out users still got the ~35 MB binary in `~/.agentfield/bin`. Regressed with #924, which introduced both the hook and the flag.

## Changes Made
- `scripts/install.sh`: when `AFORGE_MODE=none`, `export AGENTFIELD_SKIP_AFORGE=1` right after arg parsing so every `af` / `af-tray` call the script makes honours the opt-out (that env var is the one switch the Go side checks). Comment updated on the mode block. `install.ps1` is unaffected (it does not run the skill install).

## Verification (live, isolated HOME, `VERSION=v0.1.130-rc.5`)
- Patched script `--no-tray --no-aforge` → exit 0, `af 0.1.130-rc.5` + skill catalog + furrow installed, **no** `~/.agentfield/bin/aforge`.
- Unpatched `origin/main` script, same flags → `~/.agentfield/bin/aforge` present despite the flag.
- `bash -n scripts/install.sh` clean.

## Test Plan
- [x] Patched vs unpatched side-by-side against the rc.5 release
- [ ] CI

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)