### PR TITLE
fix(execute): propagate agent 4xx in async lane instead of blanket 502

### DIFF
--- a/control-plane/internal/handlers/execute.go
+++ b/control-plane/internal/handlers/execute.go
@@ -125,6 +125,11 @@ type executionStatusUpdateRequest struct {
 	DurationMS   *int64                 `json:"duration_ms,omitempty"`
 	CompletedAt  *time.Time             `json:"completed_at,omitempty"`
 	Progress     *int                   `json:"progress,omitempty"`
+	// ErrorStatusCode is the optional HTTP status code the agent SDK sends to
+	// indicate whether the failure is client-facing (4xx) or an upstream error
+	// (5xx). When present and in the 4xx range, the control plane propagates it
+	// to callers instead of returning a blanket 502 Bad Gateway.
+	ErrorStatusCode *int `json:"error_status_code,omitempty"`
 	// Usage is the optional token/cost usage object the agent SDK attaches at
 	// the top level of the status-callback body. It is a sibling of Result, so
 	// it is never persisted into the result payload. Absent = no-op.
@@ -359,7 +364,7 @@ func (c *executionController) handleSync(ctx *gin.Context) {
 			}
 			ctx.Header("X-Execution-ID", exec.ExecutionID)
 			ctx.Header("X-Run-ID", exec.RunID)
-			ctx.JSON(http.StatusBadGateway, response)
+			ctx.JSON(httpStatusForFailedExecution(exec), response)
 			return
 		}
 
@@ -942,6 +947,16 @@ func (c *executionController) handleStatusUpdate(ctx *gin.Context) {
 
 		current.Status = normalizedStatus
 		current.StatusReason = req.StatusReason
+		// When the SDK sends an error_status_code in the 4xx range, record it in
+		// StatusReason so the async-completion branch can propagate the correct
+		// HTTP status to the caller (instead of a blanket 502).
+		if req.ErrorStatusCode != nil && *req.ErrorStatusCode >= 400 && *req.ErrorStatusCode < 500 {
+			code := fmt.Sprintf("agent_client_error:%d", *req.ErrorStatusCode)
+			current.StatusReason = &code
+		} else if req.StatusReason == nil && req.ErrorStatusCode != nil && *req.ErrorStatusCode >= 500 {
+			reason := string(ErrorCategoryAgentError)
+			current.StatusReason = &reason
+		}
 		if len(resultBytes) > 0 {
 			current.ResultPayload = json.RawMessage(resultBytes)
 			current.ResultURI = resultURI
@@ -2744,6 +2759,56 @@ func classifyRawError(err error) ErrorCategory {
 	}
 
 	return ErrorCategoryInternal
+}
+
+// httpStatusForFailedExecution determines the HTTP status code to return to
+// callers for a failed execution record. It replaces the hardcoded 502 in the
+// async-completion branch with context-aware classification:
+//
+//  1. If StatusReason encodes a client error ("agent_client_error:<code>"), use that code.
+//  2. If StatusReason maps to a known server-side category, use the appropriate 5xx.
+//  3. Parse ErrorMessage for the "agent error (NNN):" pattern produced by the sync lane.
+//  4. Default to 502 Bad Gateway.
+func httpStatusForFailedExecution(exec *types.Execution) int {
+	// Check StatusReason for an encoded client error status code.
+	if exec.StatusReason != nil {
+		reason := *exec.StatusReason
+		if strings.HasPrefix(reason, "agent_client_error:") {
+			codeStr := strings.TrimPrefix(reason, "agent_client_error:")
+			if code, err := strconv.Atoi(codeStr); err == nil && code >= 400 && code < 500 {
+				return code
+			}
+		}
+		// Map known server-side categories.
+		switch ErrorCategory(reason) {
+		case ErrorCategoryAgentTimeout:
+			return http.StatusGatewayTimeout
+		case ErrorCategoryAgentUnreachable:
+			return http.StatusBadGateway
+		case ErrorCategoryTargetNotFound:
+			return http.StatusNotFound
+		case ErrorCategoryNodeUnavailable:
+			return http.StatusServiceUnavailable
+		case ErrorCategoryConcurrencyLimit:
+			return http.StatusTooManyRequests
+		}
+	}
+
+	// Fallback: parse ErrorMessage for the "agent error (NNN):" pattern that
+	// the sync lane produces when the agent returns an HTTP error directly.
+	if exec.ErrorMessage != nil {
+		msg := *exec.ErrorMessage
+		if strings.HasPrefix(msg, "agent error (") {
+			if idx := strings.Index(msg, "):"); idx > 13 {
+				codeStr := msg[13:idx]
+				if code, err := strconv.Atoi(codeStr); err == nil && code >= 400 && code < 500 {
+					return code
+				}
+			}
+		}
+	}
+
+	return http.StatusBadGateway
 }
 
 func pointerTime(t time.Time) *time.Time {

--- a/control-plane/internal/handlers/execute_handler_test.go
+++ b/control-plane/internal/handlers/execute_handler_test.go
@@ -544,3 +544,137 @@ func TestGetExecutionStatusHandler_NoWebhook(t *testing.T) {
 	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &payload))
 	require.False(t, payload.WebhookRegistered, "webhook_registered must be false when no webhook exists")
 }
