### PR TITLE
fix(sdk/go): propagate caller context through MemoryBackend interface

### DIFF
--- a/sdk/go/agent/control_plane_memory_backend.go
+++ b/sdk/go/agent/control_plane_memory_backend.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -45,7 +46,7 @@ type memoryAPIResponse struct {
 	UpdatedAt string `json:"updated_at"`
 }
 
-func (b *ControlPlaneMemoryBackend) Set(scope MemoryScope, scopeID, key string, value any) error {
+func (b *ControlPlaneMemoryBackend) Set(ctx context.Context, scope MemoryScope, scopeID, key string, value any) error {
 	endpoint, err := url.JoinPath(b.baseURL, "/api/v1/memory/set")
 	if err != nil {
 		return err
@@ -60,7 +61,7 @@ func (b *ControlPlaneMemoryBackend) Set(scope MemoryScope, scopeID, key string, 
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest(http.MethodPost, endpoint, reader)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, reader)
 	if err != nil {
 		return err
 	}
@@ -79,13 +80,13 @@ func (b *ControlPlaneMemoryBackend) Set(scope MemoryScope, scopeID, key string, 
 	return nil
 }
 
-func (b *ControlPlaneMemoryBackend) Get(scope MemoryScope, scopeID, key string) (any, bool, error) {
+func (b *ControlPlaneMemoryBackend) Get(ctx context.Context, scope MemoryScope, scopeID, key string) (any, bool, error) {
 	endpoint, err := url.JoinPath(b.baseURL, "/api/v1/memory/get")
 	if err != nil {
 		return nil, false, err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, endpoint, keyScopeReader(key, b.apiScope(scope)))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, keyScopeReader(key, b.apiScope(scope)))
 	if err != nil {
 		return nil, false, err
 	}
@@ -112,13 +113,13 @@ func (b *ControlPlaneMemoryBackend) Get(scope MemoryScope, scopeID, key string) 
 	return mem.Data, true, nil
 }
 
-func (b *ControlPlaneMemoryBackend) Delete(scope MemoryScope, scopeID, key string) error {
+func (b *ControlPlaneMemoryBackend) Delete(ctx context.Context, scope MemoryScope, scopeID, key string) error {
 	endpoint, err := url.JoinPath(b.baseURL, "/api/v1/memory/delete")
 	if err != nil {
 		return err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, endpoint, keyScopeReader(key, b.apiScope(scope)))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, keyScopeReader(key, b.apiScope(scope)))
 	if err != nil {
 		return err
 	}
@@ -140,13 +141,13 @@ func (b *ControlPlaneMemoryBackend) Delete(scope MemoryScope, scopeID, key strin
 	return nil
 }
 
-func (b *ControlPlaneMemoryBackend) List(scope MemoryScope, scopeID string) ([]string, error) {
+func (b *ControlPlaneMemoryBackend) List(ctx context.Context, scope MemoryScope, scopeID string) ([]string, error) {
 	endpoint, err := url.JoinPath(b.baseURL, "/api/v1/memory/list")
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequest(http.MethodGet, endpoint+"?scope="+url.QueryEscape(b.apiScope(scope)), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"?scope="+url.QueryEscape(b.apiScope(scope)), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +179,7 @@ func (b *ControlPlaneMemoryBackend) List(scope MemoryScope, scopeID string) ([]s
 	return keys, nil
 }
 
-func (b *ControlPlaneMemoryBackend) SetVector(scope MemoryScope, scopeID, key string, embedding []float64, metadata map[string]any) error {
+func (b *ControlPlaneMemoryBackend) SetVector(ctx context.Context, scope MemoryScope, scopeID, key string, embedding []float64, metadata map[string]any) error {
 	endpoint, err := url.JoinPath(b.baseURL, "/api/v1/memory/vector")
 	if err != nil {
 		return err
@@ -200,7 +201,7 @@ func (b *ControlPlaneMemoryBackend) SetVector(scope MemoryScope, scopeID, key st
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest(http.MethodPost, endpoint, reader)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, reader)
 	if err != nil {
 		return err
 	}
@@ -219,13 +220,13 @@ func (b *ControlPlaneMemoryBackend) SetVector(scope MemoryScope, scopeID, key st
 	return nil
 }
 
-func (b *ControlPlaneMemoryBackend) GetVector(scope MemoryScope, scopeID, key string) ([]float64, map[string]any, bool, error) {
+func (b *ControlPlaneMemoryBackend) GetVector(ctx context.Context, scope MemoryScope, scopeID, key string) ([]float64, map[string]any, bool, error) {
 	endpoint, err := url.JoinPath(b.baseURL, "/api/v1/memory/vector", url.PathEscape(key))
 	if err != nil {
 		return nil, nil, false, err
 	}
 
-	req, err := http.NewRequest(http.MethodGet, endpoint+"?scope="+url.QueryEscape(b.apiScope(scope)), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"?scope="+url.QueryEscape(b.apiScope(scope)), nil)
 	if err != nil {
 		return nil, nil, false, err
 	}
@@ -262,7 +263,7 @@ func (b *ControlPlaneMemoryBackend) GetVector(scope MemoryScope, scopeID, key st
 	return embeddingF64, res.Metadata, true, nil
 }
 
-func (b *ControlPlaneMemoryBackend) SearchVector(scope MemoryScope, scopeID string, embedding []float64, opts SearchOptions) ([]VectorSearchResult, error) {
+func (b *ControlPlaneMemoryBackend) SearchVector(ctx context.Context, scope MemoryScope, scopeID string, embedding []float64, opts SearchOptions) ([]VectorSearchResult, error) {
 	endpoint, err := url.JoinPath(b.baseURL, "/api/v1/memory/vector/search")
 	if err != nil {
 		return nil, err
@@ -289,7 +290,7 @@ func (b *ControlPlaneMemoryBackend) SearchVector(scope MemoryScope, scopeID stri
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest(http.MethodPost, endpoint, reader)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, reader)
 	if err != nil {
 		return nil, err
 	}
@@ -330,13 +331,13 @@ func (b *ControlPlaneMemoryBackend) SearchVector(scope MemoryScope, scopeID stri
 	return results, nil
 }
 
-func (b *ControlPlaneMemoryBackend) DeleteVector(scope MemoryScope, scopeID, key string) error {
+func (b *ControlPlaneMemoryBackend) DeleteVector(ctx context.Context, scope MemoryScope, scopeID, key string) error {
 	endpoint, err := url.JoinPath(b.baseURL, "/api/v1/memory/vector", url.PathEscape(key))
 	if err != nil {
 		return err
 	}
 
-	req, err := http.NewRequest(http.MethodDelete, endpoint+"?scope="+url.QueryEscape(b.apiScope(scope)), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint+"?scope="+url.QueryEscape(b.apiScope(scope)), nil)
 	if err != nil {
 		return err
 	}

--- a/sdk/go/agent/control_plane_memory_backend_branch_additional_test.go
+++ b/sdk/go/agent/control_plane_memory_backend_branch_additional_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -29,14 +30,14 @@ func TestControlPlaneMemoryBackend_AdditionalHTTPBranches(t *testing.T) {
 		defer srv.Close()
 
 		b := NewControlPlaneMemoryBackend(srv.URL, "", "agent-1")
-		val, found, err := b.Get(ScopeSession, "sess-1", "k")
+		val, found, err := b.Get(context.Background(), ScopeSession, "sess-1", "k")
 		require.NoError(t, err)
 		require.True(t, found)
 		assert.Equal(t, map[string]any{"ok": true}, val)
 
-		require.NoError(t, b.Delete(ScopeSession, "sess-1", "k"))
+		require.NoError(t, b.Delete(context.Background(), ScopeSession, "sess-1", "k"))
 
-		keys, err := b.List(ScopeSession, "sess-1")
+		keys, err := b.List(context.Background(), ScopeSession, "sess-1")
 		require.NoError(t, err)
 		assert.Equal(t, []string{"kept"}, keys)
 	})
@@ -60,19 +61,19 @@ func TestControlPlaneMemoryBackend_AdditionalHTTPBranches(t *testing.T) {
 
 		b := NewControlPlaneMemoryBackend(srv.URL, "", "agent-1")
 
-		err := b.Set(ScopeSession, "sess-1", "k", "v")
+		err := b.Set(context.Background(), ScopeSession, "sess-1", "k", "v")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "memory set failed")
 
-		_, _, err = b.Get(ScopeSession, "sess-1", "k")
+		_, _, err = b.Get(context.Background(), ScopeSession, "sess-1", "k")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "memory get failed")
 
-		err = b.Delete(ScopeSession, "sess-1", "k")
+		err = b.Delete(context.Background(), ScopeSession, "sess-1", "k")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "memory delete failed")
 
-		_, err = b.List(ScopeSession, "sess-1")
+		_, err = b.List(context.Background(), ScopeSession, "sess-1")
 		require.Error(t, err)
 	})
 
@@ -97,21 +98,21 @@ func TestControlPlaneMemoryBackend_AdditionalHTTPBranches(t *testing.T) {
 
 		b := NewControlPlaneMemoryBackend(srv.URL, "", "agent-1")
 
-		err := b.SetVector(ScopeSession, "sess-1", "bad", []float64{1, 2}, nil)
+		err := b.SetVector(context.Background(), ScopeSession, "sess-1", "bad", []float64{1, 2}, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "vector memory set failed")
 
-		_, _, _, err = b.GetVector(ScopeSession, "sess-1", "bad")
+		_, _, _, err = b.GetVector(context.Background(), ScopeSession, "sess-1", "bad")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "vector memory get failed")
 
-		_, _, _, err = b.GetVector(ScopeSession, "sess-1", "decode")
+		_, _, _, err = b.GetVector(context.Background(), ScopeSession, "sess-1", "decode")
 		require.Error(t, err)
 
-		_, err = b.SearchVector(ScopeSession, "sess-1", []float64{1}, SearchOptions{})
+		_, err = b.SearchVector(context.Background(), ScopeSession, "sess-1", []float64{1}, SearchOptions{})
 		require.Error(t, err)
 
-		err = b.DeleteVector(ScopeSession, "sess-1", "bad")
+		err = b.DeleteVector(context.Background(), ScopeSession, "sess-1", "bad")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "vector memory delete failed")
 	})

--- a/sdk/go/agent/control_plane_memory_backend_context_test.go
+++ b/sdk/go/agent/control_plane_memory_backend_context_test.go
@@ -1,0 +1,105 @@
+package agent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestControlPlaneMemoryBackend_ContextCancellation verifies that in-flight
+// HTTP calls are cancelled promptly when the caller's context is cancelled.
+// This is the core fix for issue #433.
+func TestControlPlaneMemoryBackend_ContextCancellation(t *testing.T) {
+	t.Run("Set returns context.Canceled", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		b := NewControlPlaneMemoryBackend(server.URL, "token", "node-1")
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately before the request
+
+		err := b.Set(ctx, ScopeSession, "s1", "k", "v")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("Get returns context.Canceled", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		b := NewControlPlaneMemoryBackend(server.URL, "token", "node-1")
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, _, err := b.Get(ctx, ScopeSession, "s1", "k")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("Delete returns context.Canceled", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		b := NewControlPlaneMemoryBackend(server.URL, "token", "node-1")
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := b.Delete(ctx, ScopeSession, "s1", "k")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("List returns context.Canceled", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		b := NewControlPlaneMemoryBackend(server.URL, "token", "node-1")
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := b.List(ctx, ScopeSession, "s1")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("DeadlineExceeded returns promptly", func(t *testing.T) {
+		var requestReceived atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestReceived.Add(1)
+			// Simulate a slow server - sleep longer than the client deadline
+			time.Sleep(5 * time.Second)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		b := NewControlPlaneMemoryBackend(server.URL, "token", "node-1")
+
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		err := b.Set(ctx, ScopeSession, "s1", "k", "v")
+		elapsed := time.Since(start)
+
+		require.Error(t, err)
+		// Should return well before the 15s HTTP client timeout.
+		assert.Less(t, elapsed, 2*time.Second)
+		// The request should have been initiated (proving context cancellation
+		// is what aborted it, not a pre-send check).
+		assert.GreaterOrEqual(t, requestReceived.Load(), int32(1))
+	})
+}

--- a/sdk/go/agent/control_plane_memory_backend_test.go
+++ b/sdk/go/agent/control_plane_memory_backend_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -33,7 +34,7 @@ func TestControlPlaneMemoryBackend_SetSendsScopeHeaders(t *testing.T) {
 	defer srv.Close()
 
 	b := NewControlPlaneMemoryBackend(srv.URL, "", "agent-1")
-	if err := b.Set(ScopeWorkflow, "wf-1", "k", map[string]any{"v": 1}); err != nil {
+	if err := b.Set(context.Background(), ScopeWorkflow, "wf-1", "k", map[string]any{"v": 1}); err != nil {
 		t.Fatalf("Set: %v", err)
 	}
 	if gotPath != "/api/v1/memory/set" {
@@ -63,7 +64,7 @@ func TestControlPlaneMemoryBackend_UserScopeMapsToActor(t *testing.T) {
 	defer srv.Close()
 
 	b := NewControlPlaneMemoryBackend(srv.URL, "", "agent-1")
-	if err := b.Set(ScopeUser, "u-1", "k", "v"); err != nil {
+	if err := b.Set(context.Background(), ScopeUser, "u-1", "k", "v"); err != nil {
 		t.Fatalf("Set: %v", err)
 	}
 	if gotActor != "u-1" {
@@ -82,7 +83,7 @@ func TestControlPlaneMemoryBackend_GetNotFound(t *testing.T) {
 	defer srv.Close()
 
 	b := NewControlPlaneMemoryBackend(srv.URL, "", "agent-1")
-	val, found, err := b.Get(ScopeSession, "s-1", "missing")
+	val, found, err := b.Get(context.Background(), ScopeSession, "s-1", "missing")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
@@ -109,7 +110,7 @@ func TestControlPlaneMemoryBackend_ListReturnsKeys(t *testing.T) {
 	defer srv.Close()
 
 	b := NewControlPlaneMemoryBackend(srv.URL, "", "agent-1")
-	keys, err := b.List(ScopeGlobal, "global")
+	keys, err := b.List(context.Background(), ScopeGlobal, "global")
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -148,22 +149,22 @@ func TestControlPlaneMemoryBackend_VectorOperationsRoundTrip(t *testing.T) {
 	defer srv.Close()
 
 	b := NewControlPlaneMemoryBackend(srv.URL, "token-123", "agent-1")
-	require.NoError(t, b.SetVector(ScopeSession, "sess-1", "vector-key", []float64{1.25, 2.5}, map[string]any{"kind": "cached"}))
+	require.NoError(t, b.SetVector(context.Background(), ScopeSession, "sess-1", "vector-key", []float64{1.25, 2.5}, map[string]any{"kind": "cached"}))
 
-	embedding, metadata, found, err := b.GetVector(ScopeSession, "sess-1", "vector-key")
+	embedding, metadata, found, err := b.GetVector(context.Background(), ScopeSession, "sess-1", "vector-key")
 	require.NoError(t, err)
 	assert.True(t, found)
 	assert.InDeltaSlice(t, []float64{1.25, 2.5}, embedding, 1e-6)
 	assert.Equal(t, map[string]any{"kind": "cached"}, metadata)
 
-	results, err := b.SearchVector(ScopeSession, "sess-1", []float64{1.25, 2.5}, SearchOptions{Limit: 3, Threshold: 0.5, Filters: map[string]any{"kind": "cached"}, Scope: ScopeWorkflow})
+	results, err := b.SearchVector(context.Background(), ScopeSession, "sess-1", []float64{1.25, 2.5}, SearchOptions{Limit: 3, Threshold: 0.5, Filters: map[string]any{"kind": "cached"}, Scope: ScopeWorkflow})
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.Equal(t, "vector-key", results[0].Key)
 	assert.Equal(t, ScopeWorkflow, results[0].Scope)
 	assert.Equal(t, "wf-1", results[0].ScopeID)
 
-	require.NoError(t, b.DeleteVector(ScopeSession, "sess-1", "vector-key"))
+	require.NoError(t, b.DeleteVector(context.Background(), ScopeSession, "sess-1", "vector-key"))
 	assert.Equal(t, "Bearer token-123", sawAuthorization)
 	assert.Equal(t, "sess-1", sawSession)
 	assert.Equal(t, "session", setVectorBody["scope"])
@@ -180,12 +181,12 @@ func TestControlPlaneMemoryBackend_ErrorPathsAndHelpers(t *testing.T) {
 		defer srv.Close()
 
 		b := NewControlPlaneMemoryBackend(srv.URL, "", "agent-1")
-		embedding, metadata, found, err := b.GetVector(ScopeWorkflow, "wf-1", "missing")
+		embedding, metadata, found, err := b.GetVector(context.Background(), ScopeWorkflow, "wf-1", "missing")
 		require.NoError(t, err)
 		assert.False(t, found)
 		assert.Nil(t, embedding)
 		assert.Nil(t, metadata)
-		require.NoError(t, b.DeleteVector(ScopeWorkflow, "wf-1", "missing"))
+		require.NoError(t, b.DeleteVector(context.Background(), ScopeWorkflow, "wf-1", "missing"))
 	})
 
 	t.Run("vector search surfaces server errors", func(t *testing.T) {
@@ -196,7 +197,7 @@ func TestControlPlaneMemoryBackend_ErrorPathsAndHelpers(t *testing.T) {
 		defer srv.Close()
 
 		b := NewControlPlaneMemoryBackend(srv.URL, "", "agent-1")
-		_, err := b.SearchVector(ScopeGlobal, "global", []float64{1}, SearchOptions{})
+		_, err := b.SearchVector(context.Background(), ScopeGlobal, "global", []float64{1}, SearchOptions{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "vector memory search failed")
 	})

--- a/sdk/go/agent/memory.go
+++ b/sdk/go/agent/memory.go
@@ -24,24 +24,25 @@ const (
 
 // MemoryBackend is the pluggable storage interface for memory operations.
 // Implementations can use in-memory storage, Redis, databases, or external APIs.
+// All methods accept a context.Context to support cancellation and timeouts.
 type MemoryBackend interface {
 	// Set stores a value at the given scope and key.
-	Set(scope MemoryScope, scopeID, key string, value any) error
+	Set(ctx context.Context, scope MemoryScope, scopeID, key string, value any) error
 	// Get retrieves a value; returns (value, found, error).
-	Get(scope MemoryScope, scopeID, key string) (any, bool, error)
+	Get(ctx context.Context, scope MemoryScope, scopeID, key string) (any, bool, error)
 	// Delete removes a key from storage.
-	Delete(scope MemoryScope, scopeID, key string) error
+	Delete(ctx context.Context, scope MemoryScope, scopeID, key string) error
 	// List returns all keys in a scope.
-	List(scope MemoryScope, scopeID string) ([]string, error)
+	List(ctx context.Context, scope MemoryScope, scopeID string) ([]string, error)
 
 	// SetVector stores a vector embedding with optional metadata.
-	SetVector(scope MemoryScope, scopeID, key string, embedding []float64, metadata map[string]any) error
+	SetVector(ctx context.Context, scope MemoryScope, scopeID, key string, embedding []float64, metadata map[string]any) error
 	// GetVector retrieves a vector and its metadata.
-	GetVector(scope MemoryScope, scopeID, key string) (embedding []float64, metadata map[string]any, found bool, err error)
+	GetVector(ctx context.Context, scope MemoryScope, scopeID, key string) (embedding []float64, metadata map[string]any, found bool, err error)
 	// SearchVector performs a similarity search.
-	SearchVector(scope MemoryScope, scopeID string, embedding []float64, opts SearchOptions) ([]VectorSearchResult, error)
+	SearchVector(ctx context.Context, scope MemoryScope, scopeID string, embedding []float64, opts SearchOptions) ([]VectorSearchResult, error)
 	// DeleteVector removes a vector from storage.
-	DeleteVector(scope MemoryScope, scopeID, key string) error
+	DeleteVector(ctx context.Context, scope MemoryScope, scopeID, key string) error
 }
 
 // SearchOptions defines parameters for similarity search.
@@ -84,7 +85,7 @@ func (m *Memory) Set(ctx context.Context, key string, value any) error {
 	if scopeID == "" {
 		scopeID = execCtx.RunID
 	}
-	return m.backend.Set(ScopeSession, scopeID, key, value)
+	return m.backend.Set(ctx, ScopeSession, scopeID, key, value)
 }
 
 // Get retrieves a value from the session scope (default scope).
@@ -95,7 +96,7 @@ func (m *Memory) Get(ctx context.Context, key string) (any, error) {
 	if scopeID == "" {
 		scopeID = execCtx.RunID
 	}
-	val, _, err := m.backend.Get(ScopeSession, scopeID, key)
+	val, _, err := m.backend.Get(ctx, ScopeSession, scopeID, key)
 	return val, err
 }
 
@@ -116,7 +117,7 @@ func (m *Memory) GetWithDefault(ctx context.Context, key string, defaultVal any)
 	if scopeID == "" {
 		scopeID = execCtx.RunID
 	}
-	val, found, err := m.backend.Get(ScopeSession, scopeID, key)
+	val, found, err := m.backend.Get(ctx, ScopeSession, scopeID, key)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +134,7 @@ func (m *Memory) Delete(ctx context.Context, key string) error {
 	if scopeID == "" {
 		scopeID = execCtx.RunID
 	}
-	return m.backend.Delete(ScopeSession, scopeID, key)
+	return m.backend.Delete(ctx, ScopeSession, scopeID, key)
 }
 
 // List returns all keys in the session scope.
@@ -143,7 +144,7 @@ func (m *Memory) List(ctx context.Context) ([]string, error) {
 	if scopeID == "" {
 		scopeID = execCtx.RunID
 	}
-	return m.backend.List(ScopeSession, scopeID)
+	return m.backend.List(ctx, ScopeSession, scopeID)
 }
 
 // SetVector stores a vector in the session scope (default scope).
@@ -153,7 +154,7 @@ func (m *Memory) SetVector(ctx context.Context, key string, embedding []float64,
 	if scopeID == "" {
 		scopeID = execCtx.RunID
 	}
-	return m.backend.SetVector(ScopeSession, scopeID, key, embedding, metadata)
+	return m.backend.SetVector(ctx, ScopeSession, scopeID, key, embedding, metadata)
 }
 
 // GetVector retrieves a vector from the session scope (default scope).
@@ -163,7 +164,7 @@ func (m *Memory) GetVector(ctx context.Context, key string) (embedding []float64
 	if scopeID == "" {
 		scopeID = execCtx.RunID
 	}
-	embedding, metadata, found, err := m.backend.GetVector(ScopeSession, scopeID, key)
+	embedding, metadata, found, err := m.backend.GetVector(ctx, ScopeSession, scopeID, key)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -180,7 +181,7 @@ func (m *Memory) SearchVector(ctx context.Context, embedding []float64, opts Sea
 	if scopeID == "" {
 		scopeID = execCtx.RunID
 	}
-	return m.backend.SearchVector(ScopeSession, scopeID, embedding, opts)
+	return m.backend.SearchVector(ctx, ScopeSession, scopeID, embedding, opts)
 }
 
 // DeleteVector removes a vector from the session scope (default scope).
@@ -190,7 +191,7 @@ func (m *Memory) DeleteVector(ctx context.Context, key string) error {
 	if scopeID == "" {
 		scopeID = execCtx.RunID
 	}
-	return m.backend.DeleteVector(ScopeSession, scopeID, key)
+	return m.backend.DeleteVector(ctx, ScopeSession, scopeID, key)
 }
 
 // WorkflowScope returns a ScopedMemory for workflow-level storage.
@@ -266,20 +267,20 @@ type ScopedMemory struct {
 
 // Set stores a value in this scope.
 func (s *ScopedMemory) Set(ctx context.Context, key string, value any) error {
-	return s.backend.Set(s.scope, s.getID(ctx), key, value)
+	return s.backend.Set(ctx, s.scope, s.getID(ctx), key, value)
 }
 
 // Get retrieves a value from this scope.
 // Returns nil if the key does not exist.
 func (s *ScopedMemory) Get(ctx context.Context, key string) (any, error) {
-	val, _, err := s.backend.Get(s.scope, s.getID(ctx), key)
+	val, _, err := s.backend.Get(ctx, s.scope, s.getID(ctx), key)
 	return val, err
 }
 
 // GetWithDefault retrieves a value from this scope,
 // returning the default if the key does not exist.
 func (s *ScopedMemory) GetWithDefault(ctx context.Context, key string, defaultVal any) (any, error) {
-	val, found, err := s.backend.Get(s.scope, s.getID(ctx), key)
+	val, found, err := s.backend.Get(ctx, s.scope, s.getID(ctx), key)
 	if err != nil {
 		return nil, err
 	}
@@ -291,22 +292,22 @@ func (s *ScopedMemory) GetWithDefault(ctx context.Context, key string, defaultVa
 
 // Delete removes a key from this scope.
 func (s *ScopedMemory) Delete(ctx context.Context, key string) error {
-	return s.backend.Delete(s.scope, s.getID(ctx), key)
+	return s.backend.Delete(ctx, s.scope, s.getID(ctx), key)
 }
 
 // List returns all keys in this scope.
 func (s *ScopedMemory) List(ctx context.Context) ([]string, error) {
-	return s.backend.List(s.scope, s.getID(ctx))
+	return s.backend.List(ctx, s.scope, s.getID(ctx))
 }
 
 // SetVector stores a vector in this scope.
 func (s *ScopedMemory) SetVector(ctx context.Context, key string, embedding []float64, metadata map[string]any) error {
-	return s.backend.SetVector(s.scope, s.getID(ctx), key, embedding, metadata)
+	return s.backend.SetVector(ctx, s.scope, s.getID(ctx), key, embedding, metadata)
 }
 
 // GetVector retrieves a vector from this scope.
 func (s *ScopedMemory) GetVector(ctx context.Context, key string) (embedding []float64, metadata map[string]any, err error) {
-	embedding, metadata, found, err := s.backend.GetVector(s.scope, s.getID(ctx), key)
+	embedding, metadata, found, err := s.backend.GetVector(ctx, s.scope, s.getID(ctx), key)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -318,18 +319,18 @@ func (s *ScopedMemory) GetVector(ctx context.Context, key string) (embedding []f
 
 // SearchVector performs a similarity search in this scope.
 func (s *ScopedMemory) SearchVector(ctx context.Context, embedding []float64, opts SearchOptions) ([]VectorSearchResult, error) {
-	return s.backend.SearchVector(s.scope, s.getID(ctx), embedding, opts)
+	return s.backend.SearchVector(ctx, s.scope, s.getID(ctx), embedding, opts)
 }
 
 // DeleteVector removes a vector from this scope.
 func (s *ScopedMemory) DeleteVector(ctx context.Context, key string) error {
-	return s.backend.DeleteVector(s.scope, s.getID(ctx), key)
+	return s.backend.DeleteVector(ctx, s.scope, s.getID(ctx), key)
 }
 
 // GetTyped retrieves a value and unmarshals it into the provided type.
 // This is useful when storing complex objects as JSON.
 func (s *ScopedMemory) GetTyped(ctx context.Context, key string, dest any) error {
-	val, found, err := s.backend.Get(s.scope, s.getID(ctx), key)
+	val, found, err := s.backend.Get(ctx, s.scope, s.getID(ctx), key)
 	if err != nil {
 		return err
 	}
@@ -450,7 +451,7 @@ func (b *InMemoryBackend) compositeKey(scope MemoryScope, scopeID string) string
 }
 
 // Set stores a value.
-func (b *InMemoryBackend) Set(scope MemoryScope, scopeID, key string, value any) error {
+func (b *InMemoryBackend) Set(_ context.Context, scope MemoryScope, scopeID, key string, value any) error {
 	copied, err := deepCopyAny(value)
 	if err != nil {
 		return err
@@ -468,7 +469,7 @@ func (b *InMemoryBackend) Set(scope MemoryScope, scopeID, key string, value any)
 }
 
 // Get retrieves a value.
-func (b *InMemoryBackend) Get(scope MemoryScope, scopeID, key string) (any, bool, error) {
+func (b *InMemoryBackend) Get(_ context.Context, scope MemoryScope, scopeID, key string) (any, bool, error) {
 	b.mu.RLock()
 
 	ck := b.compositeKey(scope, scopeID)
@@ -489,7 +490,7 @@ func (b *InMemoryBackend) Get(scope MemoryScope, scopeID, key string) (any, bool
 }
 
 // Delete removes a key.
-func (b *InMemoryBackend) Delete(scope MemoryScope, scopeID, key string) error {
+func (b *InMemoryBackend) Delete(_ context.Context, scope MemoryScope, scopeID, key string) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -501,7 +502,7 @@ func (b *InMemoryBackend) Delete(scope MemoryScope, scopeID, key string) error {
 }
 
 // List returns all keys in a scope.
-func (b *InMemoryBackend) List(scope MemoryScope, scopeID string) ([]string, error) {
+func (b *InMemoryBackend) List(_ context.Context, scope MemoryScope, scopeID string) ([]string, error) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
@@ -517,7 +518,7 @@ func (b *InMemoryBackend) List(scope MemoryScope, scopeID string) ([]string, err
 }
 
 // SetVector stores a vector.
-func (b *InMemoryBackend) SetVector(scope MemoryScope, scopeID, key string, embedding []float64, metadata map[string]any) error {
+func (b *InMemoryBackend) SetVector(_ context.Context, scope MemoryScope, scopeID, key string, embedding []float64, metadata map[string]any) error {
 	copiedMetadata, err := deepCopyAny(metadata)
 	if err != nil {
 		return err
@@ -538,7 +539,7 @@ func (b *InMemoryBackend) SetVector(scope MemoryScope, scopeID, key string, embe
 }
 
 // GetVector retrieves a vector.
-func (b *InMemoryBackend) GetVector(scope MemoryScope, scopeID, key string) ([]float64, map[string]any, bool, error) {
+func (b *InMemoryBackend) GetVector(_ context.Context, scope MemoryScope, scopeID, key string) ([]float64, map[string]any, bool, error) {
 	b.mu.RLock()
 
 	ck := b.compositeKey(scope, scopeID)
@@ -559,13 +560,13 @@ func (b *InMemoryBackend) GetVector(scope MemoryScope, scopeID, key string) ([]f
 }
 
 // SearchVector performs similarity search (stubbed - returns empty list for in-memory).
-func (b *InMemoryBackend) SearchVector(scope MemoryScope, scopeID string, embedding []float64, opts SearchOptions) ([]VectorSearchResult, error) {
+func (b *InMemoryBackend) SearchVector(_ context.Context, scope MemoryScope, scopeID string, embedding []float64, opts SearchOptions) ([]VectorSearchResult, error) {
 	// In-memory similarity search is not implemented in this mock; it requires vector math.
 	return []VectorSearchResult{}, nil
 }
 
 // DeleteVector removes a vector.
-func (b *InMemoryBackend) DeleteVector(scope MemoryScope, scopeID, key string) error {
+func (b *InMemoryBackend) DeleteVector(_ context.Context, scope MemoryScope, scopeID, key string) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 

--- a/sdk/go/agent/memory_backend_test.go
+++ b/sdk/go/agent/memory_backend_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -59,7 +60,7 @@ func TestControlPlaneMemoryBackend_SetAppliesScopeHeaders(t *testing.T) {
 			defer server.Close()
 
 			backend := NewControlPlaneMemoryBackend(server.URL, "token-1", "agent-1")
-			err := backend.Set(tt.scope, tt.scopeID, "key", map[string]any{"ok": true})
+			err := backend.Set(context.Background(), tt.scope, tt.scopeID, "key", map[string]any{"ok": true})
 			require.NoError(t, err)
 
 			assert.Equal(t, http.MethodPost, gotMethod)
@@ -87,7 +88,7 @@ func TestControlPlaneMemoryBackend_GetHandlesNotFoundAndServerErrors(t *testing.
 		defer server.Close()
 
 		backend := NewControlPlaneMemoryBackend(server.URL, "", "")
-		value, found, err := backend.Get(ScopeSession, "s-1", "missing")
+		value, found, err := backend.Get(context.Background(), ScopeSession, "s-1", "missing")
 		require.NoError(t, err)
 		assert.Nil(t, value)
 		assert.False(t, found)
@@ -100,7 +101,7 @@ func TestControlPlaneMemoryBackend_GetHandlesNotFoundAndServerErrors(t *testing.
 		defer server.Close()
 
 		backend := NewControlPlaneMemoryBackend(server.URL, "", "")
-		value, found, err := backend.Get(ScopeSession, "s-1", "key")
+		value, found, err := backend.Get(context.Background(), ScopeSession, "s-1", "key")
 		require.Error(t, err)
 		assert.Nil(t, value)
 		assert.False(t, found)
@@ -129,7 +130,7 @@ func TestControlPlaneMemoryBackend_DeleteUsesPostEndpointAndScopeHeaders(t *test
 	backend := NewControlPlaneMemoryBackend(server.URL, "", "")
 
 	// Current behavior is POST /api/v1/memory/delete rather than HTTP DELETE.
-	err := backend.Delete(ScopeSession, "s-1", "key")
+	err := backend.Delete(context.Background(), ScopeSession, "s-1", "key")
 	require.NoError(t, err)
 
 	assert.Equal(t, http.MethodPost, gotMethod)
@@ -158,7 +159,7 @@ func TestControlPlaneMemoryBackend_ListUsesScopeQueryAndHeaders(t *testing.T) {
 	defer server.Close()
 
 	backend := NewControlPlaneMemoryBackend(server.URL, "", "")
-	keys, err := backend.List(ScopeSession, "s-1")
+	keys, err := backend.List(context.Background(), ScopeSession, "s-1")
 	require.NoError(t, err)
 
 	assert.Equal(t, "session", gotQuery.Get("scope"))
@@ -176,7 +177,7 @@ func TestControlPlaneMemoryBackend_EmptyScopeIDDoesNotErrorForNonGlobalScope(t *
 	defer server.Close()
 
 	backend := NewControlPlaneMemoryBackend(server.URL, "", "")
-	err := backend.Set(ScopeSession, "", "key", "value")
+	err := backend.Set(context.Background(), ScopeSession, "", "key", "value")
 	require.NoError(t, err)
 
 	// The backend does not resolve missing scope IDs from execution context.

--- a/sdk/go/agent/memory_branch_additional_test.go
+++ b/sdk/go/agent/memory_branch_additional_test.go
@@ -19,49 +19,49 @@ type memoryErrorBackend struct {
 	searchErr   error
 }
 
-func (b *memoryErrorBackend) Set(scope MemoryScope, scopeID, key string, value any) error {
+func (b *memoryErrorBackend) Set(_ context.Context, scope MemoryScope, scopeID, key string, value any) error {
 	b.lastScope = scope
 	b.lastScopeID = scopeID
 	return nil
 }
 
-func (b *memoryErrorBackend) Get(scope MemoryScope, scopeID, key string) (any, bool, error) {
+func (b *memoryErrorBackend) Get(_ context.Context, scope MemoryScope, scopeID, key string) (any, bool, error) {
 	b.lastScope = scope
 	b.lastScopeID = scopeID
 	return nil, false, b.getErr
 }
 
-func (b *memoryErrorBackend) Delete(scope MemoryScope, scopeID, key string) error {
+func (b *memoryErrorBackend) Delete(_ context.Context, scope MemoryScope, scopeID, key string) error {
 	b.lastScope = scope
 	b.lastScopeID = scopeID
 	return b.deleteErr
 }
 
-func (b *memoryErrorBackend) List(scope MemoryScope, scopeID string) ([]string, error) {
+func (b *memoryErrorBackend) List(_ context.Context, scope MemoryScope, scopeID string) ([]string, error) {
 	b.lastScope = scope
 	b.lastScopeID = scopeID
 	return nil, b.listErr
 }
 
-func (b *memoryErrorBackend) SetVector(scope MemoryScope, scopeID, key string, embedding []float64, metadata map[string]any) error {
+func (b *memoryErrorBackend) SetVector(_ context.Context, scope MemoryScope, scopeID, key string, embedding []float64, metadata map[string]any) error {
 	b.lastScope = scope
 	b.lastScopeID = scopeID
 	return nil
 }
 
-func (b *memoryErrorBackend) GetVector(scope MemoryScope, scopeID, key string) ([]float64, map[string]any, bool, error) {
+func (b *memoryErrorBackend) GetVector(_ context.Context, scope MemoryScope, scopeID, key string) ([]float64, map[string]any, bool, error) {
 	b.lastScope = scope
 	b.lastScopeID = scopeID
 	return nil, nil, false, b.vectorErr
 }
 
-func (b *memoryErrorBackend) SearchVector(scope MemoryScope, scopeID string, embedding []float64, opts SearchOptions) ([]VectorSearchResult, error) {
+func (b *memoryErrorBackend) SearchVector(_ context.Context, scope MemoryScope, scopeID string, embedding []float64, opts SearchOptions) ([]VectorSearchResult, error) {
 	b.lastScope = scope
 	b.lastScopeID = scopeID
 	return nil, b.searchErr
 }
 
-func (b *memoryErrorBackend) DeleteVector(scope MemoryScope, scopeID, key string) error {
+func (b *memoryErrorBackend) DeleteVector(_ context.Context, scope MemoryScope, scopeID, key string) error {
 	b.lastScope = scope
 	b.lastScopeID = scopeID
 	return b.deleteErr

--- a/sdk/go/agent/memory_performance_test.go
+++ b/sdk/go/agent/memory_performance_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 	"strings"
@@ -71,7 +72,7 @@ func TestInMemoryBackendMemoryPerformance(t *testing.T) {
 				key := fmt.Sprintf("key_%06d", i)
 				// Create ~1KB payload per entry
 				value := strings.Repeat("x", 1000)
-				_ = backend.Set(ScopeSession, "test-session", key, value)
+				_ = backend.Set(context.Background(), ScopeSession, "test-session", key, value)
 			}
 		})
 
@@ -98,7 +99,7 @@ func TestInMemoryBackendMemoryPerformance(t *testing.T) {
 					key := fmt.Sprintf("key_%06d", i)
 					value := strings.Repeat("y", 500)
 					scopeID := fmt.Sprintf("scope_%d", i%10)
-					_ = backend.Set(scope, scopeID, key, value)
+					_ = backend.Set(context.Background(), scope, scopeID, key, value)
 				}
 			}
 		})
@@ -117,7 +118,7 @@ func TestInMemoryBackendMemoryPerformance(t *testing.T) {
 		for i := 0; i < 5000; i++ {
 			key := fmt.Sprintf("key_%06d", i)
 			value := strings.Repeat("z", 2000)
-			_ = backend.Set(ScopeSession, "test-session", key, value)
+			_ = backend.Set(context.Background(), ScopeSession, "test-session", key, value)
 		}
 
 		// Force GC and measure before clear
@@ -160,7 +161,7 @@ func BenchmarkInMemoryBackendSet(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		key := fmt.Sprintf("key_%d", i)
-		_ = backend.Set(ScopeSession, "bench-session", key, value)
+		_ = backend.Set(context.Background(), ScopeSession, "bench-session", key, value)
 	}
 }
 
@@ -172,7 +173,7 @@ func BenchmarkInMemoryBackendGet(b *testing.B) {
 	for i := 0; i < 10000; i++ {
 		key := fmt.Sprintf("key_%d", i)
 		value := strings.Repeat("x", 1000)
-		_ = backend.Set(ScopeSession, "bench-session", key, value)
+		_ = backend.Set(context.Background(), ScopeSession, "bench-session", key, value)
 	}
 
 	b.ResetTimer()
@@ -180,7 +181,7 @@ func BenchmarkInMemoryBackendGet(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		key := fmt.Sprintf("key_%d", i%10000)
-		_, _, _ = backend.Get(ScopeSession, "bench-session", key)
+		_, _, _ = backend.Get(context.Background(), ScopeSession, "bench-session", key)
 	}
 }
 
@@ -192,14 +193,14 @@ func BenchmarkInMemoryBackendList(b *testing.B) {
 	for i := 0; i < 1000; i++ {
 		key := fmt.Sprintf("key_%d", i)
 		value := strings.Repeat("x", 100)
-		_ = backend.Set(ScopeSession, "bench-session", key, value)
+		_ = backend.Set(context.Background(), ScopeSession, "bench-session", key, value)
 	}
 
 	b.ResetTimer()
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		_, _ = backend.List(ScopeSession, "bench-session")
+		_, _ = backend.List(context.Background(), ScopeSession, "bench-session")
 	}
 }
 
@@ -212,7 +213,7 @@ func TestMemoryPerformanceReport(t *testing.T) {
 		backend := NewInMemoryBackend()
 		for i := 0; i < n; i++ {
 			key := fmt.Sprintf("k_%d", i)
-			_ = backend.Set(ScopeSession, "s", key, strings.Repeat("x", 10000))
+			_ = backend.Set(context.Background(), ScopeSession, "s", key, strings.Repeat("x", 10000))
 		}
 	}))
 
@@ -223,7 +224,7 @@ func TestMemoryPerformanceReport(t *testing.T) {
 		for i := 0; i < n; i++ {
 			for _, scope := range scopes {
 				key := fmt.Sprintf("k_%d", i)
-				_ = backend.Set(scope, fmt.Sprintf("id_%d", i%10), key, strings.Repeat("y", 1000))
+				_ = backend.Set(context.Background(), scope, fmt.Sprintf("id_%d", i%10), key, strings.Repeat("y", 1000))
 			}
 		}
 	}))
@@ -233,8 +234,8 @@ func TestMemoryPerformanceReport(t *testing.T) {
 		backend := NewInMemoryBackend()
 		for i := 0; i < n; i++ {
 			key := fmt.Sprintf("k_%d", i%100)
-			_ = backend.Set(ScopeSession, "s", key, i)
-			_, _, _ = backend.Get(ScopeSession, "s", key)
+			_ = backend.Set(context.Background(), ScopeSession, "s", key, i)
+			_, _, _ = backend.Get(context.Background(), ScopeSession, "s", key)
 		}
 	}))
 

--- a/sdk/go/agent/memory_test.go
+++ b/sdk/go/agent/memory_test.go
@@ -15,56 +15,56 @@ func TestInMemoryBackend(t *testing.T) {
 	backend := NewInMemoryBackend()
 
 	t.Run("Set and Get", func(t *testing.T) {
-		err := backend.Set(ScopeSession, "session-1", "key1", "value1")
+		err := backend.Set(context.Background(), ScopeSession, "session-1", "key1", "value1")
 		require.NoError(t, err)
 
-		val, found, err := backend.Get(ScopeSession, "session-1", "key1")
+		val, found, err := backend.Get(context.Background(), ScopeSession, "session-1", "key1")
 		require.NoError(t, err)
 		assert.True(t, found)
 		assert.Equal(t, "value1", val)
 	})
 
 	t.Run("Get non-existent key", func(t *testing.T) {
-		val, found, err := backend.Get(ScopeSession, "session-1", "nonexistent")
+		val, found, err := backend.Get(context.Background(), ScopeSession, "session-1", "nonexistent")
 		require.NoError(t, err)
 		assert.False(t, found)
 		assert.Nil(t, val)
 	})
 
 	t.Run("Get from non-existent scope", func(t *testing.T) {
-		val, found, err := backend.Get(ScopeSession, "nonexistent-session", "key1")
+		val, found, err := backend.Get(context.Background(), ScopeSession, "nonexistent-session", "key1")
 		require.NoError(t, err)
 		assert.False(t, found)
 		assert.Nil(t, val)
 	})
 
 	t.Run("Delete key", func(t *testing.T) {
-		err := backend.Set(ScopeSession, "session-1", "to-delete", "value")
+		err := backend.Set(context.Background(), ScopeSession, "session-1", "to-delete", "value")
 		require.NoError(t, err)
 
-		err = backend.Delete(ScopeSession, "session-1", "to-delete")
+		err = backend.Delete(context.Background(), ScopeSession, "session-1", "to-delete")
 		require.NoError(t, err)
 
-		val, found, err := backend.Get(ScopeSession, "session-1", "to-delete")
+		val, found, err := backend.Get(context.Background(), ScopeSession, "session-1", "to-delete")
 		require.NoError(t, err)
 		assert.False(t, found)
 		assert.Nil(t, val)
 	})
 
 	t.Run("Delete non-existent key (no error)", func(t *testing.T) {
-		err := backend.Delete(ScopeSession, "session-1", "nonexistent")
+		err := backend.Delete(context.Background(), ScopeSession, "session-1", "nonexistent")
 		require.NoError(t, err)
 	})
 
 	t.Run("List keys", func(t *testing.T) {
 		// Clear and set up fresh data
 		backend.ClearScope(ScopeWorkflow, "workflow-1")
-		err := backend.Set(ScopeWorkflow, "workflow-1", "key-a", "value-a")
+		err := backend.Set(context.Background(), ScopeWorkflow, "workflow-1", "key-a", "value-a")
 		require.NoError(t, err)
-		err = backend.Set(ScopeWorkflow, "workflow-1", "key-b", "value-b")
+		err = backend.Set(context.Background(), ScopeWorkflow, "workflow-1", "key-b", "value-b")
 		require.NoError(t, err)
 
-		keys, err := backend.List(ScopeWorkflow, "workflow-1")
+		keys, err := backend.List(context.Background(), ScopeWorkflow, "workflow-1")
 		require.NoError(t, err)
 		assert.Len(t, keys, 2)
 		assert.Contains(t, keys, "key-a")
@@ -72,20 +72,20 @@ func TestInMemoryBackend(t *testing.T) {
 	})
 
 	t.Run("List empty scope", func(t *testing.T) {
-		keys, err := backend.List(ScopeGlobal, "nonexistent")
+		keys, err := backend.List(context.Background(), ScopeGlobal, "nonexistent")
 		require.NoError(t, err)
 		assert.Nil(t, keys)
 	})
 
 	t.Run("Scope isolation", func(t *testing.T) {
 		// Set same key in different scopes
-		err := backend.Set(ScopeSession, "id-1", "shared-key", "session-value")
+		err := backend.Set(context.Background(), ScopeSession, "id-1", "shared-key", "session-value")
 		require.NoError(t, err)
-		err = backend.Set(ScopeWorkflow, "id-1", "shared-key", "workflow-value")
+		err = backend.Set(context.Background(), ScopeWorkflow, "id-1", "shared-key", "workflow-value")
 		require.NoError(t, err)
 
-		sessionVal, _, _ := backend.Get(ScopeSession, "id-1", "shared-key")
-		workflowVal, _, _ := backend.Get(ScopeWorkflow, "id-1", "shared-key")
+		sessionVal, _, _ := backend.Get(context.Background(), ScopeSession, "id-1", "shared-key")
+		workflowVal, _, _ := backend.Get(context.Background(), ScopeWorkflow, "id-1", "shared-key")
 
 		assert.Equal(t, "session-value", sessionVal)
 		assert.Equal(t, "workflow-value", workflowVal)
@@ -93,25 +93,25 @@ func TestInMemoryBackend(t *testing.T) {
 
 	t.Run("ScopeID isolation", func(t *testing.T) {
 		// Same scope, different IDs
-		err := backend.Set(ScopeSession, "session-a", "key", "value-a")
+		err := backend.Set(context.Background(), ScopeSession, "session-a", "key", "value-a")
 		require.NoError(t, err)
-		err = backend.Set(ScopeSession, "session-b", "key", "value-b")
+		err = backend.Set(context.Background(), ScopeSession, "session-b", "key", "value-b")
 		require.NoError(t, err)
 
-		valA, _, _ := backend.Get(ScopeSession, "session-a", "key")
-		valB, _, _ := backend.Get(ScopeSession, "session-b", "key")
+		valA, _, _ := backend.Get(context.Background(), ScopeSession, "session-a", "key")
+		valB, _, _ := backend.Get(context.Background(), ScopeSession, "session-b", "key")
 
 		assert.Equal(t, "value-a", valA)
 		assert.Equal(t, "value-b", valB)
 	})
 
 	t.Run("Clear all data", func(t *testing.T) {
-		err := backend.Set(ScopeGlobal, "global", "test", "value")
+		err := backend.Set(context.Background(), ScopeGlobal, "global", "test", "value")
 		require.NoError(t, err)
 
 		backend.Clear()
 
-		val, found, _ := backend.Get(ScopeGlobal, "global", "test")
+		val, found, _ := backend.Get(context.Background(), ScopeGlobal, "global", "test")
 		assert.False(t, found)
 		assert.Nil(t, val)
 	})
@@ -122,10 +122,10 @@ func TestInMemoryBackend(t *testing.T) {
 			"count":  42,
 			"nested": map[string]any{"key": "value"},
 		}
-		err := backend.Set(ScopeSession, "session-1", "complex", complexData)
+		err := backend.Set(context.Background(), ScopeSession, "session-1", "complex", complexData)
 		require.NoError(t, err)
 
-		val, found, err := backend.Get(ScopeSession, "session-1", "complex")
+		val, found, err := backend.Get(context.Background(), ScopeSession, "session-1", "complex")
 		require.NoError(t, err)
 		assert.True(t, found)
 		assert.Equal(t, complexData, val)
@@ -347,7 +347,7 @@ func TestMemory_FallbackToRunID(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify it was stored under RunID
-		val, found, _ := backend.Get(ScopeSession, "run-123", "key")
+		val, found, _ := backend.Get(context.Background(), ScopeSession, "run-123", "key")
 		assert.True(t, found)
 		assert.Equal(t, "value", val)
 	})
@@ -356,7 +356,7 @@ func TestMemory_FallbackToRunID(t *testing.T) {
 		err := memory.WorkflowScope().Set(ctx, "wf-key", "wf-value")
 		require.NoError(t, err)
 
-		val, found, _ := backend.Get(ScopeWorkflow, "run-123", "wf-key")
+		val, found, _ := backend.Get(context.Background(), ScopeWorkflow, "run-123", "wf-key")
 		assert.True(t, found)
 		assert.Equal(t, "wf-value", val)
 	})
@@ -491,7 +491,7 @@ func TestAgentWithCustomMemoryBackend(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify directly on backend
-	val, found, _ := customBackend.Get(ScopeSession, "test-session", "custom-key")
+	val, found, _ := customBackend.Get(context.Background(), ScopeSession, "test-session", "custom-key")
 	assert.True(t, found)
 	assert.Equal(t, "custom-value", val)
 }
@@ -501,7 +501,7 @@ func TestInMemoryBackend_DeepCopy(t *testing.T) {
 
 	t.Run("Set deep-copies map - mutation does not affect stored value", func(t *testing.T) {
 		input := map[string]any{"key": "original", "nested": map[string]any{"a": 1}}
-		err := backend.Set(ScopeSession, "s1", "map-key", input)
+		err := backend.Set(context.Background(), ScopeSession, "s1", "map-key", input)
 		require.NoError(t, err)
 
 		input["key"] = "mutated"
@@ -510,7 +510,7 @@ func TestInMemoryBackend_DeepCopy(t *testing.T) {
 			nested["a"] = 999
 		}
 
-		val, found, err := backend.Get(ScopeSession, "s1", "map-key")
+		val, found, err := backend.Get(context.Background(), ScopeSession, "s1", "map-key")
 		require.NoError(t, err)
 		require.True(t, found)
 
@@ -526,10 +526,10 @@ func TestInMemoryBackend_DeepCopy(t *testing.T) {
 	})
 
 	t.Run("Get deep-copies map - mutation does not affect stored value", func(t *testing.T) {
-		err := backend.Set(ScopeSession, "s2", "map2", map[string]any{"x": "y", "inner": map[string]any{"z": "w"}})
+		err := backend.Set(context.Background(), ScopeSession, "s2", "map2", map[string]any{"x": "y", "inner": map[string]any{"z": "w"}})
 		require.NoError(t, err)
 
-		val1, found, err := backend.Get(ScopeSession, "s2", "map2")
+		val1, found, err := backend.Get(context.Background(), ScopeSession, "s2", "map2")
 		require.NoError(t, err)
 		require.True(t, found)
 
@@ -541,7 +541,7 @@ func TestInMemoryBackend_DeepCopy(t *testing.T) {
 		}
 		m1["new-key"] = "new-value"
 
-		val2, found, err := backend.Get(ScopeSession, "s2", "map2")
+		val2, found, err := backend.Get(context.Background(), ScopeSession, "s2", "map2")
 		require.NoError(t, err)
 		require.True(t, found)
 
@@ -560,7 +560,7 @@ func TestInMemoryBackend_DeepCopy(t *testing.T) {
 		embedding := []float64{1.0, 2.0, 3.0}
 		metadata := map[string]any{"kind": "original", "tags": map[string]any{"env": "dev"}}
 
-		err := backend.SetVector(ScopeSession, "s3", "vec1", embedding, metadata)
+		err := backend.SetVector(context.Background(), ScopeSession, "s3", "vec1", embedding, metadata)
 		require.NoError(t, err)
 
 		embedding[0] = 999.0
@@ -571,7 +571,7 @@ func TestInMemoryBackend_DeepCopy(t *testing.T) {
 		metadata["added"] = "extra"
 		embedding = append(embedding, 4.0)
 
-		retrievedEmb, retrievedMeta, found, err := backend.GetVector(ScopeSession, "s3", "vec1")
+		retrievedEmb, retrievedMeta, found, err := backend.GetVector(context.Background(), ScopeSession, "s3", "vec1")
 		require.NoError(t, err)
 		require.True(t, found)
 
@@ -586,17 +586,17 @@ func TestInMemoryBackend_DeepCopy(t *testing.T) {
 	})
 
 	t.Run("GetVector deep-copies embedding and metadata", func(t *testing.T) {
-		err := backend.SetVector(ScopeSession, "s4", "vec2", []float64{0.1, 0.2}, map[string]any{"meta": "orig"})
+		err := backend.SetVector(context.Background(), ScopeSession, "s4", "vec2", []float64{0.1, 0.2}, map[string]any{"meta": "orig"})
 		require.NoError(t, err)
 
-		emb1, meta1, found, err := backend.GetVector(ScopeSession, "s4", "vec2")
+		emb1, meta1, found, err := backend.GetVector(context.Background(), ScopeSession, "s4", "vec2")
 		require.NoError(t, err)
 		require.True(t, found)
 
 		emb1[0] = 555.0
 		meta1["meta"] = "changed"
 
-		emb2, meta2, found, err := backend.GetVector(ScopeSession, "s4", "vec2")
+		emb2, meta2, found, err := backend.GetVector(context.Background(), ScopeSession, "s4", "vec2")
 		require.NoError(t, err)
 		require.True(t, found)
 
@@ -608,7 +608,7 @@ func TestInMemoryBackend_DeepCopy(t *testing.T) {
 func TestInMemoryBackend_DeepCopyConcurrent(t *testing.T) {
 	backend := NewInMemoryBackend()
 
-	err := backend.Set(ScopeSession, "s1", "shared", map[string]any{"counter": 0})
+	err := backend.Set(context.Background(), ScopeSession, "s1", "shared", map[string]any{"counter": 0})
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
@@ -617,7 +617,7 @@ func TestInMemoryBackend_DeepCopyConcurrent(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 1000; i++ {
-			val, found, _ := backend.Get(ScopeSession, "s1", "shared")
+			val, found, _ := backend.Get(context.Background(), ScopeSession, "s1", "shared")
 			if found {
 				if m, ok := val.(map[string]any); ok {
 					m["counter"] = i
@@ -629,7 +629,7 @@ func TestInMemoryBackend_DeepCopyConcurrent(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 1000; i++ {
-			val, found, _ := backend.Get(ScopeSession, "s1", "shared")
+			val, found, _ := backend.Get(context.Background(), ScopeSession, "s1", "shared")
 			if found {
 				if m, ok := val.(map[string]any); ok {
 					_ = m["counter"]
@@ -723,10 +723,10 @@ func TestInMemoryBackendRejectsCyclicValues(t *testing.T) {
 	cycle := map[string]any{}
 	cycle["self"] = cycle
 
-	err := backend.Set(ScopeSession, "session", "key", cycle)
+	err := backend.Set(context.Background(), ScopeSession, "session", "key", cycle)
 	require.ErrorIs(t, err, ErrCyclicMemoryValue)
 
-	_, found, err := backend.Get(ScopeSession, "session", "key")
+	_, found, err := backend.Get(context.Background(), ScopeSession, "session", "key")
 	require.NoError(t, err)
 	assert.False(t, found)
 }
@@ -736,10 +736,10 @@ func TestInMemoryBackendRejectsCyclicVectorMetadata(t *testing.T) {
 	cycle := []any{nil}
 	cycle[0] = cycle
 
-	err := backend.SetVector(ScopeSession, "session", "key", []float64{1}, map[string]any{"cycle": cycle})
+	err := backend.SetVector(context.Background(), ScopeSession, "session", "key", []float64{1}, map[string]any{"cycle": cycle})
 	require.ErrorIs(t, err, ErrCyclicMemoryValue)
 
-	_, _, found, err := backend.GetVector(ScopeSession, "session", "key")
+	_, _, found, err := backend.GetVector(context.Background(), ScopeSession, "session", "key")
 	require.NoError(t, err)
 	assert.False(t, found)
 }

--- a/sdk/go/agent/run_memory_additional_test.go
+++ b/sdk/go/agent/run_memory_additional_test.go
@@ -121,9 +121,9 @@ func TestMemory_UserScopeVectorAndTypedHelpers(t *testing.T) {
 		Age  int    `json:"age"`
 	}
 
-	require.NoError(t, backend.Set(ScopeSession, "typed", "bytes", []byte(`{"name":"bytes","age":1}`)))
-	require.NoError(t, backend.Set(ScopeSession, "typed", "string", `{"name":"string","age":2}`))
-	require.NoError(t, backend.Set(ScopeSession, "typed", "map", map[string]any{"name": "map", "age": 3}))
+	require.NoError(t, backend.Set(context.Background(), ScopeSession, "typed", "bytes", []byte(`{"name":"bytes","age":1}`)))
+	require.NoError(t, backend.Set(context.Background(), ScopeSession, "typed", "string", `{"name":"string","age":2}`))
+	require.NoError(t, backend.Set(context.Background(), ScopeSession, "typed", "map", map[string]any{"name": "map", "age": 3}))
 
 	scoped := memory.Scoped(ScopeSession, "typed")
 	var got payload
@@ -135,7 +135,7 @@ func TestMemory_UserScopeVectorAndTypedHelpers(t *testing.T) {
 	assert.Equal(t, payload{Name: "map", Age: 3}, got)
 	require.NoError(t, scoped.GetTyped(context.Background(), "missing", &got))
 
-	require.NoError(t, backend.Set(ScopeSession, "typed", "invalid", make(chan int)))
+	require.NoError(t, backend.Set(context.Background(), ScopeSession, "typed", "invalid", make(chan int)))
 	err = scoped.GetTyped(context.Background(), "invalid", &got)
 	require.Error(t, err)
 }


### PR DESCRIPTION
## Summary

Fixes #433. All HTTP methods in `ControlPlaneMemoryBackend` used `http.NewRequest` (without context), so a cancelled execution context could not cancel in-flight memory I/O. This caused 15-second hangs on timeout under load when cancelled executions held HTTP connections and goroutines until the `http.Client` timeout fired.

## Type of change

- [x] Bug fix
- [x] Breaking change

## What changed

### Interface (`memory.go`)
- Added `context.Context` as the first parameter to all 8 `MemoryBackend` interface methods: `Set`, `Get`, `Delete`, `List`, `SetVector`, `GetVector`, `SearchVector`, `DeleteVector`

### ControlPlaneMemoryBackend (`control_plane_memory_backend.go`)
- All `http.NewRequest` calls replaced with `http.NewRequestWithContext(ctx, ...)`
- Cancelled contexts now abort HTTP calls immediately instead of waiting 15s

### InMemoryBackend (`memory.go`)
- Accepts `context.Context` (ignored, since in-memory ops are instant and non-blocking)
- Interface consistency for callers that pass context through

### Memory / ScopedMemory (`memory.go`)
- All backend calls now pass the caller's `ctx` through (already available from method signatures)

### Breaking change note
Any external `MemoryBackend` implementations must add `context.Context` as the first parameter to all methods. The `InMemoryBackend` pattern (accept and ignore) is the recommended approach for backends that don't do I/O.

## Test plan

- [x] `cd sdk/go && go test ./agent/ -run "Memory|ControlPlane" -v -timeout 60s` (all pass)
- [x] `cd sdk/go && go test ./agent/ -run TestControlPlaneMemoryBackend_ContextCancellation -v` (5 cases: 4 methods return context.Canceled, 1 deadline returns promptly)
- [x] `cd sdk/go && go build ./...`
- [x] `cd sdk/go && go vet ./...`

## Test coverage

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR (no bare additions).
- [x] If I removed code, I updated `coverage-baseline.json` in this PR *only if* the removal caused a legitimate regression.
- [ ] The coverage gate check is green in CI before requesting review.

## Checklist

- [x] Commits follow conventional-commits style.
- [x] I have linked any related issues (Fixes #433).

## Related issues / PRs

Fixes #433

## Notes

- `TestWithEventTrigger_StampsCallerFileAndLine` is a pre-existing failure on Windows (drive letter in path confuses the split assertion). Unrelated to this change.