### PR TITLE
fix(control-plane): stop counting agent restarts as failed executions

### DIFF
--- a/control-plane/internal/config/config.go
+++ b/control-plane/internal/config/config.go
@@ -202,6 +202,12 @@ type NodeHealthConfig struct {
 	ConsecutiveFailures     int           `yaml:"consecutive_failures" mapstructure:"consecutive_failures"`           // Failures before marking inactive (0 = default 3; set 1 for instant)
 	RecoveryDebounce        time.Duration `yaml:"recovery_debounce" mapstructure:"recovery_debounce"`                 // Wait before allowing inactive->active (0 = default 5s)
 	HeartbeatStaleThreshold time.Duration `yaml:"heartbeat_stale_threshold" mapstructure:"heartbeat_stale_threshold"` // Heartbeat age before marking stale (0 = default 60s)
+	// AgentRestartGrace is how long a dispatch waits for a long-running agent
+	// node to come back after the connection is refused, before failing the
+	// execution. This absorbs the edit-restart loop, where the node is down
+	// for a few seconds but the control plane has not noticed yet.
+	// 0 = default 15s. Set to a negative duration to disable the wait.
+	AgentRestartGrace time.Duration `yaml:"agent_restart_grace" mapstructure:"agent_restart_grace"`
 }
 
 // ExecutionCleanupConfig holds configuration for execution cleanup and garbage collection
@@ -634,6 +640,11 @@ func ApplyEnvOverrides(cfg *Config) {
 	if val := os.Getenv("AGENTFIELD_HEARTBEAT_STALE_THRESHOLD"); val != "" {
 		if d, err := time.ParseDuration(val); err == nil {
 			cfg.AgentField.NodeHealth.HeartbeatStaleThreshold = d
+		}
+	}
+	if val := os.Getenv("AGENTFIELD_AGENT_RESTART_GRACE"); val != "" {
+		if d, err := time.ParseDuration(val); err == nil {
+			cfg.AgentField.NodeHealth.AgentRestartGrace = d
 		}
 	}
 

--- a/control-plane/internal/config/config_additional_test.go
+++ b/control-plane/internal/config/config_additional_test.go
@@ -606,3 +606,46 @@ func TestShutdownTimeoutEnvOverrideIgnoresInvalidValue(t *testing.T) {
 		t.Fatalf("expected invalid shutdown timeout env value to be ignored, got %v", cfg.AgentField.ShutdownTimeout)
 	}
 }
+
+func TestAgentRestartGrace(t *testing.T) {
+	writeMinimalConfig := func(t *testing.T) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "agentfield.yaml")
+		if err := os.WriteFile(path, []byte("agentfield:\n  port: 8080\n"), 0o644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		return path
+	}
+
+	t.Run("is unset by default so the handler default applies", func(t *testing.T) {
+		cfg, err := LoadConfig(writeMinimalConfig(t))
+		if err != nil {
+			t.Fatalf("load config: %v", err)
+		}
+		if cfg.AgentField.NodeHealth.AgentRestartGrace != 0 {
+			t.Fatalf("expected an unset restart grace, got %s", cfg.AgentField.NodeHealth.AgentRestartGrace)
+		}
+	})
+
+	t.Run("is overridable from the environment", func(t *testing.T) {
+		t.Setenv("AGENTFIELD_AGENT_RESTART_GRACE", "25s")
+		cfg, err := LoadConfig(writeMinimalConfig(t))
+		if err != nil {
+			t.Fatalf("load config: %v", err)
+		}
+		if cfg.AgentField.NodeHealth.AgentRestartGrace != 25*time.Second {
+			t.Fatalf("expected 25s restart grace, got %s", cfg.AgentField.NodeHealth.AgentRestartGrace)
+		}
+	})
+
+	t.Run("ignores an unparseable value", func(t *testing.T) {
+		t.Setenv("AGENTFIELD_AGENT_RESTART_GRACE", "soon")
+		cfg, err := LoadConfig(writeMinimalConfig(t))
+		if err != nil {
+			t.Fatalf("load config: %v", err)
+		}
+		if cfg.AgentField.NodeHealth.AgentRestartGrace != 0 {
+			t.Fatalf("expected an unparseable value to be ignored, got %s", cfg.AgentField.NodeHealth.AgentRestartGrace)
+		}
+	})
+}

--- a/control-plane/internal/handlers/execute.go
+++ b/control-plane/internal/handlers/execute.go
@@ -1544,17 +1544,27 @@ func (c *executionController) prepareExecutionForTarget(ctx context.Context, tar
 		}
 	}
 
+	if agent.DeploymentType == "" && agent.Metadata.Custom != nil {
+		if v, ok := agent.Metadata.Custom["serverless"]; ok && fmt.Sprint(v) == "true" {
+			agent.DeploymentType = "serverless"
+		}
+	}
+
 	// Reject a call to a node we already know is down BEFORE the execution
 	// record is created. Dispatching into a dead node would persist a row and
 	// then fail it, charging the caller for a failed execution when nothing
 	// was ever attempted. See execute_agent_restart.go.