+
+// TestHttpStatusForFailedExecution validates the helper that replaces the
+// hardcoded 502 in the async-completion branch (issue #862).
+func TestHttpStatusForFailedExecution(t *testing.T) {
+	tests := []struct {
+		name         string
+		statusReason *string
+		errorMessage *string
+		wantStatus   int
+	}{
+		{
+			name:         "client error encoded in status_reason",
+			statusReason: ptrString("agent_client_error:422"),
+			wantStatus:   422,
+		},
+		{
+			name:         "client error 400 encoded in status_reason",
+			statusReason: ptrString("agent_client_error:400"),
+			wantStatus:   400,
+		},
+		{
+			name:         "agent_timeout maps to 504",
+			statusReason: ptrString("agent_timeout"),
+			wantStatus:   http.StatusGatewayTimeout,
+		},
+		{
+			name:         "agent_unreachable maps to 502",
+			statusReason: ptrString("agent_unreachable"),
+			wantStatus:   http.StatusBadGateway,
+		},
+		{
+			name:         "target_not_found maps to 404",
+			statusReason: ptrString("target_not_found"),
+			wantStatus:   http.StatusNotFound,
+		},
+		{
+			name:         "concurrency_limit maps to 429",
+			statusReason: ptrString("concurrency_limit"),
+			wantStatus:   http.StatusTooManyRequests,
+		},
+		{
+			name:         "node_unavailable maps to 503",
+			statusReason: ptrString("node_unavailable"),
+			wantStatus:   http.StatusServiceUnavailable,
+		},
+		{
+			name:         "error message with agent error 422 pattern",
+			statusReason: ptrString("agent_error"),
+			errorMessage: ptrString(`agent error (422): {"detail":"Missing required field"}`),
+			wantStatus:   422,
+		},
+		{
+			name:         "error message with agent error 500 stays 502",
+			statusReason: ptrString("agent_error"),
+			errorMessage: ptrString(`agent error (500): {"error":"internal"}`),
+			wantStatus:   http.StatusBadGateway,
+		},
+		{
+			name:         "no status_reason no error pattern defaults to 502",
+			statusReason: nil,
+			errorMessage: ptrString("something went wrong"),
+			wantStatus:   http.StatusBadGateway,
+		},
+		{
+			name:         "nil status_reason and nil error defaults to 502",
+			statusReason: nil,
+			errorMessage: nil,
+			wantStatus:   http.StatusBadGateway,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			exec := &types.Execution{
+				StatusReason: tc.statusReason,
+				ErrorMessage: tc.errorMessage,
+			}
+			got := httpStatusForFailedExecution(exec)
+			require.Equal(t, tc.wantStatus, got)
+		})
+	}
+}
+
+// TestUpdateExecutionStatusHandler_ErrorStatusCode verifies that the control
+// plane persists error_status_code from the SDK callback and uses it to classify
+// the failure for async-completion responses (issue #862).
+func TestUpdateExecutionStatusHandler_ErrorStatusCode(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	agent := &types.AgentNode{
+		ID:        "node-1",
+		BaseURL:   "http://agent.example",
+		Reasoners: []types.ReasonerDefinition{{ID: "reasoner-a"}},
+	}
+
+	store := newTestExecutionStorage(agent)
+	payloads := services.NewFilePayloadStore(t.TempDir())
+
+	execution := &types.Execution{
+		ExecutionID: "exec-862",
+		RunID:       "run-1",
+		Status:      types.ExecutionStatusRunning,
+		StartedAt:   time.Now().UTC(),
+		CreatedAt:   time.Now().UTC(),
+		UpdatedAt:   time.Now().UTC(),
+	}
+	require.NoError(t, store.CreateExecutionRecord(context.Background(), execution))
+
+	router := gin.New()
+	router.PUT("/api/v1/executions/:execution_id/status", UpdateExecutionStatusHandler(store, payloads, nil, 90*time.Second))
+
+	// SDK sends error_status_code=422 indicating a client-input rejection
+	reqBody := `{
+		"status": "failed",
+		"error": "invalid_input: RuleSpec rejected field",
+		"error_status_code": 422
+	}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/executions/exec-862/status", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	// Verify the execution record has the encoded status_reason
+	updated, err := store.GetExecutionRecord(context.Background(), "exec-862")
+	require.NoError(t, err)
+	require.NotNil(t, updated.StatusReason)
+	require.Equal(t, "agent_client_error:422", *updated.StatusReason)
+
+	// Verify httpStatusForFailedExecution returns 422 for this execution
+	require.Equal(t, 422, httpStatusForFailedExecution(updated))
+}

--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -2773,6 +2773,14 @@ class Agent(FastAPI):
                 "execution_id": execution_id,
                 "reasoner": reasoner_name,
             }
+            # Propagate the HTTP status code when the exception carries one so
+            # the control plane can return the correct 4xx to callers instead of
+            # a blanket 502 Bad Gateway (issue #862).
+            exc_status = getattr(exc, "status_code", None)
+            if exc_status is None:
+                exc_status = getattr(exc, "code", None)
+            if isinstance(exc_status, int) and 400 <= exc_status < 600:
+                payload["error_status_code"] = exc_status
             # A reasoner that ran, determined its own work failed, and wants its
             # structured outcome preserved raises ReasonerFailed(result=...).
             # Carry that result onto the failed-status payload so the control


### PR DESCRIPTION
## Summary

Fixes #862. The async-completion branch in `handleSync` hardcoded HTTP 502 for all failed executions, making client-input rejections (e.g. 422 from input validation) indistinguishable from upstream outages. A reasoner validating its own input would return `invalid_input: ...` but the caller saw 502 Bad Gateway — sending operators to check pods instead of the request.

**Root cause:** The `callError.statusCode` is lost once the execution is persisted; the async lane (which reads the execution from DB after the agent calls back) had no way to recover the original HTTP status.

**Fix (two-pronged):**

### Control plane
- Add `error_status_code` field to `executionStatusUpdateRequest` so the SDK can forward the HTTP status in its failure callback
- When `error_status_code` is 4xx, encode it in `StatusReason` as `agent_client_error:<code>` for persistence
- Add `httpStatusForFailedExecution()` helper that resolves the HTTP status from:
  1. `StatusReason` — encoded client errors and known server-side categories (`agent_timeout`→504, `target_not_found`→404, etc.)
  2. `ErrorMessage` — parses `"agent error (NNN):"` pattern as fallback for existing executions
  3. Default: 502
- Replace hardcoded 502 in the async-completion branch with the helper

### Python SDK
- In `_execute_async_with_callback` failure path, propagate `error_status_code` from `exception.status_code` / `exception.code` when the value is a valid HTTP status (400–599)

**Backward-compatible:** SDKs that don't send `error_status_code` get existing behavior (502 default). SDKs that do send it get correct 4xx propagation immediately.

## Type of change

- [x] Bug fix

## Test plan

- [x] `cd control-plane && go test ./internal/handlers/ -run TestHttpStatusForFailedExecution -v` (12 cases: encoded 4xx, category mapping, error message parsing, defaults)
- [x] `cd control-plane && go test ./internal/handlers/ -run TestUpdateExecutionStatusHandler_ErrorStatusCode -v`
- [x] `cd control-plane && go test ./internal/handlers/ -run TestExecuteHandler_AgentError -v` (existing 500→502 preserved)
- [x] `cd control-plane && go test ./internal/handlers/ -timeout 120s` (full suite)
- [x] `cd control-plane && go vet ./internal/handlers/...`
- [x] `cd control-plane && golangci-lint run ./internal/handlers/` (no new warnings)
- [x] `cd sdk/python && python -m pytest tests/test_usage_transport.py` (async callback path)
- [x] `python -c "import agentfield.agent"` (syntax OK)

## Test coverage

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR (no bare additions).
- [x] If I removed code, I updated `coverage-baseline.json` in this PR *only if* the removal caused a legitimate regression and I called it out in the summary above.
- [ ] The coverage gate check is green in CI before requesting review.

## Checklist

- [x] Commits follow conventional-commits style.
- [x] I have linked any related issues (Fixes #862).

## Related issues / PRs

Fixes #862

Note: `TestCallAgent_ErrorResponse` is a pre-existing flaky test (timing-sensitive `elapsed > 0` assertion) — confirmed by running it with `-count=5` on both main and this branch.