### PR TITLE
fix(ci): stop functional-test runs from reporting to production telemetry

### DIFF
--- a/tests/functional/docker/agentfield-test.yaml
+++ b/tests/functional/docker/agentfield-test.yaml
@@ -58,6 +58,14 @@ agentfield:
         - "http://test-runner:9777/api/v1/ard"
       default_search_limit: 20
 
+# CI runs must never report to production telemetry. Every functional-test
+# run starts the control plane on a fresh /data volume, which mints a brand
+# new anonymous install ID — so each run shows up in product metrics as a
+# "first-time user" whose activity is the suite's fixed success/failure
+# counts, drowning out real first-run signal.
+telemetry:
+  enabled: false
+
 ui:
   enabled: true
   mode: "embedded"


### PR DESCRIPTION
## Summary

Product metrics show a steady stream of "first-time users" that always produce the same fixed success/failure counts. Those are not users — they are CI runs.

Every functional-test run starts the control plane on a fresh `/data` volume, which mints a brand-new anonymous install ID. Telemetry is enabled by default and neither the test config (`agentfield-test.yaml`) nor the compose stacks disable it, so each run — every PR and push, times the two-mode storage matrix — reports the suite's fixed set of `execution_completed` / `execution_failed` events to production telemetry as a fresh first-time user, drowning out real first-run signal.

## Changes Made

- Add `telemetry: enabled: false` to `tests/functional/docker/agentfield-test.yaml`. Both the local and postgres compose stacks (and the log-demo one) mount this same config file, so one setting covers every functional CI path.

## Test Plan

- [x] `TelemetryConfig.IsEnabled()` returns false when `enabled: false` is set explicitly (existing config behavior — `control-plane/internal/config/config.go`)
- [x] Functional-test workflow exercises the same config file on both storage modes, so the next CI run validates the config parses

Related: #941 fixes the genuine restart-window failures real users hit; this PR removes the phantom cohort from the metrics.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)