### PR TITLE
fix(harness): staging installs put aforge beside af; doctor exits 0 on a survey; doctor knows grok

### DIFF
--- a/control-plane/internal/cli/harness_doctor.go
+++ b/control-plane/internal/cli/harness_doctor.go
@@ -64,8 +64,10 @@ func newHarnessDoctorCommand() *cobra.Command {
 	var providers []string
 	var jsonOut bool
 	cmd := &cobra.Command{
-		Use:   "doctor",
-		Short: "Verify harness provider binaries, versions, and authentication",
+		Use:           "doctor",
+		Short:         "Verify harness provider binaries, versions, and authentication",
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reports, err := buildHarnessDoctorReports(providers)
 			if err != nil {
@@ -80,9 +82,13 @@ func newHarnessDoctorCommand() *cobra.Command {
 			} else {
 				printHarnessDoctorReports(cmd, reports)
 			}
-			for _, report := range reports {
-				if !report.Usable {
-					return fmt.Errorf("requested harness provider is unavailable: %s", report.Provider)
+			// A fresh machine legitimately has providers it has not installed, so a
+			// bare doctor is an informational survey; only requested providers fail.
+			if len(providers) > 0 {
+				for _, report := range reports {
+					if !report.Usable {
+						return cliExitError{Code: 1, Err: fmt.Errorf("requested harness provider is unavailable: %s", report.Provider)}
+					}
 				}
 			}
 			return nil

--- a/control-plane/internal/cli/harness_doctor.go
+++ b/control-plane/internal/cli/harness_doctor.go
@@ -46,6 +46,7 @@ var harnessProviderSpecs = []harnessProviderSpec{
 	{Name: "codex", Binary: "codex", InstallCommand: "npm install -g @openai/codex", AuthEnvVars: []string{"OPENAI_API_KEY"}},
 	{Name: "gemini", Binary: "gemini", InstallCommand: "npm install -g @google/gemini-cli", AuthEnvVars: []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"}},
 	{Name: "opencode", Binary: "opencode", InstallCommand: "curl -fsSL https://opencode.ai/install | bash", AuthEnvVars: []string{}},
+	{Name: "grok", Binary: "grok", InstallCommand: "Install the Grok Build CLI, then run: grok login", AuthEnvVars: []string{"XAI_API_KEY"}},
 }
 
 // NewHarnessCommand builds harness-related environment checks.
@@ -94,7 +95,7 @@ func newHarnessDoctorCommand() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringSliceVar(&providers, "provider", nil, "Provider(s) to check: aforge, claude-code, codex, gemini, opencode")
+	cmd.Flags().StringSliceVar(&providers, "provider", nil, "Provider(s) to check: aforge, claude-code, codex, gemini, opencode, grok")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output structured JSON")
 	return cmd
 }

--- a/control-plane/internal/cli/harness_doctor_test.go
+++ b/control-plane/internal/cli/harness_doctor_test.go
@@ -63,8 +63,40 @@ func TestHarnessDoctorJSONReportsRequestedProvider(t *testing.T) {
 	}}, reports)
 }
 
+func TestHarnessDoctorSurveyReturnsSuccessWhenProvidersAreMissing(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("AGENTFIELD_HOME", t.TempDir())
+
+	cmd := NewHarnessCommand()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"doctor"})
+
+	require.NoError(t, cmd.Execute())
+	require.Contains(t, stdout.String(), "aforge: unavailable")
+}
+
+func TestHarnessDoctorJSONSurveyReturnsSuccessWhenProvidersAreMissing(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("AGENTFIELD_HOME", t.TempDir())
+
+	cmd := NewHarnessCommand()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"doctor", "--json"})
+
+	require.NoError(t, cmd.Execute())
+	var reports []HarnessProviderHealth
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &reports))
+	require.NotEmpty(t, reports)
+	for _, report := range reports {
+		require.False(t, report.Usable)
+	}
+}
+
 func TestHarnessDoctorReturnsErrorForRequestedMissingProvider(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
+	t.Setenv("AGENTFIELD_HOME", t.TempDir())
 	cmd := NewHarnessCommand()
 	var stdout bytes.Buffer
 	cmd.SetOut(&stdout)
@@ -72,6 +104,8 @@ func TestHarnessDoctorReturnsErrorForRequestedMissingProvider(t *testing.T) {
 
 	err := cmd.Execute()
 	require.ErrorContains(t, err, "requested harness provider is unavailable")
+	require.True(t, IsCLIExitError(err))
+	require.Equal(t, 1, ExitCode(err))
 
 	var reports []HarnessProviderHealth
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &reports))

--- a/control-plane/internal/cli/harness_doctor_test.go
+++ b/control-plane/internal/cli/harness_doctor_test.go
@@ -242,6 +242,56 @@ func TestHarnessDoctorAforgeSpec(t *testing.T) {
 	require.Equal(t, []string{"OPENROUTER_API_KEY"}, reports[0].AuthEnvVars)
 }
 
