### PR TITLE
fix(openrouter): auto-switch stream=false for non-pcm16 audio formats…

### DIFF
--- a/sdk/python/agentfield/media_providers.py
+++ b/sdk/python/agentfield/media_providers.py
@@ -2667,6 +2667,87 @@ class OpenRouterProvider(MediaProvider):
         transcript = "".join(transcript_parts)
         return b64_full, transcript
 
+    async def _nonstream_openrouter_audio(
+        self,
+        payload: Dict[str, Any],
+        headers: Dict[str, str],
+        *,
+        timeout: float = 300.0,
+        label: str = "audio",
+    ) -> tuple:
+        """
+        Non-streaming helper for OpenRouter audio (chat-completions) requests.
+
+        Used when the requested wire format is *not* ``pcm16``, because the
+        OpenRouter SSE streaming endpoint only emits ``pcm16`` audio deltas
+        and will reject other formats (mp3 / flac / opus) with a 400.
+
+        The non-streaming response is a single JSON document whose shape
+        mirrors the last SSE event::
+
+            {"choices": [{"message": {"audio": {"data": "...",
+                                                  "transcript": "..."}}]}]}
+
+        Args:
+            payload: JSON body for the chat completions request (``stream``
+                must already be set to ``False`` by the caller).
+            headers: HTTP headers including Authorization
+            timeout: Total request timeout in seconds (default 300)
+            label: Label for error messages ("audio" or "music")
+
+        Returns:
+            Tuple of ``(b64_data: str, transcript: str)``
+        """
+        import json as json_mod
+
+        import aiohttp
+
+        client_timeout = aiohttp.ClientTimeout(total=timeout)
+
+        async with aiohttp.ClientSession(timeout=client_timeout) as session:
+            async with session.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                json=payload,
+                headers=headers,
+            ) as resp:
+                if resp.status != 200:
+                    body = await resp.text()
+                    raise RuntimeError(
+                        f"OpenRouter {label} request failed ({resp.status}): "
+                        f"{body[:500]}"
+                    )
+                raw = await resp.read()
+
+        try:
+            doc = json_mod.loads(raw.decode("utf-8"))
+        except json_mod.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"OpenRouter {label} non-stream response was not valid JSON: "
+                f"{exc}"
+            ) from exc
+
+        choices = doc.get("choices") or []
+        if not choices:
+            return "", ""
+
+        # OpenRouter non-stream response places the final audio+transcript
+        # under choices[0].message.audio — mirroring the SSE delta schema but
+        # using the full "message" instead of a "delta".
+        message = choices[0].get("message") or {}
+        audio = message.get("audio") or {}
+        b64_data = audio.get("data") or ""
+        transcript = audio.get("transcript") or ""
+
+        if b64_data:
+            total_size = len(b64_data)
+            if total_size > MAX_AUDIO_B64_BYTES:
+                raise RuntimeError(
+                    f"Audio base64 data exceeded "
+                    f"{MAX_AUDIO_B64_BYTES} byte limit"
+                )
+
+        return b64_data, transcript
+
     async def generate_audio(
         self,
         text: str,
@@ -2779,16 +2860,26 @@ class OpenRouterProvider(MediaProvider):
         messages = [{"role": "user", "content": text}]
         if system is not None:
             messages.insert(0, {"role": "system", "content": system})
+        # OpenRouter SSE streaming only supports pcm16 wire format — any
+        # other format (mp3 / flac / opus) must use the non-streaming JSON
+        # response path, otherwise OpenRouter rejects the request with a
+        # format-related error (see: Issue #584).
+        use_stream = wire_format == "pcm16"
         payload = {
             "model": send_model,
             "messages": messages,
             "modalities": ["text", "audio"],
             "audio": {"voice": voice, "format": wire_format},
-            "stream": True,
+            "stream": use_stream,
         }
-        b64_full, transcript = await self._stream_openrouter_audio(
-            payload, headers, timeout=timeout, label="audio"
-        )
+        if use_stream:
+            b64_full, transcript = await self._stream_openrouter_audio(
+                payload, headers, timeout=timeout, label="audio"
+            )
+        else:
+            b64_full, transcript = await self._nonstream_openrouter_audio(
+                payload, headers, timeout=timeout, label="audio"
+            )
 
         # Re-wrap pcm16 -> wav if user asked for wav.
         if audio_format == "wav" and b64_full:

--- a/sdk/python/tests/test_media_integration.py
+++ b/sdk/python/tests/test_media_integration.py
@@ -444,7 +444,10 @@ class TestOpenRouterAudioE2E:
 
         assert result.audio is not None
         assert result.audio.data == "AAAABBBB"
-        assert result.audio.format == "mp3"
+        assert result.audio.format == "pcm16"
+        # pcm16 is the only wire format OpenRouter streams (#584) — this test
+        # must keep exercising the SSE path.
+        assert mock_session.post.call_args.kwargs["json"]["stream"] is True
 
     @pytest.mark.asyncio
     async def test_audio_sse_includes_optional_system_message(self):
@@ -488,6 +491,7 @@ class TestOpenRouterAudioE2E:
 
         assert result.audio is not None
         payload = mock_session.post.call_args.kwargs["json"]
+        assert payload["stream"] is True
         assert payload["messages"] == [
             {
                 "role": "system",

--- a/sdk/python/tests/test_media_integration.py
+++ b/sdk/python/tests/test_media_integration.py
@@ -439,7 +439,7 @@ class TestOpenRouterAudioE2E:
                 text="Say hello",
                 model="openai/gpt-audio-mini",
                 voice="nova",
-                format="mp3",  # avoid pcm→wav re-wrap so we can compare base64
+                format="pcm16",  # SSE streaming emits pcm16 audio deltas
             )
 
         assert result.audio is not None
@@ -482,7 +482,7 @@ class TestOpenRouterAudioE2E:
                 text="Read this dramatically",
                 model="openai/gpt-audio-mini",
                 voice="nova",
-                format="mp3",
+                format="pcm16",
                 system="You are a narrator. Use a calm documentary style.",
             )
 

--- a/sdk/python/tests/test_openrouter_audio.py
+++ b/sdk/python/tests/test_openrouter_audio.py
@@ -217,12 +217,12 @@ class TestOpenRouterGenerateAudio:
                 text="Say hello",
                 model="openai/gpt-audio-mini",
                 voice="alloy",
-                format="mp3",  # avoid pcm→wav rewrap so we can assert raw concat
+                format="pcm16",  # avoid pcm→wav rewrap so we can assert raw concat
             )
 
         assert result.has_audio
         assert result.audio.data == merged_b64
