### PR TITLE
fix(sdk/typescript): opencode surfaces exit-0 stderr failures and signals as errors

### DIFF
--- a/sdk/typescript/src/harness/providers/opencode.ts
+++ b/sdk/typescript/src/harness/providers/opencode.ts
@@ -8,6 +8,25 @@ import {
   openRouterAttributionHeaders,
 } from '../../ai/openrouterAttribution.js';
 
+const ANSI_PATTERN = /\x1B\[[0-?]*[ -/]*[@-~]/g;
+const STDERR_ERROR_PATTERNS = [
+  /^Error:/m,
+  /\bModel not found\b/,
+  /\bAuthenticationError\b/,
+  /\bUnauthorized\b/,
+  /\bAPIError\b/,
+];
+
+function extractOpenCodeError(stderr: string): string {
+  const lines = stderr.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    if (STDERR_ERROR_PATTERNS.some((pattern) => pattern.test(lines[index]))) {
+      return lines.slice(Math.max(0, index - 1), index + 5).join('\n').trim().slice(0, 1000);
+    }
+  }
+  return stderr.slice(0, 1000);
+}
+
 export class OpenCodeProvider implements HarnessProvider {
   private readonly bin: string;
 
@@ -82,7 +101,28 @@ export class OpenCodeProvider implements HarnessProvider {
       const { stdout, stderr, exitCode } = await runCli(cmd, { env });
 
       const resultText = stdout.trim() || undefined;
-      const isError = exitCode !== 0 && !resultText;
+      const cleanStderr = stderr.trim().replace(ANSI_PATTERN, '');
+      let isError = false;
+      let errorMessage: string | undefined;
+
+      if (exitCode < 0) {
+        isError = true;
+        errorMessage = cleanStderr
+          ? `Process killed by signal ${-exitCode}. stderr: ${cleanStderr.slice(0, 500)}`
+          : `Process killed by signal ${-exitCode}.`;
+      } else if (exitCode !== 0 && !resultText) {
+        isError = true;
+        errorMessage = cleanStderr
+          ? extractOpenCodeError(cleanStderr)
+          : `Process exited with code ${exitCode} and produced no output.`;
+      } else if (
+        !resultText &&
+        cleanStderr &&
+        STDERR_ERROR_PATTERNS.some((pattern) => pattern.test(cleanStderr))
+      ) {
+        isError = true;
+        errorMessage = extractOpenCodeError(cleanStderr);
+      }
 
       return createRawResult({
         result: resultText,
@@ -94,7 +134,8 @@ export class OpenCodeProvider implements HarnessProvider {
           model: modelValue,
         }),
         isError,
-        errorMessage: isError ? stderr.trim() : undefined,
+        errorMessage,
+        failureType: isError ? 'crash' : 'none',
       });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/sdk/typescript/tests/harness_provider_opencode.test.ts
+++ b/sdk/typescript/tests/harness_provider_opencode.test.ts
@@ -56,6 +56,84 @@ describe('opencode provider', () => {
     expect(result.isError).toBe(true);
     expect(result.result).toBeUndefined();
     expect(result.errorMessage).toBe('boom');
+    expect(result.failureType).toBe('crash');
+  });
+
+  it('returns a fallback when non-zero exit has no output', async () => {
+    vi.spyOn(cli, 'runCli').mockResolvedValue({ stdout: '', stderr: '', exitCode: 1 });
+
+    const result = await new OpenCodeProvider().execute('hello', {});
+
+    expect(result.isError).toBe(true);
+    expect(result.errorMessage).toBe('Process exited with code 1 and produced no output.');
+    expect(result.failureType).toBe('crash');
+  });
+
+  it.each(['Model not found: foo/bar', 'Unauthorized'])(
+    'treats an empty successful result with known stderr failure %j as an error',
+    async (stderr) => {
+      vi.spyOn(cli, 'runCli').mockResolvedValue({ stdout: '', stderr, exitCode: 0 });
+
+      const result = await new OpenCodeProvider().execute('hello', {});
+
+      expect(result.isError).toBe(true);
+      expect(result.errorMessage).toContain(stderr);
+      expect(result.failureType).toBe('crash');
+    },
+  );
+
+  it('strips ANSI before matching and surfaces the matching stderr window', async () => {
+    vi.spyOn(cli, 'runCli').mockResolvedValue({
+      stdout: '',
+      stderr: `migration prelude\n\u001b[31mModel not found: foo/bar\u001b[0m\ncontext`,
+      exitCode: 0,
+    });
+
+    const result = await new OpenCodeProvider().execute('hello', {});
+
+    expect(result.isError).toBe(true);
+    expect(result.errorMessage).toBe('migration prelude\nModel not found: foo/bar\ncontext');
+  });
+
+  it('lets a non-empty result win over stderr failure noise', async () => {
+    vi.spyOn(cli, 'runCli').mockResolvedValue({
+      stdout: 'answer',
+      stderr: 'Unauthorized',
+      exitCode: 0,
+    });
+
+    const result = await new OpenCodeProvider().execute('hello', {});
+
+    expect(result.isError).toBe(false);
+    expect(result.result).toBe('answer');
+    expect(result.failureType).toBe('none');
+  });
+
+  it('does not treat unknown stderr with an empty successful result as an error', async () => {
+    vi.spyOn(cli, 'runCli').mockResolvedValue({
+      stdout: '',
+      stderr: 'one-time migration complete',
+      exitCode: 0,
+    });
+
+    const result = await new OpenCodeProvider().execute('hello', {});
+
+    expect(result.isError).toBe(false);
+    expect(result.failureType).toBe('none');
+  });
+
+  it('reports a negative exit code as a signal crash', async () => {
+    vi.spyOn(cli, 'runCli').mockResolvedValue({
+      stdout: '',
+      stderr: 'last diagnostic',
+      exitCode: -9,
+    });
+
+    const result = await new OpenCodeProvider().execute('hello', {});
+
+    expect(result.isError).toBe(true);
+    expect(result.errorMessage).toBe('Process killed by signal 9. stderr: last diagnostic');
+    expect(result.failureType).toBe('crash');
   });
 
   it('passes model flag', async () => {


### PR DESCRIPTION
## Summary
The TS opencode provider only treated `exitCode !== 0 && no output` as an error. Python and Go additionally flag: a negative exit code (killed by signal), and exit 0 with empty output whose stderr matches opencode's known failure patterns (`^Error:`, `Model not found`, `AuthenticationError`, `Unauthorized`, `APIError`) — opencode sometimes exits 0 on hard failures — surfacing the matching stderr window instead of returning an empty non-error result. TS now does the same, with the identical pattern list, ANSI stripped before matching, `failureType` set, and the "Process exited with code N and produced no output." fallback.

## Validation contract
- exit 0, empty stdout, stderr `Model not found …` / `Unauthorized` → `isError=true`, message from stderr, `failureType='crash'`.
- exit 0, non-empty stdout → not an error (result wins) — unchanged.
- exit ≠ 0, empty stdout, empty stderr → error with the fallback message; with stderr → message from stderr.
- negative exit code → `Process killed by signal N…`.
- exit 0, empty stdout, unrecognised stderr → unchanged (not an error), parity with Python/Go.
- Event parsing, model attribution, `--format json`, OpenRouter headers unchanged.

## Test plan
- [x] `npm ci` (Node 20) · `npm run lint` · `npm test` — 867 passed

Note: the shared `runCli` maps a `null` exit code (signal) to `0`, so real OS signal metadata does not reach the provider today; the negative-code branch is implemented and tested at the provider boundary for parity, and improving `runCli` is a separate change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)