### PR TITLE
fix(sdk/go): attribute default-provider harness runs to aforge, prefer result.Model

### DIFF
--- a/sdk/go/agent/cost_tracker_test.go
+++ b/sdk/go/agent/cost_tracker_test.go
@@ -301,6 +301,52 @@ func TestRecordHarnessUsage(t *testing.T) {
 		assert.Equal(t, "openrouter", entries[0]["provider"])
 	})
 
+	t.Run("provider defaults to aforge", func(t *testing.T) {
+		t.Setenv(harness.ProviderEnvVar, "")
+		a := newAgentForTest(t)
+		tracker := NewCostTracker()
+		ctx := contextWithCostTracker(context.Background(), tracker)
+
+		a.recordHarnessUsage(ctx, &harness.Result{InputTokens: 1}, harness.Options{})
+
+		entries := tracker.Serialize()["entries"].([]map[string]any)
+		require.Len(t, entries, 1)
+		assert.Equal(t, "aforge", entries[0]["harness"])
+		assert.Equal(t, "aforge", entries[0]["model"])
+	})
+
+	t.Run("provider falls back to environment", func(t *testing.T) {
+		t.Setenv(harness.ProviderEnvVar, "codex")
+		a := newAgentForTest(t)
+		tracker := NewCostTracker()
+		ctx := contextWithCostTracker(context.Background(), tracker)
+
+		a.recordHarnessUsage(ctx, &harness.Result{InputTokens: 1}, harness.Options{})
+
+		entries := tracker.Serialize()["entries"].([]map[string]any)
+		require.Len(t, entries, 1)
+		assert.Equal(t, "codex", entries[0]["harness"])
+		assert.Equal(t, "codex", entries[0]["model"])
+	})
+
+	t.Run("result model wins and has variant suffix stripped", func(t *testing.T) {
+		t.Setenv(harness.ProviderEnvVar, "")
+		a := newAgentForTest(t)
+		tracker := NewCostTracker()
+		ctx := contextWithCostTracker(context.Background(), tracker)
+
+		a.recordHarnessUsage(ctx, &harness.Result{
+			Model:       "~deepseek/deepseek-v4-flash-latest#high",
+			InputTokens: 1,
+		}, harness.Options{Model: "ignored/options-model"})
+
+		entries := tracker.Serialize()["entries"].([]map[string]any)
+		require.Len(t, entries, 1)
+		assert.Equal(t, "aforge", entries[0]["harness"])
+		assert.Equal(t, "~deepseek/deepseek-v4-flash-latest", entries[0]["model"])
+		assert.Equal(t, "~deepseek", entries[0]["provider"])
+	})
+
 	t.Run("model variant suffix is stripped for attribution", func(t *testing.T) {
 		a := newAgentForTest(t)
 		tracker := NewCostTracker()

--- a/sdk/go/agent/usage.go
+++ b/sdk/go/agent/usage.go
@@ -139,9 +139,13 @@ func (a *Agent) recordHarnessUsage(ctx context.Context, result *harness.Result, 
 	if provider == "" && a.cfg.HarnessConfig != nil {
 		provider = a.cfg.HarnessConfig.Provider
 	}
+	provider = harness.ResolveProviderName(provider)
 	harnessName := strings.ReplaceAll(provider, "-", "_")
 
-	model := opts.Model
+	model := result.Model
+	if model == "" {
+		model = opts.Model
+	}
 	if model == "" && a.cfg.HarnessConfig != nil {
 		model = a.cfg.HarnessConfig.Model
 	}


### PR DESCRIPTION
## Summary
Go SDK counterpart of #928. Since v0.1.130 the harness provider is optional (`AGENTFIELD_HARNESS_PROVIDER`, else `aforge`), but `recordHarnessUsage` still derived the usage `harness` column only from `opts.Provider` / `HarnessConfig.Provider`. A default-provider run was therefore recorded as `harness=""` and `model="harness"`.

## Changes
- `sdk/go/agent/usage.go`: resolve the effective provider through `harness.ResolveProviderName` (same precedence the runner uses: explicit → env → `aforge`); let the provider-reported `result.Model` win over `opts.Model` / `HarnessConfig.Model` before `#variant` stripping.
- `sdk/go/agent/cost_tracker_test.go`: three subtests — default → `harness=aforge`/`model=aforge`; env `AGENTFIELD_HARNESS_PROVIDER=codex` → `codex`; `result.Model` wins and the `#variant` suffix is stripped. Existing explicit-provider tests unchanged.

## Validation contract
- No provider anywhere, env unset → entry `harness == "aforge"`.
- Env `AGENTFIELD_HARNESS_PROVIDER=codex` → `harness == "codex"`.
- Explicit `opts.Provider` still wins over env/config (existing tests).
- Model precedence: `result.Model` → `opts.Model` → `HarnessConfig.Model` → resolved provider; default run with empty `result.Model` records `model == "aforge"`, never `"harness"`.

## Test plan
- [x] `gofmt -l` clean on touched files
- [x] `go vet ./agent/... ./harness/...`
- [x] `go test ./agent/... ./harness/...` (agent 30s, harness 6s — ok)
- [x] `go mod tidy` (no diff) + `go build ./...` (sdk-go.yml literal steps)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)