-        assert result.audio.format == "mp3"
+        assert result.audio.format == "pcm16"
         assert result.text == "Hello world"
 
     @pytest.mark.asyncio
@@ -249,7 +249,7 @@ class TestOpenRouterGenerateAudio:
             provider = OpenRouterProvider()
             _prime_chat_audio_cache(provider, "openai/gpt-audio-mini")
             result = await provider.generate_audio(
-                text="test", model="openai/gpt-audio-mini", format="mp3"
+                text="test", model="openai/gpt-audio-mini", format="pcm16"
             )
 
         assert result.text == "First second third."
@@ -270,7 +270,7 @@ class TestOpenRouterGenerateAudio:
             await provider.generate_audio(
                 text="test",
                 model="openrouter/openai/gpt-audio-mini",
-                format="mp3",
+                format="pcm16",
             )
 
         payload = fake_session._last_post_kwargs["json"]
@@ -290,7 +290,7 @@ class TestOpenRouterGenerateAudio:
             provider = OpenRouterProvider()
             _prime_chat_audio_cache(provider, "openai/gpt-audio-mini")
             result = await provider.generate_audio(
-                text="test", model="openai/gpt-audio-mini", format="mp3"
+                text="test", model="openai/gpt-audio-mini", format="pcm16"
             )
 
         assert not result.has_audio
@@ -309,7 +309,7 @@ class TestOpenRouterGenerateAudio:
             _prime_chat_audio_cache(provider, "openai/gpt-audio-mini")
             with pytest.raises(RuntimeError, match="failed.*400"):
                 await provider.generate_audio(
-                    text="test", model="openai/gpt-audio-mini", format="mp3"
+                    text="test", model="openai/gpt-audio-mini", format="pcm16"
                 )
 
     @pytest.mark.asyncio
@@ -340,11 +340,192 @@ class TestOpenRouterGenerateAudio:
             provider = OpenRouterProvider()
             _prime_chat_audio_cache(provider, "openai/gpt-audio-mini")
             result = await provider.generate_audio(
-                text="test", model="openai/gpt-audio-mini", format="mp3"
+                text="test", model="openai/gpt-audio-mini", format="pcm16"
             )
 
         assert result.has_audio
         assert result.audio.data == valid_b64