-	if err := ensureAgentDispatchable(agent); err != nil {
-		return nil, err
-	}
-
-	if agent.DeploymentType == "" && agent.Metadata.Custom != nil {
-		if v, ok := agent.Metadata.Custom["serverless"]; ok && fmt.Sprint(v) == "true" {
-			agent.DeploymentType = "serverless"
+	//
+	// Serverless nodes are exempt: they have no heartbeat loop and the health
+	// monitor never polls them, so the presence sweep marks every serverless
+	// node inactive shortly after registration — their recorded health says
+	// nothing about whether an invocation would succeed. Replay requests are
+	// also exempt: a replay hit is served from the recorded run without ever
+	// contacting the agent, so the node being down must not reject it (a
+	// replay miss simply dials and fails exactly as it did before this gate).
+	if agent.DeploymentType != "serverless" && strings.TrimSpace(headers.replaySourceRunID) == "" {
+		if err := ensureAgentDispatchable(agent); err != nil {
+			return nil, err
 		}
 	}
 	if agent.DeploymentType == "serverless" && (agent.InvocationURL == nil || strings.TrimSpace(*agent.InvocationURL) == "") {

--- a/control-plane/internal/handlers/execute.go
+++ b/control-plane/internal/handlers/execute.go
@@ -1544,6 +1544,14 @@ func (c *executionController) prepareExecutionForTarget(ctx context.Context, tar
 		}
 	}
 
+	// Reject a call to a node we already know is down BEFORE the execution
+	// record is created. Dispatching into a dead node would persist a row and
+	// then fail it, charging the caller for a failed execution when nothing
+	// was ever attempted. See execute_agent_restart.go.
+	if err := ensureAgentDispatchable(agent); err != nil {
+		return nil, err
+	}
+
 	if agent.DeploymentType == "" && agent.Metadata.Custom != nil {
 		if v, ok := agent.Metadata.Custom["serverless"]; ok && fmt.Sprint(v) == "true" {
 			agent.DeploymentType = "serverless"
@@ -1871,50 +1879,13 @@ func (c *executionController) callAgent(ctx context.Context, plan *preparedExecu
 		}
 	}
 
-	url := buildAgentURL(plan.agent, plan.target)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(plan.requestBody))
-	if err != nil {
-		return nil, 0, false, fmt.Errorf("create agent request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Run-ID", plan.exec.RunID)
-	req.Header.Set("X-Execution-ID", plan.exec.ExecutionID)
-	req.Header.Set("X-Workflow-ID", plan.exec.RunID)
-	if plan.exec.ParentExecutionID != nil {
-		req.Header.Set("X-Parent-Execution-ID", *plan.exec.ParentExecutionID)
-	}
-	if plan.exec.SessionID != nil {
-		req.Header.Set("X-Session-ID", *plan.exec.SessionID)
-	}
-	if plan.exec.ActorID != nil {
-		req.Header.Set("X-Actor-ID", *plan.exec.ActorID)
-	}
-	if c.internalToken != "" {
-		req.Header.Set("Authorization", "Bearer "+c.internalToken)
-	}
-	if plan.callerDID != "" {
-		req.Header.Set("X-Caller-DID", plan.callerDID)
-	}
-	if plan.targetDID != "" {
-		req.Header.Set("X-Target-DID", plan.targetDID)
-	}
-	if plan.replaySourceRunID != "" {
-		req.Header.Set("X-AgentField-Replay-Source-Run-ID", plan.replaySourceRunID)
-	}
-	if plan.replayBeforeExecutionID != "" {
-		req.Header.Set("X-AgentField-Replay-Before-Execution-ID", plan.replayBeforeExecutionID)
-	}
-	if plan.replayMode != "" {
-		req.Header.Set("X-AgentField-Replay-Mode", plan.replayMode)
-	}
-
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.dispatchAgentRequest(ctx, plan)
 	if err != nil {
 		return nil, time.Since(start), false, fmt.Errorf("agent call failed: %w", err)
 	}
 	defer resp.Body.Close()
 
+	url := buildAgentURL(plan.agent, plan.target)
 	if resp.StatusCode == http.StatusAccepted {
 		logger.Logger.Info().
 			Str("execution_id", plan.exec.ExecutionID).
@@ -2745,6 +2716,14 @@ func classifyRawError(err error) ErrorCategory {
 	// Cancelled context
 	if errors.Is(err, context.Canceled) || strings.Contains(errStr, "context canceled") {
 		return ErrorCategoryInternal
+	}
+
+	// An agent or reasoner that does not exist. Matched on the messages
+	// prepareExecutionForTarget and determineTargetType produce, in the same
+	// style as the transport patterns above.
+	if strings.Contains(errStr, "not found") &&
+		(strings.HasPrefix(errStr, "agent '") || strings.HasPrefix(errStr, "target '")) {
+		return ErrorCategoryTargetNotFound
 	}
 
 	return ErrorCategoryInternal

--- a/control-plane/internal/handlers/execute_agent_restart.go
+++ b/control-plane/internal/handlers/execute_agent_restart.go
@@ -1,0 +1,413 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/Agent-Field/agentfield/control-plane/internal/logger"
+	"github.com/Agent-Field/agentfield/control-plane/internal/storage"
+	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
+)
+
+// Absorbing agent restarts.
+//
+// A long-running agent node restarts constantly during development: the user
+// saves a file, hits Ctrl-C, or the process crashes on a syntax error. The
+// control plane keeps believing the node is healthy for as long as it takes
+// the active health checker to notice (check_interval x consecutive_failures,
+// ~30s by default) or the heartbeat to go stale (60s). Every call that lands
+// inside that window used to create an execution record, fail to dial the
+// dead process, and be recorded as a failed execution — charging the user for
+// a failure that was really a five-second restart.
+//
+// Two mechanisms fix that, and they are deliberately different:
+//
+//   1. ensureAgentDispatchable — when we ALREADY know the node is down, do
+//      not create an execution record at all. A request we never dispatched
+//      is a rejected request (503 node_unavailable), not a failed execution.
+//      This mirrors the check reasoners.go has always had on the legacy
+//      proxy route; the /execute path simply never grew one.
+//
+//   2. dispatchAgentRequest — when we do NOT know the node is down and the
+//      dial fails, wait out the restart instead of failing. A dial failure
+//      is the one transport error where retrying is unambiguously safe: no
+//      bytes reached the agent, so nothing can be executed twice.
+//
+// When the wait expires we mark the node unreachable, so the NEXT caller
+// takes path 1 and fails fast instead of repeating the wait.
+
+const (
+	// defaultAgentRestartGrace is how long a dispatch waits for a restarting
+	// long-running node before giving up. A Python SDK agent takes ~5-7s to
+	// import, register and start serving; 15s covers that with headroom while
+	// staying well inside the 90s default agent call timeout.
+	defaultAgentRestartGrace = 15 * time.Second
+
+	// agentRestartPoll is how often the node record is re-read while waiting.
+	// The SDK heartbeats every 2s and re-registers immediately on boot, so a
+	// sub-second poll turns the recovery around as soon as it is visible.
+	agentRestartPoll = 250 * time.Millisecond
+)
+
+// agentRestartGraceNanos holds the configured grace window. It follows the
+// package-level pattern already used by defaultRedactPayloads: set once at
+// server startup, read on every dispatch. Stored as an int64 so tests can
+// change it without racing the async worker pool.
+var agentRestartGraceNanos atomic.Int64
+
+func init() {
+	agentRestartGraceNanos.Store(int64(defaultAgentRestartGrace))
+}
+
+// SetAgentRestartGrace configures how long a dispatch waits for a restarting
+// agent node. A value of zero or less disables the wait entirely, restoring
+// the previous fail-on-first-dial-error behaviour. Call once at startup.
+func SetAgentRestartGrace(d time.Duration) {
+	agentRestartGraceNanos.Store(int64(d))
+}
+
+func agentRestartGrace() time.Duration {
+	return time.Duration(agentRestartGraceNanos.Load())
+}
+
+// agentHealthMarker is the optional slice of storage used to demote a node we
+// could not reach. It is deliberately NOT added to ExecutionStore: every test
+// fake in the package implements that interface, and marking health is not a
+// capability the execution path may assume. Storage that cannot do it simply
+// skips the demotion.
+type agentHealthMarker interface {
+	UpdateAgentHealthAtomic(ctx context.Context, id string, status types.HealthStatus, expectedLastHeartbeat *time.Time) error
+}
+
+var _ agentHealthMarker = (*storage.LocalStorage)(nil)
+
+// ensureAgentDispatchable rejects a request aimed at a node we already know is
+// down, before any execution record exists.
+//
+// Only definitively-down states are rejected. "unknown" means the node has not
+// heartbeated yet — common in the seconds after registration — and must be
+// allowed through, otherwise the very first call of a session fails. Same for
+// "degraded", which is a partial-capacity signal, not an outage.
+func ensureAgentDispatchable(agent *types.AgentNode) error {
+	if agent == nil {
+		return nil
+	}
+	if agent.HealthStatus == types.HealthStatusInactive {
+		return &executionPreconditionError{
+			code:      http.StatusServiceUnavailable,
+			message:   fmt.Sprintf("agent node '%s' is not reachable (health: %s); start the node and retry", agent.ID, agent.HealthStatus),
+			category:  ErrorCategoryNodeUnavailable,
+			errorCode: "node_unavailable",
+		}
+	}
+	if agent.LifecycleStatus == types.AgentStatusOffline {
+		return &executionPreconditionError{
+			code:      http.StatusServiceUnavailable,
+			message:   fmt.Sprintf("agent node '%s' is offline; start the node and retry", agent.ID),
+			category:  ErrorCategoryNodeUnavailable,
+			errorCode: "node_unavailable",
+		}
+	}
+	return nil
+}
+
+// isDialFailure reports whether err means the connection was never
+// established, so no part of the request reached the agent.
+//
+// This is the safety property the retry depends on. A dial failure is safe to
+// repeat; a read/write failure mid-request is not, because the agent may
+// already be running the reasoner. net.OpError.Op is the portable signal —
+// checking syscall.ECONNREFUSED would not compile the same way across the
+// linux/darwin/windows build matrix.
+func isDialFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return opErr.Op == "dial"
+	}
+	return false
+}
+
+// newAgentRequest builds the POST the control plane sends to an agent node.
+//
+// Extracted from callAgent so the restart retry can build a second, identical
+// request: an *http.Request body is single-use, and the retry may also target
+// a different address if the node came back on another port.
+func (c *executionController) newAgentRequest(ctx context.Context, plan *preparedExecution, url string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(plan.requestBody))
+	if err != nil {
+		return nil, fmt.Errorf("create agent request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Run-ID", plan.exec.RunID)
+	req.Header.Set("X-Execution-ID", plan.exec.ExecutionID)
+	req.Header.Set("X-Workflow-ID", plan.exec.RunID)
+	if plan.exec.ParentExecutionID != nil {
+		req.Header.Set("X-Parent-Execution-ID", *plan.exec.ParentExecutionID)
+	}
+	if plan.exec.SessionID != nil {
+		req.Header.Set("X-Session-ID", *plan.exec.SessionID)
+	}
+	if plan.exec.ActorID != nil {
+		req.Header.Set("X-Actor-ID", *plan.exec.ActorID)
+	}
+	if c.internalToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.internalToken)
+	}
+	if plan.callerDID != "" {
+		req.Header.Set("X-Caller-DID", plan.callerDID)
+	}
+	if plan.targetDID != "" {
+		req.Header.Set("X-Target-DID", plan.targetDID)
+	}
+	if plan.replaySourceRunID != "" {
+		req.Header.Set("X-AgentField-Replay-Source-Run-ID", plan.replaySourceRunID)
+	}
+	if plan.replayBeforeExecutionID != "" {
+		req.Header.Set("X-AgentField-Replay-Before-Execution-ID", plan.replayBeforeExecutionID)
+	}
+	if plan.replayMode != "" {
+		req.Header.Set("X-AgentField-Replay-Mode", plan.replayMode)
+	}
+	return req, nil
+}
+
+// dispatchAgentRequest sends the prepared request, absorbing a restart of the
+// target node if one is in flight.
+//
+// The returned response is the caller's to close.
+func (c *executionController) dispatchAgentRequest(ctx context.Context, plan *preparedExecution) (*http.Response, error) {
+	req, err := c.newAgentRequest(ctx, plan, buildAgentURL(plan.agent, plan.target))
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err == nil {
+		return resp, nil
+	}
+	if !isDialFailure(err) || !c.agentMayRestart(plan) {
+		return nil, err
+	}
+	return c.retryAfterAgentRestart(ctx, plan, err)
+}
+
+// agentMayRestart reports whether waiting for this target can ever help.
+// Serverless nodes have no resident process to come back, so a dial failure
+// against one is a real outage and must surface immediately.
+func (c *executionController) agentMayRestart(plan *preparedExecution) bool {
+	if agentRestartGrace() <= 0 {
+		return false
+	}
+	if plan == nil || plan.agent == nil || plan.target == nil {
+		return false
+	}
+	return plan.agent.DeploymentType != "serverless"
+}
+
+// retryAfterAgentRestart waits for the target node to come back, then replays
+// the dispatch against its current address.
+//
+// Recovery is detected from the node record rather than by blindly retrying:
+// the SDK re-registers on boot with a fresh InstanceID, and it may come back
+// on a different port, so re-reading the record is what makes the retry land
+// on the right process at the right address.
+//
+// Note on the orphan reaper: re-registration also fails this execution's row
+// via MarkAgentExecutionsOrphaned. That is harmless here — completeExecution
+// overwrites a non-cancelled row with the terminal result, so a successful
+// retry still lands as succeeded, and the reaper publishes no event, so no
+// spurious failure is reported.
+func (c *executionController) retryAfterAgentRestart(ctx context.Context, plan *preparedExecution, dialErr error) (*http.Response, error) {
+	observedInstance := plan.agent.InstanceID
+	observedHeartbeat := plan.agent.LastHeartbeat
+	deadline := time.Now().Add(agentRestartGrace())
+
+	logger.Logger.Info().
+		Str("execution_id", plan.exec.ExecutionID).
+		Str("agent_node_id", plan.target.NodeID).
+		Dur("grace", agentRestartGrace()).
+		Msg("agent node did not accept the connection; waiting for it to come back before failing the execution")
+
+	// Claim the execution before the node re-registers, so the orphan reaper
+	// leaves it alone. Without this the restart we are waiting for fails the
+	// very execution we are holding, and the caller receives that failure even
+	// though the retry went on to succeed.
+	c.markExecutionAwaitingRestart(ctx, plan)
+
+	ticker := time.NewTicker(agentRestartPoll)
+	defer ticker.Stop()
+
+	lastErr := dialErr
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, lastErr
+		case <-ticker.C:
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+
+		agent, err := c.store.GetAgent(ctx, plan.target.NodeID)
+		if err != nil || agent == nil {
+			continue
+		}
+		if !agentCameBack(agent, observedInstance, observedHeartbeat) {
+			continue
+		}
+
+		plan.agent = agent
+		req, reqErr := c.newAgentRequest(ctx, plan, buildAgentURL(agent, plan.target))
+		if reqErr != nil {
+			return nil, reqErr
+		}
+		resp, callErr := c.httpClient.Do(req)
+		if callErr == nil {
+			c.clearExecutionAwaitingRestart(ctx, plan)
+			logger.Logger.Info().
+				Str("execution_id", plan.exec.ExecutionID).
+				Str("agent_node_id", plan.target.NodeID).
+				Msg("agent node came back; execution resumed instead of failing")
+			return resp, nil
+		}
+		if !isDialFailure(callErr) {
+			return nil, callErr
+		}
+		// The node announced itself but is not serving yet. Keep waiting
+		// against the refreshed record.
+		lastErr = callErr
+		observedInstance = agent.InstanceID
+		observedHeartbeat = agent.LastHeartbeat
+	}
+
+	c.clearExecutionAwaitingRestart(ctx, plan)
+	c.markAgentUnreachable(ctx, plan)
+	return nil, lastErr
+}
+
+// markExecutionAwaitingRestart stamps the execution as held across an agent
+// restart. The status stays "running" — only the reason changes — so nothing
+// but the orphan reaper's exclusion depends on it.
+//
+// Best-effort: a failure here costs the exemption, not the execution, and the
+// pre-existing behaviour (a reaped row that completeExecution later corrects)
+// still applies. There is a sub-millisecond window between the failed dial and
+// this write in which a re-registration could still reap the row; the retry
+// itself is unaffected, and the terminal write wins.
+func (c *executionController) markExecutionAwaitingRestart(ctx context.Context, plan *preparedExecution) {
+	c.setExecutionRestartReason(ctx, plan, types.ExecutionReasonAwaitingAgentRestart)
+}
+
+// clearExecutionAwaitingRestart releases the claim once the wait is over, so a
+// row that goes on to succeed does not carry a stale reason.
+func (c *executionController) clearExecutionAwaitingRestart(ctx context.Context, plan *preparedExecution) {
+	c.setExecutionRestartReason(ctx, plan, "")
+}
+
+func (c *executionController) setExecutionRestartReason(ctx context.Context, plan *preparedExecution, reason string) {
+	if plan == nil || plan.exec == nil {
+		return
+	}
+	_, err := c.store.UpdateExecutionRecord(ctx, plan.exec.ExecutionID, func(current *types.Execution) (*types.Execution, error) {
+		if current == nil {
+			return nil, fmt.Errorf("execution %s not found", plan.exec.ExecutionID)
+		}
+		// Only ever touch a running row. A terminal or paused execution is
+		// somebody else's to describe.
+		if current.Status != types.ExecutionStatusRunning {
+			return current, nil
+		}
+		if reason == "" {
+			if current.StatusReason == nil || *current.StatusReason != types.ExecutionReasonAwaitingAgentRestart {
+				return current, nil
+			}
+			current.StatusReason = nil
+		} else {
+			current.StatusReason = &reason
+		}
+		current.UpdatedAt = time.Now().UTC()
+		return current, nil
+	})
+	if err != nil {
+		logger.Logger.Debug().Err(err).
+			Str("execution_id", plan.exec.ExecutionID).
+			Str("reason", reason).
+			Msg("could not record the agent-restart hold on the execution")
+	}
+
+	// workflow_executions is the source of truth for the DAG UI and for the
+	// dashboard's failure counts, and the reaper writes to it separately. The
+	// hold has to be stamped on both rows or the run still shows as failed
+	// even though the retry succeeded.
+	wfErr := c.store.UpdateWorkflowExecution(ctx, plan.exec.ExecutionID, func(current *types.WorkflowExecution) (*types.WorkflowExecution, error) {
+		if current == nil {
+			return nil, fmt.Errorf("workflow execution %s not found", plan.exec.ExecutionID)
+		}
+		if current.Status != types.ExecutionStatusRunning {
+			return current, nil
+		}
+		if reason == "" {
+			if current.StatusReason == nil || *current.StatusReason != types.ExecutionReasonAwaitingAgentRestart {
+				return current, nil
+			}
+			current.StatusReason = nil
+		} else {
+			current.StatusReason = &reason
+		}
+		current.UpdatedAt = time.Now().UTC()
+		return current, nil
+	})
+	if wfErr != nil {
+		logger.Logger.Debug().Err(wfErr).
+			Str("execution_id", plan.exec.ExecutionID).
+			Str("reason", reason).
+			Msg("could not record the agent-restart hold on the workflow execution")
+	}
+}
+
+// agentCameBack reports whether the node record now describes a live process
+// that is not the one we failed to dial.
+//
+// A changed, non-empty InstanceID is the definitive signal. Older SDKs do not
+// report one, so a heartbeat newer than the one we dialled against is accepted
+// as the fallback — it can only advance while a process is running.
+func agentCameBack(agent *types.AgentNode, observedInstance string, observedHeartbeat time.Time) bool {
+	if agent.InstanceID != "" && agent.InstanceID != observedInstance {
+		return true
+	}
+	return agent.LastHeartbeat.After(observedHeartbeat)
+}
+
+// markAgentUnreachable demotes a node we waited out, so the next caller is
+// rejected by ensureAgentDispatchable instead of repeating the wait.
+//
+// The update is conditional on the heartbeat we last observed: if the node
+// heartbeated while we were waiting, the write is skipped and the health
+// checker keeps ownership of the node's status. Failure is logged and
+// swallowed — the health checker converges on its own, and losing this
+// optimisation must never fail an execution.
+func (c *executionController) markAgentUnreachable(ctx context.Context, plan *preparedExecution) {
+	marker, ok := c.store.(agentHealthMarker)
+	if !ok || plan.agent == nil {
+		return
+	}
+	expected := plan.agent.LastHeartbeat
+	err := marker.UpdateAgentHealthAtomic(ctx, plan.target.NodeID, types.HealthStatusInactive, &expected)
+	if err != nil {
+		logger.Logger.Debug().Err(err).
+			Str("agent_node_id", plan.target.NodeID).
+			Msg("could not demote unreachable agent node; leaving it to the health checker")
+		return
+	}
+	logger.Logger.Warn().
+		Str("agent_node_id", plan.target.NodeID).
+		Msg("agent node stayed unreachable for the full restart grace; marked inactive so further calls fail fast")
+}

