### PR TITLE
fix(sdk): send X-OpenRouter-Categories on OpenRouter requests

### DIFF
--- a/sdk/go/ai/client_test.go
+++ b/sdk/go/ai/client_test.go
@@ -296,6 +296,9 @@ func TestComplete_WithOptions(t *testing.T) {
 }
 
 func TestComplete_WithOpenRouterHeaders(t *testing.T) {
+	t.Setenv("AGENTFIELD_OPENROUTER_CATEGORIES", "")
+	t.Setenv("OR_CATEGORIES", "")
+
 	var receivedHeaders http.Header
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedHeaders = r.Header
@@ -347,9 +350,13 @@ func TestComplete_WithOpenRouterHeaders(t *testing.T) {
 	assert.Equal(t, "https://example.com", receivedHeaders.Get("HTTP-Referer"))
 	assert.Equal(t, "MyApp", receivedHeaders.Get("X-OpenRouter-Title"))
 	assert.Equal(t, "MyApp", receivedHeaders.Get("X-Title"))
+	assert.Equal(t, defaultOpenRouterCategories, receivedHeaders.Get("X-OpenRouter-Categories"))
 }
 
 func TestStreamComplete_WithOpenRouterHeaders(t *testing.T) {
+	t.Setenv("AGENTFIELD_OPENROUTER_CATEGORIES", "")
+	t.Setenv("OR_CATEGORIES", "")
+
 	var receivedHeaders http.Header
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedHeaders = r.Header
@@ -380,6 +387,7 @@ func TestStreamComplete_WithOpenRouterHeaders(t *testing.T) {
 	assert.Equal(t, "https://stream.example", receivedHeaders.Get("HTTP-Referer"))
 	assert.Equal(t, "Stream App", receivedHeaders.Get("X-OpenRouter-Title"))
 	assert.Equal(t, "Stream App", receivedHeaders.Get("X-Title"))
+	assert.Equal(t, defaultOpenRouterCategories, receivedHeaders.Get("X-OpenRouter-Categories"))
 }
 
 func TestComplete_ErrorHandling(t *testing.T) {

--- a/sdk/go/ai/config.go
+++ b/sdk/go/ai/config.go
@@ -91,7 +91,10 @@ func DefaultConfig() *Config {
 	}
 	switch {
 	case cfg.IsOpenRouter():
-		cfg.SiteURL, cfg.SiteName, _ = resolveOpenRouterAttribution("", "")
+		if attr, ok := resolveOpenRouterAttribution("", ""); ok {
+			cfg.SiteURL = attr.siteURL
+			cfg.SiteName = attr.appName
+		}
 	case cfg.IsInfron():
 		cfg.SiteURL, cfg.SiteName, _ = resolveInfronAttribution("", "")
 	}

--- a/sdk/go/ai/openrouter_attribution.go
+++ b/sdk/go/ai/openrouter_attribution.go
@@ -7,9 +7,16 @@ import (
 )
 
 const (
-	defaultOpenRouterSiteURL = "https://agentfield.ai"
-	defaultOpenRouterAppName = "AgentField AI"
+	defaultOpenRouterSiteURL    = "https://agentfield.ai"
+	defaultOpenRouterAppName    = "AgentField AI"
+	defaultOpenRouterCategories = "cli-agent,programming-app"
 )
+
+type resolvedOpenRouterAttribution struct {
+	siteURL    string
+	appName    string
+	categories string
+}
 
 func openRouterAttributionEnabled() bool {
 	value := strings.TrimSpace(os.Getenv("AGENTFIELD_OPENROUTER_ATTRIBUTION"))
@@ -24,37 +31,46 @@ func openRouterAttributionEnabled() bool {
 	}
 }
 
-func resolveOpenRouterAttribution(siteURL, siteName string) (string, string, bool) {
+func resolveOpenRouterAttribution(siteURL, siteName string) (resolvedOpenRouterAttribution, bool) {
 	if !openRouterAttributionEnabled() {
-		return "", "", false
+		return resolvedOpenRouterAttribution{}, false
 	}
 
-	resolvedURL := firstNonEmpty(
-		siteURL,
-		os.Getenv("AGENTFIELD_OPENROUTER_SITE_URL"),
-		os.Getenv("OR_SITE_URL"),
-		defaultOpenRouterSiteURL,
-	)
-	resolvedName := firstNonEmpty(
-		siteName,
-		os.Getenv("AGENTFIELD_OPENROUTER_APP_NAME"),
-		os.Getenv("OR_APP_NAME"),
-		defaultOpenRouterAppName,
-	)
-	return resolvedURL, resolvedName, true
+	return resolvedOpenRouterAttribution{
+		siteURL: firstNonEmpty(
+			siteURL,
+			os.Getenv("AGENTFIELD_OPENROUTER_SITE_URL"),
+			os.Getenv("OR_SITE_URL"),
+			defaultOpenRouterSiteURL,
+		),
+		appName: firstNonEmpty(
+			siteName,
+			os.Getenv("AGENTFIELD_OPENROUTER_APP_NAME"),
+			os.Getenv("OR_APP_NAME"),
+			defaultOpenRouterAppName,
+		),
+		categories: firstNonEmpty(
+			os.Getenv("AGENTFIELD_OPENROUTER_CATEGORIES"),
+			os.Getenv("OR_CATEGORIES"),
+			defaultOpenRouterCategories,
+		),
+	}, true
 }
 
 func applyOpenRouterAttributionHeaders(header http.Header, siteURL, siteName string) {
-	resolvedURL, resolvedName, ok := resolveOpenRouterAttribution(siteURL, siteName)
+	resolved, ok := resolveOpenRouterAttribution(siteURL, siteName)
 	if !ok {
 		return
 	}
-	if resolvedURL != "" {
-		header.Set("HTTP-Referer", resolvedURL)
+	if resolved.siteURL != "" {
+		header.Set("HTTP-Referer", resolved.siteURL)
 	}
-	if resolvedName != "" {
-		header.Set("X-OpenRouter-Title", resolvedName)
-		header.Set("X-Title", resolvedName)
+	if resolved.appName != "" {
+		header.Set("X-OpenRouter-Title", resolved.appName)
+		header.Set("X-Title", resolved.appName)
+	}
+	if resolved.categories != "" {
+		header.Set("X-OpenRouter-Categories", resolved.categories)
 	}
 }
 

--- a/sdk/go/ai/openrouter_attribution_test.go
+++ b/sdk/go/ai/openrouter_attribution_test.go
@@ -1,0 +1,48 @@
+package ai
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplyOpenRouterAttributionHeadersIncludesCategories(t *testing.T) {
+	t.Setenv("AGENTFIELD_OPENROUTER_SITE_URL", "")
+	t.Setenv("AGENTFIELD_OPENROUTER_APP_NAME", "")
+	t.Setenv("AGENTFIELD_OPENROUTER_CATEGORIES", "")
+	t.Setenv("OR_SITE_URL", "")
+	t.Setenv("OR_APP_NAME", "")
+	t.Setenv("OR_CATEGORIES", "")
+
+	header := make(http.Header)
+	applyOpenRouterAttributionHeaders(header, "", "")
+
+	assert.Equal(t, defaultOpenRouterSiteURL, header.Get("HTTP-Referer"))
+	assert.Equal(t, defaultOpenRouterAppName, header.Get("X-OpenRouter-Title"))
+	assert.Equal(t, defaultOpenRouterAppName, header.Get("X-Title"))
+	assert.Equal(t, defaultOpenRouterCategories, header.Get("X-OpenRouter-Categories"))
+}
+
+func TestApplyOpenRouterAttributionHeadersCategoriesEnvOverride(t *testing.T) {
+	t.Setenv("AGENTFIELD_OPENROUTER_CATEGORIES", "research,translation")
+
+	header := make(http.Header)
+	applyOpenRouterAttributionHeaders(header, "https://example.com", "Example")
+
+	assert.Equal(t, "https://example.com", header.Get("HTTP-Referer"))
+	assert.Equal(t, "Example", header.Get("X-OpenRouter-Title"))
+	assert.Equal(t, "research,translation", header.Get("X-OpenRouter-Categories"))
+}
+
+func TestApplyOpenRouterAttributionHeadersDisabled(t *testing.T) {
+	t.Setenv("AGENTFIELD_OPENROUTER_ATTRIBUTION", "false")
+
+	header := make(http.Header)
+	applyOpenRouterAttributionHeaders(header, "https://example.com", "Example")
+
+	assert.Empty(t, header.Get("HTTP-Referer"))
+	assert.Empty(t, header.Get("X-OpenRouter-Title"))
+	assert.Empty(t, header.Get("X-Title"))
+	assert.Empty(t, header.Get("X-OpenRouter-Categories"))
+}

--- a/sdk/go/ai/openrouter_media.go
+++ b/sdk/go/ai/openrouter_media.go
@@ -58,13 +58,13 @@ func NewOpenRouterMediaProvider(apiKey string) (*OpenRouterMediaProvider, error)
 	if apiKey == "" {
 		return nil, fmt.Errorf("OpenRouter API key required: pass apiKey or set OPENROUTER_API_KEY")
 	}
-	siteURL, siteName, _ := resolveOpenRouterAttribution("", "")
+	attr, _ := resolveOpenRouterAttribution("", "")
 	return &OpenRouterMediaProvider{
 		APIKey:   apiKey,
 		BaseURL:  defaultOpenRouterBaseURL,
 		Client:   &http.Client{Timeout: 60 * time.Second},
-		SiteURL:  siteURL,
-		SiteName: siteName,
+		SiteURL:  attr.siteURL,
+		SiteName: attr.appName,
 	}, nil
 }
 

--- a/sdk/go/ai/openrouter_media_coverage_test.go
+++ b/sdk/go/ai/openrouter_media_coverage_test.go
@@ -21,6 +21,9 @@ func TestBaseURLEmptyUsesDefault(t *testing.T) {
 }
 
 func TestOpenRouterMediaProviderHeadersIncludeAttribution(t *testing.T) {
+	t.Setenv("AGENTFIELD_OPENROUTER_CATEGORIES", "")
+	t.Setenv("OR_CATEGORIES", "")
+
 	var received http.Header
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		received = r.Header
@@ -48,6 +51,7 @@ func TestOpenRouterMediaProviderHeadersIncludeAttribution(t *testing.T) {
 	assert.Equal(t, "https://media.example", received.Get("HTTP-Referer"))
 	assert.Equal(t, "Media App", received.Get("X-OpenRouter-Title"))
 	assert.Equal(t, "Media App", received.Get("X-Title"))
+	assert.Equal(t, defaultOpenRouterCategories, received.Get("X-OpenRouter-Categories"))
 }
 
 // GenerateVideo exercises every optional payload field.

--- a/sdk/go/harness/openrouter_attribution.go
+++ b/sdk/go/harness/openrouter_attribution.go
@@ -5,9 +5,16 @@ import (
 )
 
 const (
-	defaultOpenRouterSiteURL = "https://agentfield.ai"
-	defaultOpenRouterAppName = "AgentField AI"
+	defaultOpenRouterSiteURL    = "https://agentfield.ai"
+	defaultOpenRouterAppName    = "AgentField AI"
+	defaultOpenRouterCategories = "cli-agent,programming-app"
 )
+
+type resolvedOpenRouterAttribution struct {
+	siteURL    string
+	appName    string
+	categories string
+}
 
 func openRouterAttributionEnabled(env map[string]string) bool {
 	value := strings.TrimSpace(env["AGENTFIELD_OPENROUTER_ATTRIBUTION"])
@@ -22,50 +29,59 @@ func openRouterAttributionEnabled(env map[string]string) bool {
 	}
 }
 
-func applyOpenRouterAttributionEnv(env map[string]string) {
+func resolveOpenRouterAttribution(env map[string]string) (resolvedOpenRouterAttribution, bool) {
 	if !openRouterAttributionEnabled(env) {
+		return resolvedOpenRouterAttribution{}, false
+	}
+	return resolvedOpenRouterAttribution{
+		siteURL: firstNonEmpty(
+			env["AGENTFIELD_OPENROUTER_SITE_URL"],
+			env["OR_SITE_URL"],
+			defaultOpenRouterSiteURL,
+		),
+		appName: firstNonEmpty(
+			env["AGENTFIELD_OPENROUTER_APP_NAME"],
+			env["OR_APP_NAME"],
+			defaultOpenRouterAppName,
+		),
+		categories: firstNonEmpty(
+			env["AGENTFIELD_OPENROUTER_CATEGORIES"],
+			env["OR_CATEGORIES"],
+			defaultOpenRouterCategories,
+		),
+	}, true
+}
+
+func applyOpenRouterAttributionEnv(env map[string]string) {
+	resolved, ok := resolveOpenRouterAttribution(env)
+	if !ok {
 		delete(env, "AGENTFIELD_OPENROUTER_SITE_URL")
 		delete(env, "AGENTFIELD_OPENROUTER_APP_NAME")
+		delete(env, "AGENTFIELD_OPENROUTER_CATEGORIES")
 		delete(env, "OR_SITE_URL")
 		delete(env, "OR_APP_NAME")
+		delete(env, "OR_CATEGORIES")
 		return
 	}
 
-	siteURL := firstNonEmpty(
-		env["AGENTFIELD_OPENROUTER_SITE_URL"],
-		env["OR_SITE_URL"],
-		defaultOpenRouterSiteURL,
-	)
-	appName := firstNonEmpty(
-		env["AGENTFIELD_OPENROUTER_APP_NAME"],
-		env["OR_APP_NAME"],
-		defaultOpenRouterAppName,
-	)
-
-	setDefaultEnv(env, "AGENTFIELD_OPENROUTER_SITE_URL", siteURL)
-	setDefaultEnv(env, "AGENTFIELD_OPENROUTER_APP_NAME", appName)
-	setDefaultEnv(env, "OR_SITE_URL", siteURL)
-	setDefaultEnv(env, "OR_APP_NAME", appName)
+	setDefaultEnv(env, "AGENTFIELD_OPENROUTER_SITE_URL", resolved.siteURL)
+	setDefaultEnv(env, "AGENTFIELD_OPENROUTER_APP_NAME", resolved.appName)
+	setDefaultEnv(env, "AGENTFIELD_OPENROUTER_CATEGORIES", resolved.categories)
+	setDefaultEnv(env, "OR_SITE_URL", resolved.siteURL)
+	setDefaultEnv(env, "OR_APP_NAME", resolved.appName)
+	setDefaultEnv(env, "OR_CATEGORIES", resolved.categories)
 }
 
 func openRouterAttributionHeaders(env map[string]string) map[string]string {
-	if !openRouterAttributionEnabled(env) {
+	resolved, ok := resolveOpenRouterAttribution(env)
+	if !ok {
 		return map[string]string{}
 	}
-	siteURL := firstNonEmpty(
-		env["AGENTFIELD_OPENROUTER_SITE_URL"],
-		env["OR_SITE_URL"],
-		defaultOpenRouterSiteURL,
-	)
-	appName := firstNonEmpty(
-		env["AGENTFIELD_OPENROUTER_APP_NAME"],
-		env["OR_APP_NAME"],
-		defaultOpenRouterAppName,
-	)
 	return map[string]string{
-		"HTTP-Referer":       siteURL,
-		"X-OpenRouter-Title": appName,
-		"X-Title":            appName,
+		"HTTP-Referer":            resolved.siteURL,
+		"X-OpenRouter-Title":      resolved.appName,
+		"X-Title":                 resolved.appName,
+		"X-OpenRouter-Categories": resolved.categories,
 	}
 }
 

--- a/sdk/go/harness/runner_test.go
+++ b/sdk/go/harness/runner_test.go
@@ -421,6 +421,7 @@ func TestOpenCodeProvider_OpenRouterConfigOverlay(t *testing.T) {
 	assert.Equal(t, "https://agentfield.ai", headers["HTTP-Referer"])
 	assert.Equal(t, "AgentField AI", headers["X-OpenRouter-Title"])
 	assert.Equal(t, "AgentField AI", headers["X-Title"])
+	assert.Equal(t, defaultOpenRouterCategories, headers["X-OpenRouter-Categories"])
 }
 
 // --- Codex provider tests ---

--- a/sdk/python/agentfield/openrouter_attribution.py
+++ b/sdk/python/agentfield/openrouter_attribution.py
@@ -11,6 +11,7 @@ from typing import Dict, Mapping, MutableMapping, Optional
 
 DEFAULT_OPENROUTER_SITE_URL = "https://agentfield.ai"
 DEFAULT_OPENROUTER_APP_NAME = "AgentField AI"
+DEFAULT_OPENROUTER_CATEGORIES = "cli-agent,programming-app"
 
 _FALSE_VALUES = {"0", "false", "no", "off"}
 
@@ -58,10 +59,25 @@ def resolve_attribution(
     return resolved_site, resolved_name
 
 
+def _resolve_categories(
+    *,
+    categories: Optional[str] = None,
+    env: Optional[Mapping[str, str]] = None,
+) -> str:
+    source = env if env is not None else os.environ
+    return (
+        _clean(categories)
+        or _clean(source.get("AGENTFIELD_OPENROUTER_CATEGORIES"))
+        or _clean(source.get("OR_CATEGORIES"))
+        or DEFAULT_OPENROUTER_CATEGORIES
+    )
+
+
 def attribution_headers(
     *,
     site_url: Optional[str] = None,
     app_name: Optional[str] = None,
+    categories: Optional[str] = None,
     env: Optional[Mapping[str, str]] = None,
 ) -> Dict[str, str]:
     if not attribution_enabled(env):
@@ -70,12 +86,15 @@ def attribution_headers(
     resolved_site, resolved_name = resolve_attribution(
         site_url=site_url, app_name=app_name, env=env
     )
+    resolved_categories = _resolve_categories(categories=categories, env=env)
     headers: Dict[str, str] = {}
     if resolved_site:
         headers["HTTP-Referer"] = resolved_site
     if resolved_name:
         headers["X-OpenRouter-Title"] = resolved_name
         headers["X-Title"] = resolved_name
+    if resolved_categories:
+        headers["X-OpenRouter-Categories"] = resolved_categories
     return headers
 
 
@@ -84,12 +103,13 @@ def merge_attribution_headers(
     *,
     site_url: Optional[str] = None,
     app_name: Optional[str] = None,
+    categories: Optional[str] = None,
     env: Optional[Mapping[str, str]] = None,
 ) -> Dict[str, str]:
     merged = dict(existing or {})
     lower_keys = {key.lower() for key in merged}
     for key, value in attribution_headers(
-        site_url=site_url, app_name=app_name, env=env
+        site_url=site_url, app_name=app_name, categories=categories, env=env
     ).items():
         if key.lower() not in lower_keys:
             merged[key] = value
@@ -102,6 +122,7 @@ def apply_litellm_attribution(
     *,
     site_url: Optional[str] = None,
     app_name: Optional[str] = None,
+    categories: Optional[str] = None,
 ) -> None:
     if not is_openrouter_request(
         model=str(params.get("model") or ""),
@@ -114,11 +135,13 @@ def apply_litellm_attribution(
         _string_dict(params.get("headers")),
         site_url=site_url,
         app_name=app_name,
+        categories=categories,
     )
     params["extra_headers"] = merge_attribution_headers(
         _string_dict(params.get("extra_headers")),
         site_url=site_url,
         app_name=app_name,
+        categories=categories,
     )
 
 
@@ -156,6 +179,7 @@ def attribution_env(env: Optional[Mapping[str, str]] = None) -> Dict[str, str]:
         return {}
 
     site_url, app_name = resolve_attribution(env=source)
+    categories = _resolve_categories(env=source)
     result: Dict[str, str] = {}
     if site_url:
         result["AGENTFIELD_OPENROUTER_SITE_URL"] = site_url
@@ -163,6 +187,9 @@ def attribution_env(env: Optional[Mapping[str, str]] = None) -> Dict[str, str]:
     if app_name:
         result["AGENTFIELD_OPENROUTER_APP_NAME"] = app_name
         result["OR_APP_NAME"] = app_name
+    if categories:
+        result["AGENTFIELD_OPENROUTER_CATEGORIES"] = categories
+        result["OR_CATEGORIES"] = categories
     return result
 
 
@@ -171,8 +198,10 @@ def apply_subprocess_env(env: MutableMapping[str, str]) -> None:
         for key in (
             "AGENTFIELD_OPENROUTER_SITE_URL",
             "AGENTFIELD_OPENROUTER_APP_NAME",
+            "AGENTFIELD_OPENROUTER_CATEGORIES",
             "OR_SITE_URL",
             "OR_APP_NAME",
+            "OR_CATEGORIES",
         ):
             env.pop(key, None)
         return

--- a/sdk/python/tests/test_ai_config.py
+++ b/sdk/python/tests/test_ai_config.py
@@ -59,15 +59,19 @@ def test_ai_config_get_litellm_params_uses_overrides_and_prunes_none():
 def test_ai_config_get_litellm_params_adds_openrouter_attribution(monkeypatch):
     monkeypatch.delenv("AGENTFIELD_OPENROUTER_SITE_URL", raising=False)
     monkeypatch.delenv("AGENTFIELD_OPENROUTER_APP_NAME", raising=False)
+    monkeypatch.delenv("AGENTFIELD_OPENROUTER_CATEGORIES", raising=False)
     monkeypatch.delenv("OR_SITE_URL", raising=False)
     monkeypatch.delenv("OR_APP_NAME", raising=False)
+    monkeypatch.delenv("OR_CATEGORIES", raising=False)
 
     params = AIConfig(model="openrouter/openai/gpt-4o").get_litellm_params()
 
     assert params["headers"]["HTTP-Referer"] == "https://agentfield.ai"
     assert params["headers"]["X-OpenRouter-Title"] == "AgentField AI"
     assert params["headers"]["X-Title"] == "AgentField AI"
+    assert params["headers"]["X-OpenRouter-Categories"] == "cli-agent,programming-app"
     assert params["extra_headers"]["HTTP-Referer"] == "https://agentfield.ai"
+    assert params["extra_headers"]["X-OpenRouter-Categories"] == "cli-agent,programming-app"
 
 
 def test_ai_config_openrouter_attribution_preserves_explicit_headers():
@@ -85,8 +89,19 @@ def test_ai_config_openrouter_attribution_preserves_explicit_headers():
 
     assert params["headers"]["HTTP-Referer"] == "https://caller.example"
     assert params["headers"]["X-OpenRouter-Title"] == "Override App"
+    assert params["headers"]["X-OpenRouter-Categories"] == "cli-agent,programming-app"
     assert params["extra_headers"]["x-openrouter-title"] == "Caller Title"
     assert params["extra_headers"]["HTTP-Referer"] == "https://override.example"
+    assert params["extra_headers"]["X-OpenRouter-Categories"] == "cli-agent,programming-app"
+
+
+def test_ai_config_openrouter_categories_env_override(monkeypatch):
+    monkeypatch.setenv("AGENTFIELD_OPENROUTER_CATEGORIES", "research,translation")
+
+    params = AIConfig(model="openrouter/openai/gpt-4o").get_litellm_params()
+
+    assert params["headers"]["X-OpenRouter-Categories"] == "research,translation"
+    assert params["extra_headers"]["X-OpenRouter-Categories"] == "research,translation"
 
 
 def test_ai_config_get_litellm_params_skips_non_openrouter():

--- a/sdk/python/tests/test_openrouter_video.py
+++ b/sdk/python/tests/test_openrouter_video.py
@@ -175,8 +175,10 @@ class TestOpenRouterVideoHappyPath:
     def test_media_requests_include_openrouter_attribution(self, monkeypatch):
         monkeypatch.delenv("AGENTFIELD_OPENROUTER_SITE_URL", raising=False)
         monkeypatch.delenv("AGENTFIELD_OPENROUTER_APP_NAME", raising=False)
+        monkeypatch.delenv("AGENTFIELD_OPENROUTER_CATEGORIES", raising=False)
         monkeypatch.delenv("OR_SITE_URL", raising=False)
         monkeypatch.delenv("OR_APP_NAME", raising=False)
+        monkeypatch.delenv("OR_CATEGORIES", raising=False)
 
         resp = _make_response(200, {"choices": []})
         session = CaptureSession(resp)
@@ -190,6 +192,7 @@ class TestOpenRouterVideoHappyPath:
         assert headers["HTTP-Referer"] == "https://agentfield.ai"
         assert headers["X-OpenRouter-Title"] == "AgentField AI"
         assert headers["X-Title"] == "AgentField AI"
+        assert headers["X-OpenRouter-Categories"] == "cli-agent,programming-app"
 
 
 class TestOpenRouterVideoDownloadSafety:

--- a/sdk/python/tests/test_run_cli_env.py
+++ b/sdk/python/tests/test_run_cli_env.py
@@ -90,15 +90,17 @@ async def test_run_cli_works_without_explicit_env(monkeypatch):
 def test_run_cli_merges_openrouter_attribution_defaults(monkeypatch):
     monkeypatch.delenv("AGENTFIELD_OPENROUTER_SITE_URL", raising=False)
     monkeypatch.delenv("AGENTFIELD_OPENROUTER_APP_NAME", raising=False)
+    monkeypatch.delenv("AGENTFIELD_OPENROUTER_CATEGORIES", raising=False)
     monkeypatch.delenv("OR_SITE_URL", raising=False)
     monkeypatch.delenv("OR_APP_NAME", raising=False)
+    monkeypatch.delenv("OR_CATEGORIES", raising=False)
 
     stdout, _stderr, returncode = asyncio.run(
         run_cli(
             [
                 "bash",
                 "-c",
-                "echo $AGENTFIELD_OPENROUTER_SITE_URL:$AGENTFIELD_OPENROUTER_APP_NAME:$OR_SITE_URL:$OR_APP_NAME",
+                "echo $AGENTFIELD_OPENROUTER_SITE_URL:$AGENTFIELD_OPENROUTER_APP_NAME:$AGENTFIELD_OPENROUTER_CATEGORIES:$OR_SITE_URL:$OR_APP_NAME:$OR_CATEGORIES",
             ],
             timeout=10.0,
         )
@@ -106,7 +108,8 @@ def test_run_cli_merges_openrouter_attribution_defaults(monkeypatch):
 
     assert returncode == 0
     assert stdout.strip() == (
-        "https://agentfield.ai:AgentField AI:https://agentfield.ai:AgentField AI"
+        "https://agentfield.ai:AgentField AI:cli-agent,programming-app:"
+        "https://agentfield.ai:AgentField AI:cli-agent,programming-app"
     )
 
 

--- a/sdk/typescript/src/ai/openrouterAttribution.ts
+++ b/sdk/typescript/src/ai/openrouterAttribution.ts
@@ -1,11 +1,13 @@
 const DEFAULT_OPENROUTER_SITE_URL = 'https://agentfield.ai';
 const DEFAULT_OPENROUTER_APP_NAME = 'AgentField AI';
+const DEFAULT_OPENROUTER_CATEGORIES = 'cli-agent,programming-app';
 
 type EnvMap = Record<string, string | undefined>;
 
 export interface OpenRouterAttributionOptions {
   siteUrl?: string;
   appName?: string;
+  categories?: string;
   headers?: Record<string, string | undefined>;
   env?: EnvMap;
 }
@@ -39,7 +41,7 @@ export function openRouterAttributionEnabled(env: EnvMap = process.env): boolean
 
 export function resolveOpenRouterAttribution(
   options: OpenRouterAttributionOptions = {}
-): { siteUrl: string; appName: string } | undefined {
+): { siteUrl: string; appName: string; categories: string } | undefined {
   const env = options.env ?? process.env;
   if (!openRouterAttributionEnabled(env)) {
     return undefined;
@@ -57,7 +59,13 @@ export function resolveOpenRouterAttribution(
     clean(env.OR_APP_NAME) ??
     DEFAULT_OPENROUTER_APP_NAME;
 
-  return { siteUrl, appName };
+  const categories =
+    clean(options.categories) ??
+    clean(env.AGENTFIELD_OPENROUTER_CATEGORIES) ??
+    clean(env.OR_CATEGORIES) ??
+    DEFAULT_OPENROUTER_CATEGORIES;
+
+  return { siteUrl, appName, categories };
 }
 
 export function openRouterAttributionHeaders(
@@ -71,6 +79,7 @@ export function openRouterAttributionHeaders(
     'HTTP-Referer': resolved.siteUrl,
     'X-OpenRouter-Title': resolved.appName,
     'X-Title': resolved.appName,
+    'X-OpenRouter-Categories': resolved.categories,
   };
 }
 
@@ -107,8 +116,10 @@ export function openRouterAttributionEnv(env: EnvMap = process.env): Record<stri
   return {
     AGENTFIELD_OPENROUTER_SITE_URL: resolved.siteUrl,
     AGENTFIELD_OPENROUTER_APP_NAME: resolved.appName,
+    AGENTFIELD_OPENROUTER_CATEGORIES: resolved.categories,
     OR_SITE_URL: resolved.siteUrl,
     OR_APP_NAME: resolved.appName,
+    OR_CATEGORIES: resolved.categories,
   };
 }
 
@@ -117,8 +128,10 @@ export function applyOpenRouterAttributionEnv(env: Record<string, string | undef
     for (const key of [
       'AGENTFIELD_OPENROUTER_SITE_URL',
       'AGENTFIELD_OPENROUTER_APP_NAME',
+      'AGENTFIELD_OPENROUTER_CATEGORIES',
       'OR_SITE_URL',
       'OR_APP_NAME',
+      'OR_CATEGORIES',
     ]) {
       delete env[key];
     }

--- a/sdk/typescript/tests/ai_client.test.ts
+++ b/sdk/typescript/tests/ai_client.test.ts
@@ -192,7 +192,8 @@ describe('AIClient', () => {
           headers: {
             'HTTP-Referer': 'https://agentfield.ai',
             'X-OpenRouter-Title': 'AgentField AI',
-            'X-Title': 'AgentField AI'
+            'X-Title': 'AgentField AI',
+            'X-OpenRouter-Categories': 'cli-agent,programming-app'
           }
         })
       );
@@ -213,7 +214,8 @@ describe('AIClient', () => {
           headers: {
             'X-Title': 'Header Title',
             'HTTP-Referer': 'https://caller.example',
-            'X-OpenRouter-Title': 'Caller App'
+            'X-OpenRouter-Title': 'Caller App',
+            'X-OpenRouter-Categories': 'cli-agent,programming-app'
           }
         })
       );

--- a/sdk/typescript/tests/harness_cli.test.ts
+++ b/sdk/typescript/tests/harness_cli.test.ts
@@ -80,8 +80,10 @@ describe('harness cli utilities', () => {
       env: expect.objectContaining({
         AGENTFIELD_OPENROUTER_SITE_URL: 'https://agentfield.ai',
         AGENTFIELD_OPENROUTER_APP_NAME: 'Caller App',
+        AGENTFIELD_OPENROUTER_CATEGORIES: 'cli-agent,programming-app',
         OR_SITE_URL: 'https://agentfield.ai',
-        OR_APP_NAME: 'Caller App'
+        OR_APP_NAME: 'Caller App',
+        OR_CATEGORIES: 'cli-agent,programming-app'
       }),
       cwd: undefined,
       stdio: ['ignore', 'pipe', 'pipe']

--- a/sdk/typescript/tests/harness_provider_opencode.test.ts
+++ b/sdk/typescript/tests/harness_provider_opencode.test.ts
@@ -162,6 +162,7 @@ describe('opencode provider', () => {
       'HTTP-Referer': 'https://agentfield.ai',
       'X-OpenRouter-Title': 'AgentField AI',
       'X-Title': 'AgentField AI',
+      'X-OpenRouter-Categories': 'cli-agent,programming-app',
     });
   });
 

--- a/sdk/typescript/tests/media_provider.test.ts
+++ b/sdk/typescript/tests/media_provider.test.ts
@@ -130,6 +130,7 @@ describe('OpenRouterMediaProvider', () => {
         'HTTP-Referer': 'https://agentfield.ai',
         'X-OpenRouter-Title': 'AgentField AI',
         'X-Title': 'AgentField AI',
+        'X-OpenRouter-Categories': 'cli-agent,programming-app',
       })
     );
   });

--- a/sdk/typescript/tests/openrouter_attribution.test.ts
+++ b/sdk/typescript/tests/openrouter_attribution.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  openRouterAttributionEnv,
+  openRouterAttributionHeaders,
+} from '../src/ai/openrouterAttribution.js';
+
+const CATEGORY_ENV_KEYS = [
+  'AGENTFIELD_OPENROUTER_CATEGORIES',
+  'OR_CATEGORIES',
+] as const;
+
+const originalCategoryEnv = Object.fromEntries(
+  CATEGORY_ENV_KEYS.map((key) => [key, process.env[key]])
+);
+
+afterEach(() => {
+  for (const key of CATEGORY_ENV_KEYS) {
+    const previous = originalCategoryEnv[key];
+    if (previous === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = previous;
+    }
+  }
+});
+
+describe('openRouterAttributionHeaders', () => {
+  it('includes X-OpenRouter-Categories by default', () => {
+    delete process.env.AGENTFIELD_OPENROUTER_CATEGORIES;
+    delete process.env.OR_CATEGORIES;
+
+    expect(openRouterAttributionHeaders({ env: {} })).toEqual({
+      'HTTP-Referer': 'https://agentfield.ai',
+      'X-OpenRouter-Title': 'AgentField AI',
+      'X-Title': 'AgentField AI',
+      'X-OpenRouter-Categories': 'cli-agent,programming-app',
+    });
+  });
+
+  it('resolves categories from AGENTFIELD_OPENROUTER_CATEGORIES then OR_CATEGORIES', () => {
+    expect(
+      openRouterAttributionHeaders({
+        env: { AGENTFIELD_OPENROUTER_CATEGORIES: 'research,translation' },
+      })['X-OpenRouter-Categories']
+    ).toBe('research,translation');
+
+    expect(
+      openRouterAttributionHeaders({
+        env: { OR_CATEGORIES: 'roleplay' },
+      })['X-OpenRouter-Categories']
+    ).toBe('roleplay');
+  });
+
+  it('omits attribution headers when disabled', () => {
+    expect(
+      openRouterAttributionHeaders({
+        env: { AGENTFIELD_OPENROUTER_ATTRIBUTION: 'false' },
+      })
+    ).toEqual({});
+  });
+});
+
+describe('openRouterAttributionEnv', () => {
+  it('injects category env defaults for subprocesses', () => {
+    expect(openRouterAttributionEnv({})).toMatchObject({
+      AGENTFIELD_OPENROUTER_CATEGORIES: 'cli-agent,programming-app',
+      OR_CATEGORIES: 'cli-agent,programming-app',
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

OpenRouter ranks apps using `X-OpenRouter-Categories`, but the Go, TypeScript, and Python SDKs only sent Referer/Title headers. Every OpenRouter request that already goes through the attribution module now also sends `X-OpenRouter-Categories: cli-agent,programming-app`, overridable with `AGENTFIELD_OPENROUTER_CATEGORIES` or `OR_CATEGORIES` — the same first-non-empty chain used for site URL and app name.

Harness subprocess env injection was updated in lockstep so OpenCode overlays and child processes inherit the same category value. Non-OpenRouter providers are unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] Tests only
- [ ] CI / tooling
- [ ] Breaking change

## Test plan

- [x] `cd sdk/go && go test ./ai ./harness` — pass
- [x] `cd sdk/typescript && npx vitest run tests/openrouter_attribution.test.ts tests/ai_client.test.ts tests/media_provider.test.ts tests/harness_provider_opencode.test.ts tests/harness_cli.test.ts` — 78 passed
- [x] `cd sdk/python && python -m pytest tests/test_ai_config.py tests/test_openrouter_video.py tests/test_run_cli_env.py -q` — pass
- [x] `cd sdk/typescript && npx tsc --noEmit` — pass

## Test coverage

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR (no bare additions).
- [ ] If I removed code, I updated `coverage-baseline.json` in this PR *only if* the removal caused a legitimate regression and I called it out in the summary above.
- [ ] The coverage gate check is green in CI before requesting review.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) (if present) and [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
- [x] Commits are signed and follow conventional-commits style.
- [ ] I have linked any related issues (Fixes #123 / Closes #456).

## Related issues / PRs

SDK OpenRouter attribution omitted `X-OpenRouter-Categories`, so AgentField traffic was unclassified on the OpenRouter dashboard.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4c30831-eb78-42ca-957c-0abb484899ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4c30831-eb78-42ca-957c-0abb484899ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

