### PR TITLE
feat(sdk/python): configure OpenCode harness per run

### DIFF
--- a/docs/design/harness-v2-design.md
+++ b/docs/design/harness-v2-design.md
@@ -98,6 +98,7 @@ fix = await app.harness(
     "Refactor to async/await",
     provider="codex",      # Override default provider
     model="o3",            # Override default model
+    variant="high",        # Provider-specific reasoning effort
     max_turns=100,
     tools=["Read", "Write", "Edit", "Bash"],
     max_budget_usd=5.0,
@@ -139,7 +140,7 @@ async def fix_issue(issue: dict) -> dict:
 
 ### 3.1 System Diagram
 
-```
+```text
 Agent
 ├── .ai()      → AIConfig      → LiteLLM     → LLM APIs (100+ providers)
 └── .harness() → HarnessConfig → HarnessRunner → Provider → {Aforge, Claude Code, Codex, Gemini, OpenCode}
@@ -147,7 +148,7 @@ Agent
 
 ### 3.2 Component Stack
 
-```
+```text
 ┌──────────────────────────────────────────────────────────────┐
 │                    Agent.harness()                            │
 │          HarnessConfig (constructor param, optional)          │
@@ -260,12 +261,13 @@ type Provider interface {
 **Core principle**: Always instruct the coding agent to write JSON output to a file using its Write tool. Never rely on native `--json-schema` / `--output-schema` flags as the primary mechanism.
 
 **Why file-write over native flags:**
+
 - Native flags constrain the model's *text response* — a wrong abstraction for multi-turn coding agents whose core competency is writing files
 - Large schemas can produce JSON that exceeds response token limits or gets truncated
 - File-write works identically across ALL 4 providers (one code path, half the tests)
 - Writing a JSON file is trivially easy for agents that refactor entire codebases
 
-```
+```text
 Developer writes:  await app.harness("...", schema=MyModel)
 
 Runner (ALL providers):
@@ -277,7 +279,7 @@ Runner (ALL providers):
 
 ### 5.2 Output File Convention
 
-```
+```text
 {cwd}/.agentfield_output.json
 ```
 
@@ -287,9 +289,9 @@ Runner (ALL providers):
 
 ### 5.3 Prompt Suffix
 
-Appended to the **end** of the user prompt (recency bias — models weight the end of input most heavily). Not in system prompt — CLI wrappers for Gemini/OpenCode may not expose system prompt control.
+Appended to the **end** of the user prompt (recency bias — models weight the end of input most heavily). OpenCode's Python adapter now configures a non-blank system prompt through its per-run `OPENCODE_CONFIG_CONTENT` agent overlay; other CLI wrappers may not expose system prompt control. See [the provider contract](../harness-providers.md#opencode-standalone-runs-python) for the OpenCode-specific behavior.
 
-```
+```text
 {user's actual task prompt}
 
 ---
@@ -306,7 +308,7 @@ Do not include any text outside the JSON in that file. Do not wrap in markdown f
 
 On schema validation failure, recover cheapest-first:
 
-```
+```text
 Layer 1: Parse file → validate against schema           (happy path, no cost)
     ↓ fail
 Layer 2: Cosmetic repair → re-validate                  (zero cost)
@@ -356,6 +358,7 @@ class HarnessConfig(BaseModel):
     # Provider selection: explicit > AGENTFIELD_HARNESS_PROVIDER > "aforge"
     provider: str = "aforge"    # | "claude-code" | "codex" | "gemini" | "opencode"
     model: Optional[str] = None  # None → the provider's own default
+    variant: Optional[str] = None  # Explicit reasoning-effort variant
     
     # Execution limits
     max_turns: int = 30
@@ -422,7 +425,7 @@ interface HarnessConfig {
 
 ### 6.3 Config Resolution (hierarchical, matches .ai pattern)
 
-```
+```text
 1. HarnessConfig defaults (set at agent construction)
 2. Per-call overrides (passed to .harness() method)
    → Per-call values win over HarnessConfig defaults
@@ -500,7 +503,7 @@ class Metrics:
 
 ### 8.1 Python SDK
 
-```
+```text
 sdk/python/agentfield/harness/
 ├── __init__.py              # Public API: AgentHarness, HarnessConfig, HarnessResult
 ├── _handler.py              # AgentHarness class (attached to Agent, like AgentAI)
@@ -520,7 +523,7 @@ sdk/python/agentfield/harness/
 
 ### 8.2 TypeScript SDK
 
-```
+```text
 sdk/typescript/src/harness/
 ├── index.ts                 # Public API exports
 ├── handler.ts               # Agent integration (like AIClient)
@@ -540,7 +543,7 @@ sdk/typescript/src/harness/
 
 ### 8.3 Go SDK (future)
 
-```
+```text
 sdk/go/harness/
 ├── config.go                # Config struct
 ├── runner.go                # Runner (retry, schema, logging)
@@ -742,18 +745,21 @@ class GeminiProvider:
 ## 12. Testing Strategy
 
 ### Unit Tests
+
 - Runner: retry behavior, config resolution, schema orchestration
 - Schema: native flag generation, file-write suffix, JSON parsing, validation
 - Factory: provider routing for each provider name
 - Each provider: command construction, output parsing
 
 ### Integration Tests (mock subprocess)
+
 - Full flow: prompt → provider → parse → schema validate → return
 - Retry on transient errors
 - Schema failure → `is_error=True`
 - Cost/metrics extraction
 
 ### E2E Tests (optional, CI-gated)
+
 - Actual Claude Code call with schema
 - Actual Codex call with schema
 - Require API keys (skip in CI by default)
@@ -763,15 +769,18 @@ class GeminiProvider:
 ## 13. Dependencies
 
 ### Python SDK
+
 - `claude-agent-sdk` (optional — lazy import, only when claude-code provider used)
 - No new required dependencies (subprocess is stdlib)
 
 ### TypeScript SDK
+
 - `@anthropic-ai/claude-agent-sdk` (optional peer dependency)
 - `@openai/codex-sdk` (optional peer dependency)
 - `zod-to-json-schema` (already a dependency)
 
 ### Go SDK
+
 - No new dependencies (os/exec is stdlib)
 
 ---

--- a/docs/harness-providers.md
+++ b/docs/harness-providers.md
@@ -133,7 +133,10 @@ result = await app.harness(
 )
 ```
 
-An explicit `variant="high"` keyword wins over the suffix. Per provider:
+An explicit `variant="high"` keyword wins over the suffix. In Python,
+`variant` is also available on `HarnessConfig` and `HarnessRunner.run`; a
+per-call `Agent.harness(..., variant=...)` value overrides the configured
+default. Per provider:
 
 | Provider | Model flag | Variant handling |
 | --- | --- | --- |
@@ -145,6 +148,36 @@ An explicit `variant="high"` keyword wins over the suffix. Per provider:
 
 The `#` separator is safe in model ids: `:` belongs to OpenRouter suffixes like
 `:free`, and `@` to Vertex-style ids, but no provider uses `#`.
+
+### OpenCode standalone runs (Python)
+
+The Python OpenCode adapter uses `opencode run` for each call; it does not use
+`opencode serve` or attach to a session. It selects the fixed
+`agentfield-harness` agent with `--agent` and supplies that agent through the
+child process's `OPENCODE_CONFIG_CONTENT` environment variable. The generated
+overlay sets `$schema` to `https://opencode.ai/config.json`, selects
+`agentfield-harness` as the default agent, and fixes its mode to `primary` with
+`steps` set to `500`. It does not modify shared OpenCode configuration files.
+
+A non-blank `system_prompt`, the resolved base `model`, and
+`reasoningEffort` are included in the agent overlay only when available. The
+base model is also passed with `-m`; a resolved variant is passed exactly once
+with `--variant`. An explicit `variant` wins over a `#variant` model suffix.
+AgentField `max_turns` remains a runner limit and is not serialized as
+OpenCode `steps`.
+
+OpenCode's initial permission baseline is headless and compatibility-oriented:
+the wildcard action is allowed, while AgentField `Read`, `Write`/`Edit`,
+`Glob`, `Grep`, and `Bash` map to OpenCode `read`, `edit`, `glob`, `grep`, and
+`bash`. Only `question` and `task` are explicitly denied, and no `ask`
+permission is generated. Omitted tools are not denied; this baseline is not
+per-role authorization. `Write`/`Edit` retain `edit` access because
+schema-constrained runs write their result file.
+
+The task prompt (including the runner's schema instructions, when applicable)
+is the only prompt sent to OpenCode: it is positional on POSIX and is the sole
+stdin payload on Windows. The system prompt is configured on the generated
+agent instead of being appended to the task.
 
 ## Verify
 

--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -3722,6 +3722,7 @@ class Agent(FastAPI):
         schema: Any = None,
         provider: Optional[str] = None,
         model: Optional[str] = None,
+        variant: Optional[str] = None,
         max_turns: Optional[int] = None,
         max_budget_usd: Optional[float] = None,
         tools: Optional[List[str]] = None,
@@ -3746,6 +3747,8 @@ class Agent(FastAPI):
                 "opencode", "grok"). Omit to use ``AGENTFIELD_HARNESS_PROVIDER``
                 when set, otherwise ``aforge``.
             model: Override model identifier. Empty uses the provider's own default.
+            variant: Provider-specific reasoning-effort variant. Wins over a
+                ``#variant`` suffix on the model when supported by the provider.
             max_turns: Maximum agent iterations.
             max_budget_usd: Cost cap in USD.
             tools: Allowed tools list.
@@ -3778,6 +3781,7 @@ class Agent(FastAPI):
             schema=schema,
             provider=provider,
             model=model,
+            variant=variant,
             max_turns=max_turns,
             max_budget_usd=max_budget_usd,
             tools=tools,

--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -753,6 +753,7 @@ class Agent(FastAPI):
         # one, and a re-import in the same process keeps the same one (since the
         # same Agent instance is being used).
         import uuid as _uuid
+
         self.agent_instance_id = _uuid.uuid4().hex
 
         # Memory-efficient handler registries (replaces old list-based storage)
@@ -835,6 +836,7 @@ class Agent(FastAPI):
         # before any user-defined reasoners are registered so the path is
         # always available for the control-plane callback.
         from .cancel import install_cancel_route
+
         install_cancel_route(self)
 
         # Initialize async execution manager (will be lazily created when needed)
@@ -1070,7 +1072,11 @@ class Agent(FastAPI):
                 metadata["accepts_webhook"] = "true"
             elif accepts_webhook is False:
                 metadata["accepts_webhook"] = "false"
-            elif isinstance(accepts_webhook, str) and accepts_webhook in ("true", "false", "warn"):
+            elif isinstance(accepts_webhook, str) and accepts_webhook in (
+                "true",
+                "false",
+                "warn",
+            ):
                 metadata["accepts_webhook"] = accepts_webhook
             else:
                 metadata["accepts_webhook"] = "warn"
@@ -1709,8 +1715,7 @@ class Agent(FastAPI):
     @property
     def sessions(self) -> List[Dict[str, Any]]:
         return [
-            entry["definition"].to_dict()
-            for entry in self._session_registry.values()
+            entry["definition"].to_dict() for entry in self._session_registry.values()
         ]
 
     def session(
@@ -1725,7 +1730,10 @@ class Agent(FastAPI):
         tools: Optional[List[str]] = None,
         tags: Optional[List[str]] = None,
         metadata: Optional[Dict[str, Any]] = None,
-    ) -> Callable[[Callable[[RealtimeSession], Awaitable[Any]]], Callable[[RealtimeSession], Awaitable[Any]]]:
+    ) -> Callable[
+        [Callable[[RealtimeSession], Awaitable[Any]]],
+        Callable[[RealtimeSession], Awaitable[Any]],
+    ]:
         """Register a realtime/voice session endpoint.
 
         Provider and transport are both explicit; AgentField does not infer or
@@ -1746,7 +1754,7 @@ class Agent(FastAPI):
         )
 
         def decorator(
-            func: Callable[[RealtimeSession], Awaitable[Any]]
+            func: Callable[[RealtimeSession], Awaitable[Any]],
         ) -> Callable[[RealtimeSession], Awaitable[Any]]:
             self._session_registry[name] = {"definition": definition, "handler": func}
             setattr(func, "_agentfield_session", definition)
@@ -2154,6 +2162,7 @@ class Agent(FastAPI):
                     # execute_async_with_callback handles its own
                     # cancellation accounting on top of this.
                     from .cancel import register_execution_task
+
                     await register_execution_task(self, execution_id_header, task)
                     return JSONResponse(
                         status_code=202,
@@ -2180,6 +2189,7 @@ class Agent(FastAPI):
                             register_execution_task,
                             deregister_execution,
                         )
+
                         sync_task = asyncio.create_task(run_reasoner())
                         await register_execution_task(
                             self, execution_id_header, sync_task
@@ -2258,7 +2268,7 @@ class Agent(FastAPI):
             vc_setting = self._effective_component_vc_setting(
                 reasoner_id, self._reasoner_vc_overrides
             )
-            
+
             self._reasoner_registry[reasoner_id] = ReasonerEntry(
                 id=reasoner_id,
                 func=func,
@@ -2294,7 +2304,9 @@ class Agent(FastAPI):
 
         return decorator
 
-    def _detect_and_unwrap_trigger_envelope(self, payload_dict: Dict[str, Any]) -> tuple[Dict[str, Any], Optional[Any]]:
+    def _detect_and_unwrap_trigger_envelope(
+        self, payload_dict: Dict[str, Any]
+    ) -> tuple[Dict[str, Any], Optional[Any]]:
         """
         Detect dispatcher webhook envelope {event: ..., _meta: ...} and unwrap it.
         Returns (unwrapped_input, trigger_context_or_none).
@@ -2303,23 +2315,25 @@ class Agent(FastAPI):
         # Check if this looks like a dispatcher envelope
         if not isinstance(payload_dict, dict):
             return payload_dict, None
-        
+
         if "event" in payload_dict and "_meta" in payload_dict:
             # This is a dispatcher envelope
             event_data = payload_dict.get("event", {})
             meta_data = payload_dict.get("_meta", {})
-            
+
             # Parse metadata into TriggerContext
             try:
                 from datetime import datetime
                 from .triggers import TriggerContext
-                
+
                 received_at_str = meta_data.get("received_at", "")
                 if received_at_str:
-                    received_at = datetime.fromisoformat(received_at_str.replace('Z', '+00:00'))
+                    received_at = datetime.fromisoformat(
+                        received_at_str.replace("Z", "+00:00")
+                    )
                 else:
                     received_at = datetime.utcnow()
-                
+
                 trigger_ctx = TriggerContext(
                     trigger_id=meta_data.get("trigger_id", ""),
                     source=meta_data.get("source", ""),
@@ -2333,15 +2347,17 @@ class Agent(FastAPI):
             except Exception:
                 # If parsing fails, return raw envelope for compatibility
                 return payload_dict, None
-        
+
         # Not an envelope
         return payload_dict, None
 
-    def _apply_trigger_transform(self, trigger_ctx, bindings: list, input_data: dict) -> dict:
+    def _apply_trigger_transform(
+        self, trigger_ctx, bindings: list, input_data: dict
+    ) -> dict:
         """
         Match trigger context against reasoner bindings and apply transform if found.
         Returns transformed input or original input if no match.
-        
+
         Matching logic:
         1. Find bindings where binding.source == trigger_ctx.source
         2. Check event_type: binding.types empty OR trigger_ctx.event_type matches (exact or prefix)
@@ -2349,21 +2365,21 @@ class Agent(FastAPI):
         4. Apply transform if binding has one
         """
         from .triggers import EventTrigger
-        
+
         if not bindings or not trigger_ctx:
             return input_data
-        
+
         # Find best-matching binding
         best_match = None
         best_specificity = -1  # -1 = no match, 0 = broad (empty types), 1+ = specific
-        
+
         for binding in bindings:
             if not isinstance(binding, EventTrigger):
                 continue
-            
+
             if binding.source != trigger_ctx.source:
                 continue
-            
+
             # Check event_type match
             if binding.types:
                 # binding has specific types — check for match
@@ -2378,21 +2394,23 @@ class Agent(FastAPI):
             else:
                 # binding accepts all types
                 specificity = 0
-            
+
             # This binding matches; is it better than current best?
             if specificity > best_specificity:
                 best_match = binding
                 best_specificity = specificity
-        
+
         # Apply transform if found
         if best_match and best_match.transform:
             try:
                 return best_match.transform(input_data)
             except Exception as e:
                 if self.dev_mode:
-                    log_warn(f"Transform failed for {trigger_ctx.source}/{trigger_ctx.event_type}: {e}; using raw input")
+                    log_warn(
+                        f"Transform failed for {trigger_ctx.source}/{trigger_ctx.event_type}: {e}; using raw input"
+                    )
                 return input_data
-        
+
         return input_data
 
     async def _execute_reasoner_endpoint(
@@ -2411,7 +2429,9 @@ class Agent(FastAPI):
         execution_context = ExecutionContext.from_request(request, self.node_id)
         payload_dict = input_data  # Already a dict from runtime validation
         # Unwrap dispatcher envelope if present (Phase 5 webhook DX)
-        payload_dict, trigger_context = self._detect_and_unwrap_trigger_envelope(payload_dict)
+        payload_dict, trigger_context = self._detect_and_unwrap_trigger_envelope(
+            payload_dict
+        )
         if trigger_context:
             execution_context.trigger = trigger_context
 
@@ -2460,9 +2480,7 @@ class Agent(FastAPI):
                 trigger_bindings = getattr(func, "_reasoner_triggers", [])
             if execution_context.trigger and trigger_bindings:
                 payload_dict = self._apply_trigger_transform(
-                    execution_context.trigger,
-                    trigger_bindings,
-                    payload_dict
+                    execution_context.trigger, trigger_bindings, payload_dict
                 )
 
             # When invoked via an inbound trigger, the (possibly transformed)
@@ -2787,6 +2805,7 @@ class Agent(FastAPI):
             # plane records status=failed WITHOUT discarding the rich result
             # (it stores the result payload regardless of terminal status).
             from .exceptions import ReasonerFailed
+
             if isinstance(exc, ReasonerFailed) and exc.result is not None:
                 payload["result"] = jsonable_encoder(exc.result)
             log_error(f"Execution {execution_id} failed asynchronously: {exc}")
@@ -2808,6 +2827,7 @@ class Agent(FastAPI):
             self._pause_clocks.pop(execution_id, None)
             # Deregister the cancel hook regardless of outcome.
             from .cancel import deregister_execution
+
             await deregister_execution(self, execution_id)
         # Attach usage on non-success terminal states too — a reasoner that
         # failed or was cancelled may still have consumed tokens before ending.
@@ -2863,7 +2883,9 @@ class Agent(FastAPI):
             + f"/api/v1/executions/{execution_id}/status"
         )
 
-    def on_change(self, pattern: Union[str, List[str]]) -> Callable[[Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]]:
+    def on_change(
+        self, pattern: Union[str, List[str]]
+    ) -> Callable[[Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]]:
         """
         Decorator to mark a function as a memory event listener.
 
@@ -3826,9 +3848,10 @@ class Agent(FastAPI):
             cache_creation = getattr(result, "cache_creation_tokens", 0) or 0
             cost = getattr(result, "cost_usd", None)
 
-            if not any(
-                (input_tokens, output_tokens, cache_read, cache_creation)
-            ) and cost is None:
+            if (
+                not any((input_tokens, output_tokens, cache_read, cache_creation))
+                and cost is None
+            ):
                 return
 
             tracker = get_current_cost_tracker()
@@ -3849,9 +3872,7 @@ class Agent(FastAPI):
                 or self._harness_model_name()
                 or (resolved_provider or "harness")
             )
-            total = getattr(result, "total_tokens", 0) or (
-                input_tokens + output_tokens
-            )
+            total = getattr(result, "total_tokens", 0) or (input_tokens + output_tokens)
             ctx = self._get_current_execution_context()
             tracker.record(
                 model=str(model_name),
@@ -4593,6 +4614,7 @@ class Agent(FastAPI):
                             ExecutionFailedError,
                             ExecutionTimeoutError,
                         )
+
                         if isinstance(
                             async_error,
                             (
@@ -4811,9 +4833,7 @@ class Agent(FastAPI):
                     if self.dev_mode:
                         from agentfield.logger import log_debug
 
-                        log_debug(
-                            f"NOTE DEBUG: api_base: {self.client.api_base}"
-                        )
+                        log_debug(f"NOTE DEBUG: api_base: {self.client.api_base}")
                         log_debug(
                             f"NOTE DEBUG: Full URL: {self.client.api_base}/executions/note"
                         )

--- a/sdk/python/agentfield/harness/_runner.py
+++ b/sdk/python/agentfield/harness/_runner.py
@@ -160,6 +160,7 @@ def _resolve_options(
         for field_name in [
             "provider",
             "model",
+            "variant",
             "max_turns",
             "max_budget_usd",
             "max_retries",
@@ -251,6 +252,7 @@ class HarnessRunner:
         schema: Any = None,
         provider: Optional[str] = None,
         model: Optional[str] = None,
+        variant: Optional[str] = None,
         max_turns: Optional[int] = None,
         max_budget_usd: Optional[float] = None,
         tools: Optional[list[str]] = None,
@@ -264,6 +266,7 @@ class HarnessRunner:
         overrides = {
             "provider": provider,
             "model": model,
+            "variant": variant,
             "max_turns": max_turns,
             "max_budget_usd": max_budget_usd,
             "tools": tools,

--- a/sdk/python/agentfield/harness/providers/opencode.py
+++ b/sdk/python/agentfield/harness/providers/opencode.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import re
@@ -36,6 +37,73 @@ _OPENCODE_STDERR_ERROR_PATTERNS = (
     re.compile(r"\bUnauthorized\b"),
     re.compile(r"\bAPIError\b"),
 )
+
+_OPENCODE_CONFIG_SCHEMA = "https://opencode.ai/config.json"
+_OPENCODE_AGENT_NAME = "agentfield-harness"
+_AGENTFIELD_TOOL_ACTIONS = {
+    "read": "read",
+    "write": "edit",
+    "edit": "edit",
+    "glob": "glob",
+    "grep": "grep",
+    "bash": "bash",
+}
+
+
+def _opencode_permissions(tools: object) -> dict[str, str]:
+    """Build the initial headless permission baseline for the harness agent.
+
+    The wildcard allow is intentional: this first integration preserves the
+    existing compatibility behavior instead of turning omitted tools into
+    denials. Recognized AgentField tools are also emitted under their OpenCode
+    action names so the translation remains visible in the effective config.
+    """
+    permissions: dict[str, str] = {"*": "allow"}
+    if isinstance(tools, (list, tuple, set, frozenset)):
+        for tool in tools:
+            if not isinstance(tool, str):
+                continue
+            action = _AGENTFIELD_TOOL_ACTIONS.get(tool.strip().lower())
+            if action is not None:
+                permissions[action] = "allow"
+
+    # Headless runs must never wait for an interactive response. Keep this
+    # baseline independent of permission_mode: structured-output runs write
+    # .agentfield_output.json, so AgentField Write/Edit must retain OpenCode's
+    # edit permission. In particular, do not add an "ask" rule here.
+    permissions["question"] = "deny"
+    permissions["task"] = "deny"
+    return permissions
+
+
+def _build_opencode_config_content(
+    options: dict[str, object],
+    model_value: Optional[str],
+    variant_value: Optional[str],
+) -> str:
+    """Serialize the per-run OpenCode agent overlay."""
+    agent: dict[str, object] = {
+        "mode": "primary",
+        "steps": 500,
+        "permission": _opencode_permissions(options.get("tools")),
+    }
+
+    system_prompt = options.get("system_prompt")
+    if isinstance(system_prompt, str) and system_prompt.strip():
+        agent["prompt"] = system_prompt.strip()
+    if model_value:
+        agent["model"] = model_value
+    if variant_value:
+        agent["reasoningEffort"] = variant_value
+
+    return json.dumps(
+        {
+            "$schema": _OPENCODE_CONFIG_SCHEMA,
+            "default_agent": _OPENCODE_AGENT_NAME,
+            "agent": {_OPENCODE_AGENT_NAME: agent},
+        },
+        ensure_ascii=False,
+    )
 
 
 def _prompt_via_stdin() -> bool:
@@ -212,6 +280,10 @@ class OpenCodeProvider:
         cmd = [self._bin, "run"]
         cmd.extend(["--format", "json"])
 
+        # Select a deterministic per-run agent. Its configuration is supplied
+        # through OPENCODE_CONFIG_CONTENT below rather than a shared file.
+        cmd.extend(["--agent", _OPENCODE_AGENT_NAME])
+
         # --dir is the project root the agent may read and write. project_dir is
         # the canonical field; fall back to cwd when it is unset. Previously cwd
         # took precedence, so a nested cwd under a shared project_dir made
@@ -237,21 +309,11 @@ class OpenCodeProvider:
         # response. opencode in non-TTY mode proceeds without permission
         # prompting, so no flag is needed. See agentfield#582.
 
-        # Handle system prompt - prepend to user prompt since OpenCode
-        # has no native --system-prompt flag
-        effective_prompt = prompt
-        system_prompt = options.get("system_prompt")
-        if isinstance(system_prompt, str) and system_prompt.strip():
-            effective_prompt = (
-                f"SYSTEM INSTRUCTIONS:\n{system_prompt.strip()}\n\n"
-                f"---\n\nUSER REQUEST:\n{prompt}"
-            )
-
-        # Prompt is a positional arg to `opencode run` (not -p) on POSIX; on
-        # Windows it goes over stdin instead (see _prompt_via_stdin).
+        # The system prompt belongs to the selected agent, so the task remains
+        # the only user-facing prompt sent to OpenCode.
         prompt_via_stdin = _prompt_via_stdin()
         if not prompt_via_stdin:
-            cmd.append(effective_prompt)
+            cmd.append(prompt)
 
         env: Dict[str, str] = {}
         env_value = options.get("env")
@@ -262,7 +324,12 @@ class OpenCodeProvider:
                 if isinstance(key, str) and isinstance(value, str)
             }
 
-        # Model is passed via -m flag on the run subcommand (see above)
+        # Model is passed via -m flag on the run subcommand (see above).
+        # Keep credentials and other caller-provided environment values in
+        # place; only the generated config content is added for this child.
+        env["OPENCODE_CONFIG_CONTENT"] = _build_opencode_config_content(
+            options, model_value, variant_value
+        )
 
         cwd: Optional[str] = None
 
@@ -309,7 +376,7 @@ class OpenCodeProvider:
                     env=env,
                     cwd=cwd,
                     timeout=timeout_seconds,
-                    input_text=effective_prompt if prompt_via_stdin else None,
+                    input_text=prompt if prompt_via_stdin else None,
                 )
             except FileNotFoundError as exc:
                 raise provider_unavailable("opencode", self._bin) from exc
@@ -387,7 +454,7 @@ class OpenCodeProvider:
         else:
             estimated_cost = estimate_cli_cost(
                 model=model_value or "",
-                prompt=effective_prompt,
+                prompt=prompt,
                 result_text=result_text,
             )
 

--- a/sdk/python/agentfield/types.py
+++ b/sdk/python/agentfield/types.py
@@ -296,6 +296,13 @@ class HarnessConfig(BaseModel):
             "(aforge picks its own; claude-code uses sonnet)."
         ),
     )
+    variant: Optional[str] = Field(
+        default=None,
+        description=(
+            "Provider-specific reasoning-effort variant (for example, "
+            '"high" or "minimal"). Wins over a #variant model suffix.'
+        ),
+    )
     max_turns: int = Field(default=30, description="Maximum agent iterations.")
     max_budget_usd: Optional[float] = Field(
         default=None, description="Cost cap in USD."

--- a/sdk/python/agentfield/types.py
+++ b/sdk/python/agentfield/types.py
@@ -346,9 +346,7 @@ class HarnessConfig(BaseModel):
         default="opencode", description="Path to opencode binary."
     )
     aforge_bin: str = Field(default="aforge", description="Path to aforge binary.")
-    grok_bin: str = Field(
-        default="grok", description="Path to Grok Build CLI binary."
-    )
+    grok_bin: str = Field(default="grok", description="Path to Grok Build CLI binary.")
     schema_mode: str = Field(
         default="single",
         description=(

--- a/sdk/python/tests/test_harness_agent_wiring.py
+++ b/sdk/python/tests/test_harness_agent_wiring.py
@@ -104,6 +104,7 @@ class TestAgentHarnessMethod:
                 "task",
                 provider="codex",
                 model="o3",
+                variant="high",
                 max_turns=10,
                 max_budget_usd=5.0,
                 tools=["Read"],
@@ -115,6 +116,7 @@ class TestAgentHarnessMethod:
             _, kwargs = mock_run.call_args
             assert kwargs["provider"] == "codex"
             assert kwargs["model"] == "o3"
+            assert kwargs["variant"] == "high"
             assert kwargs["max_turns"] == 10
             assert kwargs["max_budget_usd"] == 5.0
             assert kwargs["tools"] == ["Read"]

--- a/sdk/python/tests/test_harness_provider_opencode.py
+++ b/sdk/python/tests/test_harness_provider_opencode.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 # pyright: reportMissingImports=false
 
+import json
 from typing import Any
 from unittest.mock import patch
 
@@ -64,18 +65,101 @@ async def test_opencode_provider_constructs_command_and_maps_result(
         "run",
         "--format",
         "json",
+        "--agent",
+        "agentfield-harness",
         "--dir",
         "/tmp/work",
         "hello",
     ]
     assert captured["env"]["A"] == "1"
     assert "XDG_DATA_HOME" in captured["env"]
+    overlay = json.loads(captured["env"]["OPENCODE_CONFIG_CONTENT"])
+    assert overlay["default_agent"] == "agentfield-harness"
+    assert overlay["agent"]["agentfield-harness"] == {
+        "mode": "primary",
+        "steps": 500,
+        "permission": {
+            "*": "allow",
+            "question": "deny",
+            "task": "deny",
+        },
+    }
     # Note: cwd is None because we use --dir in command instead of cwd param
     assert raw.is_error is False
     assert raw.result == "final text"
     assert raw.metrics.session_id == ""
     assert raw.metrics.num_turns == 1
     assert raw.messages == []
+
+
+@pytest.mark.asyncio
+async def test_opencode_overlay_configures_agent_tools_and_run_options(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, Any] = {}
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None, input_text=None):
+        _ = cwd, timeout, input_text
+        captured["cmd"] = cmd
+        captured["env"] = env
+        return "ok\n", "", 0
+
+    monkeypatch.setattr("agentfield.harness.providers.opencode.run_cli", fake_run_cli)
+
+    task = "inspect the repository"
+    provider = OpenCodeProvider()
+    await provider.execute(
+        task,
+        {
+            "model": "openai/gpt-5#low",
+            "variant": "max",
+            "system_prompt": "  Work autonomously.  ",
+            "tools": ["Read", "Write", "Edit", "Glob", "Grep", "Bash"],
+            "permission_mode": "plan",
+            "max_turns": 7,
+            "env": {"OPENAI_API_KEY": "secret", "DEPLOYMENT": "local"},
+        },
+    )
+
+    overlay = json.loads(captured["env"]["OPENCODE_CONFIG_CONTENT"])
+    agent = overlay["agent"]["agentfield-harness"]
+    assert overlay["$schema"] == "https://opencode.ai/config.json"
+    assert overlay["default_agent"] == "agentfield-harness"
+    assert agent["mode"] == "primary"
+    assert agent["steps"] == 500
+    assert agent["prompt"] == "Work autonomously."
+    assert agent["model"] == "openai/gpt-5"
+    assert agent["reasoningEffort"] == "max"
+    assert agent["permission"] == {
+        "*": "allow",
+        "read": "allow",
+        "edit": "allow",
+        "glob": "allow",
+        "grep": "allow",
+        "bash": "allow",
+        "question": "deny",
+        "task": "deny",
+    }
+    assert "ask" not in agent["permission"]
+    assert "max_turns" not in agent
+
+    assert captured["cmd"] == [
+        "opencode",
+        "run",
+        "--format",
+        "json",
+        "--agent",
+        "agentfield-harness",
+        "-m",
+        "openai/gpt-5",
+        "--variant",
+        "max",
+        task,
+    ]
+    assert captured["cmd"].count("--variant") == 1
+    assert "SYSTEM INSTRUCTIONS:" not in captured["cmd"]
+    assert captured["env"]["OPENAI_API_KEY"] == "secret"
+    assert captured["env"]["DEPLOYMENT"] == "local"
 
 
 @pytest.mark.asyncio
@@ -143,6 +227,8 @@ async def test_opencode_passes_model_flag(monkeypatch: pytest.MonkeyPatch):
         "run",
         "--format",
         "json",
+        "--agent",
+        "agentfield-harness",
         "-m",
         "openai/gpt-5",
         "hello",
@@ -497,6 +583,7 @@ async def test_opencode_v14_cli_shape_no_deprecated_flags(
     # Must use `run` subcommand
     assert captured_cmd[1] == "run", "Must use 'opencode run' subcommand (v1.4+)"
     assert "--format" in captured_cmd, "Must request JSON stream for metrics parsing"
+    assert captured_cmd[captured_cmd.index("--agent") + 1] == "agentfield-harness"
     assert "json" in captured_cmd, "Must request JSON output format"
     # Must NOT use deprecated -p flag
     assert "-p" not in captured_cmd, "Must not use deprecated -p flag (v1.4+)"
@@ -624,11 +711,18 @@ async def test_opencode_windows_hands_prompt_over_stdin(
     )
 
     assert raw.is_error is False
-    # The prompt (with the system prompt folded in) went over stdin...
-    assert "a prompt far too large" in (captured["input_text"] or "")
-    assert "SYSTEM INSTRUCTIONS:" in (captured["input_text"] or "")
+    # The task prompt went over stdin without a folded system prompt.
+    assert captured["input_text"] == "a prompt far too large for a cmd.exe command line"
+    assert "SYSTEM INSTRUCTIONS:" not in (captured["input_text"] or "")
     # ...and argv carries only the fixed flags, no positional prompt.
-    assert captured["cmd"][:4] == ["opencode", "run", "--format", "json"]
+    assert captured["cmd"][:6] == [
+        "opencode",
+        "run",
+        "--format",
+        "json",
+        "--agent",
+        "agentfield-harness",
+    ]
     assert all("too large" not in part for part in captured["cmd"])
 
 
@@ -653,6 +747,8 @@ async def test_opencode_model_variant_suffix_maps_to_variant_flag(
         "run",
         "--format",
         "json",
+        "--agent",
+        "agentfield-harness",
         "-m",
         "openrouter/z-ai/glm-5.2",
         "--variant",

--- a/sdk/python/tests/test_harness_runner.py
+++ b/sdk/python/tests/test_harness_runner.py
@@ -403,6 +403,7 @@ async def test_run_resolves_harness_config_defaults_with_per_call_overrides(tmp_
     config = SimpleNamespace(
         provider="codex",
         model="default-model",
+        variant="low",
         max_turns=30,
         max_budget_usd=1.5,
         tools=["Read", "Write"],
@@ -422,6 +423,7 @@ async def test_run_resolves_harness_config_defaults_with_per_call_overrides(tmp_
         await runner.run(
             "hello",
             model="override-model",
+            variant="max",
             max_turns=5,
             env={"OVERRIDE": "1"},
             permission_mode="auto",
@@ -430,6 +432,7 @@ async def test_run_resolves_harness_config_defaults_with_per_call_overrides(tmp_
     assert provider.last_options is not None
     assert provider.last_options["provider"] == "codex"
     assert provider.last_options["model"] == "override-model"
+    assert provider.last_options["variant"] == "max"
     assert provider.last_options["max_turns"] == 5
     assert provider.last_options["max_budget_usd"] == 1.5
     assert provider.last_options["permission_mode"] == "auto"

--- a/sdk/python/tests/test_harness_types.py
+++ b/sdk/python/tests/test_harness_types.py
@@ -16,6 +16,7 @@ def test_harness_config_defaults():
 
     assert cfg.provider == "codex"
     assert cfg.model is None
+    assert cfg.variant is None
     assert cfg.max_turns == 30
     assert cfg.max_budget_usd is None
     assert cfg.max_retries == 3
@@ -31,6 +32,12 @@ def test_harness_config_defaults():
     assert cfg.codex_bin == "codex"
     assert cfg.gemini_bin == "gemini"
     assert cfg.opencode_bin == "opencode"
+
+
+def test_harness_config_accepts_explicit_variant():
+    cfg = HarnessConfig(provider="opencode", variant="high")
+
+    assert cfg.variant == "high"
 
 
 def test_build_provider_raises_for_unknown_provider():


### PR DESCRIPTION
## Summary
- add a per-run OPENCODE_CONFIG_CONTENT overlay for the fixed agentfield-harness agent
- route system prompts, models, variants, permissions, and fixed OpenCode steps through standalone runs
- expose variant on HarnessConfig, HarnessRunner.run, and Agent.harness

## Validation
- focused Python harness and public-surface tests pass
- related Python SDK harness tests pass
- documentation and lint pipeline stages completed
- automated review was skipped under captain authorization after the configured review agent failed with a token-too-long transport error

This change is intentionally limited to Python local standalone OpenCode behavior. It does not add attached sessions, profiles, role registries, deployment changes, or cross-language parity work.
