### PR TITLE
fix(install): disable VCS stamping when building Go agent nodes

### DIFF
--- a/control-plane/internal/packages/go_runtime_test.go
+++ b/control-plane/internal/packages/go_runtime_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -276,6 +277,41 @@ func TestInstallGoDependencies_BuildsBinary(t *testing.T) {
 	}
 	if err := InstallGoDependencies(dir, md); err != nil {
 		t.Fatalf("InstallGoDependencies: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "bin", "node")); err != nil {
+		t.Fatalf("expected built binary bin/node: %v", err)
+	}
+}
+
+// Contract: a Go node must build regardless of what surrounds the package
+// directory. `go build`'s VCS auto-detection walks up past the package root,
+// so a .git anywhere above ~/.agentfield/packages — a dotfiles-managed $HOME,
+// a stray /tmp/.git — used to hard-fail the install with "error obtaining VCS
+// status" (the copied package is not a repository, so there is nothing
+// truthful to stamp). Uses the real toolchain: the failure lives inside `go
+// build`'s repository detection, which stubGo cannot reproduce.
+func TestInstallGoDependencies_IgnoresParentVCS(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("real Go toolchain required")
+	}
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir fake .git: %v", err)
+	}
+	dir := filepath.Join(root, "pkg")
+	writeGoManifest(t, dir,
+		"name: n\nversion: 0.1.0\nlanguage: go\nentrypoint:\n  build: ./cmd/node\n  start: bin/node\n",
+		"1.21", "")
+	if err := os.MkdirAll(filepath.Join(dir, "cmd", "node"), 0o755); err != nil {
+		t.Fatalf("mkdir cmd/node: %v", err)
+	}
+	writeFile(t, dir, "cmd/node/main.go", "package main\n\nfunc main() {}\n")
+	md, err := ParsePackageMetadata(dir)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := InstallGoDependencies(dir, md); err != nil {
+		t.Fatalf("InstallGoDependencies under a foreign .git: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "bin", "node")); err != nil {
 		t.Fatalf("expected built binary bin/node: %v", err)

--- a/control-plane/internal/packages/gointerp.go
+++ b/control-plane/internal/packages/gointerp.go
@@ -227,7 +227,15 @@ func InstallGoDependencies(packagePath string, metadata *PackageMetadata) error 
 
 	buildPkg, outBin := metadata.goBuildTarget()
 
-	args := []string{"build"}
+	// The installed package copy is not a git checkout, so there is nothing
+	// truthful for `go build`'s VCS stamping to record — and its repo
+	// auto-detection walks up PAST the package root, so a .git anywhere above
+	// ~/.agentfield/packages (a dotfiles-managed $HOME, a stray /tmp/.git)
+	// either hard-fails the build ("error obtaining VCS status") or stamps an
+	// unrelated repository's revision into the node binary. Stamping is
+	// therefore disabled outright. (`go run` launches are unaffected: the go
+	// tool only stamps VCS info for build/install.)
+	args := []string{"build", "-buildvcs=false"}
 	if hasVendorDir(packagePath) {
 		args = append(args, "-mod=vendor")
 	} else {

--- a/control-plane/internal/templates/templates_test.go
+++ b/control-plane/internal/templates/templates_test.go
@@ -213,7 +213,11 @@ func TestRenderedGoScaffoldBuilds(t *testing.T) {
 	}
 	commands := [][]string{
 		{"mod", "edit", "-replace=github.com/Agent-Field/agentfield/sdk/go=" + sdkRoot},
-		{"build", "-mod=mod", "./..."},
+		// -buildvcs=false: the rendered scaffold is not a repository, and go
+		// build's VCS auto-detection walks above the temp dir — a .git anywhere
+		// up the tree (a dotfiles $HOME, a stray /tmp/.git) would fail the build
+		// for reasons unrelated to the template. Mirrors InstallGoDependencies.
+		{"build", "-buildvcs=false", "-mod=mod", "./..."},
 	}
 	for _, args := range commands {
 		cmd := exec.Command("go", args...)


### PR DESCRIPTION
## Summary

A stock `af install` of a Go agent node (e.g. `https://github.com/Agent-Field/sec-af`, which now redirects to its `go/` port) can fail at the build step with:

```
failed to build Go node (go build -mod=mod -o …/bin/sec-af ./cmd/sec-af): exit status 1
Output: error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
```

The installed package copy under `~/.agentfield/packages` is not a git checkout, so there is nothing truthful for `go build`'s VCS stamping to record — and the go tool's repo auto-detection walks up **past** the package root. A `.git` anywhere above the packages dir (a dotfiles-managed `$HOME`, a stray empty `/tmp/.git`, which is how this was found live) either hard-fails the install or silently stamps an unrelated repository's revision into the node binary. `InstallGoDependencies` now builds with `-buildvcs=false`. (`go run` launches are unaffected — the go tool only stamps for build/install.)

Second commit applies the same flag to `TestRenderedGoScaffoldBuilds`, which runs its own `go build` in a temp dir and fails identically in such environments for reasons unrelated to the template.

## Changes Made
- `InstallGoDependencies` passes `-buildvcs=false` (single `go build` site in the installer).
- Regression test `TestInstallGoDependencies_IgnoresParentVCS`: real toolchain, package beneath a directory containing a bogus `.git` — fails without the fix with exactly the error above, passes with it.
- `TestRenderedGoScaffoldBuilds` builds the rendered scaffold with `-buildvcs=false`.

## Test Plan
- [x] New regression test fails on the parent-`.git` layout without the fix, passes with it
- [x] `GOFLAGS=-buildvcs=false go build ./...` (CI's build gate) clean
- [x] Full control-plane suite via `./scripts/coverage-surface.sh control-plane` — green (including on a machine with a stray `/tmp/.git`, where `TestRenderedGoScaffoldBuilds` previously failed)
- [x] gofmt clean on touched files; golangci-lint reports no issues on changed lines

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)