### PR TITLE
fix(sdk/typescript): pass claude-code options to claude-agent-sdk in camelCase

### DIFF
--- a/sdk/typescript/src/harness/providers/claude.ts
+++ b/sdk/typescript/src/harness/providers/claude.ts
@@ -45,14 +45,14 @@ export class ClaudeCodeProvider implements HarnessProvider {
     const { model: modelValue } = resolveModelAndVariant(options);
     if (modelValue !== undefined) agentOptions.model = modelValue;
     if (options.cwd !== undefined) agentOptions.cwd = options.cwd;
-    if (options.maxTurns !== undefined) agentOptions.max_turns = options.maxTurns;
-    if (options.tools !== undefined) agentOptions.allowed_tools = options.tools;
-    if (options.systemPrompt !== undefined) agentOptions.system_prompt = options.systemPrompt;
-    if (options.maxBudgetUsd !== undefined) agentOptions.max_budget_usd = options.maxBudgetUsd;
+    if (options.maxTurns !== undefined) agentOptions.maxTurns = options.maxTurns;
+    if (options.tools !== undefined) agentOptions.allowedTools = options.tools;
+    if (options.systemPrompt !== undefined) agentOptions.systemPrompt = options.systemPrompt;
+    if (options.maxBudgetUsd !== undefined) agentOptions.maxBudgetUsd = options.maxBudgetUsd;
     if (options.permissionMode !== undefined) {
       const modeMap: Record<string, string> = { auto: 'bypassPermissions', plan: 'plan' };
       const raw = String(options.permissionMode);
-      agentOptions.permission_mode = modeMap[raw] ?? raw;
+      agentOptions.permissionMode = modeMap[raw] ?? raw;
     }
     if (options.env !== undefined) agentOptions.env = options.env;
 

--- a/sdk/typescript/tests/harness_provider_claude.test.ts
+++ b/sdk/typescript/tests/harness_provider_claude.test.ts
@@ -42,11 +42,11 @@ describe('ClaudeCodeProvider', () => {
     expect(captured.options).toEqual({
       model: 'sonnet',
       cwd: '/tmp/work',
-      max_turns: 8,
-      allowed_tools: ['Read', 'Write'],
-      system_prompt: 'system',
-      max_budget_usd: 3,
-      permission_mode: 'bypassPermissions',
+      maxTurns: 8,
+      allowedTools: ['Read', 'Write'],
+      systemPrompt: 'system',
+      maxBudgetUsd: 3,
+      permissionMode: 'bypassPermissions',
       env: { A: '1' },
     });
     expect(raw.isError).toBe(false);
@@ -55,6 +55,65 @@ describe('ClaudeCodeProvider', () => {
     expect(raw.metrics.numTurns).toBe(4);
     expect(raw.metrics.sessionId).toBe('sess-1');
     expect(raw.messages).toHaveLength(2);
+  });
+
+  it.each([
+    ['auto', 'bypassPermissions'],
+    ['plan', 'plan'],
+    ['default', 'default'],
+  ])('maps permission mode %s to %s', async (permissionMode, expected) => {
+    const captured: { options?: Record<string, unknown> } = {};
+
+    vi.doMock(
+      '@anthropic-ai/claude-agent-sdk',
+      () => ({
+        query: ({ options }: { prompt: string; options: Record<string, unknown> }) => {
+          captured.options = options;
+          return (async function* stream() {
+            yield { type: 'result', result: 'final' };
+          })();
+        },
+      }),
+      { virtual: true }
+    );
+
+    const { ClaudeCodeProvider } = await import('../src/harness/providers/claude.js');
+    const provider = new ClaudeCodeProvider();
+    await provider.execute('hello', { permissionMode });
+
+    expect(captured.options).toEqual({ permissionMode: expected });
+  });
+
+  it('omits undefined options from the SDK request', async () => {
+    const captured: { options?: Record<string, unknown> } = {};
+
+    vi.doMock(
+      '@anthropic-ai/claude-agent-sdk',
+      () => ({
+        query: ({ options }: { prompt: string; options: Record<string, unknown> }) => {
+          captured.options = options;
+          return (async function* stream() {
+            yield { type: 'result', result: 'final' };
+          })();
+        },
+      }),
+      { virtual: true }
+    );
+
+    const { ClaudeCodeProvider } = await import('../src/harness/providers/claude.js');
+    const provider = new ClaudeCodeProvider();
+    await provider.execute('hello', {
+      model: undefined,
+      cwd: undefined,
+      maxTurns: undefined,
+      tools: undefined,
+      systemPrompt: undefined,
+      maxBudgetUsd: undefined,
+      permissionMode: undefined,
+      env: undefined,
+    });
+
+    expect(captured.options).toEqual({});
   });
 
   it('strips a #variant model suffix before handing the model to the SDK', async () => {


### PR DESCRIPTION
## Summary
`ClaudeCodeProvider` built the `query()` options with snake_case keys (`max_turns`, `allowed_tools`, `system_prompt`, `max_budget_usd`, `permission_mode`). `@anthropic-ai/claude-agent-sdk`'s `Options` type is camelCase (`maxTurns`, `allowedTools`, `systemPrompt`, `maxBudgetUsd`, `permissionMode` — verified in 0.3.234 `sdk.d.ts`), so those keys were dropped and turn caps, USD budget, tool allowlist, system prompt and permission mode were silently ignored on TypeScript. Found while verifying the harness docs: the docs say the USD cap is enforced by claude-code — that was false on TS.

## Validation contract
- Given `{ maxTurns, tools, systemPrompt, maxBudgetUsd, permissionMode, cwd, model, env }`, the object handed to `query` has exactly `maxTurns`, `allowedTools`, `systemPrompt`, `maxBudgetUsd`, `permissionMode`, `cwd`, `model`, `env` — no snake_case keys.
- `permissionMode` mapping unchanged: `auto` → `bypassPermissions`, `plan` → `plan`, else pass-through.
- Undefined options are not set (no `undefined` values leak).
- Result parsing / usage / model attribution / `#variant` stripping unchanged (existing tests pass).

The pre-existing options test asserted the snake_case keys (it mirrored the bug); it now asserts the SDK boundary.

## Test plan
- [x] `npm ci` (Node 20) · `npm run lint` · `npm test` — 864 passed

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)