### PR TITLE
fix(sdk/typescript): convert zod 4 schemas with the native toJSONSchema

### DIFF
--- a/sdk/typescript/src/harness/schema.ts
+++ b/sdk/typescript/src/harness/schema.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { createRequire } from 'node:module';
+import { isZod4Schema, zod4ToJsonSchema } from '../utils/zod-schema.js';
 
 export const OUTPUT_FILENAME = '.agentfield_output.json';
 export const SCHEMA_FILENAME = '.agentfield_schema.json';
@@ -85,6 +86,10 @@ export function getSchemaPath(cwd: string): string {
 }
 
 export function schemaToJsonSchema(schema: unknown): JsonSchemaRecord {
+  if (isZod4Schema(schema)) {
+    return zod4ToJsonSchema(schema);
+  }
+
   if (isRecord(schema)) {
     if ('type' in schema || 'properties' in schema || '$schema' in schema) {
       return schema;
@@ -99,7 +104,9 @@ export function schemaToJsonSchema(schema: unknown): JsonSchemaRecord {
     return converter(schema);
   }
 
-  throw new TypeError('Unsupported schema type. Expected a Zod schema, JSON schema object, or jsonSchema() provider.');
+  throw new TypeError(
+    'Unsupported schema type. Expected a Zod schema (requires "zod-to-json-schema" for Zod 3 or "zod" for Zod 4), JSON schema object, or jsonSchema() provider.',
+  );
 }
 
 export function isLargeSchema(schemaJson: string): boolean {

--- a/sdk/typescript/src/utils/schema.ts
+++ b/sdk/typescript/src/utils/schema.ts
@@ -1,5 +1,6 @@
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import type { ZodType } from 'zod';
+import { isZod4Schema, zod4ToJsonSchema } from './zod-schema.js';
 
 /**
  * Check if a value is a Zod schema by looking for Zod's internal structure.
@@ -23,6 +24,11 @@ function isZodSchema(value: unknown): value is ZodType {
 export function toJsonSchema(schema: unknown): Record<string, unknown> {
   if (schema === undefined || schema === null) {
     return {};
+  }
+
+  if (isZod4Schema(schema)) {
+    const { $schema, ...rest } = zod4ToJsonSchema(schema);
+    return rest;
   }
 
   if (isZodSchema(schema)) {

--- a/sdk/typescript/src/utils/zod-schema.ts
+++ b/sdk/typescript/src/utils/zod-schema.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module';
+import path from 'node:path';
 
 type JsonSchemaRecord = Record<string, unknown>;
 type JsonSchemaFactory = (schema: unknown) => JsonSchemaRecord;
@@ -20,26 +21,50 @@ export function isZod4Schema(value: unknown): boolean {
   return isRecord(value._zod.def);
 }
 
+/**
+ * Resolve zod 4's native `toJSONSchema`.
+ *
+ * Order matters: the application's own zod copy (resolved from the working
+ * directory) is tried first because it is the copy that built the schema
+ * instance. zod 4 keeps `.describe()` metadata in a per-copy registry, so a
+ * *different* copy (e.g. the SDK's nested zod 3.25 exposing `zod/v4`) still
+ * converts the structure but silently drops descriptions and some
+ * refinements (`.int()` → `number`). The SDK-relative copies are the fallback.
+ */
 function getZod4Converter(): JsonSchemaFactory | null {
   if (zod4Converter !== undefined) {
     return zod4Converter;
   }
 
-  const require = createRequire(import.meta.url);
-  for (const moduleName of ['zod', 'zod/v4']) {
-    try {
-      const mod = require(moduleName) as ZodModule;
-      if (typeof mod.toJSONSchema === 'function') {
-        zod4Converter = mod.toJSONSchema;
-        return zod4Converter;
+  const requires: NodeJS.Require[] = [];
+  try {
+    requires.push(createRequire(path.join(process.cwd(), 'package.json')));
+  } catch {
+    // No resolvable application root; fall through to the SDK's own tree.
+  }
+  requires.push(createRequire(import.meta.url));
+
+  for (const req of requires) {
+    for (const moduleName of ['zod', 'zod/v4']) {
+      try {
+        const mod = req(moduleName) as ZodModule;
+        if (typeof mod.toJSONSchema === 'function') {
+          zod4Converter = mod.toJSONSchema;
+          return zod4Converter;
+        }
+      } catch {
+        // Try the next Zod 4 entry point.
       }
-    } catch {
-      // Try the next Zod 4 entry point.
     }
   }
 
   zod4Converter = null;
   return zod4Converter;
+}
+
+/** Test hook: forget the cached converter so resolution runs again. */
+export function resetZod4ConverterCache(): void {
+  zod4Converter = undefined;
 }
 
 export function zod4ToJsonSchema(schema: unknown): JsonSchemaRecord {

--- a/sdk/typescript/src/utils/zod-schema.ts
+++ b/sdk/typescript/src/utils/zod-schema.ts
@@ -1,0 +1,53 @@
+import { createRequire } from 'node:module';
+
+type JsonSchemaRecord = Record<string, unknown>;
+type JsonSchemaFactory = (schema: unknown) => JsonSchemaRecord;
+
+type ZodModule = {
+  toJSONSchema?: JsonSchemaFactory;
+};
+
+let zod4Converter: JsonSchemaFactory | null | undefined;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function isZod4Schema(value: unknown): boolean {
+  if (!isRecord(value) || !('_zod' in value) || !isRecord(value._zod)) {
+    return false;
+  }
+  return isRecord(value._zod.def);
+}
+
+function getZod4Converter(): JsonSchemaFactory | null {
+  if (zod4Converter !== undefined) {
+    return zod4Converter;
+  }
+
+  const require = createRequire(import.meta.url);
+  for (const moduleName of ['zod', 'zod/v4']) {
+    try {
+      const mod = require(moduleName) as ZodModule;
+      if (typeof mod.toJSONSchema === 'function') {
+        zod4Converter = mod.toJSONSchema;
+        return zod4Converter;
+      }
+    } catch {
+      // Try the next Zod 4 entry point.
+    }
+  }
+
+  zod4Converter = null;
+  return zod4Converter;
+}
+
+export function zod4ToJsonSchema(schema: unknown): JsonSchemaRecord {
+  const converter = getZod4Converter();
+  if (converter === null) {
+    throw new TypeError(
+      'Cannot convert a Zod 4 schema: install the "zod" package with its "zod/v4" entry point available.',
+    );
+  }
+  return converter(schema);
+}

--- a/sdk/typescript/tests/harness_schema.test.ts
+++ b/sdk/typescript/tests/harness_schema.test.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
+import * as z4 from 'zod/v4';
 
 import {
   LARGE_SCHEMA_TOKEN_THRESHOLD,
@@ -51,6 +52,21 @@ describe('harness schema', () => {
 
     const plain = { type: 'object', properties: { name: { type: 'string' } } };
     expect(schemaToJsonSchema(plain)).toEqual(plain);
+  });
+
+  it('converts a zod 4 schema with the native converter', () => {
+    const jsonSchema = schemaToJsonSchema(
+      z4.object({ name: z4.string(), count: z4.number().optional() }),
+    );
+
+    expect(jsonSchema).toMatchObject({
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        count: { type: 'number' },
+      },
+      required: ['name'],
+    });
   });
 
   it('detects large schema threshold', () => {

--- a/sdk/typescript/tests/utils_schema.test.ts
+++ b/sdk/typescript/tests/utils_schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
+import * as z4 from 'zod/v4';
 
 import { toJsonSchema } from '../src/utils/schema.js';
 
@@ -19,6 +20,18 @@ describe('toJsonSchema', () => {
     const result = toJsonSchema(z.object({ name: z.string() }));
 
     expect(result).not.toHaveProperty('$schema');
+  });
+
+  it('converts zod 4 objects with the native converter', () => {
+    expect(toJsonSchema(z4.object({ name: z4.string(), count: z4.number().optional() }))).toEqual({
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        count: { type: 'number' },
+      },
+      required: ['name'],
+      additionalProperties: false,
+    });
   });
 
   it('returns plain json schema objects unchanged', () => {

--- a/sdk/typescript/tests/utils_zod_schema.test.ts
+++ b/sdk/typescript/tests/utils_zod_schema.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import * as z4 from 'zod/v4';
+
+import { resetZod4ConverterCache, zod4ToJsonSchema } from '../src/utils/zod-schema.js';
+
+// Contract: a zod 4 schema is converted by the APPLICATION's own zod copy when
+// one is resolvable from the working directory, because that is the copy that
+// built the schema instance (a different copy converts the structure but drops
+// registry-backed metadata such as descriptions). The SDK's own zod is the
+// fallback.
+describe('zod4ToJsonSchema converter resolution', () => {
+  const tempRoots: string[] = [];
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetZod4ConverterCache();
+    for (const root of tempRoots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers the zod copy resolvable from the working directory', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'agentfield-zod4-'));
+    tempRoots.push(root);
+    const fakeZod = path.join(root, 'node_modules', 'zod');
+    mkdirSync(fakeZod, { recursive: true });
+    writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name: 'app', version: '0.0.0' }));
+    writeFileSync(path.join(fakeZod, 'package.json'), JSON.stringify({ name: 'zod', version: '4.99.0', main: 'index.js' }));
+    writeFileSync(
+      path.join(fakeZod, 'index.js'),
+      "module.exports = { toJSONSchema: () => ({ type: 'object', properties: {}, 'x-converter': 'app-copy' }) };",
+    );
+    vi.spyOn(process, 'cwd').mockReturnValue(root);
+    resetZod4ConverterCache();
+
+    const out = zod4ToJsonSchema(z4.object({ name: z4.string() }));
+
+    expect(out['x-converter']).toBe('app-copy');
+  });
+
+  it('falls back to the SDK-relative zod when the working directory has none', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'agentfield-zod4-empty-'));
+    tempRoots.push(root);
+    writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name: 'app', version: '0.0.0' }));
+    vi.spyOn(process, 'cwd').mockReturnValue(root);
+    resetZod4ConverterCache();
+
+    // Structure only: zod 3.25's `zod/v4` shim keeps separate metadata
+    // registries for its ESM and CJS builds, so `.describe()` fidelity across
+    // that boundary is not part of this contract (zod 4 proper shares one
+    // registry between both builds — verified end to end).
+    const out = zod4ToJsonSchema(z4.object({ name: z4.string() }));
+
+    expect(out).toMatchObject({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
`harness()` / `ai()` schema conversion only knew `zod-to-json-schema`, which does not understand zod 4 instances — and a fresh `npm i zod` is 4.x today — so zod 4 schemas were serialized as zod internals. Zod 4 schemas (`_zod` on the instance) are now converted with zod's own `toJSONSchema` (resolved from `zod`, then `zod/v4`); zod 3 keeps using `zod-to-json-schema` unchanged; plain JSON Schema still passes through. The "no converter" error now names `zod` / `zod/v4` / `zod-to-json-schema`. Shared helper `utils/zod-schema.ts` is used by both the harness and `.ai()` paths. No dependency or lockfile changes.

## Validation contract
- zod 4 instance → proper JSON Schema (`type: 'object'`, `properties`, `required`) via the native converter.
- zod 3 instance → unchanged conversion (existing tests pass).
- plain JSON Schema object → passthrough (existing tests pass).
- neither converter available → error names the missing packages.

## Live verification (real zod 4.4.3, fresh project, shim aforge capturing the prompt)
- released 0.1.130: schema sent to the agent is zod internals: `{"def":{"type":"object","shape":{…}}}`
- this branch: `{"type":"object","properties":{"a":{"type":"string","description":"alpha"},"n":{"type":"integer",…}},"required":["a","n"]}`; output round-trips through `schema.parse` → `{a:"x", n:1}`.
- Second commit: prefer the app's own zod copy — converting with a different copy (SDK-nested zod 3.25 `zod/v4`) silently dropped `description` and `integer`; verified before/after.

## Test plan
- [x] `npm ci` (Node 20) · `npm run lint` · `npm test` — 862 passed

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)