### PR TITLE
fix(sdk): make async teardown exception-safe

### DIFF
--- a/sdk/python/agentfield/async_execution_manager.py
+++ b/sdk/python/agentfield/async_execution_manager.py
@@ -341,12 +341,21 @@ class AsyncExecutionManager:
 
         current_loop = current_running_loop()
         owning_loop = self._loop
+        cleanup_error: Optional[Exception] = None
+
+        def remember_cleanup_error(exc: Exception) -> None:
+            nonlocal cleanup_error
+            if cleanup_error is None:
+                cleanup_error = exc
 
         # Signal shutdown only when we're on the owning loop — asyncio.Event
         # is not safe to set from a foreign loop, and the loop-aware cancel
         # below tears the tasks down regardless.
         if self._shutdown_event is not None and owning_loop is current_loop:
-            self._shutdown_event.set()
+            try:
+                self._shutdown_event.set()
+            except Exception as exc:
+                remember_cleanup_error(exc)
 
         # Cancel background tasks, awaiting only when safe (same loop).
         tasks_to_cancel = [
@@ -357,12 +366,16 @@ class AsyncExecutionManager:
         ]
 
         for task in tasks_to_cancel:
-            await cancel_and_await_if_same_loop(task, owning_loop)
+            try:
+                await cancel_and_await_if_same_loop(task, owning_loop)
+            except Exception as exc:
+                remember_cleanup_error(exc)
 
         self._polling_task = None
         self._cleanup_task = None
         self._metrics_task = None
         self._event_stream_task = None
+        self._shutdown_event = None
         self._loop = None
 
         # Cancel all active executions. The _execution_lock is an asyncio.Lock
@@ -371,11 +384,17 @@ class AsyncExecutionManager:
         # schedule the cancellation on the owning loop so executions are
         # actually terminated rather than left dangling.
         if owning_loop is current_loop:
-            async with self._execution_lock:
-                for execution in self._executions.values():
-                    if execution.is_active:
-                        execution.cancel("Manager shutdown")
-                        self._release_capacity_for_execution(execution)
+            try:
+                async with self._execution_lock:
+                    for execution in self._executions.values():
+                        if execution.is_active:
+                            try:
+                                execution.cancel("Manager shutdown")
+                                self._release_capacity_for_execution(execution)
+                            except Exception as exc:
+                                remember_cleanup_error(exc)
+            except Exception as exc:
+                remember_cleanup_error(exc)
         elif owning_loop is not None and not owning_loop.is_closed():
             # Schedule execution cancellation on the owning loop so it runs
             # under the correct lock. Fire-and-forget — we can't await it.
@@ -386,17 +405,29 @@ class AsyncExecutionManager:
                             if execution.is_active:
                                 execution.cancel("Manager shutdown (cross-loop)")
                                 self._release_capacity_for_execution(execution)
+
                 owning_loop.create_task(_do_cancel())
+
             try:
                 owning_loop.call_soon_threadsafe(_cancel_on_owner)
             except Exception:
                 logger.debug("Could not schedule cross-loop execution cancel", exc_info=True)
 
         # Stop components
-        await self.connection_manager.close()
-        await self.result_cache.stop()
+        try:
+            await self.connection_manager.close()
+        except Exception as exc:
+            remember_cleanup_error(exc)
+
+        try:
+            await self.result_cache.stop()
+        except Exception as exc:
+            remember_cleanup_error(exc)
 
         logger.info("AsyncExecutionManager stopped")
