### PR TITLE
fix(execute): make terminal status callbacks idempotent, reject cross-terminal rewrites

### DIFF
--- a/control-plane/internal/handlers/execute.go
+++ b/control-plane/internal/handlers/execute.go
@@ -865,6 +865,12 @@ func (c *executionController) handleBatchStatus(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, response)
 }
 
+// errTerminalStatusConflict marks a callback that tries to rewrite one
+// terminal status as a different one (e.g. succeeded → failed). The handler
+// answers it with 409 so bounded SDK retries fail fast instead of looking
+// like a server fault.
+var errTerminalStatusConflict = errors.New("terminal status conflict")
+
 func (c *executionController) handleStatusUpdate(ctx *gin.Context) {
 	reqCtx := ctx.Request.Context()
 	executionID := ctx.Param("execution_id")
@@ -901,8 +907,10 @@ func (c *executionController) handleStatusUpdate(ctx *gin.Context) {
 	isTerminal := types.IsTerminalExecutionStatus(normalizedStatus)
 	var elapsed time.Duration
 	var errorMsg *string
+	var terminalNoop bool
 
 	updated, err := c.store.UpdateExecutionRecord(reqCtx, executionID, func(current *types.Execution) (*types.Execution, error) {
+		terminalNoop = false
 		if current == nil {
 			return nil, fmt.Errorf("execution %s not found", executionID)
 		}
@@ -928,21 +936,30 @@ func (c *executionController) handleStatusUpdate(ctx *gin.Context) {
 			}
 		}
 
-		// Terminal-state regression guard. Once an execution has reached
-		// a terminal state, reject any non-terminal write — otherwise a
-		// late /status callback (e.g. from a retried fire-and-forget update)
-		// can stomp the terminal status back to "running" and strand the
-		// caller's poll loop. Idempotent terminal→same-terminal updates
-		// are allowed so callers can retry their own callback safely.
+		// Terminal-state guard. Once an execution has reached a terminal
+		// state, the only accepted write is an idempotent re-delivery of
+		// that same status (so callers can retry their own callback); it is
+		// acknowledged as a no-op so the record is not rewritten and none of
+		// the side effects (lifecycle event, webhook, usage ingestion) run a
+		// second time. A non-terminal write is rejected — a late retried
+		// fire-and-forget update must not stomp the status back to "running"
+		// and strand the caller's poll loop. A different terminal status is
+		// rejected too: a duplicate callback must not flip "succeeded" to
+		// "failed" after the outcome was already observed.
 		if types.IsTerminalExecutionStatus(string(current.Status)) {
-			if !types.IsTerminalExecutionStatus(normalizedStatus) {
-				logger.Logger.Warn().
-					Str("execution_id", executionID).
-					Str("current_status", string(current.Status)).
-					Str("requested_status", normalizedStatus).
-					Msg("rejecting status update: execution is already in a terminal state")
-				return nil, fmt.Errorf("execution %s is already in terminal state '%s'; cannot transition to '%s'", executionID, current.Status, normalizedStatus)
+			if normalizedStatus == string(current.Status) {
+				terminalNoop = true
+				return current, nil
 			}
+			logger.Logger.Warn().
+				Str("execution_id", executionID).
+				Str("current_status", string(current.Status)).
+				Str("requested_status", normalizedStatus).
+				Msg("rejecting status update: execution is already in a terminal state")
+			if types.IsTerminalExecutionStatus(normalizedStatus) {
+				return nil, fmt.Errorf("execution %s is already in terminal state '%s'; cannot transition to '%s': %w", executionID, current.Status, normalizedStatus, errTerminalStatusConflict)
+			}
+			return nil, fmt.Errorf("execution %s is already in terminal state '%s'; cannot transition to '%s'", executionID, current.Status, normalizedStatus)
 		}
 
 		current.Status = normalizedStatus
@@ -1004,11 +1021,19 @@ func (c *executionController) handleStatusUpdate(ctx *gin.Context) {
 		return current, nil
 	})
 	if err != nil {
+		if errors.Is(err, errTerminalStatusConflict) {
+			ctx.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("failed to update execution: %v", err)})
+			return
+		}
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to update execution: %v", err)})
 		return
 	}
 	if updated == nil {
 		ctx.JSON(http.StatusNotFound, gin.H{"error": "execution not found"})
+		return
+	}
+	if terminalNoop {
+		ctx.JSON(http.StatusOK, c.renderStatusWithApproval(reqCtx, updated))
 		return
 	}
 	if elapsed == 0 && updated.DurationMS != nil {

--- a/control-plane/internal/handlers/execute_status_update_test.go
+++ b/control-plane/internal/handlers/execute_status_update_test.go
@@ -32,13 +32,13 @@ func TestUpdateExecutionStatusHandler_Success(t *testing.T) {
 	// Create an execution record
 	execution := &types.Execution{
 		ExecutionID: "exec-1",
-		RunID:        "run-1",
-		AgentNodeID:  "node-1",
-		ReasonerID:   "reasoner-a",
-		Status:       types.ExecutionStatusRunning,
-		StartedAt:    time.Now().UTC(),
-		CreatedAt:    time.Now().UTC(),
-		UpdatedAt:    time.Now().UTC(),
+		RunID:       "run-1",
+		AgentNodeID: "node-1",
+		ReasonerID:  "reasoner-a",
+		Status:      types.ExecutionStatusRunning,
+		StartedAt:   time.Now().UTC(),
+		CreatedAt:   time.Now().UTC(),
+		UpdatedAt:   time.Now().UTC(),
 	}
 	require.NoError(t, store.CreateExecutionRecord(context.Background(), execution))
 
@@ -388,6 +388,144 @@ func TestUpdateExecutionStatusHandler_TerminalIdempotent(t *testing.T) {
 	updated, err := store.GetExecutionRecord(context.Background(), "exec-idempotent")
 	require.NoError(t, err)
 	require.Equal(t, types.ExecutionStatusFailed, updated.Status)
+}
+
+// TestUpdateExecutionStatusHandler_CrossTerminalConflict verifies the guard
+// also refuses to rewrite one terminal status as a different one. Before this
+// guard, a duplicate or late callback could flip "succeeded" to "failed" (or
+// the reverse) after the outcome had already been observed by pollers,
+// webhooks, and telemetry.
+func TestUpdateExecutionStatusHandler_CrossTerminalConflict(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	store := newTestExecutionStorage(nil)
+	payloads := services.NewFilePayloadStore(t.TempDir())
+
+	completed := time.Now().UTC().Add(-time.Minute)
+	execution := &types.Execution{
+		ExecutionID: "exec-cross-terminal",
+		RunID:       "run-1",
+		Status:      types.ExecutionStatusSucceeded,
+		StartedAt:   time.Now().UTC().Add(-5 * time.Minute),
+		CompletedAt: &completed,
+		CreatedAt:   time.Now().UTC().Add(-5 * time.Minute),
+		UpdatedAt:   completed,
+	}
+	require.NoError(t, store.CreateExecutionRecord(context.Background(), execution))
+
+	router := gin.New()
+	router.PUT("/api/v1/executions/:execution_id/status", UpdateExecutionStatusHandler(store, payloads, nil, 90*time.Second))
+
+	reqBody := `{"status": "failed", "error": "late duplicate callback"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/executions/exec-cross-terminal/status", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusConflict, resp.Code)
+
+	updated, err := store.GetExecutionRecord(context.Background(), "exec-cross-terminal")
+	require.NoError(t, err)
+	require.Equal(t, types.ExecutionStatusSucceeded, updated.Status)
+	require.Nil(t, updated.ErrorMessage)
+	require.NotNil(t, updated.CompletedAt)
+	require.Equal(t, completed.Unix(), updated.CompletedAt.Unix())
+}
+
+// TestUpdateExecutionStatusHandler_TerminalRetryIsNoOp confirms an idempotent
+// re-delivery of the final status is acknowledged with 200 but runs no side
+// effect a second time: no second lifecycle event on the bus (every bus
+// consumer — SSE clients, tracing, telemetry — would re-count the
+// completion), no second webhook notification, and no rewrite of the
+// persisted record.
+func TestUpdateExecutionStatusHandler_TerminalRetryIsNoOp(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	agent := &types.AgentNode{
+		ID:        "node-1",
+		BaseURL:   "http://agent.example",
+		Reasoners: []types.ReasonerDefinition{{ID: "reasoner-a"}},
+	}
+
+	store := newTestExecutionStorage(agent)
+	payloads := services.NewFilePayloadStore(t.TempDir())
+
+	notifyCount := 0
+	mockWebhook := &mockWebhookDispatcher{
+		notifyFunc: func(ctx context.Context, executionID string) error {
+			notifyCount++
+			return nil
+		},
+	}
+
+	execution := &types.Execution{
+		ExecutionID: "exec-retry-noop",
+		RunID:       "run-1",
+		Status:      types.ExecutionStatusRunning,
+		StartedAt:   time.Now().UTC(),
+		CreatedAt:   time.Now().UTC(),
+		UpdatedAt:   time.Now().UTC(),
+	}
+	require.NoError(t, store.CreateExecutionRecord(context.Background(), execution))
+
+	secret := "test-secret"
+	require.NoError(t, store.RegisterExecutionWebhook(context.Background(), &types.ExecutionWebhook{
+		ExecutionID: "exec-retry-noop",
+		URL:         "https://example.com/webhook",
+		Secret:      &secret,
+	}))
+
+	eventCh := store.GetExecutionEventBus().Subscribe("terminal-retry-noop-test")
+	defer store.GetExecutionEventBus().Unsubscribe("terminal-retry-noop-test")
+
+	router := gin.New()
+	router.PUT("/api/v1/executions/:execution_id/status", UpdateExecutionStatusHandler(store, payloads, mockWebhook, 90*time.Second))
+
+	send := func(body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/executions/exec-retry-noop/status", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+		return resp
+	}
+	drain := func() int {
+		count := 0
+		for {
+			select {
+			case <-eventCh:
+				count++
+			default:
+				return count
+			}
+		}
+	}
+
+	// First delivery completes the execution and runs the side effects once.
+	resp := send(`{"status": "succeeded", "result": {"output": "original"}, "duration_ms": 1200}`)
+	require.Equal(t, http.StatusOK, resp.Code)
+	require.Equal(t, 1, notifyCount)
+	require.Equal(t, 1, drain(), "first terminal delivery must publish exactly one lifecycle event")
+
+	first, err := store.GetExecutionRecord(context.Background(), "exec-retry-noop")
+	require.NoError(t, err)
+	require.Equal(t, types.ExecutionStatusSucceeded, first.Status)
+
+	// Re-delivery of the same terminal status (e.g. the SDK retrying after a
+	// lost 200) is acknowledged but must not repeat any side effect or
+	// rewrite the record — even when the retry carries a different payload.
+	resp = send(`{"status": "succeeded", "result": {"output": "rewritten"}, "duration_ms": 9999}`)
+	require.Equal(t, http.StatusOK, resp.Code)
+	require.Equal(t, 1, notifyCount, "webhook must not be re-notified on an idempotent retry")
+	require.Equal(t, 0, drain(), "idempotent retry must not publish a duplicate lifecycle event")
+
+	second, err := store.GetExecutionRecord(context.Background(), "exec-retry-noop")
+	require.NoError(t, err)
+	require.Equal(t, types.ExecutionStatusSucceeded, second.Status)
+	require.Equal(t, string(first.ResultPayload), string(second.ResultPayload), "retry must not rewrite the result payload")
+	require.Equal(t, *first.DurationMS, *second.DurationMS, "retry must not rewrite the duration")
+	require.NotNil(t, second.CompletedAt)
+	require.Equal(t, first.CompletedAt.UnixNano(), second.CompletedAt.UnixNano(), "retry must not move completed_at")
 }
 
 func TestWaitForExecutionCompletion_Success(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes the remaining control-plane half of the Aug 23 telemetry-spike investigation: the status-callback handler accepted every terminal→terminal write, so a single execution could emit multiple `execution_completed` lifecycle events and even have its recorded outcome silently flipped after the fact.

Two defects in `handleStatusUpdate`:

1. **Duplicate terminal callbacks re-ran every side effect.** A re-delivered final status (e.g. an SDK retrying after a lost 200) rewrote the record (result, `duration_ms`, `completed_at`), re-notified the webhook, re-ingested usage, and published another completed/failed event to the execution bus — double-counting the execution for every bus consumer (SSE clients, tracing, product telemetry).
2. **Cross-terminal transitions were accepted.** The guard's comment promised "idempotent terminal→same-terminal updates are allowed", but the code only rejected terminal→*non-terminal* writes — a late `failed` callback could flip an already-observed `succeeded` outcome (and emit `execution_failed` for an execution that had completed).

## Changes

- terminal→same-terminal: acknowledged with **200 as a strict no-op** — no record rewrite, no webhook, no usage ingestion, no lifecycle event.
- terminal→different-terminal: **rejected with 409** via a new `errTerminalStatusConflict` sentinel, so bounded SDK retries fail fast instead of reading as a server fault.
- terminal→non-terminal: unchanged (still rejected; pinned by `TestUpdateExecutionStatusHandler_TerminalRegression`).

## Validation contract → tests

- Duplicate final-status delivery returns 200 but repeats no side effect and rewrites nothing → `TestUpdateExecutionStatusHandler_TerminalRetryIsNoOp` (asserts exactly one bus event, one webhook notification, unchanged payload/duration/completed_at across a retry carrying different values).
- A different terminal status is refused and changes nothing → `TestUpdateExecutionStatusHandler_CrossTerminalConflict` (409, record intact).
- Existing pinned behaviors (`TerminalRegression`, `TerminalIdempotent`, webhook trigger from store) unchanged and green.

## Manual verification (live)

Ran an isolated control plane (isolated `HOME`, local ports) wired through the real telemetry relay to a local PostHog sink, registered a dummy agent node, completed one async execution, then sent two duplicate `succeeded` callbacks and one `failed` callback:

- **main (unfixed):** 3× `oss:execution_completed` + 1× `oss:execution_failed` for the single execution; final record flipped to `failed` with the late error message and rewritten duration.
- **this branch:** exactly 1× `oss:execution_completed`; duplicates answered 200 without re-emitting; the flip answered 409; record untouched.

## Gates run locally

- `go build ./...`, `gofmt` on touched files: clean.
- `golangci-lint run internal/handlers/...`: identical findings to unmodified main (zero new issues).
- `./scripts/coverage-surface.sh control-plane`: handlers suite green (87.8%). `TestDevServiceRunDev` (internal/core/services) fails on this WSL machine with an agent-port-discovery timeout, reproduced identically on unmodified `origin/main` in isolation — environmental, unrelated to this diff.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)