### PR TITLE
fix(sdk/go,sdk/typescript): gemini argv — drop the nonexistent -C flag, map permission modes like Python

### DIFF
--- a/sdk/go/harness/coverage_branches_test.go
+++ b/sdk/go/harness/coverage_branches_test.go
@@ -188,7 +188,8 @@ fi
 		require.NoError(t, err)
 		assert.False(t, raw.IsError)
 		assert.Contains(t, raw.Result, dir)
-		assert.Contains(t, raw.Result, "--sandbox")
+		assert.Contains(t, raw.Result, "--yolo")
+		assert.NotContains(t, raw.Result, "-C")
 		assert.Contains(t, raw.Result, "-m gemini-model")
 	})
 

--- a/sdk/go/harness/gemini.go
+++ b/sdk/go/harness/gemini.go
@@ -25,14 +25,10 @@ func NewGeminiProvider(binPath string) *GeminiProvider {
 func (p *GeminiProvider) Execute(ctx context.Context, prompt string, options Options) (*RawResult, error) {
 	cmd := []string{p.BinPath}
 
-	if options.Cwd != "" {
-		cmd = append(cmd, "-C", options.Cwd)
-	} else if options.ProjectDir != "" {
-		cmd = append(cmd, "-C", options.ProjectDir)
-	}
-
 	if options.PermissionMode == "auto" {
-		cmd = append(cmd, "--sandbox")
+		cmd = append(cmd, "--yolo")
+	} else if options.PermissionMode == "plan" {
+		cmd = append(cmd, "--approval-mode", "plan")
 	}
 
 	// gemini has no reasoning-effort flag; strip any "#variant" suffix so

--- a/sdk/go/harness/runner_test.go
+++ b/sdk/go/harness/runner_test.go
@@ -548,18 +548,44 @@ func TestGeminiProvider_NonZeroExit(t *testing.T) {
 
 func TestGeminiProvider_WithModel(t *testing.T) {
 	dir := t.TempDir()
-	script := writeTestScript(t, dir, "gemini", "#!/bin/sh\necho \"args: $@\"\n")
+	script := writeTestScript(t, dir, "gemini", "#!/bin/sh\nprintf '%s\\n' \"$@\"\n")
 
-	p := NewGeminiProvider(script)
-	raw, err := p.Execute(context.Background(), "test prompt", Options{
-		Model:          "gemini-2.5-pro",
-		PermissionMode: "auto",
-	})
-	assert.NoError(t, err)
-	assert.False(t, raw.IsError)
-	assert.Contains(t, raw.Result, "-m")
-	assert.Contains(t, raw.Result, "gemini-2.5-pro")
-	assert.Contains(t, raw.Result, "--sandbox")
+	tests := []struct {
+		name    string
+		options Options
+		want    []string
+	}{
+		{
+			name:    "auto uses yolo",
+			options: Options{Cwd: dir, PermissionMode: "auto"},
+			want:    []string{"--yolo", "-p", "test prompt"},
+		},
+		{
+			name:    "plan precedes stripped model and prompt",
+			options: Options{PermissionMode: "plan", Model: "gemini-2.5-pro#high"},
+			want:    []string{"--approval-mode", "plan", "-m", "gemini-2.5-pro", "-p", "test prompt"},
+		},
+		{
+			name: "unset permission mode adds no flag",
+			want: []string{"-p", "test prompt"},
+		},
+		{
+			name:    "unknown permission mode adds no flag",
+			options: Options{PermissionMode: "unknown", Model: "gemini-2.5-flash"},
+			want:    []string{"-m", "gemini-2.5-flash", "-p", "test prompt"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := NewGeminiProvider(script).Execute(context.Background(), "test prompt", tc.options)
+			require.NoError(t, err)
+			assert.False(t, raw.IsError)
+			assert.Equal(t, tc.want, strings.Split(raw.Result, "\n"))
+			assert.NotContains(t, raw.Result, "-C")
+			assert.NotContains(t, raw.Result, "--sandbox")
+		})
+	}
 }
 
 // --- BuildProvider factory tests ---

--- a/sdk/typescript/src/harness/providers/gemini.ts
+++ b/sdk/typescript/src/harness/providers/gemini.ts
@@ -14,11 +14,10 @@ export class GeminiProvider implements HarnessProvider {
   async execute(prompt: string, options: Record<string, unknown>): Promise<RawResult> {
     const cmd = [this.bin];
 
-    if (options.cwd) {
-      cmd.push('-C', String(options.cwd));
-    }
     if (options.permissionMode === 'auto') {
-      cmd.push('--sandbox');
+      cmd.push('--yolo');
+    } else if (options.permissionMode === 'plan') {
+      cmd.push('--approval-mode', 'plan');
     }
     // gemini has no reasoning-effort flag; strip any "#variant" suffix so
     // the CLI still receives a valid model id.

--- a/sdk/typescript/tests/harness_provider_gemini.test.ts
+++ b/sdk/typescript/tests/harness_provider_gemini.test.ts
@@ -9,7 +9,46 @@ afterEach(() => {
 });
 
 describe('gemini provider', () => {
-  it('constructs command and maps result', async () => {
+  it.each([
+    {
+      name: 'auto mode uses yolo and applies cwd only to the subprocess',
+      options: { cwd: '/tmp/work', permissionMode: 'auto', env: { A: '1' } },
+      expectedArgv: ['/usr/local/bin/gemini', '--yolo', '-p', 'hello'],
+      expectedRunOptions: { cwd: '/tmp/work', env: { A: '1' } },
+    },
+    {
+      name: 'plan mode uses approval-mode plan before model and prompt',
+      options: { permissionMode: 'plan', model: 'gemini-2.5-pro#high' },
+      expectedArgv: [
+        '/usr/local/bin/gemini',
+        '--approval-mode',
+        'plan',
+        '-m',
+        'gemini-2.5-pro',
+        '-p',
+        'hello',
+      ],
+      expectedRunOptions: { cwd: undefined, env: undefined },
+    },
+    {
+      name: 'unset permission mode adds no permission flag',
+      options: {},
+      expectedArgv: ['/usr/local/bin/gemini', '-p', 'hello'],
+      expectedRunOptions: { cwd: undefined, env: undefined },
+    },
+    {
+      name: 'unknown permission mode adds no permission flag',
+      options: { permissionMode: 'unknown', model: 'gemini-2.5-flash' },
+      expectedArgv: [
+        '/usr/local/bin/gemini',
+        '-m',
+        'gemini-2.5-flash',
+        '-p',
+        'hello',
+      ],
+      expectedRunOptions: { cwd: undefined, env: undefined },
+    },
+  ])('$name', async ({ options, expectedArgv, expectedRunOptions }) => {
     vi.spyOn(cli, 'runCli').mockResolvedValue({
       stdout: 'final text\n',
       stderr: '',
@@ -17,16 +56,11 @@ describe('gemini provider', () => {
     });
 
     const provider = new GeminiProvider('/usr/local/bin/gemini');
-    const result = await provider.execute('hello', {
-      cwd: '/tmp/work',
-      permissionMode: 'auto',
-      env: { A: '1' },
-    });
+    const result = await provider.execute('hello', options);
 
-    expect(cli.runCli).toHaveBeenCalledWith(
-      ['/usr/local/bin/gemini', '-C', '/tmp/work', '--sandbox', '-p', 'hello'],
-      { cwd: '/tmp/work', env: { A: '1' } }
-    );
+    expect(cli.runCli).toHaveBeenCalledWith(expectedArgv, expectedRunOptions);
+    expect(expectedArgv).not.toContain('-C');
+    expect(expectedArgv).not.toContain('--sandbox');
     expect(result.isError).toBe(false);
     expect(result.result).toBe('final text');
     expect(result.metrics.numTurns).toBe(1);


### PR DESCRIPTION
## Summary
The Gemini CLI (`@google/gemini-cli`, checked with `gemini --help` at 0.35.x) has no `-C` flag; its flags are `-p/--prompt`, `-m/--model`, `-y/--yolo`, `--approval-mode default|auto_edit|yolo|plan`, `-s/--sandbox` (runs tools in a sandbox — a restriction, not a grant), `--include-directories`. Both the Go and TS providers passed `-C <cwd>` (the cwd is already the subprocess working directory) and mapped `permission_mode=auto` → `--sandbox`. Python's provider was fixed in #687; this brings Go and TS to parity.

## Validation contract (both SDKs)
- argv never contains `-C`; cwd (or ProjectDir fallback in Go) is still applied as the subprocess working directory.
- `auto` → `--yolo`, never `--sandbox`; `plan` → `--approval-mode plan`; unset/other → none of those flags.
- Order as Python: `[bin, (--yolo | --approval-mode plan)?, -m <model>?, -p <prompt>]`; `#variant` suffix stripped from the model.
- Result parsing/error paths unchanged.

Tests that pinned the old argv are rewritten table-driven from the contract (TS `harness_provider_gemini.test.ts`; Go `runner_test.go`, `coverage_branches_test.go`).

## Test plan
- [x] TS: `npm ci` (Node 20) · `npm run lint` · `npm test` — 863 passed
- [x] Go: `gofmt -l ./harness` clean · `go mod tidy` (no diff) · `go build ./...` · `go vet ./harness/...` · `go test ./harness/...` ok

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)