### PR TITLE
fix(execute): resolve webhook not triggering on async status callback (#936)

### DIFF
--- a/control-plane/internal/handlers/execute.go
+++ b/control-plane/internal/handlers/execute.go
@@ -39,6 +39,7 @@ type ExecutionStore interface {
 	UpdateExecutionRecord(ctx context.Context, executionID string, update func(*types.Execution) (*types.Execution, error)) (*types.Execution, error)
 	QueryExecutionRecords(ctx context.Context, filter types.ExecutionFilter) ([]*types.Execution, error)
 	RegisterExecutionWebhook(ctx context.Context, webhook *types.ExecutionWebhook) error
+	HasExecutionWebhook(ctx context.Context, executionID string) (bool, error)
 	StoreWorkflowExecution(ctx context.Context, execution *types.WorkflowExecution) error
 	UpdateWorkflowExecution(ctx context.Context, executionID string, updateFunc func(*types.WorkflowExecution) (*types.WorkflowExecution, error)) error
 	GetWorkflowExecution(ctx context.Context, executionID string) (*types.WorkflowExecution, error)
@@ -1007,7 +1008,7 @@ func (c *executionController) handleStatusUpdate(ctx *gin.Context) {
 
 	if isTerminal {
 		c.updateWorkflowExecutionFinalState(reqCtx, executionID, types.ExecutionStatus(normalizedStatus), updated.ResultPayload, elapsed, errorMsg)
-		if updated.WebhookRegistered {
+		if hasWH, _ := c.store.HasExecutionWebhook(reqCtx, executionID); hasWH {
 			c.triggerWebhook(executionID)
 		}
 	}
@@ -2433,6 +2434,12 @@ func renderStatus(exec *types.Execution) ExecutionStatusResponse {
 // fields from the corresponding WorkflowExecution record, if one exists.
 func (c *executionController) renderStatusWithApproval(ctx context.Context, exec *types.Execution) ExecutionStatusResponse {
 	resp := renderStatus(exec)
+
+	// Resolve webhook_registered from the execution_webhooks table since the
+	// field is not persisted on the execution record itself (db:"-").
+	if hasWH, err := c.store.HasExecutionWebhook(ctx, exec.ExecutionID); err == nil {
+		resp.WebhookRegistered = hasWH
+	}
 
 	// Best-effort enrichment — if the lookup fails we still return the base response.
 	wfExec, err := c.store.GetWorkflowExecution(ctx, exec.ExecutionID)

--- a/control-plane/internal/handlers/execute_handler_test.go
+++ b/control-plane/internal/handlers/execute_handler_test.go
@@ -467,3 +467,80 @@ func TestBatchExecutionStatusHandler_MixedResults(t *testing.T) {
 func ptrString(value string) *string {
 	return &value
 }
+
+// TestGetExecutionStatusHandler_WebhookRegisteredFromStore verifies that the
+// GET /executions/:id endpoint reports webhook_registered=true based on the
+// execution_webhooks table, not the unpersisted field on the execution record.
+// Regression test for issue #936.
+func TestGetExecutionStatusHandler_WebhookRegisteredFromStore(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	store := newTestExecutionStorage(nil)
+	now := time.Now().UTC()
+
+	execution := &types.Execution{
+		ExecutionID:       "exec-wh",
+		RunID:             "run-1",
+		Status:            types.ExecutionStatusSucceeded,
+		StartedAt:         now,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+		WebhookRegistered: false, // As if loaded from DB (db:"-")
+	}
+	require.NoError(t, store.CreateExecutionRecord(context.Background(), execution))
+
+	// Register webhook separately (simulates the real execution_webhooks table)
+	secret := "s3cr3t"
+	require.NoError(t, store.RegisterExecutionWebhook(context.Background(), &types.ExecutionWebhook{
+		ExecutionID: "exec-wh",
+		URL:         "https://example.com/hook",
+		Secret:      &secret,
+	}))
+
+	router := gin.New()
+	router.GET("/api/v1/executions/:execution_id", GetExecutionStatusHandler(store))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/executions/exec-wh", nil)
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var payload ExecutionStatusResponse
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &payload))
+	require.True(t, payload.WebhookRegistered, "webhook_registered must be true when a webhook exists in the store (issue #936)")
+}
+
+// TestGetExecutionStatusHandler_NoWebhook verifies webhook_registered=false
+// when no webhook is registered for the execution.
+func TestGetExecutionStatusHandler_NoWebhook(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	store := newTestExecutionStorage(nil)
+	now := time.Now().UTC()
+
+	execution := &types.Execution{
+		ExecutionID: "exec-no-wh",
+		RunID:       "run-1",
+		Status:      types.ExecutionStatusSucceeded,
+		StartedAt:   now,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	require.NoError(t, store.CreateExecutionRecord(context.Background(), execution))
+
+	router := gin.New()
+	router.GET("/api/v1/executions/:execution_id", GetExecutionStatusHandler(store))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/executions/exec-no-wh", nil)
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var payload ExecutionStatusResponse
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &payload))
+	require.False(t, payload.WebhookRegistered, "webhook_registered must be false when no webhook exists")
+}

--- a/control-plane/internal/handlers/execute_status_update_test.go
+++ b/control-plane/internal/handlers/execute_status_update_test.go
@@ -562,3 +562,71 @@ type testExecutionStorageWithoutEventBus struct {
 func (s *testExecutionStorageWithoutEventBus) GetExecutionEventBus() *events.ExecutionEventBus {
 	return nil
 }
+
+// TestUpdateExecutionStatusHandler_WebhookTriggeredFromStore validates the fix
+// for issue #936: webhook delivery must be triggered based on the
+// execution_webhooks table, not the in-memory WebhookRegistered field (which
+// is not persisted due to db:"-" tag).
+func TestUpdateExecutionStatusHandler_WebhookTriggeredFromStore(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	agent := &types.AgentNode{
+		ID:        "node-1",
+		BaseURL:   "http://agent.example",
+		Reasoners: []types.ReasonerDefinition{{ID: "reasoner-a"}},
+	}
+
+	store := newTestExecutionStorage(agent)
+	payloads := services.NewFilePayloadStore(t.TempDir())
+
+	webhookCalled := false
+	mockWebhook := &mockWebhookDispatcher{
+		notifyFunc: func(ctx context.Context, executionID string) error {
+			webhookCalled = true
+			return nil
+		},
+	}
+
+	// Create execution WITHOUT WebhookRegistered set (simulates loading from DB
+	// where the field is always false due to db:"-").
+	execution := &types.Execution{
+		ExecutionID:       "exec-wh-store",
+		RunID:             "run-1",
+		Status:            types.ExecutionStatusRunning,
+		StartedAt:         time.Now().UTC(),
+		CreatedAt:         time.Now().UTC(),
+		UpdatedAt:         time.Now().UTC(),
+		WebhookRegistered: false, // Explicitly false — as if loaded from DB
+	}
+	require.NoError(t, store.CreateExecutionRecord(context.Background(), execution))
+
+	// Register webhook in the store (separate table)
+	secret := "test-secret"
+	webhook := &types.ExecutionWebhook{
+		ExecutionID: "exec-wh-store",
+		URL:         "https://example.com/webhook",
+		Secret:      &secret,
+	}
+	require.NoError(t, store.RegisterExecutionWebhook(context.Background(), webhook))
+
+	router := gin.New()
+	router.PUT("/api/v1/executions/:execution_id/status", UpdateExecutionStatusHandler(store, payloads, mockWebhook, 90*time.Second))
+
+	reqBody := `{
+		"status": "succeeded",
+		"result": {"output": "done"}
+	}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/executions/exec-wh-store/status", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+	require.True(t, webhookCalled, "webhook must be triggered even when WebhookRegistered is false on the execution record (issue #936)")
+
+	// Also verify the status response reports webhook_registered=true
+	var statusResp ExecutionStatusResponse
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &statusResp))
+	require.True(t, statusResp.WebhookRegistered, "GET status must report webhook_registered=true from the webhooks table")
+}

--- a/control-plane/internal/handlers/test_helpers_test.go
+++ b/control-plane/internal/handlers/test_helpers_test.go
@@ -242,6 +242,13 @@ func (s *testExecutionStorage) RegisterExecutionWebhook(ctx context.Context, web
 	return nil
 }
 
+func (s *testExecutionStorage) HasExecutionWebhook(ctx context.Context, executionID string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.webhooks[executionID]
+	return ok, nil
+}
+
 func (s *testExecutionStorage) CreateExecutionRecord(ctx context.Context, execution *types.Execution) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
## Summary

Fixes the silent webhook failure reported in #936. The `WebhookRegistered` field on `types.Execution` has a `db:"-"` tag and is never persisted, causing two failures:

1. **Status callback path:** when an async execution completes via the agent's `PUT /executions/:id/status` callback, the handler checked `updated.WebhookRegistered` (always `false` from DB) and never triggered webhook delivery  clients relying on callbacks hung forever.
2. **GET /executions/:id:** `renderStatus` read the same unpersisted field, always reporting `webhook_registered: false` to polling clients.

**Fix:** Add `HasExecutionWebhook` to the `ExecutionStore` interface (already exists on `StorageProvider`) and use it in both the status-callback trigger path and `renderStatusWithApproval` to resolve webhook state from the `execution_webhooks` table.

## Type of change

- [x] Bug fix

## Test plan

- [x] `cd control-plane && go test ./internal/handlers/ -run TestUpdateExecutionStatusHandler_WebhookTriggeredFromStore -v`
- [x] `cd control-plane && go test ./internal/handlers/ -run TestGetExecutionStatusHandler_WebhookRegisteredFromStore -v`
- [x] `cd control-plane && go test ./internal/handlers/ -run TestGetExecutionStatusHandler_NoWebhook -v`
- [x] `cd control-plane && go test ./internal/handlers/ -run TestUpdateExecutionStatusHandler_WithWebhook -v`
- [x] `cd control-plane && go test ./internal/handlers/ -timeout 120s` (full suite passes)
- [x] `cd control-plane && go vet ./internal/handlers/...`
- [x] `cd control-plane && golangci-lint run ./internal/handlers/` (no new warnings)

## Test coverage

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR (no bare additions).
- [x] If I removed code, I updated `coverage-baseline.json` in this PR *only if* the removal caused a legitimate regression and I called it out in the summary above.
- [ ] The coverage gate check is green in CI before requesting review.

## Checklist

- [x] Commits are signed and follow conventional-commits style.
- [x] I have linked any related issues (Fixes #936).

## Related issues / PRs

Fixes #936