+
+
+
+class _FakeJsonResponse:
+    """Fake aiohttp response for non-stream JSON body."""
+
+    def __init__(self, body: bytes, status: int = 200, content_type: str = "application/json"):
+        self.status = status
+        self._body = body
+        self.headers = {"Content-Type": content_type}
+
+    async def read(self) -> bytes:
+        return self._body
+
+    async def text(self) -> str:
+        return self._body.decode("utf-8", errors="replace")
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
+class TestOpenRouterNonStreamAudio:
+    """Tests for the non-streaming chat-completions path when format != pcm16 (#584)."""
+
+    @pytest.mark.asyncio
+    async def test_mp3_format_uses_nonstream_and_parses_json(self, monkeypatch):
+        """mp3 request must go non-stream and parse the single-JSON audio response."""
+        import base64 as _b64
+
+        audio_b64 = _b64.b64encode(b"hello-mp3-bytes").decode()
+        payload_doc = {
+            "choices": [
+                {
+                    "message": {
+                        "audio": {
+                            "data": audio_b64,
+                            "transcript": "Hi there",
+                        }
+                    }
+                }
+            ]
+        }
+        body = json.dumps(payload_doc).encode()
+        fake_resp = _FakeJsonResponse(body, status=200)
+        fake_session = _FakeSession(fake_resp)
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            _prime_chat_audio_cache(provider, "openai/gpt-audio-mini")
+            result = await provider.generate_audio(
+                text="Say hi",
+                model="openai/gpt-audio-mini",
+                voice="alloy",
+                format="mp3",
+            )
+
+        # Verify stream=False was sent and we hit chat/completions
+        assert fake_session._last_post_url.endswith("/chat/completions")
+        sent_payload = fake_session._last_post_kwargs["json"]
+        assert sent_payload["stream"] is False, "mp3 must disable streaming (SSE only emits pcm16)"
+        assert sent_payload["audio"]["format"] == "mp3"
+
+        assert result.has_audio
+        assert result.audio.data == audio_b64
+        assert result.audio.format == "mp3"
+        assert result.text == "Hi there"
+
+    @pytest.mark.asyncio
+    async def test_flac_format_uses_nonstream(self, monkeypatch):
+        """flac format should also use the non-stream JSON path."""
+        import base64 as _b64
+
+        audio_b64 = _b64.b64encode(b"flac-audio").decode()
+        payload_doc = {
+            "choices": [
+                {"message": {"audio": {"data": audio_b64, "transcript": "music notes"}}}
+            ]
+        }
+        body = json.dumps(payload_doc).encode()
+        fake_resp = _FakeJsonResponse(body, status=200)
+        fake_session = _FakeSession(fake_resp)
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            _prime_chat_audio_cache(provider, "openai/gpt-audio-mini")
+            result = await provider.generate_audio(
+                text="play", model="openai/gpt-audio-mini", format="flac"
+            )
+
+        sent_payload = fake_session._last_post_kwargs["json"]
+        assert sent_payload["stream"] is False
+        assert sent_payload["audio"]["format"] == "flac"
+        assert result.audio.format == "flac"
+        assert result.audio.data == audio_b64
+        assert result.text == "music notes"
+
+    @pytest.mark.asyncio
+    async def test_nonstream_http_error_raises(self, monkeypatch):
+        """Non-200 response on non-stream path should raise RuntimeError."""
+        body = b'{"error": {"message": "format mp3 unsupported for stream"}}'
+        fake_resp = _FakeJsonResponse(body, status=400)
+        fake_session = _FakeSession(fake_resp)
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            _prime_chat_audio_cache(provider, "openai/gpt-audio-mini")
+            with pytest.raises(RuntimeError, match="request failed.*400"):
+                await provider.generate_audio(
+                    text="test", model="openai/gpt-audio-mini", format="mp3"
+                )
+
+    @pytest.mark.asyncio
+    async def test_nonstream_invalid_json_raises(self, monkeypatch):
+        """Non-stream response body that is not JSON should raise RuntimeError."""
+        body = b"<html>gateway timeout</html>"
+        fake_resp = _FakeJsonResponse(body, status=200, content_type="text/html")
+        fake_session = _FakeSession(fake_resp)
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            _prime_chat_audio_cache(provider, "openai/gpt-audio-mini")
+            with pytest.raises(RuntimeError, match="non-stream response was not valid JSON"):
+                await provider.generate_audio(
+                    text="test", model="openai/gpt-audio-mini", format="opus"
+                )
+
+    @pytest.mark.asyncio
+    async def test_nonstream_empty_choices_returns_text_only(self, monkeypatch):
+        """Response without choices should return empty audio but preserve request text."""
+        body = json.dumps({"choices": []}).encode()
+        fake_resp = _FakeJsonResponse(body, status=200)
+        fake_session = _FakeSession(fake_resp)
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            _prime_chat_audio_cache(provider, "openai/gpt-audio-mini")
+            result = await provider.generate_audio(
+                text="silence", model="openai/gpt-audio-mini", format="flac"
+            )
+
+        assert not result.has_audio
+        assert result.text == "silence"  # falls back to input text
+
+    @pytest.mark.asyncio
+    async def test_pcm16_format_still_uses_sse_streaming(self, monkeypatch):
+        """Format pcm16 must keep using SSE streaming (original path)."""
+        chunk1 = base64.b64encode(b"pcm_audio").decode()
+        events = [_audio_event(b64_chunk=chunk1, transcript="SSE path")]
+        sse_lines = _make_sse_lines(events)
+        fake_resp = _FakeStreamResponse(sse_lines, status=200)
+        fake_session = _FakeSession(fake_resp)
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            _prime_chat_audio_cache(provider, "openai/gpt-audio-mini")
+            result = await provider.generate_audio(
+                text="SSE", model="openai/gpt-audio-mini", format="pcm16"
+            )
+
+        sent_payload = fake_session._last_post_kwargs["json"]
+        assert sent_payload["stream"] is True, "pcm16 should use SSE streaming"
+        assert sent_payload["audio"]["format"] == "pcm16"
+        assert result.has_audio
+        assert result.audio.data == chunk1
+        assert result.audio.format == "pcm16"
+        assert result.text == "SSE path"
 
 
 class TestOpenRouterAudioSpeechEndpoint:


