### PR TITLE
fix(harness): attribute default-provider runs to aforge, set HarnessResult.model, pass max_turns to aforge

### DIFF
--- a/sdk/go/harness/aforge.go
+++ b/sdk/go/harness/aforge.go
@@ -12,6 +12,8 @@ import (
 )
 
 const (
+	// DefaultAforgeModel comes from aforge's DefaultModel; keep it in step with aforge's built-in default.
+	DefaultAforgeModel         = "~deepseek/deepseek-v4-flash-latest"
 	defaultAforgeMaxConcurrent = 8
 	defaultAforgeTimeout       = 1800
 	aforgeLandingWindow        = 5
@@ -233,6 +235,7 @@ func (p *AforgeProvider) Execute(ctx context.Context, prompt string, options Opt
 	for key, value := range options.Env {
 		env[key] = value
 	}
+	effectiveModel := firstNonEmpty(model, env["AFORGE_MODEL"], DefaultAforgeModel)
 
 	started := time.Now()
 	cliResult, err := p.runCLI(ctx, cmd, env, "", outerTimeout, 0, input)
@@ -288,7 +291,7 @@ func (p *AforgeProvider) Execute(ctx context.Context, prompt string, options Opt
 		isError = cliResult.ReturnCode < 0 || resultText == "" ||
 			(cliResult.ReturnCode != 0 && cliResult.ReturnCode != 2 && cliResult.ReturnCode != 3)
 	}
-	metrics := Metrics{DurationAPIMS: apiMS}
+	metrics := Metrics{DurationAPIMS: apiMS, Model: effectiveModel}
 	if value, ok := aforgeNumber(usage["calls"]); ok {
 		metrics.NumTurns = int(value)
 	}

--- a/sdk/go/harness/aforge.go
+++ b/sdk/go/harness/aforge.go
@@ -203,8 +203,13 @@ func (p *AforgeProvider) Execute(ctx context.Context, prompt string, options Opt
 		cmd = []string{
 			p.BinPath, "exec", "--json", "-w", root,
 			"--timeout", strconv.Itoa(aforgeInnerTimeout(outerTimeout)),
-			"--context-fill", "60", "--completion-reserve", "65536",
 		}
+		// --turns exists only on exec, not do. Aforge's --budget is a token
+		// budget, not a USD cap, so MaxBudgetUSD has no honest mapping.
+		if options.MaxTurns > 0 {
+			cmd = append(cmd, "--turns", strconv.Itoa(options.MaxTurns))
+		}
+		cmd = append(cmd, "--context-fill", "60", "--completion-reserve", "65536")
 		if systemPrompt := strings.TrimSpace(options.SystemPrompt); systemPrompt != "" {
 			cmd = append(cmd, "--system", systemPrompt)
 		}

--- a/sdk/go/harness/aforge_test.go
+++ b/sdk/go/harness/aforge_test.go
@@ -89,6 +89,7 @@ func TestAforgeProviderMapsDoCommandEnvelopeAndMetrics(t *testing.T) {
 	assert.Equal(t, 100, raw.Metrics.InputTokens)
 	assert.Equal(t, 50, raw.Metrics.OutputTokens)
 	assert.Equal(t, 20, raw.Metrics.CacheReadTokens)
+	assert.Equal(t, "openrouter/z-ai/glm-5.2", raw.Metrics.Model)
 	require.NotNil(t, raw.Metrics.CostUSD)
 	assert.InDelta(t, 0.0123, *raw.Metrics.CostUSD, 1e-9)
 	require.Len(t, raw.Messages, 1)
@@ -129,6 +130,7 @@ func TestAforgeProviderMapsExecCommandEnvelopeAndMetrics(t *testing.T) {
 	assert.False(t, raw.IsError)
 	assert.Equal(t, 4, raw.Metrics.NumTurns)
 	assert.Equal(t, 100, raw.Metrics.InputTokens)
+	assert.Equal(t, "openrouter/deepseek/deepseek-v4-flash-0731", raw.Metrics.Model)
 	require.NotNil(t, raw.Metrics.CostUSD)
 	assert.InDelta(t, 0.0123, *raw.Metrics.CostUSD, 1e-9)
 }
@@ -184,6 +186,30 @@ func TestAforgeProviderModelVariantAndEnvironmentPrecedence(t *testing.T) {
 	assert.Equal(t, "override/model", captured[1]["AFORGE_MODEL"])
 	assert.Equal(t, "off", captured[1]["AFORGE_EXEC_REASONING"])
 	assert.Equal(t, "1", captured[1]["EXTRA"])
+}
+
+func TestAforgeProviderReportsEffectiveModel(t *testing.T) {
+	useAforgeDo(t)
+	tests := []struct {
+		name    string
+		options Options
+		want    string
+	}{
+		{name: "variant stripped", options: Options{Model: "some/model#high"}, want: "some/model"},
+		{name: "environment", options: Options{Env: map[string]string{"AFORGE_MODEL": "env/model"}}, want: "env/model"},
+		{name: "default", want: DefaultAforgeModel},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p := NewAforgeProvider("aforge")
+			p.runCLI = func(context.Context, []string, map[string]string, string, int, int, []byte) (*CLIResult, error) {
+				return &CLIResult{Stdout: aforgeEnvelope("done", true, "", "")}, nil
+			}
+			raw, err := p.Execute(context.Background(), "hello", test.options)
+			require.NoError(t, err)
+			assert.Equal(t, test.want, raw.Metrics.Model)
+		})
+	}
 }
 
 func TestAforgeProviderRootAndTimeoutResolution(t *testing.T) {
@@ -395,6 +421,7 @@ printf '%s\n' '{"settled":true,"deliverable":"done","blocked_on":"","spend_usd":
 		require.NoError(t, got.err)
 		require.NotNil(t, got.result)
 		assert.False(t, got.result.IsError, got.result.ErrorMessage)
+		assert.Equal(t, DefaultAforgeModel, got.result.Model)
 		seen[got.dest.Name] = got.dest.Count
 	}
 	assert.Equal(t, map[string]int{"first": 1, "second": 2}, seen)

--- a/sdk/go/harness/aforge_test.go
+++ b/sdk/go/harness/aforge_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -133,6 +134,45 @@ func TestAforgeProviderMapsExecCommandEnvelopeAndMetrics(t *testing.T) {
 	assert.Equal(t, "openrouter/deepseek/deepseek-v4-flash-0731", raw.Metrics.Model)
 	require.NotNil(t, raw.Metrics.CostUSD)
 	assert.InDelta(t, 0.0123, *raw.Metrics.CostUSD, 1e-9)
+}
+
+func TestAforgeProviderTurnCapArgv(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		options Options
+		want    []string
+	}{
+		{name: "positive exec", command: "exec", options: Options{MaxTurns: 2}, want: []string{"--timeout", "1795", "--turns", "2", "--context-fill"}},
+		{name: "unset exec", command: "exec"},
+		{name: "zero exec", command: "exec", options: Options{MaxTurns: 0}},
+		{name: "negative exec", command: "exec", options: Options{MaxTurns: -2}},
+		{name: "positive do", command: "do", options: Options{MaxTurns: 2}},
+		{name: "cost cap only", command: "exec", options: Options{MaxBudgetUSD: 1.5}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("AGENTFIELD_AFORGE_COMMAND", test.command)
+			var captured []string
+			p := NewAforgeProvider("aforge")
+			p.runCLI = func(_ context.Context, cmd []string, _ map[string]string, _ string, _, _ int, _ []byte) (*CLIResult, error) {
+				captured = append([]string(nil), cmd...)
+				if test.command == "exec" {
+					return &CLIResult{Stdout: aforgeExecEnvelope("done", "done", "", 1)}, nil
+				}
+				return &CLIResult{Stdout: aforgeEnvelope("done", true, "", "")}, nil
+			}
+
+			_, err := p.Execute(context.Background(), "hello", test.options)
+			require.NoError(t, err)
+			if test.want != nil {
+				assert.Contains(t, strings.Join(captured, " "), strings.Join(test.want, " "))
+			} else {
+				assert.NotContains(t, captured, "--turns")
+			}
+			assert.NotContains(t, captured, "--budget")
+		})
+	}
 }
 
 func TestAforgeProviderExecBudgetPartialIsUsable(t *testing.T) {

--- a/sdk/go/harness/result.go
+++ b/sdk/go/harness/result.go
@@ -21,6 +21,8 @@ type Metrics struct {
 	DurationAPIMS int
 	NumTurns      int
 	SessionID     string
+	// Model is the model the provider actually ran, when the provider reports one; empty when unknown.
+	Model string
 
 	// CostUSD is the cost in USD reported by the provider for this single
 	// execution, or nil when the provider does not report a cost. Mirrors the
@@ -65,6 +67,8 @@ type Result struct {
 	IsError      bool
 	ErrorMessage string
 	FailureType  FailureType
+	// Model is the model the provider actually ran, when the provider reports one; empty when unknown.
+	Model string
 
 	// CostUSD is the total cost in USD accumulated across every provider
 	// execution that contributed to this result (including failed retry

--- a/sdk/go/harness/runner.go
+++ b/sdk/go/harness/runner.go
@@ -163,6 +163,7 @@ func (r *Runner) Run(ctx context.Context, prompt string, schema map[string]any, 
 		IsError:      raw.IsError,
 		ErrorMessage: raw.ErrorMessage,
 		FailureType:  raw.FailureType,
+		Model:        raw.Metrics.Model,
 		CostUSD:      raw.Metrics.CostUSD,
 		NumTurns:     raw.Metrics.NumTurns,
 		DurationMS:   elapsed,
@@ -418,6 +419,7 @@ func (r *Runner) handleSchemaWithRetry(
 			NumTurns:   turns,
 			DurationMS: elapsed,
 			SessionID:  sid,
+			Model:      firstMetricsModel(allRaws),
 			Messages:   msgs,
 		}
 		tok.applyTo(res)
@@ -446,6 +448,7 @@ func (r *Runner) handleSchemaWithRetry(
 			NumTurns:     turns,
 			DurationMS:   elapsed,
 			SessionID:    sid,
+			Model:        firstMetricsModel(allRaws),
 			Messages:     msgs,
 		}
 		tok.applyTo(res)
@@ -472,6 +475,7 @@ func (r *Runner) handleSchemaWithRetry(
 					NumTurns:     turns,
 					DurationMS:   elapsed,
 					SessionID:    sid,
+					Model:        firstMetricsModel(allRaws),
 					Messages:     msgs,
 				}
 				tok.applyTo(res)
@@ -554,6 +558,7 @@ func (r *Runner) handleSchemaWithRetry(
 				NumTurns:   turns,
 				DurationMS: elapsed,
 				SessionID:  sid,
+				Model:      firstMetricsModel(allRaws),
 				Messages:   msgs,
 			}
 			tok.applyTo(res)
@@ -576,6 +581,7 @@ func (r *Runner) handleSchemaWithRetry(
 		NumTurns:    turns,
 		DurationMS:  elapsed,
 		SessionID:   sid,
+		Model:       firstMetricsModel(allRaws),
 		Messages:    msgs,
 	}
 	tok.applyTo(res)
@@ -608,6 +614,15 @@ func accumulateMetrics(raws []*RawResult) (totalCost *float64, totalTurns int, s
 		tokens.cacheCreationTokens += raw.Metrics.CacheCreationTokens
 	}
 	return
+}
+
+func firstMetricsModel(raws []*RawResult) string {
+	for _, raw := range raws {
+		if raw.Metrics.Model != "" {
+			return raw.Metrics.Model
+		}
+	}
+	return ""
 }
 
 func fileExists(path string) bool {

--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -3806,6 +3806,7 @@ class Agent(FastAPI):
                 derive_provider,
                 get_current_cost_tracker,
             )
+            from agentfield.harness._defaults import resolve_harness_provider
 
             input_tokens = getattr(result, "input_tokens", 0) or 0
             output_tokens = getattr(result, "output_tokens", 0) or 0
@@ -3824,7 +3825,7 @@ class Agent(FastAPI):
             if tracker is None:
                 return
 
-            resolved_provider = (
+            resolved_provider = resolve_harness_provider(
                 str(provider) if provider else self._harness_provider_name()
             )
             harness_name = (

--- a/sdk/python/agentfield/harness/providers/aforge.py
+++ b/sdk/python/agentfield/harness/providers/aforge.py
@@ -20,6 +20,9 @@ from agentfield.harness._result import FailureType, Metrics, RawResult
 
 logger = logging.getLogger("agentfield.harness.aforge")
 
+# From aforge's DefaultModel; keep in step with aforge's built-in default.
+AFORGE_DEFAULT_MODEL = "~deepseek/deepseek-v4-flash-latest"
+
 _REASONING_VARIANTS = {"off", "low", "medium", "high"}
 
 
@@ -196,6 +199,8 @@ class AforgeProvider:
                 }
             )
 
+        effective_model = model_value or env.get("AFORGE_MODEL") or AFORGE_DEFAULT_MODEL
+
         start_api = time.monotonic()
 
         try:
@@ -310,7 +315,7 @@ class AforgeProvider:
                 output_tokens=int(output_tokens_value or 0),
                 cache_read_tokens=int(cached_tokens_value or 0),
                 cache_creation_tokens=0,
-                model=model_value,
+                model=effective_model,
             ),
             is_error=is_error,
             error_message=error_message,

--- a/sdk/python/agentfield/harness/providers/aforge.py
+++ b/sdk/python/agentfield/harness/providers/aforge.py
@@ -153,11 +153,19 @@ class AforgeProvider:
                 root,
                 "--timeout",
                 str(aforge_timeout),
-                "--context-fill",
-                "60",
-                "--completion-reserve",
-                "65536",
             ]
+            # --turns exists only on exec, not do. Aforge's --budget is a token
+            # budget, not a USD cap, so max_budget_usd has no honest mapping.
+            max_turns = options.get("max_turns")
+            if (
+                isinstance(max_turns, int)
+                and not isinstance(max_turns, bool)
+                and max_turns > 0
+            ):
+                cmd.extend(["--turns", str(max_turns)])
+            cmd.extend(
+                ["--context-fill", "60", "--completion-reserve", "65536"]
+            )
             system_prompt = options.get("system_prompt")
             if isinstance(system_prompt, str) and system_prompt.strip():
                 cmd.extend(["--system", system_prompt.strip()])

--- a/sdk/python/tests/test_harness_provider_aforge.py
+++ b/sdk/python/tests/test_harness_provider_aforge.py
@@ -195,6 +195,52 @@ async def test_aforge_exec_mode_maps_original_contract_and_pins_model(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("options", "expected_turns"),
+    [
+        ({"max_turns": 2}, "2"),
+        ({}, None),
+        ({"max_turns": 0}, None),
+        ({"max_turns": -2}, None),
+        ({"max_turns": True}, None),
+        ({"max_turns": "5"}, None),
+        ({"max_budget_usd": 1.5}, None),
+    ],
+)
+async def test_aforge_exec_turn_cap_argv(
+    monkeypatch: pytest.MonkeyPatch,
+    options: dict[str, object],
+    expected_turns: str | None,
+):
+    run_cli_mock = AsyncMock(return_value=(_exec_envelope(), "", 0))
+    monkeypatch.setenv("AGENTFIELD_AFORGE_COMMAND", "exec")
+    monkeypatch.setattr("agentfield.harness.providers.aforge.run_cli", run_cli_mock)
+
+    await AforgeProvider().execute("hello", options)
+
+    cmd = run_cli_mock.await_args.args[0]
+    if expected_turns is None:
+        assert "--turns" not in cmd
+    else:
+        timeout_index = cmd.index("--timeout")
+        assert cmd[timeout_index + 2 : timeout_index + 4] == [
+            "--turns",
+            expected_turns,
+        ]
+    assert "--budget" not in cmd
+
+
+@pytest.mark.asyncio
+async def test_aforge_do_does_not_pass_turn_cap(monkeypatch: pytest.MonkeyPatch):
+    run_cli_mock = AsyncMock(return_value=(_envelope(), "", 0))
+    monkeypatch.setattr("agentfield.harness.providers.aforge.run_cli", run_cli_mock)
+
+    await AforgeProvider().execute("hello", {"max_turns": 2})
+
+    assert "--turns" not in run_cli_mock.await_args.args[0]
+
+
+@pytest.mark.asyncio
 async def test_aforge_exec_mode_accepts_budget_partial(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/sdk/python/tests/test_harness_provider_aforge.py
+++ b/sdk/python/tests/test_harness_provider_aforge.py
@@ -8,7 +8,7 @@ import pytest
 
 from agentfield.exceptions import HarnessProviderUnavailable
 from agentfield.harness._result import FailureType
-from agentfield.harness.providers.aforge import AforgeProvider
+from agentfield.harness.providers.aforge import AFORGE_DEFAULT_MODEL, AforgeProvider
 
 
 @pytest.fixture(autouse=True)
@@ -102,6 +102,30 @@ async def test_aforge_success_maps_envelope_and_metrics(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("options", "expected"),
+    [
+        ({"model": "some/model#high"}, "some/model"),
+        ({"env": {"AFORGE_MODEL": "env/model"}}, "env/model"),
+        ({}, AFORGE_DEFAULT_MODEL),
+    ],
+)
+async def test_aforge_reports_effective_model(
+    monkeypatch: pytest.MonkeyPatch,
+    options: dict[str, object],
+    expected: str,
+):
+    monkeypatch.setattr(
+        "agentfield.harness.providers.aforge.run_cli",
+        AsyncMock(return_value=(_envelope(), "", 0)),
+    )
+
+    raw = await AforgeProvider().execute("hello", options)
+
+    assert raw.metrics.model == expected
+
+
+@pytest.mark.asyncio
 async def test_aforge_exec_mode_maps_original_contract_and_pins_model(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -167,6 +191,7 @@ async def test_aforge_exec_mode_maps_original_contract_and_pins_model(
     assert raw.metrics.num_turns == 4
     assert raw.metrics.input_tokens == 100
     assert raw.metrics.total_cost_usd == 0.0123
+    assert raw.metrics.model == "openrouter/deepseek/deepseek-v4-flash-0731"
 
 
 @pytest.mark.asyncio

--- a/sdk/python/tests/test_usage_transport.py
+++ b/sdk/python/tests/test_usage_transport.py
@@ -539,6 +539,87 @@ class TestEnvelopeTransport:
         assert entry["cache_read_tokens"] == 500
         assert entry["cost_usd"] == 0.03
 
+    def test_record_harness_usage_defaults_to_aforge(self, monkeypatch):
+        from agentfield.harness._result import HarnessResult
+
+        monkeypatch.delenv("AGENTFIELD_HARNESS_PROVIDER", raising=False)
+        agent = self._agent()
+        tracker = CostTracker()
+        agent.cost_tracker = tracker
+
+        agent._record_harness_usage(
+            HarnessResult(result="done", input_tokens=1), provider=None
+        )
+
+        entry = tracker.serialize()["entries"][0]
+        assert entry["harness"] == "aforge"
+        assert entry["model"] == "aforge"
+
+    def test_record_harness_usage_explicit_provider_wins(self, monkeypatch):
+        from agentfield.harness._result import HarnessResult
+
+        monkeypatch.setenv("AGENTFIELD_HARNESS_PROVIDER", "opencode")
+        agent = self._agent()
+        tracker = CostTracker()
+        agent.cost_tracker = tracker
+
+        agent._record_harness_usage(
+            HarnessResult(result="done", input_tokens=1),
+            provider="claude-code",
+        )
+
+        assert tracker.serialize()["entries"][0]["harness"] == "claude_code"
+
+    def test_record_harness_usage_honors_env_provider(self, monkeypatch):
+        from agentfield.harness._result import HarnessResult
+
+        monkeypatch.setenv("AGENTFIELD_HARNESS_PROVIDER", "opencode")
+        agent = self._agent()
+        tracker = CostTracker()
+        agent.cost_tracker = tracker
+
+        agent._record_harness_usage(
+            HarnessResult(result="done", input_tokens=1), provider=None
+        )
+
+        assert tracker.serialize()["entries"][0]["harness"] == "opencode"
+
+    def test_record_harness_usage_config_provider_wins(self, monkeypatch):
+        from agentfield.agent import Agent
+        from agentfield.harness._result import HarnessResult
+        from agentfield.types import HarnessConfig
+
+        monkeypatch.setenv("AGENTFIELD_HARNESS_PROVIDER", "opencode")
+        agent = Agent(
+            node_id="usage-test-agent",
+            harness_config=HarnessConfig(provider="codex"),
+        )
+        tracker = CostTracker()
+        agent.cost_tracker = tracker
+
+        agent._record_harness_usage(
+            HarnessResult(result="done", input_tokens=1), provider=None
+        )
+
+        assert tracker.serialize()["entries"][0]["harness"] == "codex"
+
+    def test_record_harness_usage_preserves_result_model(self, monkeypatch):
+        from agentfield.harness._result import HarnessResult
+
+        monkeypatch.setenv("AGENTFIELD_HARNESS_PROVIDER", "opencode")
+        agent = self._agent()
+        tracker = CostTracker()
+        agent.cost_tracker = tracker
+
+        agent._record_harness_usage(
+            HarnessResult(
+                result="done", input_tokens=1, model="some/model"
+            ),
+            provider=None,
+        )
+
+        assert tracker.serialize()["entries"][0]["model"] == "some/model"
+
     def test_record_harness_usage_noop_when_empty(self):
         from agentfield.harness._result import HarnessResult
 

--- a/sdk/typescript/src/harness/providers/aforge.ts
+++ b/sdk/typescript/src/harness/providers/aforge.ts
@@ -10,6 +10,9 @@ const LANDING_WINDOW_SECONDS = 5;
 const DEFAULT_MAX_CONCURRENT = 8;
 const ANSI_PATTERN = /\x1B\[[0-?]*[ -/]*[@-~]/g;
 
+// From aforge's DefaultModel; keep in step with aforge's built-in default.
+export const AFORGE_DEFAULT_MODEL = '~deepseek/deepseek-v4-flash-latest';
+
 class Semaphore {
   private active = 0;
   private readonly waiters: Array<() => void> = [];
@@ -208,6 +211,8 @@ export class AforgeProvider implements HarnessProvider {
     }
     Object.assign(env, stringOptions(options.env));
 
+    const effectiveModel = model || env.AFORGE_MODEL || AFORGE_DEFAULT_MODEL;
+
     const startApi = Date.now();
     try {
       const { stdout, stderr, exitCode } = await runCli(cmd, {
@@ -253,7 +258,7 @@ export class AforgeProvider implements HarnessProvider {
           cacheReadTokens,
           cacheCreationTokens: 0,
           totalTokens: inputTokens + outputTokens,
-          model,
+          model: effectiveModel,
         }),
         isError,
         errorMessage: isError ? crashMessage(exitCode, blockedOn || stop, resultText, stderr) : undefined,

--- a/sdk/typescript/src/harness/providers/aforge.ts
+++ b/sdk/typescript/src/harness/providers/aforge.ts
@@ -175,10 +175,6 @@ export class AforgeProvider implements HarnessProvider {
           root,
           '--timeout',
           String(innerTimeout(outerTimeout)),
-          '--context-fill',
-          '60',
-          '--completion-reserve',
-          '65536',
         ]
       : [
           this.bin,
@@ -190,6 +186,15 @@ export class AforgeProvider implements HarnessProvider {
           '--timeout',
           String(innerTimeout(outerTimeout)),
         ];
+    // --turns exists only on exec, not do. Aforge's --budget is a token budget,
+    // not a USD cap, so maxBudgetUsd has no honest mapping.
+    if (command === 'exec' && typeof options.maxTurns === 'number'
+      && Number.isFinite(options.maxTurns) && options.maxTurns > 0) {
+      cmd.push('--turns', String(Math.trunc(options.maxTurns)));
+    }
+    if (command === 'exec') {
+      cmd.push('--context-fill', '60', '--completion-reserve', '65536');
+    }
     if (command === 'exec' && typeof systemPrompt === 'string' && systemPrompt.trim()) {
       cmd.push('--system', systemPrompt.trim());
     }

--- a/sdk/typescript/tests/harness_provider_aforge.test.ts
+++ b/sdk/typescript/tests/harness_provider_aforge.test.ts
@@ -156,6 +156,40 @@ describe('aforge provider', () => {
   });
 
   it.each([
+    [{ maxTurns: 2 }, '2'],
+    [{}, undefined],
+    [{ maxTurns: 0 }, undefined],
+    [{ maxTurns: -2 }, undefined],
+    [{ maxTurns: Number.NaN }, undefined],
+    [{ maxTurns: Number.POSITIVE_INFINITY }, undefined],
+    [{ maxBudgetUsd: 1.5 }, undefined],
+  ] as const)('maps exec turn options %o to %s', async (options, expectedTurns) => {
+    process.env.AGENTFIELD_AFORGE_COMMAND = 'exec';
+    vi.spyOn(cli, 'runCli').mockResolvedValue({
+      stdout: execEnvelope(), stderr: '', exitCode: 0,
+    });
+
+    await new AforgeProvider().execute('hello', options);
+
+    const cmd = vi.mocked(cli.runCli).mock.calls[0][0];
+    if (expectedTurns === undefined) {
+      expect(cmd).not.toContain('--turns');
+    } else {
+      const timeoutIndex = cmd.indexOf('--timeout');
+      expect(cmd.slice(timeoutIndex + 2, timeoutIndex + 4)).toEqual(['--turns', expectedTurns]);
+    }
+    expect(cmd).not.toContain('--budget');
+  });
+
+  it('does not pass a positive turn cap to do', async () => {
+    vi.spyOn(cli, 'runCli').mockResolvedValue({ stdout: envelope(), stderr: '', exitCode: 0 });
+
+    await new AforgeProvider().execute('hello', { maxTurns: 2 });
+
+    expect(vi.mocked(cli.runCli).mock.calls[0][0]).not.toContain('--turns');
+  });
+
+  it.each([
     { options: { model: 'some/model#high' }, expected: 'some/model' },
     { options: { env: { AFORGE_MODEL: 'env/model' } }, expected: 'env/model' },
     { options: {}, expected: AFORGE_DEFAULT_MODEL },

--- a/sdk/typescript/tests/harness_provider_aforge.test.ts
+++ b/sdk/typescript/tests/harness_provider_aforge.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { AforgeProvider } from '../src/harness/providers/aforge.js';
+import { AFORGE_DEFAULT_MODEL, AforgeProvider } from '../src/harness/providers/aforge.js';
 import { buildProvider, SUPPORTED_PROVIDERS } from '../src/harness/providers/factory.js';
 import * as cli from '../src/harness/cli.js';
 
@@ -152,6 +152,19 @@ describe('aforge provider', () => {
     expect(result.metrics.numTurns).toBe(4);
     expect(result.metrics.inputTokens).toBe(100);
     expect(result.metrics.totalCostUsd).toBe(0.0123);
+    expect(result.metrics.model).toBe('openrouter/deepseek/deepseek-v4-flash-0731');
+  });
+
+  it.each([
+    { options: { model: 'some/model#high' }, expected: 'some/model' },
+    { options: { env: { AFORGE_MODEL: 'env/model' } }, expected: 'env/model' },
+    { options: {}, expected: AFORGE_DEFAULT_MODEL },
+  ])('reports the effective model for options $options', async ({ options, expected }) => {
+    vi.spyOn(cli, 'runCli').mockResolvedValue({ stdout: envelope(), stderr: '', exitCode: 0 });
+
+    const result = await new AforgeProvider().execute('hello', options);
+
+    expect(result.metrics.model).toBe(expected);
   });
 
   it('accepts an exec budget partial with usable text', async () => {


### PR DESCRIPTION
Three release-blocking findings from the v0.1.130-rc.5 sanity sweep, all on the aforge default path. Now that `aforge` is the default harness provider, each of these bites the *ordinary* run, not a corner case.

## What / why

**1. Default-provider runs were recorded un-attributed (Python).**
`Agent._record_harness_usage` resolved the provider from `self.harness_config`, which is `None` unless the caller explicitly built a `HarnessConfig`. On the default path that produced cost entries with `harness=None`, `provider=None`, and `model="harness"` — aforge ran, but nothing in the usage record said so. It now resolves through `agentfield.harness._defaults.resolve_harness_provider`, the same precedence the runner already uses to pick a provider: explicit value > `AGENTFIELD_HARNESS_PROVIDER` > `"aforge"`. Explicit and configured providers keep winning; only the previously-empty case changes.

**2. `HarnessResult.model` was never set by the aforge providers.**
Python and TypeScript reported `metrics.model` only when the caller pinned a model, so the default path reported nothing; Go had no model field on `Metrics`/`Result` at all. All three now report the model that was actually requested, in precedence order: the resolved caller model → `AFORGE_MODEL` as it stands in the provider's final env overlay (caller-supplied `env` wins) → aforge's own built-in default, pinned as a named constant per SDK.

The default constant is `~deepseek/deepseek-v4-flash-latest`, confirmed two ways: `aforge exec --help` on the shipped v0.1.0 binary documents `AFORGE_MODEL default ~deepseek/deepseek-v4-flash-latest`, and aforge-v2's `internal/config/config.go` defines `DefaultModel` as that same string. Each SDK carries a comment saying the constant must be kept in step with aforge's default.

Go additionally gains `Metrics.Model` and `Result.Model`, mirroring the Python SDK's fields, with the same first-non-empty-wins aggregation across schema retries.

**3. `max_turns` was silently dropped.**
The aforge providers ignored the caller's turn cap, so a run asking for two turns got aforge's 200-turn runaway backstop. A positive cap now maps to `--turns N`, placed immediately after `--timeout`.

Two deliberate limits on that mapping:
- `--turns` is appended on the **`exec` argv only**. `aforge do`'s flag set is `-db -keep -w -timeout -json -yes-spend -model -plan-model -subharness -context-fill -completion-reserve` — no `-turns` — so adding it there would make aforge exit on a flag-parse error.
- `max_budget_usd` is **not** mapped onto `--budget`. aforge's `--budget` is a *token* budget (`-budget int  token budget for the agent`, default 150000), not a USD cap; mapping dollars onto tokens would silently mis-cap runs. A comment at each of the three call sites records this.

Note for reviewers: `HarnessConfig.max_turns` defaults to `30`, so agents that construct a `HarnessConfig` at all will now send `--turns 30` where they previously inherited aforge's 200. That is the intended reading of a configured cap, but it is a real behaviour change for those callers.

## Validation contract

Usage attribution (Python, `tests/test_usage_transport.py`):
- Agent with no `harness_config`, `provider=None` → entry has `harness == "aforge"` and `model == "aforge"` (not `None`, not `"harness"`).
- Explicit `provider="claude-code"` wins over env and default → `harness == "claude_code"`.
- `AGENTFIELD_HARNESS_PROVIDER=opencode` with no config and no explicit provider → `harness == "opencode"`.
- `HarnessConfig(provider="codex")` wins over the env var → `harness == "codex"`.
- A result that already reports a model keeps it → `model == "some/model"`.

Effective model (all three SDKs, in each aforge provider test file):
- Explicit model is reported as resolved → `openrouter/z-ai/glm-5.2`.
- A `#variant` suffix is stripped → `some/model#high` reports `some/model`.
- `AFORGE_MODEL` in the caller's env overlay beats the built-in default → `env/model`.
- Neither supplied → the `AFORGE_DEFAULT_MODEL` / `DefaultAforgeModel` constant, never empty.
- Holds on both the `exec` (default) and `AGENTFIELD_AFORGE_COMMAND=do` paths.
- Go: a `Result` built from a raw result carrying `Metrics.Model` exposes it on `Result.Model`.

Turn cap (all three SDKs):
- `exec` with a positive cap → argv contains `--turns` `"2"`, immediately after the `--timeout <seconds>` pair.
- `exec` with no cap → argv contains no `--turns` (the pre-existing full-argv equality assertions still hold verbatim).
- `exec` with a non-positive cap (0, negative) → no `--turns`.
- Python: a boolean or string `max_turns` → no `--turns`, no exception.
- `do` with a positive cap → no `--turns`.
- A cost cap alone → neither `--turns` nor `--budget`.

## Verification

Regression proof for finding 1: with the fix reverted and the new tests in place, `test_record_harness_usage_defaults_to_aforge` and `test_record_harness_usage_honors_env_provider` both fail (`assert None == 'opencode'`); with the fix they pass. The tests fail for the behavioural reason they exist.

Gates, run locally as the workflow files spell them out:
- **sdk-python** — `ruff check .` (ruff 0.15.22, the pinned version) clean; `./scripts/run_pytest.sh` → **1989 passed, 4 skipped**, coverage 94%.
- **sdk-go** — `go mod tidy` (no `go.mod`/`go.sum` drift), `go build ./...`, `go test -count=1 ./...` → all 8 packages ok. `gofmt -l` clean on every touched file.
- **sdk-typescript** — Node 20.20.2: `npm ci`, `npm run lint` (`tsc --noEmit`) clean, `npm test` → **82 files, 860 tests passed**.

Live end-to-end smoke against the real aforge v0.1.0 binary (downloaded from the published v0.1.0 release, `OPENROUTER_API_KEY` exported in-shell, `AFORGE_BIN` pointed at a wrapper that logs argv), running `HarnessRunner(HarnessConfig(max_turns=2)).run(...)` against schema `{answer: str}`:

```
SMOKE_MODEL= '~deepseek/deepseek-v4-flash-latest'
SMOKE_IS_ERROR= False
SMOKE_PARSED= {"answer": "pong"}
SMOKE_TURNS= 2
SMOKE_TOKENS= 7769 128
```

and the argv the SDK actually spawned:

```
exec --json -w <cwd> --timeout 295 --turns 2 --context-fill 60 --completion-reserve 65536
```

A real model call, a real schema parse, `result.model` populated where it was `None` before, and `--turns 2` in the argv in the specified position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
