### PR TITLE
fix(storage): row-lock postgres read-modify-write updates — lost-update race stalled builds

### DIFF
--- a/control-plane/internal/storage/execution_records.go
+++ b/control-plane/internal/storage/execution_records.go
@@ -187,6 +187,9 @@ func (ls *LocalStorage) UpdateExecutionRecord(ctx context.Context, executionID s
 	}
 	defer rollbackTx(tx, "UpdateExecutionRecord:"+executionID)
 
+	// Lock the row for the duration of the read-modify-write (postgres only;
+	// see forUpdate). A concurrent updater blocks here until this transaction
+	// commits, then re-reads the committed row instead of a stale snapshot.
 	row := tx.QueryRowContext(ctx, `
 		SELECT execution_id, run_id, parent_execution_id,
 		       agent_node_id, reasoner_id, node_id,
@@ -197,7 +200,7 @@ func (ls *LocalStorage) UpdateExecutionRecord(ctx context.Context, executionID s
 		       notes,
 		       created_at, updated_at
 		FROM executions
-		WHERE execution_id = ?`, executionID)
+		WHERE execution_id = ?`+tx.forUpdate(), executionID)
 
 	current, err := scanExecution(row)
 	if err != nil {

--- a/control-plane/internal/storage/execution_records_race_test.go
+++ b/control-plane/internal/storage/execution_records_race_test.go
@@ -1,0 +1,135 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestForUpdateSuffixByMode pins the dialect gate: postgres gets a row lock,
+// sqlite (which serializes writers and rejects FOR UPDATE syntax) gets none.
+func TestForUpdateSuffixByMode(t *testing.T) {
+	require.Equal(t, " FOR UPDATE", (&sqlDatabase{mode: "postgres"}).forUpdate())
+	require.Equal(t, "", (&sqlDatabase{mode: "local"}).forUpdate())
+	require.Equal(t, " FOR UPDATE", (&sqlTx{mode: "postgres"}).forUpdate())
+	require.Equal(t, "", (&sqlTx{mode: "local"}).forUpdate())
+	var nilDB *sqlDatabase
+	var nilTx *sqlTx
+	require.Equal(t, "", nilDB.forUpdate())
+	require.Equal(t, "", nilTx.forUpdate())
+}
+
+// TestPostgresUpdateExecutionRecord_ConcurrentRMWNoLostUpdate reproduces the
+// lost-update race that stranded live builds: an execution-note write and the
+// terminal status callback both run UpdateExecutionRecord (read-modify-write
+// of the full row). Under READ COMMITTED, whichever transaction commits last
+// used to write its stale snapshot back, silently discarding the other's
+// columns — a note write reverted status "succeeded" to "running" and dropped
+// the result, so the caller's poll loop never saw the reasoner finish.
+//
+// Contract: when two read-modify-writes of the same execution overlap, both
+// effects must survive, regardless of commit order.
+//
+// The interleaving is made deterministic: updater A holds its transaction open
+// (row read, not yet committed) while updater B runs to completion, then A
+// finishes. With row locking B blocks until A commits and re-reads; without it
+// B's write is clobbered when A commits (this test fails on the pre-fix code).
+func TestPostgresUpdateExecutionRecord_ConcurrentRMWNoLostUpdate(t *testing.T) {
+	postgresURL := os.Getenv("POSTGRES_TEST_URL")
+	if postgresURL == "" {
+		t.Skip("POSTGRES_TEST_URL not set, skipping postgres tests")
+	}
+
+	ctx := context.Background()
+	cfg := StorageConfig{
+		Mode: "postgres",
+		Postgres: PostgresStorageConfig{
+			DSN:          postgresURL,
+			MaxOpenConns: 10,
+			MaxIdleConns: 5,
+		},
+	}
+
+	ls := NewPostgresStorage(PostgresStorageConfig{})
+	err := ls.Initialize(ctx, cfg)
+	if err != nil {
+		if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "does not exist") {
+			t.Skip("PostgreSQL not available, skipping test")
+		}
+		require.NoError(t, err)
+	}
+	defer ls.Close(ctx)
+
+	execID := fmt.Sprintf("exec-race-%d", time.Now().UnixNano())
+	require.NoError(t, ls.CreateExecutionRecord(ctx, &types.Execution{
+		ExecutionID: execID,
+		RunID:       fmt.Sprintf("run-race-%d", time.Now().UnixNano()),
+		AgentNodeID: "agent-race",
+		ReasonerID:  "plan",
+		NodeID:      "agent-race",
+		Status:      string(types.ExecutionStatusRunning),
+		StartedAt:   time.Now().UTC(),
+	}))
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	statusDone := make(chan error, 1)
+
+	// Updater A: the terminal status callback (succeeded + result). It parks
+	// inside the updater with the transaction open so B overlaps it.
+	go func() {
+		_, err := ls.UpdateExecutionRecord(ctx, execID, func(current *types.Execution) (*types.Execution, error) {
+			close(entered)
+			<-release
+			current.Status = string(types.ExecutionStatusSucceeded)
+			current.ResultPayload = json.RawMessage(`{"ok":true}`)
+			now := time.Now().UTC()
+			current.CompletedAt = &now
+			return current, nil
+		})
+		statusDone <- err
+	}()
+
+	<-entered
+
+	// Updater B: the note write, racing A. Run it with a timeout so a
+	// deadlocked implementation fails the test instead of hanging it.
+	noteDone := make(chan error, 1)
+	go func() {
+		noteCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		_, err := ls.UpdateExecutionRecord(noteCtx, execID, func(current *types.Execution) (*types.Execution, error) {
+			current.Notes = append(current.Notes, types.ExecutionNote{
+				Message:   "issue_writers complete",
+				Timestamp: time.Now().UTC(),
+			})
+			return current, nil
+		})
+		noteDone <- err
+	}()
+
+	// Give B time to reach the row before releasing A. With locking B is
+	// parked on the SELECT; without locking B commits a stale full row.
+	time.Sleep(500 * time.Millisecond)
+	close(release)
+
+	require.NoError(t, <-statusDone, "status update failed")
+	require.NoError(t, <-noteDone, "note update failed")
+
+	final, err := ls.GetExecutionRecord(ctx, execID)
+	require.NoError(t, err)
+	require.NotNil(t, final)
+	require.Equal(t, string(types.ExecutionStatusSucceeded), final.Status,
+		"terminal status was lost to the concurrent note write")
+	require.NotEmpty(t, final.ResultPayload, "result payload was lost")
+	require.NotNil(t, final.CompletedAt, "completed_at was lost")
+	require.Len(t, final.Notes, 1, "note was lost to the concurrent status write")
+}

--- a/control-plane/internal/storage/local.go
+++ b/control-plane/internal/storage/local.go
@@ -68,6 +68,13 @@ func (e *ValidationError) Error() string {
 
 // getWorkflowExecutionByID is a helper function that retrieves a workflow execution using DBTX interface
 func (ls *LocalStorage) getWorkflowExecutionByID(ctx context.Context, q DBTX, executionID string) (*types.WorkflowExecution, error) {
+	return ls.getWorkflowExecutionByIDSuffix(ctx, q, executionID, "")
+}
+
+// getWorkflowExecutionByIDSuffix is getWorkflowExecutionByID with a trailing
+// SQL suffix — pass a row-locking suffix (see sqlTx.forUpdate) when the same
+// transaction will write the row back, "" for plain reads.
+func (ls *LocalStorage) getWorkflowExecutionByIDSuffix(ctx context.Context, q DBTX, executionID string, suffix string) (*types.WorkflowExecution, error) {
 	query := `
 		SELECT workflow_id, execution_id, agentfield_request_id, run_id, session_id, actor_id,
 		       agent_node_id, parent_workflow_id, parent_execution_id, root_workflow_id, workflow_depth,