+
+        if cleanup_error is not None:
+            raise cleanup_error
 
     async def submit_execution(
         self,

--- a/sdk/python/agentfield/http_connection_manager.py
+++ b/sdk/python/agentfield/http_connection_manager.py
@@ -243,23 +243,50 @@ class ConnectionManager:
                     return
                 self._closed = True
 
+            cleanup_error: Optional[Exception] = None
+
             # Cancel background tasks (same loop — safe to await).
-            await cancel_and_await_if_same_loop(self._health_check_task, owning_loop)
-            self._health_check_task = None
-            await cancel_and_await_if_same_loop(self._cleanup_task, owning_loop)
-            self._cleanup_task = None
+            try:
+                await cancel_and_await_if_same_loop(
+                    self._health_check_task, owning_loop
+                )
+            except Exception as exc:
+                cleanup_error = exc
+            finally:
+                self._health_check_task = None
+
+            try:
+                await cancel_and_await_if_same_loop(self._cleanup_task, owning_loop)
+            except Exception as exc:
+                if cleanup_error is None:
+                    cleanup_error = exc
+            finally:
+                self._cleanup_task = None
 
             # Close session and connector
             if self._session:
-                await self._session.close()
-                self._session = None
+                try:
+                    await self._session.close()
+                except Exception as exc:
+                    if cleanup_error is None:
+                        cleanup_error = exc
+                finally:
+                    self._session = None
 
             if self._connector:
-                await self._connector.close()
-                self._connector = None
+                try:
+                    await self._connector.close()
+                except Exception as exc:
+                    if cleanup_error is None:
+                        cleanup_error = exc
+                finally:
+                    self._connector = None
 
             self._loop = None
             logger.info("ConnectionManager closed")
+
+            if cleanup_error is not None:
+                raise cleanup_error
 
     def _close_cross_loop(self, owning_loop: asyncio.AbstractEventLoop) -> None:
         """Tear down from a foreign loop by scheduling real teardown on the owner.

--- a/sdk/python/agentfield/result_cache.py
+++ b/sdk/python/agentfield/result_cache.py
@@ -229,13 +229,21 @@ class ResultCache:
         task = self._cleanup_task
         shutdown_event = self._shutdown_event
         owning_loop = self._loop
+        cleanup_error: Optional[Exception] = None
 
         # Signal the loop to exit promptly when we're on its own loop; the
         # shared helper then cancels + awaits it there. Cross-loop, the helper
         # cancels on the owning loop without awaiting.
         if shutdown_event is not None and owning_loop is current_loop:
-            shutdown_event.set()
-        await cancel_and_await_if_same_loop(task, owning_loop)
+            try:
+                shutdown_event.set()
+            except Exception as exc:
+                cleanup_error = exc
+        try:
+            await cancel_and_await_if_same_loop(task, owning_loop)
+        except Exception as exc:
+            if cleanup_error is None:
+                cleanup_error = exc
 
         # Compare-before-clear: only null the references if they're still the
         # ones we snapshotted. A concurrent start() on another thread/loop
@@ -248,11 +256,18 @@ class ResultCache:
         if self._loop is owning_loop:
             self._loop = None
 
-        with timed_lock(self._lock, "result_cache"):
-            self._cache.clear()
-            self.metrics.size = 0
+        try:
+            with timed_lock(self._lock, "result_cache"):
+                self._cache.clear()
+                self.metrics.size = 0
+        except Exception as exc:
+            if cleanup_error is None:
+                cleanup_error = exc
 
         logger.info("ResultCache stopped")
+
+        if cleanup_error is not None:
+            raise cleanup_error
 
     def get(self, key: str) -> Optional[Any]:
         """

--- a/sdk/python/tests/test_teardown_exception_resilience.py
+++ b/sdk/python/tests/test_teardown_exception_resilience.py
@@ -1,0 +1,155 @@
+import asyncio
+from contextlib import suppress
+
+import pytest
+
+from agentfield.async_config import AsyncConfig
+from agentfield.async_execution_manager import AsyncExecutionManager
+from agentfield.execution_state import ExecutionState, ExecutionStatus
+from agentfield.http_connection_manager import ConnectionManager
+from agentfield.result_cache import ResultCache
+
+
+async def _failing_on_cancel(started: asyncio.Event, failure: RuntimeError) -> None:
+    started.set()
+    try:
+        await asyncio.Future()
+    except asyncio.CancelledError:
+        raise failure
+
+
+async def _wait_forever(started: asyncio.Event) -> None:
+    started.set()
+    await asyncio.Future()
+
+
+async def _cancel_task(task: asyncio.Task | None) -> None:
+    if task is not None and not task.done():
+        task.cancel()
+        with suppress(asyncio.CancelledError, RuntimeError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_connection_manager_close_finishes_after_task_cleanup_error():
+    manager = ConnectionManager(AsyncConfig(enable_performance_logging=False))
+    await manager.start()
+
+    failure = RuntimeError("health cleanup failed")
+    failing_started = asyncio.Event()
+    remaining_started = asyncio.Event()
+    manager._health_check_task = asyncio.create_task(
+        _failing_on_cancel(failing_started, failure)
+    )
+    manager._cleanup_task = asyncio.create_task(_wait_forever(remaining_started))
+    await asyncio.gather(failing_started.wait(), remaining_started.wait())
+
+    try:
+        with pytest.raises(RuntimeError) as raised:
+            await manager.close()
+        assert raised.value is failure
+
+        assert manager._closed is True
+        assert manager._health_check_task is None
+        assert manager._cleanup_task is None
+        assert manager._session is None
+        assert manager._connector is None
+        assert manager._loop is None
+    finally:
+        await _cancel_task(manager._health_check_task)
+        await _cancel_task(manager._cleanup_task)
+        if manager._session is not None:
+            await manager._session.close()
+        if manager._connector is not None:
+            await manager._connector.close()
+
+
+@pytest.mark.asyncio
+async def test_async_execution_manager_stop_finishes_after_task_cleanup_error():
+    config = AsyncConfig(
+        enable_async_execution=True,
+        enable_result_caching=True,
+        enable_performance_logging=False,
+        enable_event_stream=False,
+    )
+    manager = AsyncExecutionManager("http://example", config)
+    await manager.start()
+
+    # Replace the real polling task with a task whose cancellation cleanup fails.
+    original_polling_task = manager._polling_task
+    await _cancel_task(original_polling_task)
+    failure = RuntimeError("polling cleanup failed")
+    failing_started = asyncio.Event()
+    manager._polling_task = asyncio.create_task(
+        _failing_on_cancel(failing_started, failure)
+    )
+    await failing_started.wait()
+
+    execution = ExecutionState("active-execution", "node.skill", {})
+    async with manager._execution_lock:
+        manager._executions[execution.execution_id] = execution
+        manager.metrics.active_executions = 1
+    manager.result_cache.set("cached", {"ok": True})
+
+    try:
+        with pytest.raises(RuntimeError) as raised:
+            await manager.stop()
+        assert raised.value is failure
+
+        assert execution.status == ExecutionStatus.CANCELLED
+        assert manager._polling_task is None
+        assert manager._cleanup_task is None
+        assert manager._metrics_task is None
+        assert manager._event_stream_task is None
+        assert manager._loop is None
+        assert manager.connection_manager._closed is True
+        assert manager.connection_manager._session is None
+        assert manager.result_cache.get("cached") is None
+        assert manager.result_cache._cleanup_task is None
+        assert manager.result_cache._shutdown_event is None
+        assert manager.result_cache._loop is None
+        assert manager.result_cache.metrics.size == 0
+    finally:
+        await _cancel_task(manager._polling_task)
+        await _cancel_task(manager._cleanup_task)
+        await _cancel_task(manager._metrics_task)
+        await _cancel_task(manager._event_stream_task)
+        if manager.connection_manager._session is not None:
+            await manager.connection_manager._session.close()
+        if manager.connection_manager._connector is not None:
+            await manager.connection_manager._connector.close()
+        await _cancel_task(manager.result_cache._cleanup_task)
+
+
+@pytest.mark.asyncio
+async def test_result_cache_stop_finishes_after_task_cleanup_error():
+    cache = ResultCache(
+        AsyncConfig(
+            enable_result_caching=True,
+            cleanup_interval=60.0,
+        )
+    )
+    await cache.start()
+
+    original_cleanup_task = cache._cleanup_task
+    await _cancel_task(original_cleanup_task)
+    failure = RuntimeError("cache cleanup failed")
+    failing_started = asyncio.Event()
+    cache._cleanup_task = asyncio.create_task(
+        _failing_on_cancel(failing_started, failure)
+    )
+    await failing_started.wait()
+    cache.set("cached", {"ok": True})
+
+    try:
+        with pytest.raises(RuntimeError) as raised:
+            await cache.stop()
+        assert raised.value is failure
+
+        assert cache._cleanup_task is None
+        assert cache._shutdown_event is None
+        assert cache._loop is None
+        assert cache.get("cached") is None
+        assert cache.metrics.size == 0
+    finally:
+        await _cancel_task(cache._cleanup_task)


### PR DESCRIPTION
Fixes #909

### What changed

The Python SDK's async teardown callers assumed `cancel_and_await_if_same_loop()` could not raise. If a task's cancellation cleanup raised an unrelated exception, teardown stopped midway and could leak HTTP resources, leave cache state behind, or skip cancellation of active executions.

This change captures the first cleanup exception, completes the remaining teardown and state cleanup for:

- `ConnectionManager._close_on_owner_loop`
- `AsyncExecutionManager.stop`
- `ResultCache.stop`

The original cleanup exception is re-raised after teardown completes.

### Verification

- Added focused regression coverage for all three teardown sites.
- `RTK_DISABLED=1 /home/lolind/.hermes/hermes-agent/venv/bin/python -m pytest -q -o addopts= tests/test_teardown_exception_resilience.py tests/test_async_lifecycle_deadlock.py tests/test_result_cache_deadlock.py` - 19 passed.
- `ruff check` on all changed Python files - passed.
- `git diff --check` and added-line secret scan - passed.
- The full SDK suite was attempted; unrelated baseline dependency/fixture failures remain outside this change.