### PR TITLE
fix: Update reinstalls catalog nodes from the catalog source; expose each package's recorded source

### DIFF
--- a/control-plane/internal/handlers/ui/coverage_packages_timeline_node_log_test.go
+++ b/control-plane/internal/handlers/ui/coverage_packages_timeline_node_log_test.go
@@ -112,6 +112,7 @@ func TestPackageHandlerCoverageNonIntegration(t *testing.T) {
 		router := newPackageRouter(storage)
 		description := "Searchable package"
 		author := "Author"
+		recordedSource := "https://github.com/owner/searchable//go"
 
 		storage.queryAgentPackagesFn = func(ctx context.Context, filters types.PackageFilters) ([]*types.AgentPackage, error) {
 			return []*types.AgentPackage{
@@ -121,6 +122,7 @@ func TestPackageHandlerCoverageNonIntegration(t *testing.T) {
 					Version:             "1.0.0",
 					Description:         &description,
 					Author:              &author,
+					Repository:          &recordedSource,
 					InstallPath:         "/tmp/pkg-active",
 					ConfigurationSchema: json.RawMessage(`{"required":{"token":{"type":"secret"}}}`),
 				},
@@ -165,6 +167,7 @@ func TestPackageHandlerCoverageNonIntegration(t *testing.T) {
 		body := decodeJSONResponse[PackageListResponse](t, rec)
 		require.Len(t, body.Packages, 1)
 		require.Equal(t, "pkg-active", body.Packages[0].ID)
+		require.Equal(t, recordedSource, body.Packages[0].Source)
 		require.True(t, body.Packages[0].ConfigurationRequired)
 		require.True(t, body.Packages[0].ConfigurationComplete)
 		require.Equal(t, 1, body.Total)
@@ -174,6 +177,7 @@ func TestPackageHandlerCoverageNonIntegration(t *testing.T) {
 		body = decodeJSONResponse[PackageListResponse](t, rec)
 		require.Len(t, body.Packages, 1)
 		require.Equal(t, "pkg-open", body.Packages[0].ID)
+		require.Empty(t, body.Packages[0].Source)
 		require.False(t, body.Packages[0].ConfigurationRequired)
 		require.True(t, body.Packages[0].ConfigurationComplete)
 
@@ -202,6 +206,7 @@ func TestPackageHandlerCoverageNonIntegration(t *testing.T) {
 
 		storage := &overrideStorage{StorageProvider: setupTestStorage(t)}
 		router := newPackageRouter(storage)
+		recordedSource := "https://github.com/owner/configured"
 		storage.getAgentPackageFn = func(ctx context.Context, packageID string) (*types.AgentPackage, error) {
 			switch packageID {
 			case "missing":
@@ -222,6 +227,7 @@ func TestPackageHandlerCoverageNonIntegration(t *testing.T) {
 					Version:             "2.0.0",
 					Description:         &description,
 					Author:              &author,
+					Repository:          &recordedSource,
 					InstallPath:         "/tmp/configured",
 					ConfigurationSchema: json.RawMessage(`{"required":{"token":{"type":"secret"}}}`),
 				}, nil
@@ -258,6 +264,7 @@ func TestPackageHandlerCoverageNonIntegration(t *testing.T) {
 		require.Equal(t, http.StatusOK, rec.Code)
 		configured := decodeJSONResponse[PackageDetailsResponse](t, rec)
 		require.Equal(t, "configured", configured.ID)
+		require.Equal(t, recordedSource, configured.Source)
 		require.Equal(t, "Configured package", configured.Description)
 		require.True(t, configured.Configuration.Required)
 		require.True(t, configured.Configuration.Complete)
@@ -267,6 +274,7 @@ func TestPackageHandlerCoverageNonIntegration(t *testing.T) {
 		rec = performJSONRequest(router, http.MethodGet, "/api/ui/v1/agents/packages/no-config/details", nil)
 		require.Equal(t, http.StatusOK, rec.Code)
 		openPkg := decodeJSONResponse[PackageDetailsResponse](t, rec)
+		require.Empty(t, openPkg.Source)
 		require.False(t, openPkg.Configuration.Required)
 		require.True(t, openPkg.Configuration.Complete)
 		require.Empty(t, openPkg.Configuration.Current)

--- a/control-plane/internal/handlers/ui/packages.go
+++ b/control-plane/internal/handlers/ui/packages.go
@@ -42,6 +42,7 @@ type PackageInfo struct {
 	InstallStatus         string `json:"install_status"`
 	InstalledAt           string `json:"installed_at,omitempty"`
 	InstallPath           string `json:"install_path"`
+	Source                string `json:"source"`
 	ConfigurationRequired bool   `json:"configuration_required"`
 	ConfigurationComplete bool   `json:"configuration_complete"`
 	RunningNodeID         string `json:"running_node_id,omitempty"`
@@ -60,6 +61,7 @@ type PackageDetailsResponse struct {
 	Description   string               `json:"description"`
 	Author        string               `json:"author"`
 	InstallPath   string               `json:"install_path"`
+	Source        string               `json:"source"`
 	Status        string               `json:"status"`
 	Configuration PackageConfiguration `json:"configuration"`
 	Capabilities  *PackageCapabilities `json:"capabilities,omitempty"`
@@ -159,6 +161,7 @@ func (h *PackageHandler) ListPackagesHandler(c *gin.Context) {
 			Status:                packageStatus,
 			InstallStatus:         string(pkg.Status),
 			InstallPath:           pkg.InstallPath,
+			Source:                h.safeStringValue(pkg.Repository),
 			ConfigurationRequired: configRequired,
 			ConfigurationComplete: configComplete,
 			Description:           h.safeStringValue(pkg.Description),
@@ -237,6 +240,7 @@ func (h *PackageHandler) GetPackageDetailsHandler(c *gin.Context) {
 		Description: h.safeStringValue(pkg.Description),
 		Author:      h.safeStringValue(pkg.Author),
 		InstallPath: pkg.InstallPath,
+		Source:      h.safeStringValue(pkg.Repository),
 		Status:      packageStatus,
 		Configuration: PackageConfiguration{
 			Required: configRequired,

--- a/control-plane/internal/handlers/ui/packages_install.go
+++ b/control-plane/internal/handlers/ui/packages_install.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"errors"
+	"io"
 	"net/http"
 
 	"github.com/Agent-Field/agentfield/control-plane/internal/services/packagejobs"
@@ -14,7 +15,7 @@ type PackageInstallHandler struct {
 
 type packageJobManager interface {
 	StartInstall(source string, force bool) (*packagejobs.Job, error)
-	StartUpdate(packageName string) (*packagejobs.Job, error)
+	StartUpdate(packageName, source string) (*packagejobs.Job, error)
 	Uninstall(packageName string) error
 	GetJob(id string) (*packagejobs.Job, bool)
 	ListJobs() []*packagejobs.Job
@@ -27,6 +28,10 @@ func NewPackageInstallHandler(manager packageJobManager) *PackageInstallHandler 
 type installPackageRequest struct {
 	Source string `json:"source" binding:"required"`
 	Force  bool   `json:"force"`
+}
+
+type updatePackageRequest struct {
+	Source string `json:"source"`
 }
 
 func (h *PackageInstallHandler) InstallPackageHandler(c *gin.Context) {
@@ -75,7 +80,13 @@ func (h *PackageInstallHandler) UpdatePackageHandler(c *gin.Context) {
 		RespondBadRequest(c, "packageId is required")
 		return
 	}
-	job, err := h.manager.StartUpdate(packageID)
+	var req updatePackageRequest
+	// Older clients send no body; EOF preserves their recorded-source update.
+	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
+		RespondBadRequest(c, "invalid request body")
+		return
+	}
+	job, err := h.manager.StartUpdate(packageID, req.Source)
 	if err != nil {
 		h.respondOperationError(c, err)
 		return

--- a/control-plane/internal/handlers/ui/packages_install_test.go
+++ b/control-plane/internal/handlers/ui/packages_install_test.go
@@ -14,7 +14,7 @@ import (
 
 type stubPackageJobManager struct {
 	startInstall func(string, bool) (*packagejobs.Job, error)
-	startUpdate  func(string) (*packagejobs.Job, error)
+	startUpdate  func(string, string) (*packagejobs.Job, error)
 	uninstall    func(string) error
 	jobs         map[string]*packagejobs.Job
 }
@@ -22,8 +22,8 @@ type stubPackageJobManager struct {
 func (s *stubPackageJobManager) StartInstall(source string, force bool) (*packagejobs.Job, error) {
 	return s.startInstall(source, force)
 }
-func (s *stubPackageJobManager) StartUpdate(name string) (*packagejobs.Job, error) {
-	return s.startUpdate(name)
+func (s *stubPackageJobManager) StartUpdate(name, source string) (*packagejobs.Job, error) {
+	return s.startUpdate(name, source)
 }
 func (s *stubPackageJobManager) Uninstall(name string) error { return s.uninstall(name) }
 func (s *stubPackageJobManager) GetJob(id string) (*packagejobs.Job, bool) {
@@ -143,7 +143,7 @@ func TestUpdatePackageHandlerMappings(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			manager := &stubPackageJobManager{
-				startUpdate: func(string) (*packagejobs.Job, error) { return test.job, test.err },
+				startUpdate: func(string, string) (*packagejobs.Job, error) { return test.job, test.err },
 				uninstall:   func(string) error { return errors.New("unused") },
 			}
 			ctx, response := testContext(http.MethodPost, "/", nil, gin.Param{Key: "packageId", Value: "demo"})
@@ -152,6 +152,52 @@ func TestUpdatePackageHandlerMappings(t *testing.T) {
 				t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
 			}
 		})
+	}
+}
+
+func TestUpdatePackageHandlerForwardsOptionalSource(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       []byte
+		wantSource string
+	}{
+		{name: "catalog source", body: []byte(`{"source":"https://github.com/catalog/latest"}`), wantSource: "https://github.com/catalog/latest"},
+		{name: "empty body"},
+		{name: "empty source", body: []byte(`{"source":""}`)},
+		{name: "absent source", body: []byte(`{}`)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manager := &stubPackageJobManager{
+				startUpdate: func(name, source string) (*packagejobs.Job, error) {
+					if name != "demo" || source != test.wantSource {
+						t.Fatalf("name=%q source=%q", name, source)
+					}
+					return &packagejobs.Job{ID: "update-1"}, nil
+				},
+			}
+			ctx, response := testContext(http.MethodPost, "/", test.body, gin.Param{Key: "packageId", Value: "demo"})
+			NewPackageInstallHandler(manager).UpdatePackageHandler(ctx)
+			if response.Code != http.StatusAccepted {
+				t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+			}
+		})
+	}
+}
+
+func TestUpdatePackageHandlerMapsInvalidSourceToBadRequest(t *testing.T) {
+	manager := &stubPackageJobManager{
+		startUpdate: func(_ string, source string) (*packagejobs.Job, error) {
+			if source != "invalid" {
+				t.Fatalf("source=%q", source)
+			}
+			return nil, packagejobs.ErrInvalidSource
+		},
+	}
+	ctx, response := testContext(http.MethodPost, "/", []byte(`{"source":"invalid"}`), gin.Param{Key: "packageId", Value: "demo"})
+	NewPackageInstallHandler(manager).UpdatePackageHandler(ctx)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
 	}
 }
 
@@ -246,5 +292,21 @@ func TestUninstallPackageHandlerSuccessAndInternalError(t *testing.T) {
 				t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
 			}
 		})
+	}
+}
+
+// A body that is present but not a JSON object is a client bug, not an
+// "update from the recorded source" request — only a missing body means that.
+func TestUpdatePackageHandlerRejectsMalformedJSON(t *testing.T) {
+	manager := &stubPackageJobManager{
+		startUpdate: func(string, string) (*packagejobs.Job, error) {
+			t.Fatal("manager should not be called")
+			return nil, nil
+		},
+	}
+	ctx, response := testContext(http.MethodPost, "/", []byte(`{`), gin.Param{Key: "packageId", Value: "demo"})
+	NewPackageInstallHandler(manager).UpdatePackageHandler(ctx)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
 	}
 }

--- a/control-plane/internal/server/package_sync.go
+++ b/control-plane/internal/server/package_sync.go
@@ -72,7 +72,8 @@ func SyncPackagesFromRegistry(agentfieldHome string, storageProvider packageStor
 		status := packageStatusFromRegistry(pkg.Status)
 		existing, err := storageProvider.GetAgentPackage(ctx, pkgName)
 		if err == nil && existing != nil && installedStatus(existing.Status) &&
-			existing.Status == status && existing.InstallPath == pkg.Path && existing.Version == pkg.Version {
+			existing.Status == status && existing.InstallPath == pkg.Path && existing.Version == pkg.Version &&
+			existing.Repository != nil && *existing.Repository == pkg.SourcePath {
 			continue // Already reconciled
 		}
 		// Load agentfield-package.yaml
@@ -92,11 +93,13 @@ func SyncPackagesFromRegistry(agentfieldHome string, storageProvider packageStor
 		if parsed, err := time.Parse(time.RFC3339, pkg.InstalledAt); err == nil && !parsed.IsZero() {
 			installedAt = parsed
 		}
+		recordedSource := pkg.SourcePath
 		agentPkg := &types.AgentPackage{
 			ID:                  pkgName,
 			Name:                pkg.Name,
 			Version:             pkg.Version,
 			Description:         &pkg.Description,
+			Repository:          &recordedSource,
 			InstallPath:         pkg.Path,
 			ConfigurationSchema: schemaJson,
 			Status:              status,

--- a/control-plane/internal/server/package_sync_test.go
+++ b/control-plane/internal/server/package_sync_test.go
@@ -47,6 +47,37 @@ schema:
 	require.NotEmpty(t, pkg.ConfigurationSchema)
 }
 
+func TestSyncPackagesFromRegistryTracksRecordedSource(t *testing.T) {
+	t.Parallel()
+
+	agentfieldHome := t.TempDir()
+	pkgDir := filepath.Join(agentfieldHome, "source-agent")
+	require.NoError(t, os.MkdirAll(pkgDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "agentfield-package.yaml"),
+		[]byte("name: Source Agent\nversion: 1.0.0\n"), 0o644))
+	registryPath := filepath.Join(agentfieldHome, "installed.yaml")
+	writeRegistry := func(source string) {
+		require.NoError(t, os.WriteFile(registryPath, []byte(`installed:
+  source-agent:
+    name: Source Agent
+    version: 1.0.0
+    path: `+pkgDir+`
+    source_path: `+source+`
+    status: installed
+`), 0o644))
+	}
+
+	storage := newStubPackageStorage()
+	writeRegistry("https://github.com/owner/original//go")
+	require.NoError(t, SyncPackagesFromRegistry(agentfieldHome, storage))
+	require.Equal(t, "https://github.com/owner/original//go", *storage.packages["source-agent"].Repository)
+
+	// Source changes must not be hidden by the otherwise-idempotent fast path.
+	writeRegistry("https://github.com/owner/latest//go")
+	require.NoError(t, SyncPackagesFromRegistry(agentfieldHome, storage))
+	require.Equal(t, "https://github.com/owner/latest//go", *storage.packages["source-agent"].Repository)
+}
+
 func TestSyncPackagesFromRegistryMapsRunningStatus(t *testing.T) {
 	t.Parallel()
 

--- a/control-plane/internal/services/packagejobs/manager.go
+++ b/control-plane/internal/services/packagejobs/manager.go
@@ -162,12 +162,18 @@ func (m *Manager) StartInstall(source string, force bool) (*Job, error) {
 	return m.startJob(JobInstall, normalized, "", force)
 }
 
-func (m *Manager) StartUpdate(packageName string) (*Job, error) {
+func (m *Manager) StartUpdate(packageName, source string) (*Job, error) {
 	entry, err := m.registryEntry(packageName)
 	if err != nil {
 		return nil, err
 	}
-	source, err := sourceFromRegistry(entry.SourcePath)
+	if strings.TrimSpace(source) != "" {
+		// Desktop catalog updates deliberately replace a stale recorded source;
+		// the installer will persist the source that ultimately lands.
+		source, err = ValidateSource(source)
+	} else {
+		source, err = sourceFromRegistry(entry.SourcePath)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/control-plane/internal/services/packagejobs/manager_test.go
+++ b/control-plane/internal/services/packagejobs/manager_test.go
@@ -63,6 +63,7 @@ type stubInstaller struct {
 	installed    []domain.InstalledPackage
 	afterInstall []domain.InstalledPackage
 	calls        *[]string
+	lastSource   string
 	lastOptions  domain.InstallOptions
 	listErr      error
 	infoErr      error
@@ -77,13 +78,14 @@ func (s *stubInstaller) InstallPackageWithResult(source string, options domain.I
 	return s.resultName, nil
 }
 
-func (s *stubInstaller) InstallPackage(_ string, options domain.InstallOptions) error {
+func (s *stubInstaller) InstallPackage(source string, options domain.InstallOptions) error {
 	if s.block != nil {
 		<-s.block
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.lastOptions = options
+	s.lastSource = source
 	if s.calls != nil {
 		*s.calls = append(*s.calls, "install")
 	}
@@ -319,7 +321,7 @@ func TestUpdateStopsForceInstallsAndRestarts(t *testing.T) {
 	var calls []string
 	inst := &stubInstaller{installed: []domain.InstalledPackage{{Name: "demo"}}, calls: &calls}
 	manager := newManager(inst, &stubAgentService{running: true, calls: &calls}, home)
-	job, err := manager.StartUpdate("demo")
+	job, err := manager.StartUpdate("demo", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -331,6 +333,69 @@ func TestUpdateStopsForceInstallsAndRestarts(t *testing.T) {
 	}
 	if !inst.lastOptions.Force {
 		t.Fatal("update was not forced")
+	}
+}
+
+func TestStartUpdateSelectsOverrideOrRecordedSource(t *testing.T) {
+	tests := []struct {
+		name       string
+		override   string
+		wantSource string
+		wantRepo   string
+		wantPath   string
+	}{
+		{
+			name:       "catalog override",
+			override:   " https://github.com/catalog/latest//agent/ ",
+			wantSource: "https://github.com/catalog/latest//agent",
+			wantRepo:   "https://github.com/catalog/latest",
+			wantPath:   "agent",
+		},
+		{
+			name:       "recorded source",
+			override:   " ",
+			wantSource: "https://github.com/recorded/original//go",
+			wantRepo:   "https://github.com/recorded/original",
+			wantPath:   "go",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			if err := os.WriteFile(filepath.Join(home, "installed.yaml"), []byte("installed:\n  demo:\n    source_path: https://github.com/recorded/original//go@main\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			inst := &stubInstaller{installed: []domain.InstalledPackage{{Name: "demo"}}}
+			manager := newManager(inst, &stubAgentService{}, home)
+
+			job, err := manager.StartUpdate("demo", test.override)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if job.Source != test.wantSource {
+				t.Fatalf("job source = %q, want %q", job.Source, test.wantSource)
+			}
+			if got := waitForJob(t, manager, job.ID); got.Status != StatusSucceeded {
+				t.Fatalf("job = %#v", got)
+			}
+			if inst.lastSource != test.wantRepo || inst.lastOptions.Path != test.wantPath {
+				t.Fatalf("installer source = %q, path = %q", inst.lastSource, inst.lastOptions.Path)
+			}
+		})
+	}
+}
+
+func TestStartUpdateValidatesOverrideAfterRegistryLookup(t *testing.T) {
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, "installed.yaml"), []byte("installed:\n  demo:\n    source_path: https://github.com/recorded/original\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manager := newManager(&stubInstaller{}, &stubAgentService{}, home)
+	if _, err := manager.StartUpdate("demo", "not-a-github-source"); !errors.Is(err, ErrInvalidSource) {
+		t.Fatalf("invalid override error = %v", err)
+	}
+	if _, err := manager.StartUpdate("missing", "https://github.com/catalog/latest"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("unknown package error = %v", err)
 	}
 }
 
@@ -351,7 +416,7 @@ func TestUpdateFollowsASupersededRename(t *testing.T) {
 		calls:        &calls,
 	}
 	manager := newManager(inst, &stubAgentService{running: true, calls: &calls}, home)
-	job, err := manager.StartUpdate("demo")
+	job, err := manager.StartUpdate("demo", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -452,7 +517,7 @@ func TestStartUpdateRegistryFailures(t *testing.T) {
 				}
 			}
 			manager := newManager(&stubInstaller{}, &stubAgentService{}, home)
-			_, err := manager.StartUpdate("demo")
+			_, err := manager.StartUpdate("demo", "")
 			if err == nil || (test.want != nil && !errors.Is(err, test.want)) {
 				t.Fatalf("err = %v, want %v", err, test.want)
 			}
@@ -611,7 +676,7 @@ func TestUpdateRegistryChangeHook(t *testing.T) {
 			calls := 0
 			manager.SetOnRegistryChange(func() { calls++ })
 
-			job, err := manager.StartUpdate("demo")
+			job, err := manager.StartUpdate("demo", "")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -679,5 +744,38 @@ func TestUninstallIsBusyDuringInstallAndSucceedsAfterward(t *testing.T) {
 	}
 	if got := strings.Join(calls, ","); got != "install,remove:demo" {
 		t.Fatalf("calls = %s", got)
+	}
+}
+
+// A catalog-source override changes WHERE the update fetches from and nothing
+// else: it is still an update job — forced reinstall in place, the running
+// node stopped first and restarted after — not a plain install of a new source.
+func TestStartUpdateOverrideKeepsUpdateSemantics(t *testing.T) {
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, "installed.yaml"), []byte("installed:\n  demo:\n    source_path: https://github.com/recorded/original//go\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var calls []string
+	inst := &stubInstaller{installed: []domain.InstalledPackage{{Name: "demo"}}, calls: &calls}
+	manager := newManager(inst, &stubAgentService{running: true, calls: &calls}, home)
+
+	job, err := manager.StartUpdate("demo", "https://github.com/catalog/latest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.Kind != JobUpdate {
+		t.Fatalf("job kind = %q, want %q", job.Kind, JobUpdate)
+	}
+	if got := waitForJob(t, manager, job.ID); got.Status != StatusSucceeded {
+		t.Fatalf("job = %#v", got)
+	}
+	if strings.Join(calls, ",") != "stop:demo,install,start:demo" {
+		t.Fatalf("calls = %v", calls)
+	}
+	if !inst.lastOptions.Force {
+		t.Fatal("override update was not forced")
+	}
+	if inst.lastSource != "https://github.com/catalog/latest" {
+		t.Fatalf("installer source = %q", inst.lastSource)
 	}
 }

--- a/desktop/src/main/agentfield.test.ts
+++ b/desktop/src/main/agentfield.test.ts
@@ -37,6 +37,7 @@ const API_PACKAGES: PackageInfo[] = [
     description: 'Opens draft pull requests from a task description',
     status: 'configured', install_status: 'running',
     install_path: '/home/abir/.agentfield/packages/pr-af',
+    source: 'https://github.com/owner/pr-af',
     port: 9001, process_id: 4242, configuration_required: false,
     configuration_complete: true, author: ''
   },
@@ -152,6 +153,7 @@ describe('readInstalledAgents', () => {
       description: 'Opens draft pull requests from a task description',
       status: 'running',
       path: '/home/abir/.agentfield/packages/pr-af',
+      source: 'https://github.com/owner/pr-af',
       port: 9001,
       pid: 4242
     })

--- a/desktop/src/main/agentfield.ts
+++ b/desktop/src/main/agentfield.ts
@@ -117,6 +117,7 @@ export function packageToInstalledAgent(pkg: PackageInfo): InstalledAgent {
     description: pkg.description,
     status: pkg.install_status ?? pkg.status,
     path: pkg.install_path || null,
+    ...(pkg.source === undefined ? {} : { source: pkg.source }),
     port: pkg.port ?? null,
     pid: pkg.process_id ?? null
   }

--- a/desktop/src/main/cpClient.test.ts
+++ b/desktop/src/main/cpClient.test.ts
@@ -92,7 +92,24 @@ describe('createCpClient', () => {
       source: 'https://github.com/acme/agent',
       force: true
     })
+    expect(calls[4][1]?.body).toBeUndefined()
     expect(JSON.parse(String(calls[6][1]?.body))).toEqual({ port: 9000, detach: false })
+  })
+
+  it('sends an update source only when one is provided', async () => {
+    const fetchImpl = mockFetch([json({ job_id: 'with-source' }), json({ job_id: 'legacy' })])
+    const client = createCpClient({ fetchImpl })
+
+    await expect(
+      client.updatePackage('agent', 'https://github.com/Agent-Field/SWE-AF')
+    ).resolves.toEqual({ job_id: 'with-source' })
+    await expect(client.updatePackage('agent')).resolves.toEqual({ job_id: 'legacy' })
+
+    const calls = vi.mocked(fetchImpl).mock.calls
+    expect(JSON.parse(String(calls[0][1]?.body))).toEqual({
+      source: 'https://github.com/Agent-Field/SWE-AF'
+    })
+    expect(calls[1][1]?.body).toBeUndefined()
   })
 
   it('normalizes Go nil slices in list responses', async () => {

--- a/desktop/src/main/cpClient.ts
+++ b/desktop/src/main/cpClient.ts
@@ -46,6 +46,8 @@ export interface PackageInfo {
   install_status?: string
   installed_at?: string
   install_path: string
+  /** Recorded installed.yaml source_path; absent on older control planes. */
+  source?: string
   configuration_required: boolean
   configuration_complete: boolean
   running_node_id?: string
@@ -179,7 +181,7 @@ export interface CpClient {
   /** POST /api/ui/v1/agents/packages/:packageId/uninstall. */
   uninstallPackage(packageId: string): Promise<{ package_id: string; status: string }>
   /** POST /api/ui/v1/agents/packages/:packageId/update. */
-  updatePackage(packageId: string): Promise<{ job_id: string }>
+  updatePackage(packageId: string, source?: string): Promise<{ job_id: string }>
   /** GET /api/ui/v1/agents/packages. */
   listPackages(): Promise<PackageListResponse>
   /** POST /api/ui/v1/agents/:agentId/start. */
@@ -328,10 +330,12 @@ export function createCpClient(options: CpClientOptions = {}): CpClient {
         true
       )
     },
-    updatePackage(packageId) {
+    updatePackage(packageId, source) {
       return request(
         `/api/ui/v1/agents/packages/${encodeURIComponent(packageId)}/update`,
-        { method: 'POST' },
+        source === undefined
+          ? { method: 'POST' }
+          : { method: 'POST', body: JSON.stringify({ source }) },
         true
       )
     },

--- a/desktop/src/main/installer.test.ts
+++ b/desktop/src/main/installer.test.ts
@@ -125,6 +125,12 @@ describe('control-plane installs', () => {
     expect(client.installPackage).toHaveBeenCalledWith(ENTRY.source, true)
   })
 
+  it('updates catalog agents from the current catalog source', async () => {
+    const client = installClient()
+    await updateAgent(ENTRY.name, () => {}, { cpClient: client })
+    expect(client.updatePackage).toHaveBeenCalledWith(ENTRY.name, ENTRY.source)
+  })
+
   it('surfaces conflict and old-control-plane errors without fallback', async () => {
     const conflict = installClient({ installPackage: vi.fn(async () => { throw new CpApiError({ status: 409, message: 'another install is running' }) }) })
     expect((await installAgent(ENTRY.name, () => {}, false, { cpClient: conflict })).message).toMatch(/another install/i)

--- a/desktop/src/main/installer.ts
+++ b/desktop/src/main/installer.ts
@@ -237,12 +237,10 @@ export function installFromSource(
 }
 
 /**
- * Update an installed catalog agent to the latest version of its source:
- * stop it if it is running, `af install <source> --force` (reinstall in
- * place — registry entry and secrets survive), then restore the previous run
- * state: restart only what was running, leave stopped agents stopped. Phase
- * markers ("Stopping…", "Restarting…") ride the same progress channel as the
- * install output. Resolves (never rejects) with the outcome.
+ * Update an installed catalog agent from the latest catalog source, not its
+ * recorded source — replacing a stale origin is the point. The control plane
+ * stops a running agent, reinstalls with force, then restores its prior run
+ * state. Resolves (never rejects) with the outcome.
  */
 export async function updateAgent(
   name: string,
@@ -258,12 +256,16 @@ export async function updateAgent(
       return { ok: false, message: UPDATE_REQUIRED }
     }
     onLine(`Updating ${name}…`)
-    const { job_id } = await deps.cpClient.updatePackage(name)
+    // Only a git URL can be handed to the control plane as an override (its
+    // source validator wants https://github.com/…); any other catalog source
+    // shape falls back to the recorded-source update rather than a 400.
+    const override = entry.source.startsWith('https://') ? entry.source : undefined
+    const { job_id } = await deps.cpClient.updatePackage(name, override)
     const job = await deps.cpClient.watchInstallJob(job_id, onLine)
     if (job.status !== 'succeeded') {
       return { ok: false, message: job.error || job.lines.at(-1) || `Failed to update ${name}` }
     }
-    // An update reinstalls from the recorded source, so it can hit a
+    // An update reinstalls from the catalog source, so it can hit a
     // `superseded_by:` redirect and come back as a different node. Saying
     // "<old> updated" would then name something that no longer exists.
     const landed = installedName(job)

--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -230,7 +230,6 @@ export default function App() {
 
   const cp = controlPlaneStatus(snapshot)
   const agents = snapshot?.registry.agents ?? []
-  const installedNames = agents.map((a) => a.name)
   const provisioningNames = bundled
     .filter((node) => node.phase === 'pending' || node.phase === 'installing')
     .map((node) => node.name)
@@ -370,7 +369,7 @@ export default function App() {
               {agentsSelected &&
                 (agentsAddMode ? (
                   <InstallPanel
-                    installedNames={installedNames}
+                    installedAgents={agents}
                     provisioningNames={provisioningNames}
                     onInstalled={() => void refresh()}
                     libraryCount={agents.length}

--- a/desktop/src/renderer/src/components/InstallPanel.tsx
+++ b/desktop/src/renderer/src/components/InstallPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { AnimatePresence, m, useReducedMotion } from 'motion/react'
-import type { CatalogEntry } from '../../../shared/types'
+import type { CatalogEntry, InstalledAgent } from '../../../shared/types'
+import { installedSourceLabel } from '../../../shared/catalog'
 import { COMMUNITY_LINKS } from './communityLinks'
 import { MenuPopover } from './MenuPopover'
 import { SkeletonRows } from './Skeleton'
@@ -36,7 +37,7 @@ function InstallCheck() {
 // featured marketplace card grid. Rendered by App inside the Agents view —
 // there is no separate Install view anymore.
 interface InstallPanelProps {
-  installedNames: string[]
+  installedAgents: InstalledAgent[]
   provisioningNames: string[]
   onInstalled: () => void
   /** Installed agents count — labels the "Back to installed (N)" affordance. */
@@ -119,7 +120,7 @@ export function parseRepoSource(input: string): ParsedRepo | null {
 }
 
 export function InstallPanel({
-  installedNames,
+  installedAgents,
   provisioningNames,
   onInstalled,
   libraryCount,
@@ -214,6 +215,7 @@ export function InstallPanel({
   }
 
   const installing = phase.state === 'installing'
+  const installedByName = new Map(installedAgents.map((agent) => [agent.name, agent]))
   const parsed = parseRepoSource(repoUrl)
   const repoInvalid = repoUrl.trim().length > 0 && parsed === null
   const showRepoError = repoInvalid && repoTouched
@@ -388,7 +390,7 @@ export function InstallPanel({
             <FeaturedCard
               key={entry.name}
               entry={entry}
-              installed={installedNames.includes(entry.name)}
+              installedAgent={installedByName.get(entry.name)}
               provisioning={provisioningNames.includes(entry.name)}
               installing={installing}
               phase={phase}
@@ -419,7 +421,7 @@ export function InstallPanel({
  */
 function FeaturedCard({
   entry,
-  installed,
+  installedAgent,
   provisioning,
   installing,
   phase,
@@ -433,7 +435,7 @@ function FeaturedCard({
   onToggleMenu
 }: {
   entry: CatalogEntry
-  installed: boolean
+  installedAgent?: InstalledAgent
   provisioning: boolean
   installing: boolean
   phase: InstallPhase
@@ -449,11 +451,17 @@ function FeaturedCard({
   const active = phase.state !== 'idle' && phase.name === entry.name
   const busy = installing && phase.state === 'installing' && phase.name === entry.name
   const cardLines = busy && phase.state === 'installing' ? phase.lines : []
+  const installed = installedAgent !== undefined
 
   // Curated sources are https git URLs (link out) or af://registry refs
   // (plain text). Show the short org/repo form as the trust cue.
   const sourceHref = entry.source.startsWith('https://') ? entry.source : null
   const sourceLabel = entry.source.replace(/^https:\/\/github\.com\//, '')
+  // Drift means a different REPOSITORY, not a different string: a catalog
+  // install is recorded as the redirect target (`…/SWE-AF//go`), which must
+  // not read as "installed from somewhere else".
+  const recordedSource = installedAgent?.source?.trim()
+  const recordedSourceLabel = installedSourceLabel(recordedSource, entry.source)
 
   return (
     <div className="market-card">
@@ -490,19 +498,26 @@ function FeaturedCard({
       )}
 
       <div className="market-card-foot">
-        {sourceHref ? (
-          <a
-            className="market-source"
-            href={sourceHref}
-            target="_blank"
-            rel="noreferrer"
-            title={`Open ${entry.source}`}
-          >
-            {sourceLabel} ↗
-          </a>
-        ) : (
-          <span className="market-source">{sourceLabel}</span>
-        )}
+        <div className="market-provenance">
+          {sourceHref ? (
+            <a
+              className="market-source"
+              href={sourceHref}
+              target="_blank"
+              rel="noreferrer"
+              title={`Open ${entry.source}`}
+            >
+              {sourceLabel} ↗
+            </a>
+          ) : (
+            <span className="market-source">{sourceLabel}</span>
+          )}
+          {recordedSourceLabel ? (
+            <span className="market-source market-installed-source" title={recordedSource}>
+              installed from {recordedSourceLabel}
+            </span>
+          ) : null}
+        </div>
         {provisioning ? (
           <button className="install-button" disabled>
             Installing…

--- a/desktop/src/renderer/src/styles.css
+++ b/desktop/src/renderer/src/styles.css
@@ -2269,6 +2269,12 @@ code {
   min-width: 0;
 }
 
+.market-provenance {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
 .market-source {
   min-width: 0;
   overflow: hidden;
@@ -2284,6 +2290,10 @@ a.market-source:hover,
 a.market-source:focus-visible {
   color: var(--text-secondary);
   text-decoration: underline;
+}
+
+.market-installed-source {
+  color: var(--text-secondary);
 }
 
 /* Text + glyph, not color-only (the ✓ carries the label with it). */

--- a/desktop/src/shared/catalog.test.ts
+++ b/desktop/src/shared/catalog.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { installedSourceLabel, sameSourceRepo, sourceRepo } from './catalog'
+
+// Contract C6: the installed card flags an install as coming from somewhere
+// else only when the RECORDED source names a different repository than the
+// catalog row — never because the registry kept a `//subdir` or `@ref` that the
+// catalog row does not carry.
+describe('sourceRepo', () => {
+  it('reduces a source to its owner/repo identity', () => {
+    expect(sourceRepo('https://github.com/Agent-Field/SWE-AF')).toBe('agent-field/swe-af')
+    expect(sourceRepo('https://github.com/Agent-Field/SWE-AF//go')).toBe('agent-field/swe-af')
+    expect(sourceRepo('https://github.com/Agent-Field/SWE-AF@main//go')).toBe('agent-field/swe-af')
+    expect(sourceRepo('https://github.com/Agent-Field/SWE-AF.git/')).toBe('agent-field/swe-af')
+    expect(sourceRepo('Agent-Field/SWE-AF@v1.2.3')).toBe('agent-field/swe-af')
+  })
+
+  it('is empty for a blank source', () => {
+    expect(sourceRepo('')).toBe('')
+    expect(sourceRepo('   ')).toBe('')
+  })
+})
+
+describe('sameSourceRepo', () => {
+  const catalog = 'https://github.com/Agent-Field/SWE-AF'
+
+  it('treats the redirect target of a catalog install as the same repo', () => {
+    expect(sameSourceRepo('https://github.com/Agent-Field/SWE-AF//go', catalog)).toBe(true)
+    expect(sameSourceRepo('https://github.com/agent-field/swe-af@main', catalog)).toBe(true)
+    expect(sameSourceRepo(catalog, catalog)).toBe(true)
+  })
+
+  it('flags an install recorded from a different repository', () => {
+    expect(sameSourceRepo('https://github.com/AbirAbbas/swe-af-furrow-e2e//go', catalog)).toBe(
+      false
+    )
+    expect(sameSourceRepo('https://github.com/Agent-Field/SWE-AF-fork', catalog)).toBe(false)
+  })
+
+  it('never matches an unknown origin', () => {
+    expect(sameSourceRepo('', catalog)).toBe(false)
+    expect(sameSourceRepo('', '')).toBe(false)
+  })
+})
+
+describe('installedSourceLabel', () => {
+  const catalog = 'https://github.com/Agent-Field/SWE-AF'
+
+  it('names the recorded repository when it differs from the catalog row', () => {
+    expect(
+      installedSourceLabel('https://github.com/AbirAbbas/swe-af-furrow-e2e//go', catalog)
+    ).toBe('AbirAbbas/swe-af-furrow-e2e//go')
+  })
+
+  it('is silent for a catalog install, including its redirect target', () => {
+    expect(installedSourceLabel(catalog, catalog)).toBeNull()
+    expect(installedSourceLabel('https://github.com/Agent-Field/SWE-AF//go', catalog)).toBeNull()
+  })
+
+  it('is silent when the control plane reported no source', () => {
+    expect(installedSourceLabel(undefined, catalog)).toBeNull()
+    expect(installedSourceLabel('  ', catalog)).toBeNull()
+  })
+})

--- a/desktop/src/shared/catalog.ts
+++ b/desktop/src/shared/catalog.ts
@@ -52,3 +52,45 @@ export const CATALOG: CatalogEntry[] = []
 export function catalogEntry(name: string): CatalogEntry | undefined {
   return [...CATALOG, ...BUNDLED_NODES].find((entry) => entry.name === name)
 }
+
+/**
+ * The repository a source string points at, with the parts that vary between
+ * a catalog row and an install record stripped away: the `//subdir` selector,
+ * an `@ref` pin, a `.git` suffix, trailing slashes, and case. A catalog row
+ * names the bare repo (`…/SWE-AF`) while the registry records what the
+ * `superseded_by:` redirect landed on (`…/SWE-AF//go`), so comparing the raw
+ * strings would flag every correct install as drift. Returns '' for a blank
+ * source so an unknown origin never compares equal to anything.
+ */
+export function sourceRepo(source: string): string {
+  let repo = source.trim()
+  if (!repo) return ''
+  repo = repo.replace(/^https?:\/\/github\.com\//i, '')
+  const subdir = repo.indexOf('//')
+  if (subdir >= 0) repo = repo.slice(0, subdir)
+  const ref = repo.lastIndexOf('@')
+  if (ref > repo.lastIndexOf('/')) repo = repo.slice(0, ref)
+  return repo.replace(/\/+$/, '').replace(/\.git$/i, '').toLowerCase()
+}
+
+/** True when two source strings name the same repository (see sourceRepo). */
+export function sameSourceRepo(a: string, b: string): boolean {
+  const left = sourceRepo(a)
+  return left !== '' && left === sourceRepo(b)
+}
+
+/**
+ * What an installed catalog card says about where the install actually came
+ * from: the recorded source in short `owner/repo…` form when it names a
+ * DIFFERENT repository than the catalog row, null when it is the same repo
+ * (a `//subdir` or `@ref` left by a `superseded_by:` redirect is not drift) or
+ * when the control plane did not report a source at all.
+ */
+export function installedSourceLabel(
+  recorded: string | undefined,
+  catalogSource: string
+): string | null {
+  const source = recorded?.trim()
+  if (!source || sameSourceRepo(source, catalogSource)) return null
+  return source.replace(/^https:\/\/github\.com\//, '')
+}

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -30,6 +30,8 @@ export interface InstalledAgent {
   status: string
   /** Install dir (~/.agentfield/packages/<name>) — where the manifest lives. */
   path: string | null
+  /** installed.yaml source_path; absent when an older control plane omits it. */
+  source?: string
   port: number | null
   pid: number | null
 }


### PR DESCRIPTION
## What

"Update" on an installed catalog node now reinstalls from the **catalog source** (e.g. `https://github.com/Agent-Field/SWE-AF`), not from whatever source the package happened to be installed from. The control plane exposes each package's recorded source so the desktop can show where an install actually came from.

## Why

A cloud control plane had `swe-planner` installed from a personal e2e repo (`…/swe-af-furrow-e2e//go`, last pushed Aug 6). Weeks later "Update" was clicked on the desktop card for swe-planner — the card whose footer links to `Agent-Field/SWE-AF` as its trust cue. The update job re-installed the Aug-6 e2e repo: `POST /api/ui/v1/agents/packages/:id/update` takes no body, and `StartUpdate` resolves the source from `installed.yaml` → `source_path`. Nothing in the desktop or web UI renders the recorded source, so the drift was invisible; the only place it shows is the install job record.

## Changes

**Control plane**
- `POST /api/ui/v1/agents/packages/:packageId/update` accepts an optional JSON body `{"source": "<url>"}`. A present source is validated (`ValidateSource`) and used for the job; an absent/empty body keeps today's recorded-source behaviour (older desktops send none). Job semantics are unchanged (`update` kind, force reinstall in place, stop-if-running / restart-if-was-running).
- `Manager.StartUpdate(packageName, source)`; unknown package is still `ErrNotFound` either way.
- `SyncPackagesFromRegistry` copies `installed.yaml` `source_path` into the existing `AgentPackage.Repository` column (no migration), and re-reconciles rows whose recorded source changed.
- `GET /api/ui/v1/agents/packages` and `/:packageId/details` include `source` (empty when unknown).

**Desktop**
- `updateAgent(name)` passes `catalogEntry(name).source` to `updatePackage(name, source)`; the IPC boundary still carries only a vetted catalog *name* — the source comes from main-process catalog data.
- `PackageInfo.source` / `InstalledAgent.source` are threaded to the renderer; the installed catalog card shows `installed from <owner/repo…>` when the recorded source names a **different repository** than the catalog row. Same repo with a `//subdir` or `@ref` (what a `superseded_by` redirect records, e.g. `…/SWE-AF//go`) is not drift — `sameSourceRepo` in `shared/catalog.ts` compares repo identity.

## Validation contract

- C1 Update on a catalog/bundled package → job `source` is the catalog source, regardless of `installed.yaml`.
- C2 Update on a pasted-URL package → recorded `source_path` as before (ref stripped, `//subdir` kept).
- C3 `…/update` with `{"source"}` uses it; invalid → 400; no body → unchanged behaviour; unknown package → 404.
- C4 After an override update, the registry records what the installer landed on, so later updates track the new source (existing installer path, incl. `superseded_by`).
- C5 Packages list/details expose `source`; existing fields unchanged.
- C6 Installed card shows the recorded source only when it is a different repository than the catalog source.
- C7 New desktop against an older control plane degrades gracefully (body ignored, no label).

Tests: control-plane `packagejobs/manager_test.go`, `handlers/ui/packages_install_test.go`, `handlers/ui` package tests, `server/package_sync_test.go`; desktop `installer.test.ts`, `cpClient.test.ts`, `agentfield.test.ts`, `shared/catalog.test.ts`.

## Gates run locally

- control-plane: `GOFLAGS=-buildvcs=false go build ./...`, `go vet ./...`, `go test -tags sqlite_fts5 ./...` (web UI dist built for `//go:embed`), `golangci-lint run` (CI marks it continue-on-error).
- desktop (Node 22): `npm ci`, `npm run typecheck`, `npm test`, `npm run build`.

## Follow-ups (not in this PR)

- Nodes are not restarted after a control-plane restart/redeploy; an update after a restart completes "succeeded" and leaves the node stopped.
- `af install` / `af uninstall` / `af secrets` accept `-s/-k` but operate on the local `~/.agentfield` silently.
- The package `not_configured` status (missing "active" configuration record) masks "stopped".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
