### PR TITLE
Bundle sec-af and cloudsecurity-af with the desktop app

### DIFF
--- a/desktop/src/main/agentfield.test.ts
+++ b/desktop/src/main/agentfield.test.ts
@@ -546,9 +546,14 @@ describe('fetchUsageStats', () => {
 })
 
 describe('install catalog', () => {
+  // catalogEntry resolves over the marketplace CATALOG and the bundled roster
+  // alike, so the shape and uniqueness invariants hold across their union.
+  // CATALOG itself is currently empty — every vetted node ships with the app.
+  const VETTED = [...CATALOG, ...BUNDLED_NODES]
+
   it('every entry has a name, description, and an https or af:// source', () => {
-    expect(CATALOG.length).toBeGreaterThan(0)
-    for (const entry of CATALOG) {
+    expect(VETTED.length).toBeGreaterThan(0)
+    for (const entry of VETTED) {
       expect(entry.name).toMatch(/^[a-z0-9][a-z0-9-]*$/)
       expect(entry.description.length).toBeGreaterThan(0)
       expect(entry.source).toMatch(/^(https:\/\/|af:\/\/)/)
@@ -556,12 +561,12 @@ describe('install catalog', () => {
   })
 
   it('entry names are unique', () => {
-    const names = CATALOG.map((e) => e.name)
+    const names = VETTED.map((e) => e.name)
     expect(new Set(names).size).toBe(names.length)
   })
 
   it('catalogEntry resolves known names and rejects unknown ones', () => {
-    expect(catalogEntry(CATALOG[0].name)).toEqual(CATALOG[0])
+    expect(catalogEntry(VETTED[0].name)).toEqual(VETTED[0])
     expect(catalogEntry('definitely-not-real')).toBeUndefined()
   })
 
@@ -576,7 +581,9 @@ describe('install catalog', () => {
   // return to the Install view.
   it.each([
     { repo: 'Agent-Field/SWE-AF', name: 'swe-planner', retired: 'swe-planner-go' },
-    { repo: 'Agent-Field/pr-af', name: 'pr-af', retired: 'pr-af-go' }
+    { repo: 'Agent-Field/pr-af', name: 'pr-af', retired: 'pr-af-go' },
+    { repo: 'Agent-Field/sec-af', name: 'sec-af', retired: 'sec-af-go' },
+    { repo: 'Agent-Field/cloudsecurity-af', name: 'cloudsecurity-af', retired: 'cloudsecurity-af-go' }
   ])('ships $name as one product-named bundled node sourced at the bare repo', (tc) => {
     const entries = BUNDLED_NODES.filter((e) => e.source.includes(tc.repo))
     expect(entries).toHaveLength(1)
@@ -594,9 +601,9 @@ describe('installCommand', () => {
   // Contract: the renderer sends catalog *names* over IPC; only vetted
   // sources ever reach spawn, and unknown names are refused.
   it('builds a control-plane install preview for a catalog name', () => {
-    expect(installCommand(CATALOG[0].name)).toEqual({
+    expect(installCommand(BUNDLED_NODES[0].name)).toEqual({
       command: 'control-plane',
-      args: ['install', CATALOG[0].source]
+      args: ['install', BUNDLED_NODES[0].source]
     })
   })
 

--- a/desktop/src/main/bundledAgents.test.ts
+++ b/desktop/src/main/bundledAgents.test.ts
@@ -24,8 +24,8 @@ const baseInput: BundledPlanInput = {
 }
 
 describe('BUNDLED_NODES', () => {
-  it('ships swe-planner and pr-af as go nodes sourced at the bare repo', () => {
-    expect(NAMES).toEqual(['swe-planner', 'pr-af'])
+  it('ships the four agent nodes as go nodes sourced at the bare repo', () => {
+    expect(NAMES).toEqual(['swe-planner', 'pr-af', 'sec-af', 'cloudsecurity-af'])
     for (const entry of BUNDLED_NODES) {
       expect(entry.name).toMatch(/^[a-z0-9][a-z0-9-]*$/)
       expect(entry.description.length).toBeGreaterThan(0)
@@ -42,7 +42,7 @@ describe('BUNDLED_NODES', () => {
       expect(catalogEntry(name)).toEqual(bundledEntry(name))
       expect(isBundled(name)).toBe(true)
     }
-    expect(isBundled('sec-af')).toBe(false)
+    expect(isBundled('definitely-not-real')).toBe(false)
     expect(bundledEntry('definitely-not-real')).toBeUndefined()
   })
 })
@@ -120,16 +120,16 @@ describe('planBundledInstalls', () => {
   it('leaves alone nodes already in the registry', () => {
     expect(planBundledInstalls({ ...baseInput, installed: [NAMES[0]] })).toMatchObject({
       adopt: [NAMES[0]],
-      install: [NAMES[1]]
+      install: NAMES.slice(1)
     })
   })
 
   // Uninstalling a bundled node must stick: it is in provisionedBundled but no
   // longer in the registry, and it must not come back on the next launch.
   it('never re-installs a node already provisioned once', () => {
-    expect(planBundledInstalls({ ...baseInput, provisioned: [NAMES[0]] }).install).toEqual([
-      NAMES[1]
-    ])
+    expect(planBundledInstalls({ ...baseInput, provisioned: [NAMES[0]] }).install).toEqual(
+      NAMES.slice(1)
+    )
     expect(planBundledInstalls({ ...baseInput, provisioned: NAMES })).toEqual({
       install: [],
       adopt: [],
@@ -147,7 +147,7 @@ describe('planBundledInstalls', () => {
   it('does not adopt an already-recorded installed node twice', () => {
     expect(
       planBundledInstalls({ ...baseInput, installed: [NAMES[0]], provisioned: [NAMES[0]] })
-    ).toMatchObject({ adopt: [], install: [NAMES[1]] })
+    ).toMatchObject({ adopt: [], install: NAMES.slice(1) })
   })
 })
 
@@ -223,7 +223,7 @@ describe('ensureBundledAgents', () => {
       return { ok: true, message: `${name} installed` }
     })
 
-    await ensureBundledAgents({ ...baseInput, installed: [NAMES[1]] }, deps)
+    await ensureBundledAgents({ ...baseInput, installed: NAMES.slice(1) }, deps)
 
     expect(mid).toHaveLength(1)
     expect(mid[0]).toMatchObject({ name: NAMES[0], phase: 'installing', message: 'building' })
@@ -245,8 +245,8 @@ describe('ensureBundledAgents', () => {
     ])
     // The failure must not stop the next node, and must not be recorded —
     // that is what makes the next launch retry it.
-    expect(deps.markProvisioned.mock.calls.map((c) => c[0])).toEqual([NAMES[1]])
-    expect(deps.install).toHaveBeenCalledTimes(2)
+    expect(deps.markProvisioned.mock.calls.map((c) => c[0])).toEqual(NAMES.slice(1))
+    expect(deps.install).toHaveBeenCalledTimes(NAMES.length)
     expect(deps.lines.some((l) => l.includes('clone failed'))).toBe(true)
   })
 
@@ -268,7 +268,7 @@ describe('ensureBundledAgents', () => {
 
     await expect(ensureBundledAgents(baseInput, deps)).resolves.toBeUndefined()
 
-    expect(deps.install).toHaveBeenCalledTimes(2)
+    expect(deps.install).toHaveBeenCalledTimes(NAMES.length)
     expect(bundledStatuses()).toEqual([])
     expect(deps.lines.some((l) => l.includes('disk full'))).toBe(true)
     expect(deps.lines.some((l) => l.includes('autostart failed'))).toBe(true)
@@ -344,7 +344,7 @@ describe('ensureBundledAgents', () => {
       await tick()
     }
     await first
-    expect(deps.install).toHaveBeenCalledTimes(2)
+    expect(deps.install).toHaveBeenCalledTimes(NAMES.length)
   })
 
   it('resetBundledState clears rows left by a previous run', async () => {

--- a/desktop/src/main/bundledAgents.ts
+++ b/desktop/src/main/bundledAgents.ts
@@ -1,6 +1,7 @@
 // Provision the agent nodes that ship with the app (shared/bundled.ts) on
-// first launch, so a fresh install already has swe-planner and pr-af in the
-// Agents library instead of an empty view and a marketplace to shop in.
+// first launch, so a fresh install already has swe-planner, pr-af, sec-af and
+// cloudsecurity-af in the Agents library instead of an empty view and a
+// marketplace to shop in.
 //
 // Delivery is "fetch on first launch", not "baked into the installer": the app
 // installs them through the same control-plane install API a user-initiated

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -385,7 +385,7 @@ async function provisionBundledAgents(): Promise<void> {
         await saveSettings(settingsFile(), settings)
       },
       hasInstallApi: () => createCpClient().hasInstallApi(),
-      // Start it from the NEXT launch on, not now. Both bundled nodes need an
+      // Start it from the NEXT launch on, not now. Every bundled node needs an
       // API key the first-launch user has not entered yet, so starting one
       // here would only produce a dead node and an alarming badge; the Agents
       // row's "Needs keys" chip is the affordance that actually helps.
@@ -402,7 +402,7 @@ async function provisionBundledAgents(): Promise<void> {
     }
   )
 
-  // Nothing was started above, on purpose — both bundled nodes need an API key
+  // Nothing was started above, on purpose — the bundled nodes need API keys
   // the first-launch user has not entered. On a login-item launch the app is
   // hidden in the tray, so the Agents row's "Needs keys" chip is telling an
   // empty room. One OS notification is the only thing that reaches the user

--- a/desktop/src/main/installer.test.ts
+++ b/desktop/src/main/installer.test.ts
@@ -1,19 +1,23 @@
 import { describe, expect, it, vi } from 'vitest'
-import { CATALOG } from '../shared/catalog'
+import { BUNDLED_NODES } from '../shared/bundled'
 import { CpApiError, type CpClient } from './cpClient'
 import { installAgent, installCommand, installFromSource, parseRepoSource, sanitizeInstallOutput, updateAgent } from './installer'
 
+// Any vetted installable entry; the marketplace CATALOG is currently empty, so
+// the bundled roster is where installCommand's name→source contract lives.
+const ENTRY = BUNDLED_NODES[0]
+
 describe('installCommand', () => {
   it('builds a plain install for a catalog entry', () => {
-    const cmd = installCommand(CATALOG[0].name)
+    const cmd = installCommand(ENTRY.name)
     expect(cmd).not.toBeNull()
-    expect(cmd!.args).toEqual(['install', CATALOG[0].source])
+    expect(cmd!.args).toEqual(['install', ENTRY.source])
   })
 
   it('appends --force for updates (reinstall in place, secrets survive)', () => {
-    const cmd = installCommand(CATALOG[0].name, true)
+    const cmd = installCommand(ENTRY.name, true)
     expect(cmd).not.toBeNull()
-    expect(cmd!.args).toEqual(['install', CATALOG[0].source, '--force'])
+    expect(cmd!.args).toEqual(['install', ENTRY.source, '--force'])
   })
 
   it('refuses names outside the curated catalog', () => {
@@ -109,24 +113,24 @@ function installClient(overrides: Partial<CpClient> = {}): CpClient {
 describe('control-plane installs', () => {
   it('preserves progress callbacks and terminal success/failure', async () => {
     const lines: string[] = []
-    expect(await installAgent(CATALOG[0].name, (line) => lines.push(line), false, { cpClient: installClient() })).toEqual({ ok: true, message: `${CATALOG[0].name} installed` })
+    expect(await installAgent(ENTRY.name, (line) => lines.push(line), false, { cpClient: installClient() })).toEqual({ ok: true, message: `${ENTRY.name} installed` })
     expect(lines).toEqual(['Cloning', 'Installed'])
     const failed = installClient({ watchInstallJob: vi.fn(async () => ({ id: 'job', source: '', kind: 'install' as const, status: 'failed' as const, error: 'clone failed', lines: [] })) })
-    expect(await installAgent(CATALOG[0].name, () => {}, false, { cpClient: failed })).toEqual({ ok: false, message: 'clone failed' })
+    expect(await installAgent(ENTRY.name, () => {}, false, { cpClient: failed })).toEqual({ ok: false, message: 'clone failed' })
   })
 
   it('forwards force for reinstall-in-place updates', async () => {
     const client = installClient()
-    await installAgent(CATALOG[0].name, () => {}, true, { cpClient: client })
-    expect(client.installPackage).toHaveBeenCalledWith(CATALOG[0].source, true)
+    await installAgent(ENTRY.name, () => {}, true, { cpClient: client })
+    expect(client.installPackage).toHaveBeenCalledWith(ENTRY.source, true)
   })
 
   it('surfaces conflict and old-control-plane errors without fallback', async () => {
     const conflict = installClient({ installPackage: vi.fn(async () => { throw new CpApiError({ status: 409, message: 'another install is running' }) }) })
-    expect((await installAgent(CATALOG[0].name, () => {}, false, { cpClient: conflict })).message).toMatch(/another install/i)
+    expect((await installAgent(ENTRY.name, () => {}, false, { cpClient: conflict })).message).toMatch(/another install/i)
     const old = installClient({ hasInstallApi: vi.fn(async () => false) })
-    expect((await installAgent(CATALOG[0].name, () => {}, false, { cpClient: old })).message).toMatch(/update AgentField CLI/)
-    expect((await updateAgent(CATALOG[0].name, () => {}, { cpClient: old })).message).toMatch(/update AgentField CLI/)
+    expect((await installAgent(ENTRY.name, () => {}, false, { cpClient: old })).message).toMatch(/update AgentField CLI/)
+    expect((await updateAgent(ENTRY.name, () => {}, { cpClient: old })).message).toMatch(/update AgentField CLI/)
   })
 
   it('maps mid-request 404s to the update-required result', async () => {
@@ -134,7 +138,7 @@ describe('control-plane installs', () => {
     const install = installClient({
       installPackage: vi.fn(async () => { throw missing })
     })
-    expect(await installAgent(CATALOG[0].name, () => {}, false, { cpClient: install })).toEqual({
+    expect(await installAgent(ENTRY.name, () => {}, false, { cpClient: install })).toEqual({
       ok: false,
       message: 'Control plane update required — update AgentField CLI'
     })
@@ -142,7 +146,7 @@ describe('control-plane installs', () => {
     const update = installClient({
       updatePackage: vi.fn(async () => { throw missing })
     })
-    expect(await updateAgent(CATALOG[0].name, () => {}, { cpClient: update })).toEqual({
+    expect(await updateAgent(ENTRY.name, () => {}, { cpClient: update })).toEqual({
       ok: false,
       message: 'Control plane update required — update AgentField CLI'
     })
@@ -152,7 +156,7 @@ describe('control-plane installs', () => {
     const client = installClient({
       installPackage: vi.fn(async () => { throw new TypeError('offline') })
     })
-    expect(await installAgent(CATALOG[0].name, () => {}, false, { cpClient: client })).toEqual({
+    expect(await installAgent(ENTRY.name, () => {}, false, { cpClient: client })).toEqual({
       ok: false,
       message: 'Could not reach the control plane — start the control plane and try again'
     })
@@ -168,7 +172,7 @@ describe('control-plane installs', () => {
         lines: ['clone failed']
       }))
     })
-    expect(await installAgent(CATALOG[0].name, () => {}, false, { cpClient: failedWithLine })).toEqual({
+    expect(await installAgent(ENTRY.name, () => {}, false, { cpClient: failedWithLine })).toEqual({
       ok: false,
       message: 'clone failed'
     })
@@ -182,7 +186,7 @@ describe('control-plane installs', () => {
         lines: []
       }))
     })
-    expect(await installAgent(CATALOG[0].name, () => {}, false, { cpClient: failedEmpty })).toEqual({
+    expect(await installAgent(ENTRY.name, () => {}, false, { cpClient: failedEmpty })).toEqual({
       ok: false,
       message: 'Install failed'
     })
@@ -235,20 +239,20 @@ describe('superseded installs report what actually landed', () => {
 
   it('names the successor when a catalog install redirects elsewhere', async () => {
     expect(
-      await installAgent(CATALOG[0].name, () => {}, false, { cpClient: landedAs('successor-node') })
+      await installAgent(ENTRY.name, () => {}, false, { cpClient: landedAs('successor-node') })
     ).toEqual({ ok: true, message: 'successor-node installed' })
   })
 
   it('reports an update that renamed the node as a replacement', async () => {
     expect(
-      await updateAgent(CATALOG[0].name, () => {}, { cpClient: landedAs('successor-node') })
-    ).toEqual({ ok: true, message: `${CATALOG[0].name} replaced by successor-node` })
+      await updateAgent(ENTRY.name, () => {}, { cpClient: landedAs('successor-node') })
+    ).toEqual({ ok: true, message: `${ENTRY.name} replaced by successor-node` })
   })
 
   it('still reads as a plain update when the name is unchanged', async () => {
     expect(
-      await updateAgent(CATALOG[0].name, () => {}, { cpClient: landedAs(CATALOG[0].name) })
-    ).toEqual({ ok: true, message: `${CATALOG[0].name} updated` })
+      await updateAgent(ENTRY.name, () => {}, { cpClient: landedAs(ENTRY.name) })
+    ).toEqual({ ok: true, message: `${ENTRY.name} updated` })
   })
 })
 

--- a/desktop/src/main/keyNotice.ts
+++ b/desktop/src/main/keyNotice.ts
@@ -2,10 +2,10 @@
 // still cannot run for want of an API key.
 //
 // The app is designed to open at login, hidden, in the tray (applyLoginItem in
-// index.ts). On such a launch bundledAgents.ts installs swe-planner and pr-af,
-// deliberately does NOT start them — both need a key the user has not entered —
+// index.ts). On such a launch bundledAgents.ts installs the bundled nodes,
+// deliberately does NOT start them — each needs a key the user has not entered —
 // and puts a "Needs keys" chip on their Agents rows. Nobody is looking at that
-// window. Without a push the two nodes sit there unusable and the user finds
+// window. Without a push the new nodes sit there unusable and the user finds
 // out later, from a coding agent that could not call them. One native
 // notification closes that loop: name the keys, name where to enter them.
 //

--- a/desktop/src/shared/bundled.ts
+++ b/desktop/src/shared/bundled.ts
@@ -16,7 +16,7 @@ import type { CatalogEntry } from './types'
 // hard-coded here in main-process-trusted source.
 //
 // Sourcing follows the same rule catalog.ts documents at length: name the BARE
-// repo URL, never the `//go` subdirectory. Both repos' root manifests carry
+// repo URL, never the `//go` subdirectory. All four repos' root manifests carry
 // `superseded_by: …//go`, and that redirect is what carries a user who already
 // has the older Python node across — it installs the successor, migrates
 // node-scoped secrets, and only then retires the predecessor. Naming `//go`
@@ -37,6 +37,20 @@ export const BUNDLED_NODES: readonly CatalogEntry[] = [
     name: 'pr-af',
     description: 'Code review — deep, evidence-backed review of any GitHub pull request',
     source: 'https://github.com/Agent-Field/pr-af',
+    language: 'go'
+  },
+  {
+    name: 'sec-af',
+    description:
+      'Security auditor — find vulnerabilities in your codebase and prove which ones are exploitable',
+    source: 'https://github.com/Agent-Field/sec-af',
+    language: 'go'
+  },
+  {
+    name: 'cloudsecurity-af',
+    description:
+      'Cloud security — map real attack paths across your AWS, GCP, and Azure accounts',
+    source: 'https://github.com/Agent-Field/cloudsecurity-af',
     language: 'go'
   }
 ]

--- a/desktop/src/shared/catalog.ts
+++ b/desktop/src/shared/catalog.ts
@@ -22,9 +22,9 @@ import type { CatalogEntry } from './types'
 // it installs the successor first, migrates node-scoped secrets, and only then
 // retires the old package. So the catalog names the repo and lets the manifest
 // decide. shared/bundled.ts follows the identical rule for the nodes that ship
-// with the app (SWE-AF and pr-af both point their root at `//go`), which is
-// why they are no longer rows here: they are provisioned on first launch
-// instead of being offered as marketplace cards.
+// with the app (all four point their root at `//go`), which is why they are no
+// longer rows here: they are provisioned on first launch instead of being
+// offered as marketplace cards.
 //
 // `name` MUST equal the name the package ends up REGISTERED under once the
 // install settles — that is how the app detects installed state. Note that is
@@ -33,22 +33,11 @@ import type { CatalogEntry } from './types'
 // predecessor's name (an in-place rename), and it may live in a subdirectory
 // this list never names. It is often not the repo name either
 // (SWE-AF → swe-planner).
-export const CATALOG: CatalogEntry[] = [
-  {
-    name: 'sec-af',
-    description:
-      'Security auditor — find vulnerabilities in your codebase and prove which ones are exploitable',
-    source: 'https://github.com/Agent-Field/sec-af',
-    language: 'python'
-  },
-  {
-    name: 'cloudsecurity-af',
-    description:
-      'Cloud security — map real attack paths across your AWS, GCP, and Azure accounts',
-    source: 'https://github.com/Agent-Field/cloudsecurity-af',
-    language: 'python'
-  }
-]
+//
+// Currently empty: every vetted node ships with the app (shared/bundled.ts).
+// The list stays because it is the seam the next marketplace-only node — and
+// eventually the remote catalog fetch — lands in.
+export const CATALOG: CatalogEntry[] = []
 
 /**
  * Look up an installable entry by name, across the marketplace catalog AND the


### PR DESCRIPTION
## Summary

Promotes `sec-af` and `cloudsecurity-af` from marketplace catalog rows to `BUNDLED_NODES`, so a fresh desktop install provisions all four agent nodes (`swe-planner`, `pr-af`, `sec-af`, `cloudsecurity-af`) on first launch.

- Both repos carry the same `superseded_by: …//go` root-manifest redirect as SWE-AF and pr-af, and register under their product names, so the bundled-roster rules apply unchanged.
- The maintained nodes are Go — the move also retires the stale `python` language chips the catalog rows carried.
- `CATALOG` is now empty and stays as the seam for future marketplace-only rows / the remote catalog fetch.
- Users who already ran provisioning get exactly the two new nodes on their next launch (they are not in `provisionedBundled`); an uninstall still sticks.

## Testing

- `cd desktop && npm test` — 26 files, 521 tests pass; `npm run typecheck` clean.
- Live-verified on macOS against a machine that had already provisioned the original pair: dev-app launch planned `provisioning bundled nodes: sec-af, cloudsecurity-af`, both installed through the control-plane install API, registered under their product names from the `//go` redirect, and were recorded in `provisionedBundled`/`autostartAgents`. A subsequent launch reports `bundled nodes already provisioned` and auto-starts them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)