### PR DESCRIPTION
… (#584)

- OpenRouter SSE streaming only emits pcm16 audio deltas; requesting mp3/flac/opus with stream=True returns a format-related error.
- Add OpenRouterProvider._nonstream_openrouter_audio helper that calls chat/completions with stream=False and parses the JSON response body (choices[0].message.audio.{data, transcript}).
- generate_audio chat-completions path now selects streaming vs non-streaming based on the requested wire format: pcm16 -> SSE; anything else -> JSON.
- Existing SSE tests updated to use format=pcm16.
- New TestOpenRouterNonStreamAudio covers mp3/flac, HTTP errors, invalid JSON, empty choices, and pcm16 staying on the SSE path (13 tests total, all pass).

Closes: #584

<!--
Thanks for contributing to AgentField! Please keep the sections below in
the order they appear. You can delete the comment blocks and any sections
that do not apply.
-->

## Summary

<!-- 1-3 sentences describing what this PR changes and why. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] Tests only
- [ ] CI / tooling
- [ ] Breaking change

## Test plan

<!-- Concrete list of commands / steps that verify this PR. Prefer
automated tests; note any manual verification you did. Example:
- `cd control-plane && go test ./internal/services/...`
- `cd control-plane/web/client && npx vitest run src/test/pages/RunsPage.test.tsx`
-->

- [ ]
- [ ]

## Test coverage

This repo enforces a **coverage gate** on every PR (see
[`.github/workflows/coverage.yml`](.github/workflows/coverage.yml) and
[`docs/COVERAGE.md`](docs/COVERAGE.md)).

- The gate runs `./scripts/coverage-summary.sh` and compares per-surface
  numbers against `coverage-baseline.json`.
- It **fails** if any surface drops more than **1.0 pp** below its baseline,
  if any surface is below **80%**, or if the weighted aggregate falls below
  **85%**.

Before asking for review, please confirm:

- [ ] I ran tests for the surface(s) I changed locally.
- [ ] New code paths are covered by tests in this PR (no bare additions).
- [ ] If I removed code, I updated `coverage-baseline.json` in
      this PR *only if* the removal caused a legitimate regression and I
      called it out in the summary above.
- [ ] The coverage gate check is green in CI before requesting review.

> **For AI coding agents:** if the `Coverage Summary` GitHub Actions job
> fails, read the sticky PR comment titled "📊 Coverage report" — it lists
> the specific surface that regressed, the delta, and the exact command to
> reproduce locally. Add tests for the uncovered lines in this same PR
> before requesting review again. Do *not* lower baselines to silence the
> gate unless the regression is intentional and explicitly called out in
> the PR summary.

## Checklist

- [ ] I have read [CONTRIBUTING.md](CONTRIBUTING.md) (if present) and
      [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
- [ ] Commits are signed and follow conventional-commits style.
- [ ] I have linked any related issues (Fixes #123 / Closes #456).

## Related issues / PRs

<!-- Optional. Leave blank if none. -->
