### PR TITLE
fix(go-sdk): preserve structured AI API errors

### DIFF
--- a/sdk/go/ai/client.go
+++ b/sdk/go/ai/client.go
@@ -129,7 +129,7 @@ func (c *Client) doRequest(ctx context.Context, req *Request) (*Response, error)
 	}
 
 	// Check for errors
-	if httpResp.StatusCode >= 400 {
+	if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
 		return nil, newAPIError(httpResp.StatusCode, respBody)
 	}
 
@@ -217,7 +217,7 @@ func (c *Client) StreamComplete(ctx context.Context, prompt string, opts ...Opti
 		defer httpResp.Body.Close()
 
 		// Check for errors
-		if httpResp.StatusCode >= 400 {
+		if httpResp.StatusCode < http.StatusOK || httpResp.StatusCode >= http.StatusMultipleChoices {
 			respBody, _ := io.ReadAll(httpResp.Body)
 			errCh <- newAPIError(httpResp.StatusCode, respBody)
 			return

--- a/sdk/go/ai/client.go
+++ b/sdk/go/ai/client.go
@@ -130,11 +130,7 @@ func (c *Client) doRequest(ctx context.Context, req *Request) (*Response, error)
 
 	// Check for errors
 	if httpResp.StatusCode >= 400 {
-		var errResp ErrorResponse
-		if err := json.Unmarshal(respBody, &errResp); err != nil {
-			return nil, fmt.Errorf("API error (%d): %s", httpResp.StatusCode, string(respBody))
-		}
-		return nil, fmt.Errorf("API error: %s", errResp.Error.Message)
+		return nil, newAPIError(httpResp.StatusCode, respBody)
 	}
 
 	// Parse response
@@ -223,7 +219,7 @@ func (c *Client) StreamComplete(ctx context.Context, prompt string, opts ...Opti
 		// Check for errors
 		if httpResp.StatusCode >= 400 {
 			respBody, _ := io.ReadAll(httpResp.Body)
-			errCh <- fmt.Errorf("API error (%d): %s", httpResp.StatusCode, string(respBody))
+			errCh <- newAPIError(httpResp.StatusCode, respBody)
 			return
 		}
 

--- a/sdk/go/ai/client_additional_test.go
+++ b/sdk/go/ai/client_additional_test.go
@@ -67,6 +67,27 @@ func TestCompleteWithMessages_AdditionalCoverage(t *testing.T) {
 }
 
 func TestDoRequest_ErrorPaths(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusTooManyRequests} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+				_, _ = io.WriteString(w, `{"error":{"message":"retry later","type":"rate_limit","code":"busy"}}`)
+			}))
+			defer server.Close()
+
+			client, err := NewClient(&Config{APIKey: "test-key", BaseURL: server.URL, Model: "gpt-4o"})
+			require.NoError(t, err)
+			_, err = client.doRequest(context.Background(), &Request{})
+			require.Error(t, err)
+
+			var apiErr *APIError
+			require.ErrorAs(t, err, &apiErr)
+			assert.Equal(t, status, apiErr.StatusCode)
+			assert.Equal(t, "rate_limit", apiErr.Type)
+			assert.Equal(t, "busy", apiErr.Code)
+		})
+	}
+
 	t.Run("api error json body", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
@@ -79,7 +100,11 @@ func TestDoRequest_ErrorPaths(t *testing.T) {
 
 		_, err = client.doRequest(context.Background(), &Request{Messages: []Message{{Role: "user", Content: []ContentPart{{Type: "text", Text: "hello"}}}}})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "API error: bad request")
+		assert.Contains(t, err.Error(), "API error (400): bad request")
+		var apiErr *APIError
+		require.ErrorAs(t, err, &apiErr)
+		assert.Equal(t, http.StatusBadRequest, apiErr.StatusCode)
+		assert.Equal(t, "invalid_request", apiErr.Type)
 	})
 
 	t.Run("api error non json body", func(t *testing.T) {
@@ -95,6 +120,11 @@ func TestDoRequest_ErrorPaths(t *testing.T) {
 		_, err = client.doRequest(context.Background(), &Request{Messages: []Message{{Role: "user", Content: []ContentPart{{Type: "text", Text: "hello"}}}}})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "API error (500): upstream exploded")
+		var apiErr *APIError
+		require.ErrorAs(t, err, &apiErr)
+		assert.Equal(t, http.StatusInternalServerError, apiErr.StatusCode)
+		assert.Equal(t, []byte("upstream exploded"), apiErr.Body)
+		assert.ErrorIs(t, err, &APIError{StatusCode: http.StatusInternalServerError})
 	})
 
 	t.Run("invalid response json", func(t *testing.T) {
@@ -145,6 +175,9 @@ func TestStreamComplete_AdditionalCoverage(t *testing.T) {
 		}
 		require.Error(t, streamErr)
 		assert.Contains(t, streamErr.Error(), "API error (502): temporary failure")
+		var apiErr *APIError
+		require.ErrorAs(t, streamErr, &apiErr)
+		assert.Equal(t, http.StatusBadGateway, apiErr.StatusCode)
 	})
 
 	t.Run("context cancellation while sending chunk", func(t *testing.T) {

--- a/sdk/go/ai/client_additional_test.go
+++ b/sdk/go/ai/client_additional_test.go
@@ -67,6 +67,22 @@ func TestCompleteWithMessages_AdditionalCoverage(t *testing.T) {
 }
 
 func TestDoRequest_ErrorPaths(t *testing.T) {
+	t.Run("redirect is a non-2xx API error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusFound)
+			_, _ = io.WriteString(w, "redirect body")
+		}))
+		defer server.Close()
+
+		client, err := NewClient(&Config{APIKey: "test-key", BaseURL: server.URL, Model: "gpt-4o"})
+		require.NoError(t, err)
+		_, err = client.doRequest(context.Background(), &Request{})
+		require.Error(t, err)
+		var apiErr *APIError
+		require.ErrorAs(t, err, &apiErr)
+		assert.Equal(t, http.StatusFound, apiErr.StatusCode)
+	})
+
 	for _, status := range []int{http.StatusUnauthorized, http.StatusTooManyRequests} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -125,6 +141,22 @@ func TestDoRequest_ErrorPaths(t *testing.T) {
 		assert.Equal(t, http.StatusInternalServerError, apiErr.StatusCode)
 		assert.Equal(t, []byte("upstream exploded"), apiErr.Body)
 		assert.ErrorIs(t, err, &APIError{StatusCode: http.StatusInternalServerError})
+	})
+
+	t.Run("api error preserves partial structured fields", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = io.WriteString(w, `{"error":{"type":"content_filter","code":"blocked"}}`)
+		}))
+		defer server.Close()
+
+		client, err := NewClient(&Config{APIKey: "test-key", BaseURL: server.URL, Model: "gpt-4o"})
+		require.NoError(t, err)
+		_, err = client.doRequest(context.Background(), &Request{})
+		var apiErr *APIError
+		require.ErrorAs(t, err, &apiErr)
+		assert.Equal(t, "content_filter", apiErr.Type)
+		assert.Equal(t, "blocked", apiErr.Code)
 	})
 
 	t.Run("invalid response json", func(t *testing.T) {

--- a/sdk/go/ai/errors.go
+++ b/sdk/go/ai/errors.go
@@ -1,0 +1,56 @@
+package ai
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const maxAPIErrorBody = 4 << 10
+
+// APIError describes a non-success response from an AI provider.
+//
+// Body contains the raw response when the provider did not return the
+// standard ErrorResponse shape. It is capped to keep proxy or provider error
+// pages from being retained without a bound.
+type APIError struct {
+	StatusCode int
+	Message    string
+	Type       string
+	Code       string
+	Body       []byte
+}
+
+// Error returns a human-readable description including the HTTP status.
+func (e *APIError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("API error (%d): %s", e.StatusCode, e.Message)
+	}
+	if len(e.Body) > 0 {
+		return fmt.Sprintf("API error (%d): %s", e.StatusCode, e.Body)
+	}
+	return fmt.Sprintf("API error (%d)", e.StatusCode)
+}
+
+// Is matches API errors by HTTP status code.
+func (e *APIError) Is(target error) bool {
+	t, ok := target.(*APIError)
+	return ok && e.StatusCode == t.StatusCode
+}
+
+func newAPIError(statusCode int, body []byte) *APIError {
+	apiErr := &APIError{StatusCode: statusCode}
+
+	var response ErrorResponse
+	if err := json.Unmarshal(body, &response); err == nil && response.Error.Message != "" {
+		apiErr.Message = response.Error.Message
+		apiErr.Type = response.Error.Type
+		apiErr.Code = response.Error.Code
+		return apiErr
+	}
+
+	if len(body) > maxAPIErrorBody {
+		body = body[:maxAPIErrorBody]
+	}
+	apiErr.Body = append([]byte(nil), body...)
+	return apiErr
+}

--- a/sdk/go/ai/errors.go
+++ b/sdk/go/ai/errors.go
@@ -41,7 +41,8 @@ func newAPIError(statusCode int, body []byte) *APIError {
 	apiErr := &APIError{StatusCode: statusCode}
 
 	var response ErrorResponse
-	if err := json.Unmarshal(body, &response); err == nil && response.Error.Message != "" {
+	if err := json.Unmarshal(body, &response); err == nil &&
+		(response.Error.Message != "" || response.Error.Type != "" || response.Error.Code != "") {
 		apiErr.Message = response.Error.Message
 		apiErr.Type = response.Error.Type
 		apiErr.Code = response.Error.Code

--- a/sdk/go/ai/errors_test.go
+++ b/sdk/go/ai/errors_test.go
@@ -1,0 +1,19 @@
+package ai
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIErrorCapsUnparseableBody(t *testing.T) {
+	body := bytes.Repeat([]byte("x"), maxAPIErrorBody+1)
+	err := newAPIError(502, body)
+
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	require.Len(t, apiErr.Body, maxAPIErrorBody)
+	require.True(t, errors.Is(err, &APIError{StatusCode: 502}))
+}


### PR DESCRIPTION
## Summary

Fixes #436.

The Go AI client previously flattened every non-2xx response into `fmt.Errorf`, which discarded the HTTP status and structured provider fields. This also affected streaming requests.

This change:
- Adds `*APIError` with status, message, type, code, and a bounded (4 KiB) raw-body fallback.
- Returns `*APIError` from both `doRequest` and `StreamComplete` for non-2xx responses.
- Supports `errors.As` and status-based `errors.Is` matching.

## Validation

- `go test ./ai` — passed
- `go vet ./ai` — passed
- `git diff --check` — passed
- `go test ./...` — attempted, but the repository-wide run did not complete within the local timeout; no failure was reported before it was stopped.

No external API keys or services are required by the added tests.