+func TestHarnessDoctorGrokSpec(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("AGENTFIELD_HOME", t.TempDir())
+	reports, err := buildHarnessDoctorReports([]string{"grok"})
+	require.NoError(t, err)
+	require.Len(t, reports, 1)
+	require.Equal(t, "grok", reports[0].Provider)
+	require.Equal(t, "Install the Grok Build CLI, then run: grok login", reports[0].InstallCommand)
+	require.Equal(t, []string{"XAI_API_KEY"}, reports[0].AuthEnvVars)
+}
+
+func TestHarnessDoctorAcceptsGrokProvider(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("AGENTFIELD_HOME", t.TempDir())
+	cmd := NewHarnessCommand()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"doctor", "--provider", "grok", "--json"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "unknown harness provider")
+	require.Contains(t, err.Error(), "requested harness provider is unavailable: grok")
+}
+
+func TestHarnessDoctorGrokReportsUsable(t *testing.T) {
+	binDir := t.TempDir()
+	writeHarnessTestBinary(t, binDir, "grok", "grok 1.2.3")
+	t.Setenv("PATH", binDir)
+	t.Setenv("AGENTFIELD_HOME", t.TempDir())
+	t.Setenv("XAI_API_KEY", "configured")
+
+	reports, err := buildHarnessDoctorReports([]string{"grok"})
+	require.NoError(t, err)
+	require.Len(t, reports, 1)
+	require.True(t, reports[0].Usable)
+	require.Equal(t, "grok 1.2.3", reports[0].Version)
+	require.Equal(t, "configured", reports[0].Auth)
+}
+
+func TestHarnessProviderSpecsMatchPythonProviderNames(t *testing.T) {
+	// Keep in sync with sdk/python/agentfield/harness/_availability.py.
+	expected := []string{"aforge", "claude-code", "codex", "gemini", "opencode", "grok"}
+	actual := make([]string, 0, len(harnessProviderSpecs))
+	for _, spec := range harnessProviderSpecs {
+		actual = append(actual, spec.Name)
+	}
+	require.ElementsMatch(t, expected, actual)
+}
+
 // The pinned aforge release answers `version`, so aforge is held to the same
 // bar as every other provider: a binary that cannot name itself is unusable.
 func TestHarnessDoctorAforgeRequiresRealVersion(t *testing.T) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -321,7 +321,16 @@ function Install-Aforge {
         Write-Info "Installing the aforge coding harness..."
         # agentfield.exe, not the af.exe alias: Install-Binary creates the alias
         # best-effort and warns when both the hardlink and the copy fail.
-        & (Join-Path $InstallDir 'agentfield.exe') aforge ensure
+        # aforge installs into AGENTFIELD_HOME\bin, so pin its home to the
+        # install directory's parent to keep aforge beside agentfield.exe.
+        $previousAgentFieldHome = $env:AGENTFIELD_HOME
+        try {
+            $env:AGENTFIELD_HOME = Split-Path -Parent $InstallDir
+            & (Join-Path $InstallDir 'agentfield.exe') aforge ensure
+        }
+        finally {
+            $env:AGENTFIELD_HOME = $previousAgentFieldHome
+        }
         if ($LASTEXITCODE -eq 0) {
             Write-Success "aforge coding harness installed"
         }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -635,6 +635,11 @@ install_skill() {
 # mirroring how the skill install is delegated to `af skill install`.
 # Best-effort: aforge is optional, so a failure here must never fail an
 # install whose control plane is already working.
+# `af aforge ensure` installs into $AGENTFIELD_HOME/bin, defaulting to
+# ~/.agentfield/bin. Staging puts af in ~/.agentfield-staging/bin and only adds
+# that directory to PATH, so the default left aforge off PATH. Pinning the home
+# to INSTALL_DIR's parent keeps both binaries together; production remains
+# ~/.agentfield because ~/.agentfield/bin strips to ~/.agentfield.
 install_aforge() {
   local install_dir="$1"
   local af_bin="$install_dir/agentfield"
@@ -652,7 +657,7 @@ install_aforge() {
 
   printf "\n"
   print_info "Installing the aforge coding harness..."
-  if "$af_bin" aforge ensure; then
+  if AGENTFIELD_HOME="${install_dir%/bin}" "$af_bin" aforge ensure; then
     print_success "aforge coding harness installed"
   else
     print_warning "aforge install reported an issue; the control plane is unaffected"


### PR DESCRIPTION
## What / why

Three release-blocking findings from the v0.1.130-rc.5 sanity sweep.

**1. Staging installs put aforge off PATH** (high, staging channel only)

`scripts/install.sh` with `STAGING=1` installs af into `~/.agentfield-staging/bin`
and adds only that directory to PATH. But `install_aforge()` delegates to
`af aforge ensure`, which installs into `$AGENTFIELD_HOME/bin` — `~/.agentfield/bin`
by default. So a staging install downloaded aforge into a directory it never put on
PATH, and the SDK's "run `af aforge ensure`" remedy could not fix it either, because
the remedy resolves the same default home.

`install_aforge()` now pins `AGENTFIELD_HOME` to the parent of `INSTALL_DIR` for the
ensure call, so aforge always lands beside the af that installed it. Production is
unchanged: `~/.agentfield/bin` strips to `~/.agentfield`, which is what ensure already
defaulted to. `install.ps1` has the same split whenever `AGENTFIELD_INSTALL_DIR` is
set, so `Install-Aforge` pins and restores the variable the same way. `--no-aforge` /
`AFORGE_MODE=none` is untouched — ensure is still never invoked.

**2. `af harness doctor` exits 1 on a healthy machine** (medium)

Without `--provider` the command surveys the machine, but it still returned
`requested harness provider is unavailable: <first missing>`. A fresh install that
simply has not installed every coding harness exited 1, and the message was printed
three times — cobra's own copy, the `AgentHintJSON` `invalid_command` blob from
`main.go`, and the zerolog error line.

A bare doctor is informational, so the unusable gate now applies only when the caller
named providers explicitly. When it does fire it returns `cliExitError`, which makes
`main.go` print the plain message instead of the `invalid_command` blob (the command
was invoked correctly), and `SilenceErrors`/`SilenceUsage` on the subcommand drops
cobra's duplicate. `--provider unknown` is deliberately untouched: that really is a
mis-invocation, so the agent hint stays.

**3. The doctor did not know about grok** (low)

The Python SDK ships a grok entry in `PROVIDER_SPECS`
(`sdk/python/agentfield/harness/_availability.py`), so an agent can be asked to run
it, but the Go provider table omitted it and `--provider grok` was rejected as
unknown. Added the row plus a test that pins both lists to the same provider-name set.

## Validation contract

Installer:
1. Staging install → aforge lands in `~/.agentfield-staging/bin`, beside af, on the PATH the installer configured.
2. Production install → `AGENTFIELD_HOME=~/.agentfield`, i.e. byte-identical placement to today.
3. `--no-aforge` / `AFORGE_MODE=none` → `aforge ensure` is never invoked.
4. An af that cannot run `aforge ensure` still only warns; the installer exits 0.

Doctor:
5. No `--provider`, nothing installed → exit 0, table still reports the truth.
6. No `--provider`, `--json`, nothing installed → exit 0, JSON still reports `usable: false`.
7. `--provider <missing>` → exit 1, error satisfies `IsCLIExitError` with `ExitCode == 1`, message printed once.
8. `--provider <working>` → exit 0 (unchanged).
9. `--provider unknown` → still `unknown harness provider` (unchanged).
10. `--provider grok` is accepted, reported usable when a `grok` on PATH answers `--version`, and `XAI_API_KEY` marks auth configured.
11. The Go and Python provider-name sets stay identical.

## Verification

Installer, run for real from this branch against the live releases (temp `HOME`s):

- **Bug reproduced on `origin/main`'s script** — `HOME=<tmp> STAGING=1 SKILL_MODE=none bash install.sh`: `~/.agentfield-staging/bin` got `af-staging` + `agentfield` only, `aforge` landed in `~/.agentfield/bin`, and sourcing the profile the installer wrote gives `aforge NOT on PATH`.
- **Fixed on this branch** — same command: `~/.agentfield-staging/bin/{agentfield, af-staging, aforge}`, `~/.agentfield` never created, `aforge version` → `aforge v0.1.0`, and after `source ~/.bashrc` both `aforge` and `af-staging` resolve to the staging bin (contract 1).
- **Production mode** (no `STAGING`) installed v0.1.129, which predates the `aforge` subcommand: `Error: unknown command "aforge" for "af"` → `[WARNING] aforge install reported an issue; the control plane is unaffected` → installer ran to the success banner. That is the expected best-effort path, and it is the reason this run cannot itself place a binary (contract 4). Placement was proven separately by invoking the rc.5 binary with the exact expression the script now uses, `AGENTFIELD_HOME="${INSTALL_DIR%/bin}"` with `INSTALL_DIR=<tmp>/.agentfield/bin` → aforge at `<tmp>/.agentfield/bin/aforge` (contract 2).
- `bash -n scripts/install.sh` clean. `shellcheck` and `pwsh` are not available on this machine, so `install.ps1` was reviewed by hand rather than machine-parsed.

Doctor, on a binary built from this branch:

- Before: survey printed the table then `Error: …` + the `invalid_command` JSON blob + the zerolog line, `EXIT=1`.
- After: survey `EXIT=0`; `--provider aforge` with nothing installed prints the table plus one plain `requested harness provider is unavailable: aforge` line, `EXIT=1`.
- End to end against the staging install above: `aforge: ready (aforge v0.1.0)`, `grok: unavailable / install: Install the Grok Build CLI, then run: grok login`, `EXIT=0`.

Gates (the literal CI steps for the touched surfaces):

- `gofmt -l ./internal/cli` — clean.
- `go test ./internal/cli/... ./internal/aforge/... -count=1` — all packages ok.
- `golangci-lint run` — 97 pre-existing issues across the module, none introduced here. The one hit in a touched file (`harness_doctor.go` errcheck on `fmt.Fprintln`) is unchanged from `origin/main`, where it sits at line 275; my diff does not touch that line. This step is `continue-on-error: true` in `control-plane.yml`.

No SDK surface is touched, so the sdk-python / sdk-go / sdk-typescript gates do not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