@@ -79,7 +86,7 @@ func (ls *LocalStorage) getWorkflowExecutionByID(ctx context.Context, q DBTX, ex
 		       approval_request_id, approval_request_url, approval_status, approval_response,
 		       approval_requested_at, approval_responded_at, approval_callback_url, approval_expires_at,
 		       workflow_name, workflow_tags, notes, created_at, updated_at
-		FROM workflow_executions WHERE execution_id = ?`
+		FROM workflow_executions WHERE execution_id = ?` + suffix
 
 	row := q.QueryRowContext(ctx, query, executionID)
 	execution := &types.WorkflowExecution{}
@@ -2314,8 +2321,10 @@ func (ls *LocalStorage) attemptWorkflowExecutionUpdate(ctx context.Context, exec
 	}
 	defer rollbackTx(tx, "attemptWorkflowExecutionUpdate:"+executionID)
 
-	// Read the current execution within the transaction
-	currentExecution, err := ls.getWorkflowExecutionWithTx(txCtx, tx, executionID)
+	// Read the current execution within the transaction, locking the row so a
+	// concurrent read-modify-write cannot base its UPDATE on a stale snapshot
+	// (postgres only; see forUpdate).
+	currentExecution, err := ls.getWorkflowExecutionByIDSuffix(txCtx, tx, executionID, tx.forUpdate())
 	if err != nil {
 		return fmt.Errorf("failed to get workflow execution %s: %w", executionID, err)
 	}

--- a/control-plane/internal/storage/sql_helpers.go
+++ b/control-plane/internal/storage/sql_helpers.go
@@ -93,6 +93,30 @@ func newSQLTx(tx *sql.Tx, mode string) *sqlTx {
 	return &sqlTx{Tx: tx, mode: mode}
 }
 
+// forUpdate returns the row-locking suffix for a SELECT that the same
+// transaction follows with an UPDATE of that row. Postgres needs an explicit
+// FOR UPDATE: under READ COMMITTED, two read-modify-write transactions can
+// both read the same snapshot and the later UPDATE silently writes the stale
+// copy back (a lost update — e.g. an execution-note write racing the terminal
+// status callback reverted status "succeeded" to "running" and dropped the
+// result, stranding the caller's poll loop). SQLite serializes writers and
+// does not accept FOR UPDATE syntax, so the suffix is empty there.
+func (db *sqlDatabase) forUpdate() string {
+	if db != nil && db.mode == "postgres" {
+		return " FOR UPDATE"
+	}
+	return ""
+}
+
+// forUpdate mirrors sqlDatabase.forUpdate for statements running on the
+// transaction handle (the usual case for read-modify-write helpers).
+func (tx *sqlTx) forUpdate() string {
+	if tx != nil && tx.mode == "postgres" {
+		return " FOR UPDATE"
+	}
+	return ""
+}
+
 func (tx *sqlTx) rebind(query string) string {
 	if tx == nil {
 		return query


### PR DESCRIPTION
## Summary

On Postgres deployments, two concurrent read-modify-write updates of the same execution row can silently discard one another. `UpdateExecutionRecord` (and the workflow-execution updater) do `BEGIN → SELECT → mutate in Go → UPDATE every column → COMMIT` with no row lock; under READ COMMITTED both transactions read the same snapshot and the later commit writes its stale copy back.

**Observed in production** (Railway template, Postgres mode): SWE-AF's `plan` reasoner calls `app.note("… complete")` right before returning, and the SDK posts the terminal status ~1 ms later. The note transaction committed last and reverted the row from `succeeded` (with result) back to `running` with a NULL result — DB forensics: row `updated_at 15:29:42.838`, last note timestamp `15:29:42.837`, status callback 200 at the same instant. The SDK poll loop never saw the reasoner finish and the parent `build` hung until cancellation (poll timeout is 6h). SQLite never shows this because it serializes writers — which is why local `af` runs don't reproduce it.

## Fix

Mode-gated `forUpdate()` suffix (`" FOR UPDATE"` on postgres, `""` on sqlite — sqlite rejects the syntax and doesn't need it), applied to the RMW SELECTs in:

- `UpdateExecutionRecord` (used by the status callback, the note handler, cancel, etc.)
- `attemptWorkflowExecutionUpdate` (via a suffix-aware `getWorkflowExecutionByIDSuffix`; plain reads unchanged)

A concurrent updater now blocks until the first transaction commits, then re-reads the committed row. Locks are single-row by primary key, so no new deadlock ordering is introduced.

## Regression test

`TestPostgresUpdateExecutionRecord_ConcurrentRMWNoLostUpdate` reproduces the interleaving deterministically (updater A holds its transaction open while updater B runs, then A commits). Gated on `POSTGRES_TEST_URL` like the other postgres tests.

- Pre-fix code: **fails** with `note was lost to the concurrent status write` (verified against Postgres 14)
- With fix: **passes**

Also pins the dialect gate (`TestForUpdateSuffixByMode`, runs everywhere).

## Test plan

- [x] Regression test fails pre-fix / passes post-fix against a real Postgres 14
- [x] Full `go test -tags sqlite_fts5 ./...` (with web UI built for go:embed): green except the pre-existing, environment-dependent `TestDevServiceRunDev` timeouts in `internal/core/services`, which fail identically on a clean `origin/main` checkout in this environment
- [x] `gofmt` clean on touched files; everything compiles
- [ ] After release: redeploy the Railway template and re-run a `swe-planner.build` end-to-end (the stall reproduced there)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)