--- a/control-plane/internal/handlers/execute_agent_restart.go
+++ b/control-plane/internal/handlers/execute_agent_restart.go
@@ -220,11 +220,18 @@ func (c *executionController) agentMayRestart(plan *preparedExecution) bool {
 // on a different port, so re-reading the record is what makes the retry land
 // on the right process at the right address.
 //
-// Note on the orphan reaper: re-registration also fails this execution's row
-// via MarkAgentExecutionsOrphaned. That is harmless here — completeExecution
-// overwrites a non-cancelled row with the terminal result, so a successful
-// retry still lands as succeeded, and the reaper publishes no event, so no
-// spurious failure is reported.
+// Note on the orphan reaper: re-registration also triggers
+// MarkAgentExecutionsOrphaned, which is why markExecutionAwaitingRestart
+// stamps the row before the wait begins. If a re-registration lands in the
+// short window between the failed dial and that stamp, the reaper fails the
+// row first: the `executions` table is then repaired by completeExecution
+// (UpdateExecutionRecord applies no transition validation), but the
+// workflow_executions row cannot leave `failed` — its state machine has no
+// exits from terminal states — so the DAG UI keeps the reaped failure while
+// the execution record shows the retry's real outcome. That residual race is
+// narrow (one dial failure followed by a re-registration within milliseconds)
+// and strictly better than the pre-grace behaviour, where the same sequence
+// failed the run outright.
 func (c *executionController) retryAfterAgentRestart(ctx context.Context, plan *preparedExecution, dialErr error) (*http.Response, error) {
 	observedInstance := plan.agent.InstanceID
 	observedHeartbeat := plan.agent.LastHeartbeat
@@ -249,6 +256,10 @@ func (c *executionController) retryAfterAgentRestart(ctx context.Context, plan *
 	for {
 		select {
 		case <-ctx.Done():
+			// ctx is dead, so release the hold on a detached context; the
+			// caller is about to fail the execution and the reaper exemption
+			// must not outlive the wait.
+			c.clearExecutionAwaitingRestartDetached(plan)
 			return nil, lastErr
 		case <-ticker.C:
 		}
@@ -261,12 +272,36 @@ func (c *executionController) retryAfterAgentRestart(ctx context.Context, plan *
 			continue
 		}
 		if !agentCameBack(agent, observedInstance, observedHeartbeat) {
+			// While we were waiting, the health checker (or another dispatch
+			// whose grace expired first) may have declared the node down.
+			// Waiting longer cannot help — it would only serialize behind a
+			// verdict that has already been reached — so surface the dial
+			// error now instead of burning the rest of the grace.
+			if agent.HealthStatus == types.HealthStatusInactive || agent.LifecycleStatus == types.AgentStatusOffline {
+				break
+			}
 			continue
+		}
+
+		// The node is back, but the execution may have moved on while we
+		// waited: a cancel must win over the replay (mirroring the check
+		// callAgent performs before the first dispatch), and a paused
+		// execution waits for its resume before any work is handed out.
+		if currentExec, execErr := c.store.GetExecutionRecord(ctx, plan.exec.ExecutionID); execErr == nil && currentExec != nil {
+			if currentExec.Status == types.ExecutionStatusCancelled {
+				return nil, fmt.Errorf("execution cancelled while waiting for agent restart")
+			}
+			if currentExec.Status == types.ExecutionStatusPaused {
+				if resumeErr := c.waitForResume(ctx, plan.exec.ExecutionID); resumeErr != nil {
+					return nil, fmt.Errorf("execution paused during agent restart and then cancelled or timed out: %w", resumeErr)
+				}
+			}
 		}
 
 		plan.agent = agent
 		req, reqErr := c.newAgentRequest(ctx, plan, buildAgentURL(agent, plan.target))
 		if reqErr != nil {
+			c.clearExecutionAwaitingRestart(ctx, plan)
 			return nil, reqErr
 		}
 		resp, callErr := c.httpClient.Do(req)
@@ -279,6 +314,7 @@ func (c *executionController) retryAfterAgentRestart(ctx context.Context, plan *
 			return resp, nil
 		}
 		if !isDialFailure(callErr) {
+			c.clearExecutionAwaitingRestart(ctx, plan)
 			return nil, callErr
 		}
 		// The node announced itself but is not serving yet. Keep waiting
@@ -309,6 +345,14 @@ func (c *executionController) markExecutionAwaitingRestart(ctx context.Context, 
 // clearExecutionAwaitingRestart releases the claim once the wait is over, so a
 // row that goes on to succeed does not carry a stale reason.
 func (c *executionController) clearExecutionAwaitingRestart(ctx context.Context, plan *preparedExecution) {
+	c.setExecutionRestartReason(ctx, plan, "")
+}
+
+// clearExecutionAwaitingRestartDetached releases the claim when the caller's
+// context is already cancelled and could not carry the write.
+func (c *executionController) clearExecutionAwaitingRestartDetached(plan *preparedExecution) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
 	c.setExecutionRestartReason(ctx, plan, "")
 }
 

--- a/control-plane/internal/handlers/execute_agent_restart_test.go
+++ b/control-plane/internal/handlers/execute_agent_restart_test.go
@@ -1,0 +1,599 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deadAddress returns a host:port that is guaranteed to refuse connections:
+// the listener is bound (so the port is real) and then closed.
+func deadAddress(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+	return addr
+}
+
+// withRestartGrace sets the package-level grace window for one test.
+func withRestartGrace(t *testing.T, d time.Duration) {
+	t.Helper()
+	previous := agentRestartGrace()
+	SetAgentRestartGrace(d)
+	t.Cleanup(func() { SetAgentRestartGrace(previous) })
+}
+
+func testPlan(agent *types.AgentNode) *preparedExecution {
+	return &preparedExecution{
+		exec: &types.Execution{
+			ExecutionID: "exec_1",
+			RunID:       "run_1",
+		},
+		requestBody: []byte(`{"message":"hi"}`),
+		agent:       agent,
+		target:      &parsedTarget{NodeID: agent.ID, TargetName: "echo", TargetType: "reasoner"},
+	}
+}
+
+func TestEnsureAgentDispatchable(t *testing.T) {
+	t.Run("nil agent is allowed", func(t *testing.T) {
+		require.NoError(t, ensureAgentDispatchable(nil))
+	})
+
+	t.Run("unknown health is allowed so the first call of a session works", func(t *testing.T) {
+		require.NoError(t, ensureAgentDispatchable(&types.AgentNode{
+			ID:           "demoproj",
+			HealthStatus: types.HealthStatusUnknown,
+		}))
+	})
+
+	t.Run("active and degraded are allowed", func(t *testing.T) {
+		require.NoError(t, ensureAgentDispatchable(&types.AgentNode{ID: "a", HealthStatus: types.HealthStatusActive}))
+		require.NoError(t, ensureAgentDispatchable(&types.AgentNode{ID: "a", HealthStatus: types.HealthStatusDegraded}))
+	})
+
+	t.Run("inactive health is rejected as node_unavailable", func(t *testing.T) {
+		err := ensureAgentDispatchable(&types.AgentNode{ID: "demoproj", HealthStatus: types.HealthStatusInactive})
+		var pe *executionPreconditionError
+		require.ErrorAs(t, err, &pe)
+		assert.Equal(t, http.StatusServiceUnavailable, pe.HTTPStatusCode())
+		assert.Equal(t, ErrorCategoryNodeUnavailable, pe.Category())
+		assert.Equal(t, "node_unavailable", pe.ErrorCode())
+		assert.Contains(t, pe.Error(), "demoproj")
+	})
+
+	t.Run("offline lifecycle is rejected as node_unavailable", func(t *testing.T) {
+		err := ensureAgentDispatchable(&types.AgentNode{ID: "demoproj", LifecycleStatus: types.AgentStatusOffline})
+		var pe *executionPreconditionError
+		require.ErrorAs(t, err, &pe)
+		assert.Equal(t, http.StatusServiceUnavailable, pe.HTTPStatusCode())
+		assert.Equal(t, ErrorCategoryNodeUnavailable, pe.Category())
+	})
+}
+
+func TestIsDialFailure(t *testing.T) {
+	assert.False(t, isDialFailure(nil))
+	assert.False(t, isDialFailure(errors.New("boom")))
+	assert.True(t, isDialFailure(&net.OpError{Op: "dial", Err: errors.New("connection refused")}))
+	// A failure after the connection was established must NOT be retried:
+	// the agent may already be running the reasoner.
+	assert.False(t, isDialFailure(&net.OpError{Op: "read", Err: errors.New("connection reset by peer")}))
+	assert.True(t, isDialFailure(fmt.Errorf("agent call failed: %w", &net.OpError{Op: "dial", Err: errors.New("refused")})))
+}
+
+func TestAgentRestartGraceIsConfigurable(t *testing.T) {
+	withRestartGrace(t, 42*time.Second)
+	assert.Equal(t, 42*time.Second, agentRestartGrace())
+}
+
+func TestAgentCameBack(t *testing.T) {
+	base := time.Now().Add(-time.Minute)
+
+	t.Run("a new instance id is definitive", func(t *testing.T) {
+		assert.True(t, agentCameBack(&types.AgentNode{InstanceID: "new", LastHeartbeat: base}, "old", base))
+	})
+
+	t.Run("the same instance id is not a restart", func(t *testing.T) {
+		assert.False(t, agentCameBack(&types.AgentNode{InstanceID: "old", LastHeartbeat: base}, "old", base))
+	})
+
+	t.Run("a fresher heartbeat is the fallback for SDKs with no instance id", func(t *testing.T) {
+		assert.True(t, agentCameBack(&types.AgentNode{LastHeartbeat: base.Add(time.Second)}, "", base))
+		assert.False(t, agentCameBack(&types.AgentNode{LastHeartbeat: base}, "", base))
+	})
+}
+
+func TestAgentMayRestart(t *testing.T) {
+	withRestartGrace(t, time.Second)
+	longRunning := &types.AgentNode{ID: "a", DeploymentType: "long_running"}
+
+	assert.True(t, (&executionController{}).agentMayRestart(testPlan(longRunning)))
+	assert.False(t, (&executionController{}).agentMayRestart(nil))
+	assert.False(t, (&executionController{}).agentMayRestart(&preparedExecution{}))
+	// Serverless has no resident process to come back.
+	assert.False(t, (&executionController{}).agentMayRestart(testPlan(&types.AgentNode{ID: "a", DeploymentType: "serverless"})))
+
+	SetAgentRestartGrace(0)
+	assert.False(t, (&executionController{}).agentMayRestart(testPlan(longRunning)))
+}
+
+func TestNewAgentRequestCarriesExecutionContext(t *testing.T) {
+	parent := "exec_parent"
+	session := "sess_1"
+	actor := "actor_1"
+	controller := newExecutionController(newTestExecutionStorage(nil), nil, nil, 0, "internal-token")
+
+	plan := testPlan(&types.AgentNode{ID: "demoproj", BaseURL: "http://127.0.0.1:8001"})
+	plan.exec.ParentExecutionID = &parent
+	plan.exec.SessionID = &session
+	plan.exec.ActorID = &actor
+	plan.callerDID = "did:af:caller"
+	plan.targetDID = "did:af:target"
+	plan.replaySourceRunID = "run_src"
+	plan.replayBeforeExecutionID = "exec_before"
+	plan.replayMode = "strict"
+
+	req, err := controller.newAgentRequest(context.Background(), plan, buildAgentURL(plan.agent, plan.target))
+	require.NoError(t, err)
+
+	assert.Equal(t, "http://127.0.0.1:8001/reasoners/echo", req.URL.String())
+	assert.Equal(t, "application/json", req.Header.Get("Content-Type"))
+	assert.Equal(t, "run_1", req.Header.Get("X-Run-ID"))
+	assert.Equal(t, "exec_1", req.Header.Get("X-Execution-ID"))
+	assert.Equal(t, parent, req.Header.Get("X-Parent-Execution-ID"))
+	assert.Equal(t, session, req.Header.Get("X-Session-ID"))
+	assert.Equal(t, actor, req.Header.Get("X-Actor-ID"))
+	assert.Equal(t, "Bearer internal-token", req.Header.Get("Authorization"))
+	assert.Equal(t, "did:af:caller", req.Header.Get("X-Caller-DID"))
+	assert.Equal(t, "did:af:target", req.Header.Get("X-Target-DID"))
+	assert.Equal(t, "run_src", req.Header.Get("X-AgentField-Replay-Source-Run-ID"))
+	assert.Equal(t, "exec_before", req.Header.Get("X-AgentField-Replay-Before-Execution-ID"))
+	assert.Equal(t, "strict", req.Header.Get("X-AgentField-Replay-Mode"))
+
+	t.Run("an unbuildable url is reported", func(t *testing.T) {
+		_, err := controller.newAgentRequest(context.Background(), plan, "http://\x7f/bad")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "create agent request")
+	})
+}
+
+// restartingStore serves an agent record that changes on a later read, the way
+// storage does once a restarted node re-registers.
+type restartingStore struct {
+	*testExecutionStorage
+	mu      sync.Mutex
+	after   *types.AgentNode
+	reads   int
+	readsAt int // reads to serve before switching to `after`
+}
+
+func (s *restartingStore) GetAgent(ctx context.Context, id string) (*types.AgentNode, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reads++
+	if s.after != nil && s.reads >= s.readsAt {
+		return s.after, nil
+	}
+	return s.testExecutionStorage.GetAgent(ctx, id)
+}
+
+func (s *restartingStore) readCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.reads
+}
+
+// healthMarkingStore records the demotion the dispatcher asks for.
+type healthMarkingStore struct {
+	*restartingStore
+	mu     sync.Mutex
+	marked []types.HealthStatus
+	err    error
+}
+
+func (s *healthMarkingStore) UpdateAgentHealthAtomic(_ context.Context, _ string, status types.HealthStatus, _ *time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.err != nil {
+		return s.err
+	}
+	s.marked = append(s.marked, status)
+	return nil
+}
+
+func (s *healthMarkingStore) markedStatuses() []types.HealthStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]types.HealthStatus(nil), s.marked...)
+}
+
+func TestDispatchAgentRequestSucceedsWithoutRetry(t *testing.T) {
+	withRestartGrace(t, 2*time.Second)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	agent := &types.AgentNode{ID: "demoproj", BaseURL: server.URL, DeploymentType: "long_running"}
+	store := &restartingStore{testExecutionStorage: newTestExecutionStorage(agent)}
+	controller := newExecutionController(store, nil, nil, 0, "")
+
+	resp, err := controller.dispatchAgentRequest(context.Background(), testPlan(agent))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	// No wait means the node record was never re-read.
+	assert.Zero(t, store.readCount())
+}
+
+func TestDispatchAgentRequestWaitsOutARestart(t *testing.T) {
+	withRestartGrace(t, 5*time.Second)
+
+	// The address the caller dials is dead — this is the agent mid-restart.
+	dead := &types.AgentNode{
+		ID:             "demoproj",
+		BaseURL:        "http://" + deadAddress(t),
+		DeploymentType: "long_running",
+		InstanceID:     "instance-old",
+		LastHeartbeat:  time.Now().Add(-time.Second),
+	}
+
+	// The node comes back on a different port, as it may after a restart.
+	var hits atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		assert.Equal(t, "exec_1", r.Header.Get("X-Execution-ID"))
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	revived := *dead
+	revived.BaseURL = server.URL
+	revived.InstanceID = "instance-new"
+
+	store := &restartingStore{
+		testExecutionStorage: newTestExecutionStorage(dead),
+		after:                &revived,
+		readsAt:              2, // stay down for one poll, then come back
+	}
+	controller := newExecutionController(store, nil, nil, 0, "")
+
+	resp, err := controller.dispatchAgentRequest(context.Background(), testPlan(dead))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int64(1), hits.Load())
+}
+
+func TestDispatchAgentRequestGivesUpAndDemotesTheNode(t *testing.T) {
+	withRestartGrace(t, 600*time.Millisecond)
+
+	dead := &types.AgentNode{
+		ID:             "demoproj",
+		BaseURL:        "http://" + deadAddress(t),
+		DeploymentType: "long_running",
+		InstanceID:     "instance-old",
+		LastHeartbeat:  time.Now().Add(-time.Second),
+	}
+	store := &healthMarkingStore{
+		restartingStore: &restartingStore{testExecutionStorage: newTestExecutionStorage(dead)},
+	}
+	controller := newExecutionController(store, nil, nil, 0, "")
+
+	resp, err := controller.dispatchAgentRequest(context.Background(), testPlan(dead))
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.True(t, isDialFailure(err), "the original dial failure is preserved for classification")
+	assert.Equal(t, []types.HealthStatus{types.HealthStatusInactive}, store.markedStatuses())
+}
+
+func TestDispatchAgentRequestStopsWhenTheContextEnds(t *testing.T) {
+	withRestartGrace(t, 10*time.Second)
+
+	dead := &types.AgentNode{
+		ID:             "demoproj",
+		BaseURL:        "http://" + deadAddress(t),
+		DeploymentType: "long_running",
+		InstanceID:     "instance-old",
+	}
+	store := &healthMarkingStore{
+		restartingStore: &restartingStore{testExecutionStorage: newTestExecutionStorage(dead)},
+	}
+	controller := newExecutionController(store, nil, nil, 0, "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := controller.dispatchAgentRequest(ctx, testPlan(dead))
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 5*time.Second, "the wait must abandon with the request, not run the full grace")
+	assert.Empty(t, store.markedStatuses(), "an abandoned wait must not demote the node")
+}
+
+func TestDispatchAgentRequestDoesNotWaitForServerless(t *testing.T) {
+	withRestartGrace(t, 10*time.Second)
+
+	agent := &types.AgentNode{
+		ID:             "lambda",
+		BaseURL:        "http://" + deadAddress(t),
+		DeploymentType: "serverless",
+	}
+	store := &restartingStore{testExecutionStorage: newTestExecutionStorage(agent)}
+	controller := newExecutionController(store, nil, nil, 0, "")
+
+	start := time.Now()
+	_, err := controller.dispatchAgentRequest(context.Background(), testPlan(agent))
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 2*time.Second)
+	assert.Zero(t, store.readCount())
+}
+
+func TestDispatchAgentRequestDoesNotRetryNonDialFailures(t *testing.T) {
+	withRestartGrace(t, 10*time.Second)
+
+	agent := &types.AgentNode{ID: "demoproj", BaseURL: "ftp://127.0.0.1:1", DeploymentType: "long_running"}
+	store := &restartingStore{testExecutionStorage: newTestExecutionStorage(agent)}
+	controller := newExecutionController(store, nil, nil, 0, "")
+
+	start := time.Now()
+	_, err := controller.dispatchAgentRequest(context.Background(), testPlan(agent))
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 2*time.Second)
+	assert.Zero(t, store.readCount())
+}
+
+func TestMarkAgentUnreachableToleratesStoreWithoutHealthSupport(t *testing.T) {
+	agent := &types.AgentNode{ID: "demoproj", BaseURL: "http://127.0.0.1:1"}
+	controller := newExecutionController(newTestExecutionStorage(agent), nil, nil, 0, "")
+	// testExecutionStorage does not implement agentHealthMarker; this must be
+	// a no-op rather than a panic.
+	controller.markAgentUnreachable(context.Background(), testPlan(agent))
+
+	t.Run("a failing demotion is swallowed", func(t *testing.T) {
+		store := &healthMarkingStore{
+			restartingStore: &restartingStore{testExecutionStorage: newTestExecutionStorage(agent)},
+			err:             errors.New("write conflict"),
+		}
+		c := newExecutionController(store, nil, nil, 0, "")
+		c.markAgentUnreachable(context.Background(), testPlan(agent))
+		assert.Empty(t, store.markedStatuses())
+	})
+
+	t.Run("a plan without an agent is ignored", func(t *testing.T) {
+		store := &healthMarkingStore{
+			restartingStore: &restartingStore{testExecutionStorage: newTestExecutionStorage(agent)},
+		}
+		c := newExecutionController(store, nil, nil, 0, "")
+		c.markAgentUnreachable(context.Background(), &preparedExecution{target: &parsedTarget{NodeID: "demoproj"}})
+		assert.Empty(t, store.markedStatuses())
+	})
+}
+
+// The end-to-end contract: a call aimed at a node we already know is down is
+// rejected, and leaves no execution record behind to be counted as a failure.
+func TestExecuteRejectsKnownDownNodeWithoutRecordingAnExecution(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	agent := &types.AgentNode{
+		ID:              "demoproj",
+		BaseURL:         "http://127.0.0.1:8001",
+		DeploymentType:  "long_running",
+		HealthStatus:    types.HealthStatusInactive,
+		LifecycleStatus: types.AgentStatusOffline,
+		Reasoners:       []types.ReasonerDefinition{{ID: "echo"}},
+	}
+	store := newTestExecutionStorage(agent)
+	router := gin.New()
+	router.POST("/execute/:target", ExecuteHandler(store, nil, nil, 0, ""))
+
+	req := httptest.NewRequest(http.MethodPost, "/execute/demoproj.echo",
+		strings.NewReader(`{"input":{"message":"hi"}}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, "node_unavailable", body["error"])
+	assert.Equal(t, "node_unavailable", body["error_category"])
+
+	store.mu.Lock()
+	recorded := len(store.executionRecords)
+	store.mu.Unlock()
+	assert.Zero(t, recorded, "a request we never dispatched must not be counted as a failed execution")
+}
+
+// errAgentReadStore fails every node re-read, the way storage can while the
+// control plane is under load. The wait must ride it out rather than crash.
+type errAgentReadStore struct {
+	*testExecutionStorage
+}
+
+func (s *errAgentReadStore) GetAgent(context.Context, string) (*types.AgentNode, error) {
+	return nil, errors.New("storage unavailable")
+}
+
+func TestDispatchAgentRequestToleratesFailingNodeReads(t *testing.T) {
+	withRestartGrace(t, 600*time.Millisecond)
+
+	dead := &types.AgentNode{
+		ID:             "demoproj",
+		BaseURL:        "http://" + deadAddress(t),
+		DeploymentType: "long_running",
+		InstanceID:     "instance-old",
+	}
+	controller := newExecutionController(&errAgentReadStore{newTestExecutionStorage(dead)}, nil, nil, 0, "")
+
+	_, err := controller.dispatchAgentRequest(context.Background(), testPlan(dead))
+	require.Error(t, err)
+	assert.True(t, isDialFailure(err))
+}
+
+func TestDispatchAgentRequestKeepsWaitingWhenTheNodeIsNotServingYet(t *testing.T) {
+	withRestartGrace(t, 900*time.Millisecond)
+
+	dead := &types.AgentNode{
+		ID:             "demoproj",
+		BaseURL:        "http://" + deadAddress(t),
+		DeploymentType: "long_running",
+		InstanceID:     "instance-old",
+	}
+	// The node re-registered — new instance id — but its HTTP server is not
+	// listening yet, so the retry dials into another refusal.
+	announced := *dead
+	announced.InstanceID = "instance-new"
+
+	store := &healthMarkingStore{
+		restartingStore: &restartingStore{
+			testExecutionStorage: newTestExecutionStorage(dead),
+			after:                &announced,
+			readsAt:              1,
+		},
+	}
+	controller := newExecutionController(store, nil, nil, 0, "")
+
+	_, err := controller.dispatchAgentRequest(context.Background(), testPlan(dead))
+	require.Error(t, err)
+	assert.True(t, isDialFailure(err))
+	assert.Equal(t, []types.HealthStatus{types.HealthStatusInactive}, store.markedStatuses())
+	assert.Greater(t, store.readCount(), 1, "the wait keeps polling after a premature re-registration")
+}
+
+func TestDispatchAgentRequestSurfacesAnUnbuildableRetryURL(t *testing.T) {
+	withRestartGrace(t, 2*time.Second)
+
+	dead := &types.AgentNode{
+		ID:             "demoproj",
+		BaseURL:        "http://" + deadAddress(t),
+		DeploymentType: "long_running",
+		InstanceID:     "instance-old",
+	}
+	revived := *dead
+	revived.InstanceID = "instance-new"
+	revived.BaseURL = "http://\x7f"
+
+	store := &restartingStore{
+		testExecutionStorage: newTestExecutionStorage(dead),
+		after:                &revived,
+		readsAt:              1,
+	}
+	controller := newExecutionController(store, nil, nil, 0, "")
+
+	_, err := controller.dispatchAgentRequest(context.Background(), testPlan(dead))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create agent request")
+}
+
+func TestClassifyRawErrorNamesMissingTargets(t *testing.T) {
+	// The first-run case: the quickstart curl runs before `python main.py`,
+	// so the node has never registered. That is the caller's mistake, and
+	// reporting it as internal_error made the product look broken.
+	assert.Equal(t, ErrorCategoryTargetNotFound, classifyRawError(errors.New("agent 'myagent' not found")))
+	assert.Equal(t, ErrorCategoryTargetNotFound, classifyRawError(errors.New("target 'demo_ecoh' not found on agent 'myagent'")))
+	// Anything else keeps the internal fallback.
+	assert.Equal(t, ErrorCategoryInternal, classifyRawError(errors.New("config file not found")))
+	assert.Equal(t, ErrorCategoryInternal, classifyRawError(errors.New("boom")))
+}
+
+func TestExecutionRestartHoldIsStampedOnBothRows(t *testing.T) {
+	agent := &types.AgentNode{ID: "demoproj", BaseURL: "http://127.0.0.1:8001"}
+	store := newTestExecutionStorage(agent)
+	controller := newExecutionController(store, nil, nil, 0, "")
+	plan := testPlan(agent)
+
+	now := time.Now().UTC()
+	require.NoError(t, store.CreateExecutionRecord(context.Background(), &types.Execution{
+		ExecutionID: plan.exec.ExecutionID,
+		RunID:       plan.exec.RunID,
+		Status:      types.ExecutionStatusRunning,
+		StartedAt:   now,
+	}))
+	require.NoError(t, store.StoreWorkflowExecution(context.Background(), &types.WorkflowExecution{
+		ExecutionID: plan.exec.ExecutionID,
+		WorkflowID:  plan.exec.RunID,
+		Status:      types.ExecutionStatusRunning,
+		StartedAt:   now,
+	}))
+
+	reasonOf := func(t *testing.T) (string, string) {
+		t.Helper()
+		exec, err := store.GetExecutionRecord(context.Background(), plan.exec.ExecutionID)
+		require.NoError(t, err)
+		wf, err := store.GetWorkflowExecution(context.Background(), plan.exec.ExecutionID)
+		require.NoError(t, err)
+		read := func(p *string) string {
+			if p == nil {
+				return ""
+			}
+			return *p
+		}
+		return read(exec.StatusReason), read(wf.StatusReason)
+	}
+
+	controller.markExecutionAwaitingRestart(context.Background(), plan)
+	execReason, wfReason := reasonOf(t)
+	assert.Equal(t, types.ExecutionReasonAwaitingAgentRestart, execReason)
+	assert.Equal(t, types.ExecutionReasonAwaitingAgentRestart, wfReason,
+		"the DAG mirror must carry the hold too, or the reaper fails the run the retry saved")
+
+	controller.clearExecutionAwaitingRestart(context.Background(), plan)
+	execReason, wfReason = reasonOf(t)
+	assert.Empty(t, execReason)
+	assert.Empty(t, wfReason)
+
+	t.Run("clearing a hold that was never set leaves the reason alone", func(t *testing.T) {
+		other := "agent_error"
+		_, err := store.UpdateExecutionRecord(context.Background(), plan.exec.ExecutionID,
+			func(current *types.Execution) (*types.Execution, error) {
+				current.StatusReason = &other
+				return current, nil
+			})
+		require.NoError(t, err)
+		controller.clearExecutionAwaitingRestart(context.Background(), plan)
+		execReason, _ := reasonOf(t)
+		assert.Equal(t, other, execReason)
+	})
+
+	t.Run("a terminal execution is left to whoever finished it", func(t *testing.T) {
+		_, err := store.UpdateExecutionRecord(context.Background(), plan.exec.ExecutionID,
+			func(current *types.Execution) (*types.Execution, error) {
+				current.Status = types.ExecutionStatusSucceeded
+				current.StatusReason = nil
+				return current, nil
+			})
+		require.NoError(t, err)
+		controller.markExecutionAwaitingRestart(context.Background(), plan)
+		execReason, _ := reasonOf(t)
+		assert.Empty(t, execReason)
+	})
+
+	t.Run("a missing row is logged, not fatal", func(t *testing.T) {
+		missing := testPlan(agent)
+		missing.exec.ExecutionID = "exec_absent"
+		controller.markExecutionAwaitingRestart(context.Background(), missing)
+	})
+
+	t.Run("a plan without an execution is ignored", func(t *testing.T) {
+		controller.markExecutionAwaitingRestart(context.Background(), nil)
+		controller.markExecutionAwaitingRestart(context.Background(), &preparedExecution{})
+	})
+}

--- a/control-plane/internal/handlers/execute_agent_restart_test.go
+++ b/control-plane/internal/handlers/execute_agent_restart_test.go
@@ -199,7 +199,23 @@ func (s *restartingStore) readCount() int {
 	return s.reads
 }
 
-// healthMarkingStore records the demotion the dispatcher asks for.
+// peekAgent returns the record a read would currently observe, without
+// advancing the read counter — for assertions and conditional checks that
+// must not perturb the switch-over bookkeeping.
+func (s *restartingStore) peekAgent(ctx context.Context, id string) (*types.AgentNode, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.after != nil && s.reads >= s.readsAt {
+		return s.after, nil
+	}
+	return s.testExecutionStorage.GetAgent(ctx, id)
+}
+
+// healthMarkingStore records the demotion the dispatcher asks for. It mirrors
+// LocalStorage.UpdateAgentHealthAtomic's optimistic locking: when the caller
+// passes an expected heartbeat, the write is rejected unless it matches the
+// node's current LastHeartbeat, so tests exercise the same conditional
+// semantics production storage enforces.
 type healthMarkingStore struct {
 	*restartingStore
 	mu     sync.Mutex
@@ -207,11 +223,20 @@ type healthMarkingStore struct {
 	err    error
 }
 
-func (s *healthMarkingStore) UpdateAgentHealthAtomic(_ context.Context, _ string, status types.HealthStatus, _ *time.Time) error {
+func (s *healthMarkingStore) UpdateAgentHealthAtomic(ctx context.Context, id string, status types.HealthStatus, expectedLastHeartbeat *time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.err != nil {
 		return s.err
+	}
+	if expectedLastHeartbeat != nil {
+		current, err := s.restartingStore.peekAgent(ctx, id)
+		if err != nil || current == nil {
+			return fmt.Errorf("agent %s not found for conditional health update", id)
+		}
+		if !current.LastHeartbeat.Equal(*expectedLastHeartbeat) {
+			return fmt.Errorf("conditional health update rejected: heartbeat advanced")
+		}
 	}
 	s.marked = append(s.marked, status)
 	return nil
@@ -384,6 +409,151 @@ func TestMarkAgentUnreachableToleratesStoreWithoutHealthSupport(t *testing.T) {
 		c.markAgentUnreachable(context.Background(), &preparedExecution{target: &parsedTarget{NodeID: "demoproj"}})
 		assert.Empty(t, store.markedStatuses())
 	})
+}
+
+// A cancel that lands while the dispatch is waiting out a restart must win:
+// the replay is never sent, so the agent does no work the caller already
+// disowned.
+func TestDispatchAgentRequestHonoursCancelDuringTheWait(t *testing.T) {
+	withRestartGrace(t, 5*time.Second)
+
+	dead := &types.AgentNode{
+		ID:             "demoproj",
+		BaseURL:        "http://" + deadAddress(t),
+		DeploymentType: "long_running",
+		InstanceID:     "instance-old",
+		LastHeartbeat:  time.Now().Add(-time.Second),
+	}
+
+	var hits atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	revived := *dead
+	revived.BaseURL = server.URL
+	revived.InstanceID = "instance-new"
+
+	store := &restartingStore{
+		testExecutionStorage: newTestExecutionStorage(dead),
+		after:                &revived,
+		readsAt:              1,
+	}
+	// The execution was cancelled while the node was down.
+	store.executionRecords["exec_1"] = &types.Execution{
+		ExecutionID: "exec_1",
+		RunID:       "run_1",
+		Status:      types.ExecutionStatusCancelled,
+	}
+	controller := newExecutionController(store, nil, nil, 0, "")
+
+	start := time.Now()
+	resp, err := controller.dispatchAgentRequest(context.Background(), testPlan(dead))
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "cancelled")
+	assert.Zero(t, hits.Load(), "a cancelled execution must never be replayed to the agent")
+	assert.Less(t, time.Since(start), 5*time.Second, "the cancel ends the wait early")
+}
+
+// Once the node's record says the node is definitively down — the health
+// checker or another dispatch's expired grace demoted it — waiting longer
+// cannot help, and every queued dispatch aimed at it must stop burning its
+// full grace on a verdict that is already in.
+func TestDispatchAgentRequestStopsWaitingOnceTheNodeIsDemoted(t *testing.T) {
+	withRestartGrace(t, 10*time.Second)
+
+	dead := &types.AgentNode{
+		ID:             "demoproj",
+		BaseURL:        "http://" + deadAddress(t),
+		DeploymentType: "long_running",
+		InstanceID:     "instance-old",
+		LastHeartbeat:  time.Now().Add(-time.Second),
+	}
+	demoted := *dead
+	demoted.HealthStatus = types.HealthStatusInactive
+
+	store := &restartingStore{
+		testExecutionStorage: newTestExecutionStorage(dead),
+		after:                &demoted,
+		readsAt:              1,
+	}
+	controller := newExecutionController(store, nil, nil, 0, "")
+
+	start := time.Now()
+	_, err := controller.dispatchAgentRequest(context.Background(), testPlan(dead))
+	require.Error(t, err)
+	assert.True(t, isDialFailure(err), "the original dial failure is preserved for classification")
+	assert.Less(t, time.Since(start), 3*time.Second, "a demoted node ends the wait long before the grace expires")
+}
+
+// Serverless nodes have no heartbeat loop and are never polled by the health
+// monitor, so their recorded health goes inactive as a matter of course. The
+// fail-fast gate must not apply to them: a serverless target whose record
+// says inactive must still be invoked.
+func TestExecuteStillDispatchesServerlessDespiteInactiveHealth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var hits atomic.Int64
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte(`{"result":{"ok":true}}`))
+	}))
+	defer backend.Close()
+
+	agent := &types.AgentNode{
+		ID:              "lambda",
+		BaseURL:         backend.URL,
+		DeploymentType:  "serverless",
+		HealthStatus:    types.HealthStatusInactive,
+		LifecycleStatus: types.AgentStatusOffline,
+		Reasoners:       []types.ReasonerDefinition{{ID: "echo"}},
+	}
+	store := newTestExecutionStorage(agent)
+	router := gin.New()
+	router.POST("/execute/:target", ExecuteHandler(store, nil, nil, 0, ""))
+
+	req := httptest.NewRequest(http.MethodPost, "/execute/lambda.echo",
+		strings.NewReader(`{"input":{"message":"hi"}}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.NotEqual(t, http.StatusServiceUnavailable, rec.Code,
+		"serverless must not be rejected by the node-health gate; body: %s", rec.Body.String())
+	assert.NotContains(t, rec.Body.String(), "node_unavailable")
+	assert.Equal(t, int64(1), hits.Load(), "the serverless backend must be invoked")
+}
+
+// A replay request is served from the recorded run without contacting the
+// agent, so the target node being down must not reject it. (A replay miss
+// dials and fails exactly as it did before the gate existed.)
+func TestExecuteReplayRequestBypassesTheNodeHealthGate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	agent := &types.AgentNode{
+		ID:              "demoproj",
+		BaseURL:         "http://" + deadAddress(t),
+		DeploymentType:  "long_running",
+		HealthStatus:    types.HealthStatusInactive,
+		LifecycleStatus: types.AgentStatusOffline,
+		Reasoners:       []types.ReasonerDefinition{{ID: "echo"}},
+	}
+	store := newTestExecutionStorage(agent)
+	router := gin.New()
+	router.POST("/execute/:target", ExecuteHandler(store, nil, nil, 0, ""))
+
+	req := httptest.NewRequest(http.MethodPost, "/execute/demoproj.echo",
+		strings.NewReader(`{"input":{"message":"hi"}}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-AgentField-Replay-Source-Run-ID", "run_recorded")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.NotContains(t, rec.Body.String(), "node_unavailable",
+		"a replay request must not be rejected by the node-health gate")
 }
 
 // The end-to-end contract: a call aimed at a node we already know is down is

--- a/control-plane/internal/handlers/execution_guards.go
+++ b/control-plane/internal/handlers/execution_guards.go
@@ -130,6 +130,18 @@ const (
 	ErrorCategoryAgentUnreachable ErrorCategory = "agent_unreachable"
 	ErrorCategoryBadResponse      ErrorCategory = "bad_response"
 	ErrorCategoryInternal         ErrorCategory = "internal_error"
+	// ErrorCategoryTargetNotFound marks a call aimed at a node or reasoner
+	// that does not exist. It is the caller's mistake, not an internal fault,
+	// and it is the single most common first-run error: the user runs the
+	// quickstart curl before starting their agent, so the node has never
+	// registered. Reporting it as internal_error made a normal mistake look
+	// like a broken control plane.
+	ErrorCategoryTargetNotFound ErrorCategory = "target_not_found"
+	// ErrorCategoryNodeUnavailable marks a request we refused to dispatch
+	// because the target node is known to be down. It is deliberately distinct
+	// from agent_unreachable: that one means we tried and could not reach the
+	// process, this one means we never tried. See ensureAgentDispatchable.
+	ErrorCategoryNodeUnavailable ErrorCategory = "node_unavailable"
 )
 
 // executionPreconditionError carries both an HTTP status code and message.

--- a/control-plane/internal/server/server.go
+++ b/control-plane/internal/server/server.go
@@ -137,6 +137,9 @@ func NewAgentFieldServer(cfg *config.Config) (*AgentFieldServer, error) {
 
 	// Configure execution event payload redaction from logging config.
 	handlers.SetRedactPayloads(cfg.Logging.ShouldRedactPayloads())
+	if grace := cfg.AgentField.NodeHealth.AgentRestartGrace; grace != 0 {
+		handlers.SetAgentRestartGrace(grace)
+	}
 
 	Router := gin.Default()
 

--- a/control-plane/internal/storage/agent_orphan_reap_test.go
+++ b/control-plane/internal/storage/agent_orphan_reap_test.go
@@ -235,3 +235,54 @@ func TestMarkAgentExecutionsOrphaned_DefaultReasonWhenEmpty(t *testing.T) {
 	require.NotNil(t, got.StatusReason)
 	require.NotEmpty(t, *got.StatusReason, "empty reason must be replaced with a default audit string")
 }
+
+// TestMarkAgentExecutionsOrphaned_SkipsExecutionsHeldAcrossTheRestart covers
+// the exemption that makes the dispatcher's restart-absorbing retry work.
+//
+// When a call finds the agent's port closed, the control plane stamps the
+// execution ExecutionReasonAwaitingAgentRestart and waits for the process to
+// come back. The re-registration that ends the wait is exactly what triggers
+// this reaper — so without the exemption the reaper fails the one execution
+// the retry was about to complete, and the caller receives that failure even
+// though the work went on to succeed.
+func TestMarkAgentExecutionsOrphaned_SkipsExecutionsHeldAcrossTheRestart(t *testing.T) {
+	ls, ctx := setupTestLocalStorage(t)
+	now := time.Now().UTC()
+
+	seedRunningWorkflowExecution(t, ls, "exec-held", "demoproj", now.Add(-5*time.Second))
+	seedRunningWorkflowExecution(t, ls, "exec-orphan", "demoproj", now.Add(-5*time.Minute))
+
+	// The dispatcher claims exec-held while it waits out the restart.
+	held := types.ExecutionReasonAwaitingAgentRestart
+	require.NoError(t, ls.UpdateWorkflowExecution(ctx, "exec-held",
+		func(current *types.WorkflowExecution) (*types.WorkflowExecution, error) {
+			current.StatusReason = &held
+			return current, nil
+		}))
+	_, err := ls.UpdateExecutionRecord(ctx, "exec-held",
+		func(current *types.Execution) (*types.Execution, error) {
+			current.StatusReason = &held
+			return current, nil
+		})
+	require.NoError(t, err)
+
+	reaped, err := ls.MarkAgentExecutionsOrphaned(ctx, "demoproj",
+		"agent_restart_orphaned: demoproj re-registered with new instance")
+	require.NoError(t, err)
+	require.Equal(t, 1, reaped, "only the genuinely orphaned execution should be reaped")
+
+	heldRow, err := ls.GetWorkflowExecution(ctx, "exec-held")
+	require.NoError(t, err)
+	require.Equal(t, "running", heldRow.Status,
+		"an execution held across the restart must survive it")
+
+	heldExec, err := ls.GetExecutionRecord(ctx, "exec-held")
+	require.NoError(t, err)
+	require.Equal(t, "running", heldExec.Status,
+		"the executions-table mirror must be exempt too")
+
+	orphanRow, err := ls.GetWorkflowExecution(ctx, "exec-orphan")
+	require.NoError(t, err)
+	require.Equal(t, "failed", orphanRow.Status,
+		"an execution with no hold is still a real orphan")
+}

--- a/control-plane/internal/storage/execution_records.go
+++ b/control-plane/internal/storage/execution_records.go
@@ -1366,6 +1366,11 @@ func (ls *LocalStorage) MarkStaleWorkflowExecutions(ctx context.Context, staleAf
 // status used is "failed" (the agent restarted mid-execution; the work was
 // not completed and was not a deadline timeout).
 //
+// Executions marked ExecutionReasonAwaitingAgentRestart are deliberately
+// exempt: those are the ones the dispatcher is holding open ACROSS this very
+// restart and is about to re-send. Reaping them would fail the run that the
+// restart-absorbing retry exists to save.
+//
 // Two single bulk UPDATEs — workflow_executions is the source of truth for
 // the DAG UI; the legacy `executions` table is mirrored best-effort so any
 // older code path reading it sees a consistent picture. We deliberately do
@@ -1386,8 +1391,10 @@ func (ls *LocalStorage) MarkAgentExecutionsOrphaned(ctx context.Context, agentNo
 		UPDATE workflow_executions
 		SET status = ?, status_reason = ?, error_message = ?, completed_at = ?, updated_at = ?
 		WHERE agent_node_id = ?
-		  AND status IN ('running', 'pending', 'queued', 'waiting')`,
+		  AND status IN ('running', 'pending', 'queued', 'waiting')
+		  AND COALESCE(status_reason, '') <> ?`,
 		types.ExecutionStatusFailed, reasonMessage, reasonMessage, now, now, agentNodeID,
+		types.ExecutionReasonAwaitingAgentRestart,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("update orphaned workflow executions: %w", err)
@@ -1402,8 +1409,10 @@ func (ls *LocalStorage) MarkAgentExecutionsOrphaned(ctx context.Context, agentNo
 		UPDATE executions
 		SET status = ?, status_reason = ?, error_message = ?, completed_at = ?, updated_at = ?
 		WHERE agent_node_id = ?
-		  AND status IN ('running', 'pending', 'queued', 'waiting')`,
+		  AND status IN ('running', 'pending', 'queued', 'waiting')
+		  AND COALESCE(status_reason, '') <> ?`,
 		types.ExecutionStatusFailed, reasonMessage, reasonMessage, now, now, agentNodeID,
+		types.ExecutionReasonAwaitingAgentRestart,
 	)
 
 	return int(affected), nil

--- a/control-plane/pkg/types/status.go
+++ b/control-plane/pkg/types/status.go
@@ -18,6 +18,17 @@ const (
 	ExecutionStatusTimeout   ExecutionStatus = "timeout"
 )
 
+// ExecutionReasonAwaitingAgentRestart is written to an execution's
+// status_reason while the control plane is deliberately holding it through a
+// restart of its agent node — the dispatch found the port closed and is
+// waiting for the process to come back rather than failing the run.
+//
+// Such an execution is NOT an orphan: the control plane still owns it and is
+// about to re-dispatch it. MarkAgentExecutionsOrphaned therefore skips rows
+// carrying this reason, so the re-registration that ends the restart does not
+// fail the very execution that was waiting for it.
+const ExecutionReasonAwaitingAgentRestart = "awaiting_agent_restart"
+
 var canonicalExecutionStatuses = map[ExecutionStatus]struct{}{
 	ExecutionStatusUnknown:   {},
 	ExecutionStatusPending:   {},


### PR DESCRIPTION
## Why

New users produce failed executions they did not cause. The largest single source is the edit-restart loop.

A long-running agent node restarts constantly during development — save a file, Ctrl-C, or a syntax error kills the process. The control plane keeps believing the node is healthy for as long as it takes the health checker to notice (`check_interval` × `consecutive_failures`, ~30s) or the heartbeat to go stale (60s). Every call inside that window created an execution record, failed to dial the dead process, and was recorded as **failed**.

Reproduced against a real Python SDK agent on a clean install, telemetry captured locally:

| Sequence | Before | After |
|---|---|---|
| Call fired while the agent is down, process returns 4s later | `HTTP 502`, `agent_restart_orphaned`, `execution_failed` | `HTTP 200 succeeded`, `execution_completed` |
| Call to a node already known down | execution row created, then failed | `503 node_unavailable`, **no execution row** |
| Quickstart curl before `python main.py` | `error_category: internal_error` | `error_category: target_not_found` |

## What changed

Three fixes, in the order a call meets them.

**1. Fail fast on a node we already know is down.** `prepareExecutionForTarget` checked pending-approval but never health — the versioned routing path filtered healthy nodes via `selectVersionedAgent`, the unversioned path (what every new user has) did not. It now returns `503 node_unavailable` *before* the execution record exists. A request we never dispatched is a rejected request, not a failed execution — which is already how an unknown node behaves, so this only makes the two consistent. Mirrors the check `reasoners.go` has always had on the legacy proxy route.

Only definitively-down states are rejected. `unknown` (no heartbeat yet) and `degraded` still go through, or the first call of every session would fail.

**2. Absorb the restart when we do not know the node is down.** A dial failure is the one transport error that is unambiguously safe to retry — no bytes reached the agent, so nothing can execute twice. `net.OpError.Op == "dial"` is the portable signal; a read/write failure mid-request is deliberately *not* retried.

The dispatch waits for the node to come back and replays against its **current** address, which may be a different port. Recovery is read from the node record — a fresh `instance_id`, or a heartbeat that advanced — rather than guessed by blind retrying. Bounded by `agent_restart_grace` (default 15s, well inside the 90s agent call timeout, `AGENTFIELD_AGENT_RESTART_GRACE` / `node_health.agent_restart_grace` to tune, negative to disable). Serverless targets are excluded: they have no resident process to come back, so a dial failure there is a real outage and must surface immediately.

**3. Close the detection gap.** When the wait expires the node is demoted to `inactive` via `UpdateAgentHealthAtomic`, conditional on the heartbeat we last observed — so if it heartbeated while we waited, the health checker keeps ownership. The next caller then takes path 1 and fails fast instead of repeating the wait.

### Two things the end-to-end run turned up

**The orphan reaper was failing the execution the retry was saving.** Re-registration is exactly what ends a restart *and* what triggers `MarkAgentExecutionsOrphaned`. The first end-to-end run returned `HTTP 502` with an `agent_restart_orphaned` message even though the retry had succeeded and telemetry recorded `execution_completed` — the sync caller was reading the reaped row. Executions marked `awaiting_agent_restart` are now exempt, on both the `executions` table and the `workflow_executions` row the DAG UI and dashboard counts read. Those are not orphans: the control plane still owns them and is about to re-dispatch.

**`agent 'x' not found` reported as `internal_error`.** That is the quickstart curl run before `python main.py` — a normal mistake presented as a broken control plane. It now classifies as `target_not_found`, a category that already existed in `canonicalFailureCategory` and that nothing ever assigned.

## Scope

Not addressed here, and worth separate PRs:

- The three sweeps (`MarkAgentExecutionsOrphaned`, `MarkStaleExecutions`, `MarkStaleWorkflowExecutions`) write terminal failures with no event published, so `execution_started` ≠ `completed` + `failed` in telemetry.
- `validation` and `permission_denied` are still dead categories; an input-schema rejection reports as `agent_error`.
- Execution telemetry carries no `usage_context`, so the local dev loop cannot be separated from real traffic in product metrics.

## Verification

- New unit tests: 16 in `internal/handlers`, 1 in `internal/storage`, 1 in `internal/config`. New code is at 89–100% per function.
- `go build ./...`, `go vet`, `gofmt` clean. `golangci-lint` reports nothing in the changed files.
- Full `go test ./...` shows the same pre-existing failures as the base commit (`internal/cli`, `internal/packages`, `internal/skillkit` — they need a `furrow` binary and interactive secret prompts). Confirmed identical by re-running against a stash of these changes.
- The documented quickstart (`af init` → `af server` → `python main.py` → the printed curl) runs clean end to end on the final build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
