### PR TITLE
fix(sdk/python): stream all OpenRouter music requests and label audio by its real container

### DIFF
--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -4206,7 +4206,7 @@ class Agent(FastAPI):
             ```python
             result = await app.ai_generate_music("upbeat jazz piano solo")
             if result.has_audio:
-                result.audio.save("jazz.wav")
+                result.audio.save(f"jazz.{result.audio.format}")
             ```
         """
         return await self.ai_handler.ai_generate_music(

--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -4189,7 +4189,9 @@ class Agent(FastAPI):
         Generate music from a text prompt.
 
         Routes to a music-capable provider (OpenRouter with models like
-        google/lyria-3-pro). Returns a MultimodalResponse with audio data.
+        google/lyria-3-pro-preview). Returns a MultimodalResponse with audio
+        data; ``.audio.format`` reports the container the model actually
+        produced, which may differ from the requested ``format``.
 
         Args:
             prompt (str): Text description of the music to generate.

--- a/sdk/python/agentfield/agent_ai.py
+++ b/sdk/python/agentfield/agent_ai.py
@@ -2043,12 +2043,14 @@ class AgentAI:
         Generate music from a text prompt.
 
         Routes to a music-capable media provider (currently OpenRouter with
-        models like google/lyria-3-pro). Returns a MultimodalResponse with
-        generated audio data (48kHz stereo).
+        models like google/lyria-3-pro-preview). Returns a MultimodalResponse
+        whose ``.audio.format`` reports the container the model actually
+        produced — today google/lyria-3-* always returns MP3 (44.1 kHz stereo)
+        whatever ``format`` is requested.
 
         Args:
             prompt: Text description of the music to generate
-            model: Music model to use (defaults to "google/lyria-3-pro")
+            model: Music model to use (defaults to "google/lyria-3-pro-preview")
             duration: Duration hint in seconds
             **kwargs: Provider-specific parameters (e.g., format="wav")
 

--- a/sdk/python/agentfield/agent_ai.py
+++ b/sdk/python/agentfield/agent_ai.py
@@ -2060,7 +2060,7 @@ class AgentAI:
         Examples:
             result = await app.ai_generate_music("upbeat jazz piano solo")
             if result.has_audio:
-                result.audio.save("jazz.wav")
+                result.audio.save(f"jazz.{result.audio.format}")
 
             result = await app.ai_generate_music(
                 "calm ambient electronic music",

--- a/sdk/python/agentfield/media_providers.py
+++ b/sdk/python/agentfield/media_providers.py
@@ -2722,8 +2722,7 @@ class OpenRouterProvider(MediaProvider):
             doc = json_mod.loads(raw.decode("utf-8"))
         except json_mod.JSONDecodeError as exc:
             raise RuntimeError(
-                f"OpenRouter {label} non-stream response was not valid JSON: "
-                f"{exc}"
+                f"OpenRouter {label} non-stream response was not valid JSON: {exc}"
             ) from exc
 
         choices = doc.get("choices") or []
@@ -2742,8 +2741,7 @@ class OpenRouterProvider(MediaProvider):
             total_size = len(b64_data)
             if total_size > MAX_AUDIO_B64_BYTES:
                 raise RuntimeError(
-                    f"Audio base64 data exceeded "
-                    f"{MAX_AUDIO_B64_BYTES} byte limit"
+                    f"Audio base64 data exceeded {MAX_AUDIO_B64_BYTES} byte limit"
                 )
 
         return b64_data, transcript
@@ -2969,14 +2967,20 @@ class OpenRouterProvider(MediaProvider):
         """
         Generate music via OpenRouter using a music-capable model.
 
-        Uses SSE streaming chat completions with audio modality, similar to
-        generate_audio but targeting music generation models.
+        Uses chat completions with the audio modality, similar to
+        generate_audio but targeting music generation models. The transport is
+        chosen from the requested format, exactly as in generate_audio:
+        ``wav``/``pcm16`` stream over SSE (``wav`` is requested as ``pcm16`` on
+        the wire and wrapped in a RIFF container client-side), while any other
+        format (mp3 / flac / opus) uses the non-streaming JSON response,
+        because OpenRouter rejects ``stream=true`` for those (Issue #584).
 
         Args:
             prompt: Text description of the music to generate
             model: Music model (defaults to "google/lyria-3-pro")
             duration: Duration hint in seconds (must be >0 and <=600)
-            **kwargs: Additional parameters (timeout overrides default 300s)
+            **kwargs: Additional parameters (``format`` defaults to ``wav``;
+                ``timeout`` overrides the default 300s)
 
         Returns:
             MultimodalResponse with generated audio (48kHz stereo)
@@ -3006,12 +3010,22 @@ class OpenRouterProvider(MediaProvider):
         audio_format = kwargs.pop("format", "wav")
         timeout = kwargs.pop("timeout", 300.0)
 
+        # SSE streaming only emits pcm16 audio deltas — ask for pcm16 over the
+        # wire when the caller wants wav and synthesize the RIFF container
+        # client-side below (same trick as generate_audio).
+        wire_format = "pcm16" if audio_format == "wav" else audio_format
+        # OpenRouter rejects stream=true for any wire format other than pcm16
+        # ("'audio.format' does not support 'wav' when stream=true"), so any
+        # other format (mp3 / flac / opus) must use the non-streaming JSON
+        # response path instead (see: Issue #584).
+        use_stream = wire_format == "pcm16"
+
         payload = {
             "model": send_model,
             "messages": [{"role": "user", "content": user_content}],
             "modalities": ["text", "audio"],
-            "audio": {"format": audio_format},
-            "stream": True,
+            "audio": {"format": wire_format},
+            "stream": use_stream,
         }
 
         headers = {
@@ -3020,9 +3034,18 @@ class OpenRouterProvider(MediaProvider):
         }
         headers = merge_attribution_headers(headers)
 
-        b64_full, transcript = await self._stream_openrouter_audio(
-            payload, headers, timeout=timeout, label="music"
-        )
+        if use_stream:
+            b64_full, transcript = await self._stream_openrouter_audio(
+                payload, headers, timeout=timeout, label="music"
+            )
+        else:
+            b64_full, transcript = await self._nonstream_openrouter_audio(
+                payload, headers, timeout=timeout, label="music"
+            )
+
+        # Re-wrap pcm16 -> wav if the caller asked for wav.
+        if audio_format == "wav" and b64_full:
+            b64_full = _wrap_pcm16_as_wav_b64(b64_full, sample_rate=24000)
 
         audio_output = AudioOutput(
             data=b64_full if b64_full else None,

--- a/sdk/python/agentfield/media_providers.py
+++ b/sdk/python/agentfield/media_providers.py
@@ -2125,6 +2125,15 @@ def _wrap_pcm16_as_wav_b64(pcm_b64: str, *, sample_rate: int = 24000) -> str:
 # Second byte of an MPEG audio frame header (0xFF sync + MPEG1/2/2.5 Layer III).
 _MPEG_SYNC_SECOND_BYTES = frozenset({0xFA, 0xFB, 0xF2, 0xF3})
 
+# Containers that legitimately satisfy a requested format: Opus is carried in
+# an Ogg container, and "pcm" is the same raw frames as "pcm16". Anything not
+# listed is satisfied only by itself.
+_AUDIO_FORMAT_ALIASES = {
+    "opus": frozenset({"opus", "ogg"}),
+    "pcm": frozenset({"pcm", "pcm16"}),
+    "pcm16": frozenset({"pcm16", "pcm"}),
+}
+
 
 def _sniff_audio_container(data: bytes) -> Optional[str]:
     """Identify an audio container from the leading magic bytes of ``data``.
@@ -2164,7 +2173,7 @@ def _label_streamed_audio(
       labelled with the container that was found;
     * no recognised container means raw PCM16 frames, which are wrapped in a
       24 kHz mono RIFF/WAVE header when the caller asked for ``wav`` and passed
-      through with the requested label otherwise.
+      through labelled ``pcm16`` otherwise.
 
     A single warning is logged whenever the container actually present differs
     from the one the caller asked for.
@@ -2191,10 +2200,13 @@ def _label_streamed_audio(
         b64_data = _wrap_pcm16_as_wav_b64(b64_data, sample_rate=24000)
         result_format = "wav"
     else:
-        result_format = requested_format
+        # No container at all: these are raw PCM16 frames whatever was asked
+        # for. Say so rather than stamping them with a label that is untrue.
+        result_format = "pcm16"
 
     wrapped_raw_pcm = detected is None and requested_format == "wav"
-    if container != requested_format and not wrapped_raw_pcm:
+    satisfied = _AUDIO_FORMAT_ALIASES.get(requested_format, {requested_format})
+    if container not in satisfied and not wrapped_raw_pcm:
         from agentfield.logger import log_warn
 
         log_warn(

--- a/sdk/python/agentfield/media_providers.py
+++ b/sdk/python/agentfield/media_providers.py
@@ -2751,85 +2751,6 @@ class OpenRouterProvider(MediaProvider):
         transcript = "".join(transcript_parts)
         return b64_full, transcript
 
-    async def _nonstream_openrouter_audio(
-        self,
-        payload: Dict[str, Any],
-        headers: Dict[str, str],
-        *,
-        timeout: float = 300.0,
-        label: str = "audio",
-    ) -> tuple:
-        """
-        Non-streaming helper for OpenRouter audio (chat-completions) requests.
-
-        Used when the requested wire format is *not* ``pcm16``, because the
-        OpenRouter SSE streaming endpoint only emits ``pcm16`` audio deltas
-        and will reject other formats (mp3 / flac / opus) with a 400.
-
-        The non-streaming response is a single JSON document whose shape
-        mirrors the last SSE event::
-
-            {"choices": [{"message": {"audio": {"data": "...",
-                                                  "transcript": "..."}}]}]}
-
-        Args:
-            payload: JSON body for the chat completions request (``stream``
-                must already be set to ``False`` by the caller).
-            headers: HTTP headers including Authorization
-            timeout: Total request timeout in seconds (default 300)
-            label: Label for error messages ("audio" or "music")
-
-        Returns:
-            Tuple of ``(b64_data: str, transcript: str)``
-        """
-        import json as json_mod
-
-        import aiohttp
-
-        client_timeout = aiohttp.ClientTimeout(total=timeout)
-
-        async with aiohttp.ClientSession(timeout=client_timeout) as session:
-            async with session.post(
-                "https://openrouter.ai/api/v1/chat/completions",
-                json=payload,
-                headers=headers,
-            ) as resp:
-                if resp.status != 200:
-                    body = await resp.text()
-                    raise RuntimeError(
-                        f"OpenRouter {label} request failed ({resp.status}): "
-                        f"{body[:500]}"
-                    )
-                raw = await resp.read()
-
-        try:
-            doc = json_mod.loads(raw.decode("utf-8"))
-        except json_mod.JSONDecodeError as exc:
-            raise RuntimeError(
-                f"OpenRouter {label} non-stream response was not valid JSON: {exc}"
-            ) from exc
-
-        choices = doc.get("choices") or []
-        if not choices:
-            return "", ""
-
-        # OpenRouter non-stream response places the final audio+transcript
-        # under choices[0].message.audio — mirroring the SSE delta schema but
-        # using the full "message" instead of a "delta".
-        message = choices[0].get("message") or {}
-        audio = message.get("audio") or {}
-        b64_data = audio.get("data") or ""
-        transcript = audio.get("transcript") or ""
-
-        if b64_data:
-            total_size = len(b64_data)
-            if total_size > MAX_AUDIO_B64_BYTES:
-                raise RuntimeError(
-                    f"Audio base64 data exceeded {MAX_AUDIO_B64_BYTES} byte limit"
-                )
-
-        return b64_data, transcript
-
     async def generate_audio(
         self,
         text: str,
@@ -2862,9 +2783,11 @@ class OpenRouterProvider(MediaProvider):
                 "hexgrad/kokoro-82m"). Default: ``hexgrad/kokoro-82m``.
             voice: Voice identifier (model-specific — e.g. ``alloy`` for
                 OpenAI, ``af_bella`` for Kokoro)
-            format: Audio format (wav, mp3, flac, opus, pcm16). ``wav`` is
-                synthesized client-side when the upstream endpoint only emits
-                pcm.
+            format: Audio format. ``/audio/speech`` models accept
+                wav / mp3 / flac / opus / aac; chat-audio models
+                (``openai/gpt-audio*``) can only deliver ``pcm16``, so only
+                ``pcm16`` and ``wav`` (wrapped client-side from pcm16) are
+                accepted there — any other value raises ``ValueError``.
             speed: Optional speech speed for ``/audio/speech`` models.
             extra: Optional extra request fields for ``/audio/speech`` models.
             system: Optional system instructions for chat-completions audio
@@ -2873,6 +2796,11 @@ class OpenRouterProvider(MediaProvider):
 
         Returns:
             MultimodalResponse with generated audio
+
+        Raises:
+            ValueError: if a chat-audio model is asked for a container other
+                than ``pcm16``/``wav`` (raised before the generation request
+                is sent).
         """
         import os
 
@@ -2936,32 +2864,34 @@ class OpenRouterProvider(MediaProvider):
             )
 
         # Chat-completions audio modality path (gpt-audio family).
-        # Streaming on the OpenAI provider only emits pcm16 — fall back to
-        # pcm16 over the wire and re-wrap to user's requested format below.
-        wire_format = "pcm16" if audio_format == "wav" else audio_format
+        # OpenRouter's gateway rejects stream=false for *any* audio-output
+        # request, and the streaming transport only ever emits pcm16 deltas —
+        # so pcm16 is the only container this route can deliver. Refuse the
+        # impossible formats here, before a request is spent on a 400. (The
+        # /audio/speech route above is unaffected and still serves
+        # mp3/flac/opus/aac.)
+        if audio_format not in ("wav", "pcm16"):
+            raise ValueError(
+                f"format={audio_format!r} is not available from OpenRouter "
+                f"chat-audio models: the audio modality delivers pcm16 only. "
+                f"Use format='pcm16', or format='wav' to have the pcm16 "
+                f"stream wrapped in a RIFF container client-side."
+            )
+
+        wire_format = "pcm16"
         messages = [{"role": "user", "content": text}]
         if system is not None:
             messages.insert(0, {"role": "system", "content": system})
-        # OpenRouter SSE streaming only supports pcm16 wire format — any
-        # other format (mp3 / flac / opus) must use the non-streaming JSON
-        # response path, otherwise OpenRouter rejects the request with a
-        # format-related error (see: Issue #584).
-        use_stream = wire_format == "pcm16"
         payload = {
             "model": send_model,
             "messages": messages,
             "modalities": ["text", "audio"],
             "audio": {"voice": voice, "format": wire_format},
-            "stream": use_stream,
+            "stream": True,
         }
-        if use_stream:
-            b64_full, transcript = await self._stream_openrouter_audio(
-                payload, headers, timeout=timeout, label="audio"
-            )
-        else:
-            b64_full, transcript = await self._nonstream_openrouter_audio(
-                payload, headers, timeout=timeout, label="audio"
-            )
+        b64_full, transcript = await self._stream_openrouter_audio(
+            payload, headers, timeout=timeout, label="audio"
+        )
 
         # Re-wrap pcm16 -> wav if user asked for wav.
         if audio_format == "wav" and b64_full:

--- a/sdk/python/agentfield/media_providers.py
+++ b/sdk/python/agentfield/media_providers.py
@@ -2122,6 +2122,90 @@ def _wrap_pcm16_as_wav_b64(pcm_b64: str, *, sample_rate: int = 24000) -> str:
     return base64.b64encode(wav).decode("ascii")
 
 
+# Second byte of an MPEG audio frame header (0xFF sync + MPEG1/2/2.5 Layer III).
+_MPEG_SYNC_SECOND_BYTES = frozenset({0xFA, 0xFB, 0xF2, 0xF3})
+
+
+def _sniff_audio_container(data: bytes) -> Optional[str]:
+    """Identify an audio container from the leading magic bytes of ``data``.
+
+    Returns ``"mp3"``, ``"wav"``, ``"flac"`` or ``"ogg"`` when ``data`` starts
+    with that container's signature, and ``None`` when nothing matches — which,
+    for OpenRouter's chat-completions audio modality, means the payload is raw
+    little-endian PCM16 frames carrying no container at all.
+    """
+    if len(data) < 4:
+        return None
+    if data[:3] == b"ID3":
+        return "mp3"
+    if data[0] == 0xFF and data[1] in _MPEG_SYNC_SECOND_BYTES:
+        return "mp3"
+    if data[:4] == b"RIFF" and data[8:12] == b"WAVE":
+        return "wav"
+    if data[:4] == b"fLaC":
+        return "flac"
+    if data[:4] == b"OggS":
+        return "ogg"
+    return None
+
+
+def _label_streamed_audio(
+    b64_data: str, requested_format: str, *, model: str = ""
+) -> tuple[str, str]:
+    """Label streamed OpenRouter audio by what the bytes actually are.
+
+    OpenRouter's music models ignore the requested ``audio.format`` and answer
+    with whatever container the upstream model produces (``google/lyria-3-*``
+    currently always returns MP3). Trusting the requested format therefore
+    mislabels — and, when it triggers a client-side RIFF wrap, corrupts — the
+    result, so the decoded bytes are sniffed instead:
+
+    * a recognised container wins: the payload is returned untouched and
+      labelled with the container that was found;
+    * no recognised container means raw PCM16 frames, which are wrapped in a
+      24 kHz mono RIFF/WAVE header when the caller asked for ``wav`` and passed
+      through with the requested label otherwise.
+
+    A single warning is logged whenever the container actually present differs
+    from the one the caller asked for.
+
+    Returns ``(b64_data, format)``.
+    """
+    import base64
+
+    if not b64_data:
+        return b64_data, requested_format
+
+    try:
+        raw = base64.b64decode(b64_data)
+    except ValueError:
+        # Undecodable payload — nothing to sniff, hand it back as requested.
+        return b64_data, requested_format
+
+    detected = _sniff_audio_container(raw)
+    container = detected or "pcm16"
+
+    if detected is not None:
+        result_format = detected
+    elif requested_format == "wav":
+        b64_data = _wrap_pcm16_as_wav_b64(b64_data, sample_rate=24000)
+        result_format = "wav"
+    else:
+        result_format = requested_format
+
+    wrapped_raw_pcm = detected is None and requested_format == "wav"
+    if container != requested_format and not wrapped_raw_pcm:
+        from agentfield.logger import log_warn
+
+        log_warn(
+            f"OpenRouter returned {container} audio for "
+            f"{model or 'the requested model'} but format={requested_format!r} "
+            f"was requested; labelling the result as {result_format!r}."
+        )
+
+    return b64_data, result_format
+
+
 class OpenRouterProvider(MediaProvider):
     """
     OpenRouter provider for image generation via chat completions.
@@ -2967,23 +3051,31 @@ class OpenRouterProvider(MediaProvider):
         """
         Generate music via OpenRouter using a music-capable model.
 
-        Uses chat completions with the audio modality, similar to
-        generate_audio but targeting music generation models. The transport is
-        chosen from the requested format, exactly as in generate_audio:
-        ``wav``/``pcm16`` stream over SSE (``wav`` is requested as ``pcm16`` on
-        the wire and wrapped in a RIFF container client-side), while any other
-        format (mp3 / flac / opus) uses the non-streaming JSON response,
-        because OpenRouter rejects ``stream=true`` for those (Issue #584).
+        Always uses SSE streaming chat completions with the audio modality:
+        OpenRouter's music models reject a non-streaming audio request with
+        ``Audio output requires stream: true``, so the transport does not vary
+        with the requested format.
+
+        The requested ``format`` is forwarded as ``audio.format``, but current
+        music models ignore it — ``google/lyria-3-*`` answers with MP3 whatever
+        is asked for. The returned container is therefore detected from the
+        bytes and reported on ``response.audio.format``, and a mismatch with
+        the requested format is logged once. A payload with no container header
+        is treated as raw PCM16 and wrapped in a 24 kHz mono WAV container when
+        ``wav`` was requested.
 
         Args:
             prompt: Text description of the music to generate
-            model: Music model (defaults to "google/lyria-3-pro")
+            model: Music model (defaults to "google/lyria-3-pro-preview")
             duration: Duration hint in seconds (must be >0 and <=600)
             **kwargs: Additional parameters (``format`` defaults to ``wav``;
                 ``timeout`` overrides the default 300s)
 
         Returns:
-            MultimodalResponse with generated audio (48kHz stereo)
+            MultimodalResponse with generated audio. The container and sample
+            rate are whatever the model produced — ``google/lyria-3-pro-preview``
+            currently returns MP3 at 44.1 kHz stereo — and the detected
+            container is reported on ``response.audio.format``.
         """
         import os
 
@@ -2993,7 +3085,7 @@ class OpenRouterProvider(MediaProvider):
                 "OpenRouter API key required. Set OPENROUTER_API_KEY env var or pass api_key."
             )
 
-        send_model = model or "google/lyria-3-pro"
+        send_model = model or "google/lyria-3-pro-preview"
         if send_model.startswith("openrouter/"):
             send_model = send_model[len("openrouter/") :]
 
@@ -3010,22 +3102,17 @@ class OpenRouterProvider(MediaProvider):
         audio_format = kwargs.pop("format", "wav")
         timeout = kwargs.pop("timeout", 300.0)
 
-        # SSE streaming only emits pcm16 audio deltas — ask for pcm16 over the
-        # wire when the caller wants wav and synthesize the RIFF container
-        # client-side below (same trick as generate_audio).
-        wire_format = "pcm16" if audio_format == "wav" else audio_format
-        # OpenRouter rejects stream=true for any wire format other than pcm16
-        # ("'audio.format' does not support 'wav' when stream=true"), so any
-        # other format (mp3 / flac / opus) must use the non-streaming JSON
-        # response path instead (see: Issue #584).
-        use_stream = wire_format == "pcm16"
-
+        # Music models require stream=true for *any* audio output — a
+        # non-streaming request is rejected with "Audio output requires
+        # stream: true" regardless of audio.format. The requested format is
+        # forwarded unchanged (models ignore it today); the container that
+        # actually comes back is detected from the bytes below.
         payload = {
             "model": send_model,
             "messages": [{"role": "user", "content": user_content}],
             "modalities": ["text", "audio"],
-            "audio": {"format": wire_format},
-            "stream": use_stream,
+            "audio": {"format": audio_format},
+            "stream": True,
         }
 
         headers = {
@@ -3034,22 +3121,17 @@ class OpenRouterProvider(MediaProvider):
         }
         headers = merge_attribution_headers(headers)
 
-        if use_stream:
-            b64_full, transcript = await self._stream_openrouter_audio(
-                payload, headers, timeout=timeout, label="music"
-            )
-        else:
-            b64_full, transcript = await self._nonstream_openrouter_audio(
-                payload, headers, timeout=timeout, label="music"
-            )
+        b64_full, transcript = await self._stream_openrouter_audio(
+            payload, headers, timeout=timeout, label="music"
+        )
 
-        # Re-wrap pcm16 -> wav if the caller asked for wav.
-        if audio_format == "wav" and b64_full:
-            b64_full = _wrap_pcm16_as_wav_b64(b64_full, sample_rate=24000)
+        b64_full, result_format = _label_streamed_audio(
+            b64_full, audio_format, model=send_model
+        )
 
         audio_output = AudioOutput(
             data=b64_full if b64_full else None,
-            format=audio_format,
+            format=result_format,
             url=None,
         )
 

--- a/sdk/python/tests/test_media_integration.py
+++ b/sdk/python/tests/test_media_integration.py
@@ -551,10 +551,15 @@ class TestOpenRouterMusicE2E:
                 prompt="upbeat jazz piano solo",
                 model="google/lyria-3-pro",
                 duration=30,
+                format="pcm16",  # SSE streaming emits pcm16 audio deltas
             )
 
         assert result.audio is not None
         assert result.audio.data == "MUSIC"
+        assert result.audio.format == "pcm16"
+        # pcm16 is the only wire format OpenRouter streams (#584) — this test
+        # must keep exercising the SSE path.
+        assert mock_session.post.call_args.kwargs["json"]["stream"] is True
 
     @pytest.mark.asyncio
     async def test_music_invalid_duration_rejected(self):

--- a/sdk/python/tests/test_media_integration.py
+++ b/sdk/python/tests/test_media_integration.py
@@ -521,8 +521,9 @@ class TestOpenRouterMusicE2E:
         """Music generation routes through SSE stream -> AudioOutput."""
         provider = OpenRouterProvider(api_key="test-key")
 
+        # base64 for b"MUSIC" — no container signature, i.e. raw pcm frames.
         sse_lines = [
-            b'data: {"choices":[{"delta":{"audio":{"data":"MUSIC"}}}]}\n',
+            b'data: {"choices":[{"delta":{"audio":{"data":"TVVTSUM="}}}]}\n',
             b"data: [DONE]\n",
         ]
 
@@ -549,17 +550,20 @@ class TestOpenRouterMusicE2E:
         with patch("aiohttp.ClientSession", return_value=session_cm):
             result = await provider.generate_music(
                 prompt="upbeat jazz piano solo",
-                model="google/lyria-3-pro",
+                model="google/lyria-3-pro-preview",
                 duration=30,
-                format="pcm16",  # SSE streaming emits pcm16 audio deltas
+                format="pcm16",  # ask for pcm16 so nothing is re-wrapped
             )
 
         assert result.audio is not None
-        assert result.audio.data == "MUSIC"
+        assert result.audio.data == "TVVTSUM="
         assert result.audio.format == "pcm16"
-        # pcm16 is the only wire format OpenRouter streams (#584) — this test
-        # must keep exercising the SSE path.
+        # Music models reject stream=false for any audio output, so every
+        # generate_music request must go out as an SSE stream.
         assert mock_session.post.call_args.kwargs["json"]["stream"] is True
+        assert mock_session.post.call_args.kwargs["json"]["audio"] == {
+            "format": "pcm16"
+        }
 
     @pytest.mark.asyncio
     async def test_music_invalid_duration_rejected(self):

--- a/sdk/python/tests/test_openrouter_audio.py
+++ b/sdk/python/tests/test_openrouter_audio.py
@@ -347,11 +347,12 @@ class TestOpenRouterGenerateAudio:
         assert result.audio.data == valid_b64
 
 
-
 class _FakeJsonResponse:
     """Fake aiohttp response for non-stream JSON body."""
 
-    def __init__(self, body: bytes, status: int = 200, content_type: str = "application/json"):
+    def __init__(
+        self, body: bytes, status: int = 200, content_type: str = "application/json"
+    ):
         self.status = status
         self._body = body
         self.headers = {"Content-Type": content_type}
@@ -409,7 +410,9 @@ class TestOpenRouterNonStreamAudio:
         # Verify stream=False was sent and we hit chat/completions
         assert fake_session._last_post_url.endswith("/chat/completions")
         sent_payload = fake_session._last_post_kwargs["json"]
-        assert sent_payload["stream"] is False, "mp3 must disable streaming (SSE only emits pcm16)"
+        assert sent_payload["stream"] is False, (
+            "mp3 must disable streaming (SSE only emits pcm16)"
+        )
         assert sent_payload["audio"]["format"] == "mp3"
 
         assert result.has_audio
@@ -477,7 +480,9 @@ class TestOpenRouterNonStreamAudio:
         with patch("aiohttp.ClientSession", return_value=fake_session):
             provider = OpenRouterProvider()
             _prime_chat_audio_cache(provider, "openai/gpt-audio-mini")
-            with pytest.raises(RuntimeError, match="non-stream response was not valid JSON"):
+            with pytest.raises(
+                RuntimeError, match="non-stream response was not valid JSON"
+            ):
                 await provider.generate_audio(
                     text="test", model="openai/gpt-audio-mini", format="opus"
                 )
@@ -637,6 +642,9 @@ class TestGenerateMusic:
                 prompt="jazz piano",
                 model="google/lyria-3-pro",
                 duration=30,
+                # pcm16 is the only wire format OpenRouter streams (#584), and
+                # it avoids the pcm→wav re-wrap so we can compare base64.
+                format="pcm16",
             )
 
         assert result.has_audio
@@ -645,6 +653,7 @@ class TestGenerateMusic:
 
         # Verify duration was included in prompt
         payload = fake_session._last_post_kwargs["json"]
+        assert payload["stream"] is True
         assert "30 seconds" in payload["messages"][0]["content"]
         assert payload["model"] == "google/lyria-3-pro"
 
@@ -686,6 +695,175 @@ class TestGenerateMusic:
 
         payload = fake_session._last_post_kwargs["json"]
         assert payload["model"] == "google/lyria-3-pro"
+
+
+class TestOpenRouterMusicFormatRouting:
+    """generate_music picks its transport from the requested format (#584).
+
+    OpenRouter rejects ``stream=true`` for any audio wire format other than
+    ``pcm16``, so the default ``wav`` request must be sent as ``pcm16`` and
+    re-wrapped client-side, and mp3/flac/opus must go over the non-streaming
+    JSON path.
+    """
+
+    @staticmethod
+    def _sse_session(b64_chunk: str, transcript: str = ""):
+        lines = _make_sse_lines(
+            [_audio_event(b64_chunk=b64_chunk, transcript=transcript)]
+        )
+        return _FakeSession(_FakeStreamResponse(lines))
+
+    @staticmethod
+    def _json_session(audio_b64: str, transcript: str = "", status: int = 200):
+        body = json.dumps(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "audio": {"data": audio_b64, "transcript": transcript}
+                        }
+                    }
+                ]
+            }
+        ).encode()
+        return _FakeSession(_FakeJsonResponse(body, status=status))
+
+    @pytest.mark.asyncio
+    async def test_default_format_streams_pcm16_and_returns_wav(self, monkeypatch):
+        """C1: no format -> stream=True, wire pcm16, returned audio is RIFF/WAVE."""
+        pcm = b"\x00\x01" * 64
+        fake_session = self._sse_session(base64.b64encode(pcm).decode(), "lyria take 1")
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            result = await provider.generate_music(prompt="ambient pads")
+
+        sent = fake_session._last_post_kwargs["json"]
+        assert sent["stream"] is True, "wav must be requested as pcm16 over a stream"
+        assert sent["audio"]["format"] == "pcm16"
+
+        assert result.has_audio
+        assert result.audio.format == "wav"
+        wav_bytes = base64.b64decode(result.audio.data)
+        assert wav_bytes[:4] == b"RIFF"
+        assert wav_bytes[8:12] == b"WAVE"
+        assert pcm in wav_bytes, "the streamed pcm payload must survive the re-wrap"
+        assert result.text == "lyria take 1"
+
+    @pytest.mark.asyncio
+    async def test_pcm16_streams_and_returns_data_untouched(self, monkeypatch):
+        """C2: format=pcm16 -> stream=True and the base64 is returned verbatim."""
+        chunk = base64.b64encode(b"raw-pcm-frames").decode()
+        fake_session = self._sse_session(chunk, "pcm take")
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            result = await provider.generate_music(
+                prompt="ambient pads", format="pcm16"
+            )
+
+        sent = fake_session._last_post_kwargs["json"]
+        assert sent["stream"] is True
+        assert sent["audio"]["format"] == "pcm16"
+
+        assert result.audio.format == "pcm16"
+        assert result.audio.data == chunk
+        assert result.text == "pcm take"
+
+    @pytest.mark.parametrize("fmt", ["mp3", "flac"])
+    @pytest.mark.asyncio
+    async def test_compressed_formats_use_nonstream_json(self, monkeypatch, fmt):
+        """C3: mp3/flac -> stream=False, parsed from choices[0].message.audio."""
+        audio_b64 = base64.b64encode(f"{fmt}-music-bytes".encode()).decode()
+        fake_session = self._json_session(audio_b64, transcript="a short riff")
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            result = await provider.generate_music(prompt="a short riff", format=fmt)
+
+        assert fake_session._last_post_url.endswith("/chat/completions")
+        sent = fake_session._last_post_kwargs["json"]
+        assert sent["stream"] is False, f"{fmt} must disable streaming"
+        assert sent["audio"]["format"] == fmt
+
+        assert result.has_audio
+        assert result.audio.format == fmt
+        assert result.audio.data == audio_b64
+        assert result.text == "a short riff"
+
+    @pytest.mark.asyncio
+    async def test_nonstream_http_error_mentions_music_and_status(self, monkeypatch):
+        """C4: an HTTP error on the non-stream music path raises RuntimeError."""
+        body = b'{"error": {"message": "no such model"}}'
+        fake_session = _FakeSession(_FakeJsonResponse(body, status=402))
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            with pytest.raises(RuntimeError) as excinfo:
+                await provider.generate_music(prompt="a short riff", format="opus")
+
+        message = str(excinfo.value)
+        assert "music" in message
+        assert "402" in message
+        # Pin the transport: opus must have gone down the non-streaming path.
+        assert fake_session._last_post_kwargs["json"]["stream"] is False
+
+    @pytest.mark.parametrize(
+        ("fmt", "expect_stream"),
+        [("wav", True), ("pcm16", True), ("mp3", False)],
+    )
+    @pytest.mark.asyncio
+    async def test_request_shape_is_identical_across_transports(
+        self, monkeypatch, fmt, expect_stream
+    ):
+        """C5: prompt/messages/model/modalities do not vary with the transport."""
+        if expect_stream:
+            fake_session = self._sse_session(
+                base64.b64encode(b"\x00\x01\x00\x01").decode()
+            )
+        else:
+            fake_session = self._json_session(base64.b64encode(b"mp3").decode())
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            await provider.generate_music(
+                prompt="lo-fi beats",
+                model="openrouter/google/lyria-3-pro",
+                duration=45,
+                format=fmt,
+            )
+
+        sent = fake_session._last_post_kwargs["json"]
+        assert sent["model"] == "google/lyria-3-pro"
+        assert sent["messages"] == [
+            {"role": "user", "content": "lo-fi beats (duration: 45 seconds)"}
+        ]
+        assert sent["modalities"] == ["text", "audio"]
+        assert sent["stream"] is expect_stream
+
+    @pytest.mark.asyncio
+    async def test_duration_validation_runs_before_any_request(self, monkeypatch):
+        """C5: duration validation is unchanged and still precedes the HTTP call."""
+        fake_session = self._json_session(base64.b64encode(b"mp3").decode())
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            with pytest.raises(ValueError, match="duration must be"):
+                await provider.generate_music(prompt="x", duration=601, format="mp3")
+
+        assert not hasattr(fake_session, "_last_post_kwargs")
 
 
 # =============================================================================

--- a/sdk/python/tests/test_openrouter_audio.py
+++ b/sdk/python/tests/test_openrouter_audio.py
@@ -803,7 +803,7 @@ class TestOpenRouterMusicTransportAndLabelling:
     async def test_raw_pcm_with_mp3_requested_passes_through_and_warns(
         self, monkeypatch
     ):
-        """M5/M6: no container + mp3 asked for -> passthrough plus one warning."""
+        """M5/M6: no container + mp3 asked for -> passthrough, labelled pcm16, one warning."""
         warnings = self._capture_warnings(monkeypatch)
         pcm = b"\x00\x01" * 64
         chunk = base64.b64encode(pcm).decode()
@@ -815,10 +815,27 @@ class TestOpenRouterMusicTransportAndLabelling:
             result = await provider.generate_music(prompt="a riff", format="mp3")
 
         assert result.audio.data == chunk, "raw pcm must not be re-encoded"
-        assert result.audio.format == "mp3"
+        assert result.audio.format == "pcm16", "raw frames are not mp3, say so"
         assert len(warnings) == 1
         assert "pcm16" in warnings[0]
         assert "mp3" in warnings[0]
+
+    @pytest.mark.asyncio
+    async def test_opus_request_satisfied_by_ogg_container_logs_nothing(
+        self, monkeypatch
+    ):
+        """M6: Opus travels in an Ogg container - OggS for format=opus is no mismatch."""
+        warnings = self._capture_warnings(monkeypatch)
+        ogg = b"OggS" + b"\x00" * 60
+        fake_session = self._sse_session(ogg)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            result = await provider.generate_music(prompt="a riff", format="opus")
+
+        assert result.audio.format == "ogg"
+        assert warnings == []
 
     @pytest.mark.asyncio
     async def test_matching_container_logs_nothing(self, monkeypatch):

--- a/sdk/python/tests/test_openrouter_audio.py
+++ b/sdk/python/tests/test_openrouter_audio.py
@@ -3,6 +3,7 @@ Tests for OpenRouter audio output and music generation.
 
 Covers:
 - SSE stream parsing for generate_audio
+- generate_audio rejecting containers OpenRouter cannot deliver
 - Audio chunk concatenation
 - Transcript extraction
 - Model prefix stripping
@@ -352,93 +353,45 @@ class TestOpenRouterGenerateAudio:
         assert result.audio.data == valid_b64
 
 
-class _FakeJsonResponse:
-    """Fake aiohttp response for non-stream JSON body."""
+class TestOpenRouterChatAudioFormatGuard:
+    """Chat-audio models can only deliver pcm16, so anything else fails fast.
 
-    def __init__(
-        self, body: bytes, status: int = 200, content_type: str = "application/json"
-    ):
-        self.status = status
-        self._body = body
-        self.headers = {"Content-Type": content_type}
+    OpenRouter's gateway rejects ``stream: false`` for *any* audio-output
+    request (whatever the model), and the streaming transport only ever emits
+    pcm16 deltas — there is no combination that yields mp3/flac/opus from a
+    chat-audio model, so asking for one must raise before a request is spent.
+    """
 
-    async def read(self) -> bytes:
-        return self._body
-
-    async def text(self) -> str:
-        return self._body.decode("utf-8", errors="replace")
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *args):
-        pass
-
-
-class TestOpenRouterNonStreamAudio:
-    """Tests for the non-streaming chat-completions path when format != pcm16 (#584)."""
-
+    @pytest.mark.parametrize("fmt", ["mp3", "flac", "opus", "pcm"])
     @pytest.mark.asyncio
-    async def test_mp3_format_uses_nonstream_and_parses_json(self, monkeypatch):
-        """mp3 request must go non-stream and parse the single-JSON audio response."""
-        import base64 as _b64
-
-        audio_b64 = _b64.b64encode(b"hello-mp3-bytes").decode()
-        payload_doc = {
-            "choices": [
-                {
-                    "message": {
-                        "audio": {
-                            "data": audio_b64,
-                            "transcript": "Hi there",
-                        }
-                    }
-                }
-            ]
-        }
-        body = json.dumps(payload_doc).encode()
-        fake_resp = _FakeJsonResponse(body, status=200)
-        fake_session = _FakeSession(fake_resp)
+    async def test_unsupported_format_raises_before_any_request(self, monkeypatch, fmt):
+        """A1: ValueError naming the format, and nothing goes over the wire."""
+        fake_session = _FakeSession(_FakeStreamResponse(_make_sse_lines([])))
 
         monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
 
         with patch("aiohttp.ClientSession", return_value=fake_session):
             provider = OpenRouterProvider()
             _prime_chat_audio_cache(provider, "openai/gpt-audio-mini")
-            result = await provider.generate_audio(
-                text="Say hi",
-                model="openai/gpt-audio-mini",
-                voice="alloy",
-                format="mp3",
-            )
+            with pytest.raises(ValueError) as excinfo:
+                await provider.generate_audio(
+                    text="Say hi", model="openai/gpt-audio-mini", format=fmt
+                )
 
-        # Verify stream=False was sent and we hit chat/completions
-        assert fake_session._last_post_url.endswith("/chat/completions")
-        sent_payload = fake_session._last_post_kwargs["json"]
-        assert sent_payload["stream"] is False, (
-            "mp3 must disable streaming (SSE only emits pcm16)"
+        message = str(excinfo.value)
+        assert fmt in message
+        assert "pcm16" in message
+        assert "wav" in message
+        assert not hasattr(fake_session, "_last_post_kwargs"), (
+            "no request may be spent on a format that cannot come back"
         )
-        assert sent_payload["audio"]["format"] == "mp3"
-
-        assert result.has_audio
-        assert result.audio.data == audio_b64
-        assert result.audio.format == "mp3"
-        assert result.text == "Hi there"
 
     @pytest.mark.asyncio
-    async def test_flac_format_uses_nonstream(self, monkeypatch):
-        """flac format should also use the non-stream JSON path."""
-        import base64 as _b64
-
-        audio_b64 = _b64.b64encode(b"flac-audio").decode()
-        payload_doc = {
-            "choices": [
-                {"message": {"audio": {"data": audio_b64, "transcript": "music notes"}}}
-            ]
-        }
-        body = json.dumps(payload_doc).encode()
-        fake_resp = _FakeJsonResponse(body, status=200)
-        fake_session = _FakeSession(fake_resp)
+    async def test_unknown_format_still_falls_back_to_wav(self, monkeypatch):
+        """A1: an unrecognised format is normalised to wav, not rejected."""
+        pcm = b"\x00\x01" * 32
+        events = [_audio_event(b64_chunk=base64.b64encode(pcm).decode())]
+        fake_session = _FakeSession(_FakeStreamResponse(_make_sse_lines(events)))
 
         monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
 
@@ -446,58 +399,19 @@ class TestOpenRouterNonStreamAudio:
             provider = OpenRouterProvider()
             _prime_chat_audio_cache(provider, "openai/gpt-audio-mini")
             result = await provider.generate_audio(
-                text="play", model="openai/gpt-audio-mini", format="flac"
+                text="hi", model="openai/gpt-audio-mini", format="aac"
             )
 
-        sent_payload = fake_session._last_post_kwargs["json"]
-        assert sent_payload["stream"] is False
-        assert sent_payload["audio"]["format"] == "flac"
-        assert result.audio.format == "flac"
-        assert result.audio.data == audio_b64
-        assert result.text == "music notes"
+        assert fake_session._last_post_kwargs["json"]["audio"]["format"] == "pcm16"
+        assert result.audio.format == "wav"
 
     @pytest.mark.asyncio
-    async def test_nonstream_http_error_raises(self, monkeypatch):
-        """Non-200 response on non-stream path should raise RuntimeError."""
-        body = b'{"error": {"message": "format mp3 unsupported for stream"}}'
-        fake_resp = _FakeJsonResponse(body, status=400)
-        fake_session = _FakeSession(fake_resp)
-
-        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
-
-        with patch("aiohttp.ClientSession", return_value=fake_session):
-            provider = OpenRouterProvider()
-            _prime_chat_audio_cache(provider, "openai/gpt-audio-mini")
-            with pytest.raises(RuntimeError, match="request failed.*400"):
-                await provider.generate_audio(
-                    text="test", model="openai/gpt-audio-mini", format="mp3"
-                )
-
-    @pytest.mark.asyncio
-    async def test_nonstream_invalid_json_raises(self, monkeypatch):
-        """Non-stream response body that is not JSON should raise RuntimeError."""
-        body = b"<html>gateway timeout</html>"
-        fake_resp = _FakeJsonResponse(body, status=200, content_type="text/html")
-        fake_session = _FakeSession(fake_resp)
-
-        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
-
-        with patch("aiohttp.ClientSession", return_value=fake_session):
-            provider = OpenRouterProvider()
-            _prime_chat_audio_cache(provider, "openai/gpt-audio-mini")
-            with pytest.raises(
-                RuntimeError, match="non-stream response was not valid JSON"
-            ):
-                await provider.generate_audio(
-                    text="test", model="openai/gpt-audio-mini", format="opus"
-                )
-
-    @pytest.mark.asyncio
-    async def test_nonstream_empty_choices_returns_text_only(self, monkeypatch):
-        """Response without choices should return empty audio but preserve request text."""
-        body = json.dumps({"choices": []}).encode()
-        fake_resp = _FakeJsonResponse(body, status=200)
-        fake_session = _FakeSession(fake_resp)
+    async def test_wav_streams_as_pcm16_and_returns_riff(self, monkeypatch):
+        """A3: wav is still requested as pcm16 and wrapped client-side."""
+        pcm = b"\x00\x01" * 32
+        chunk = base64.b64encode(pcm).decode()
+        events = [_audio_event(b64_chunk=chunk, transcript="wav path")]
+        fake_session = _FakeSession(_FakeStreamResponse(_make_sse_lines(events)))
 
         monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
 
@@ -505,15 +419,25 @@ class TestOpenRouterNonStreamAudio:
             provider = OpenRouterProvider()
             _prime_chat_audio_cache(provider, "openai/gpt-audio-mini")
             result = await provider.generate_audio(
-                text="silence", model="openai/gpt-audio-mini", format="flac"
+                text="hi", model="openai/gpt-audio-mini", format="wav"
             )
 
-        assert not result.has_audio
-        assert result.text == "silence"  # falls back to input text
+        sent = fake_session._last_post_kwargs["json"]
+        assert sent["stream"] is True
+        assert sent["audio"]["format"] == "pcm16"
+
+        assert result.audio.format == "wav"
+        wav_bytes = base64.b64decode(result.audio.data)
+        assert wav_bytes[:4] == b"RIFF"
+        assert wav_bytes[8:12] == b"WAVE"
+        with wave.open(io.BytesIO(wav_bytes)) as handle:
+            assert handle.getframerate() == 24000
+            assert handle.getnchannels() == 1
+        assert pcm in wav_bytes
 
     @pytest.mark.asyncio
     async def test_pcm16_format_still_uses_sse_streaming(self, monkeypatch):
-        """Format pcm16 must keep using SSE streaming (original path)."""
+        """A2: pcm16 keeps streaming and returns the base64 verbatim."""
         chunk1 = base64.b64encode(b"pcm_audio").decode()
         events = [_audio_event(b64_chunk=chunk1, transcript="SSE path")]
         sse_lines = _make_sse_lines(events)
@@ -605,6 +529,8 @@ class TestOpenRouterAudioSpeechEndpoint:
         payload = fake_session._last_post_kwargs["json"]
         assert payload["speed"] == 1.25
         assert payload["language"] == "en-US"
+        # A4: the chat-audio pcm16 guard must not reach the /audio/speech
+        # route, which serves mp3/flac/opus natively.
         assert payload["response_format"] == "mp3"
 
 

--- a/sdk/python/tests/test_openrouter_audio.py
+++ b/sdk/python/tests/test_openrouter_audio.py
@@ -6,6 +6,7 @@ Covers:
 - Audio chunk concatenation
 - Transcript extraction
 - Model prefix stripping
+- generate_music transport (always SSE) and container sniffing
 - generate_music on ABC (raises NotImplementedError by default)
 - supported_modalities includes "audio" and "music"
 - ai_generate_music convenience method on AgentAI
@@ -13,7 +14,9 @@ Covers:
 
 import base64
 import copy
+import io
 import json
+import wave
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -24,6 +27,8 @@ from agentfield.media_providers import (
     FalProvider,
     LiteLLMProvider,
     OpenRouterProvider,
+    _label_streamed_audio,
+    _sniff_audio_container,
 )
 from agentfield.multimodal_response import AudioOutput, MultimodalResponse
 
@@ -637,13 +642,13 @@ class TestGenerateMusic:
 
         with patch("aiohttp.ClientSession", return_value=fake_session):
             provider = OpenRouterProvider()
-            _prime_chat_audio_cache(provider, "google/lyria-3-pro")
+            _prime_chat_audio_cache(provider, "google/lyria-3-pro-preview")
             result = await provider.generate_music(
                 prompt="jazz piano",
-                model="google/lyria-3-pro",
+                model="google/lyria-3-pro-preview",
                 duration=30,
-                # pcm16 is the only wire format OpenRouter streams (#584), and
-                # it avoids the pcm→wav re-wrap so we can compare base64.
+                # Ask for pcm16 so the payload (which carries no container
+                # header) is returned verbatim and we can compare base64.
                 format="pcm16",
             )
 
@@ -655,11 +660,11 @@ class TestGenerateMusic:
         payload = fake_session._last_post_kwargs["json"]
         assert payload["stream"] is True
         assert "30 seconds" in payload["messages"][0]["content"]
-        assert payload["model"] == "google/lyria-3-pro"
+        assert payload["model"] == "google/lyria-3-pro-preview"
 
     @pytest.mark.asyncio
     async def test_openrouter_generate_music_default_model(self, monkeypatch):
-        """generate_music should default to google/lyria-3-pro."""
+        """generate_music should default to google/lyria-3-pro-preview."""
         events = [_audio_event(b64_chunk="AAAA")]
         lines = _make_sse_lines(events)
         fake_resp = _FakeStreamResponse(lines)
@@ -669,11 +674,11 @@ class TestGenerateMusic:
 
         with patch("aiohttp.ClientSession", return_value=fake_session):
             provider = OpenRouterProvider()
-            _prime_chat_audio_cache(provider, "google/lyria-3-pro")
+            _prime_chat_audio_cache(provider, "google/lyria-3-pro-preview")
             await provider.generate_music(prompt="test")
 
         payload = fake_session._last_post_kwargs["json"]
-        assert payload["model"] == "google/lyria-3-pro"
+        assert payload["model"] == "google/lyria-3-pro-preview"
 
     @pytest.mark.asyncio
     async def test_openrouter_generate_music_strips_prefix(self, monkeypatch):
@@ -687,77 +692,175 @@ class TestGenerateMusic:
 
         with patch("aiohttp.ClientSession", return_value=fake_session):
             provider = OpenRouterProvider()
-            _prime_chat_audio_cache(provider, "google/lyria-3-pro")
+            _prime_chat_audio_cache(provider, "google/lyria-3-pro-preview")
             await provider.generate_music(
                 prompt="test",
-                model="openrouter/google/lyria-3-pro",
+                model="openrouter/google/lyria-3-pro-preview",
             )
 
         payload = fake_session._last_post_kwargs["json"]
-        assert payload["model"] == "google/lyria-3-pro"
+        assert payload["model"] == "google/lyria-3-pro-preview"
 
 
-class TestOpenRouterMusicFormatRouting:
-    """generate_music picks its transport from the requested format (#584).
+class TestSniffAudioContainer:
+    """_sniff_audio_container identifies a container from its magic bytes."""
 
-    OpenRouter rejects ``stream=true`` for any audio wire format other than
-    ``pcm16``, so the default ``wav`` request must be sent as ``pcm16`` and
-    re-wrapped client-side, and mp3/flac/opus must go over the non-streaming
-    JSON path.
+    @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [
+            (b"ID3\x03\x00\x00\x00\x00tag", "mp3"),
+            (b"\xff\xfb\x90\x64", "mp3"),
+            (b"\xff\xf3\x90\x64", "mp3"),
+            (b"\xff\xf2\x90\x64", "mp3"),
+            (b"\xff\xfa\x90\x64", "mp3"),
+            (b"RIFF\x24\x00\x00\x00WAVEfmt ", "wav"),
+            (b"fLaC\x00\x00\x00\x22", "flac"),
+            (b"OggS\x00\x02\x00\x00", "ogg"),
+            # Raw little-endian PCM16 frames carry no signature at all.
+            (b"\x00\x01\x00\x01\x00\x01", None),
+            # RIFF that is not WAVE must not be claimed as wav.
+            (b"RIFF\x24\x00\x00\x00AVI LIST", None),
+            (b"", None),
+            (b"ID", None),
+        ],
+    )
+    def test_signature_detection(self, payload, expected):
+        assert _sniff_audio_container(payload) == expected
+
+
+class TestLabelStreamedAudio:
+    """_label_streamed_audio degrades safely on inputs it cannot inspect."""
+
+    def test_empty_payload_keeps_requested_format(self):
+        assert _label_streamed_audio("", "wav") == ("", "wav")
+
+    def test_undecodable_base64_is_passed_through(self):
+        # "abcde" is not valid base64 (length % 4 == 1) — the payload must be
+        # handed back untouched rather than crashing the caller.
+        assert _label_streamed_audio("abcde", "wav") == ("abcde", "wav")
+
+
+class TestOpenRouterMusicTransportAndLabelling:
+    """generate_music always streams, and labels the result by the real bytes.
+
+    OpenRouter's music models require ``stream: true`` for any audio output
+    ("Audio output requires stream: true" otherwise) and ignore
+    ``audio.format`` — ``google/lyria-3-*`` answers with MP3 whatever was
+    asked for — so the container is sniffed from the payload instead of being
+    assumed from the request.
     """
 
     @staticmethod
-    def _sse_session(b64_chunk: str, transcript: str = ""):
+    def _sse_session(payload: bytes, transcript: str = ""):
         lines = _make_sse_lines(
-            [_audio_event(b64_chunk=b64_chunk, transcript=transcript)]
+            [
+                _audio_event(
+                    b64_chunk=base64.b64encode(payload).decode(),
+                    transcript=transcript,
+                )
+            ]
         )
         return _FakeSession(_FakeStreamResponse(lines))
 
     @staticmethod
-    def _json_session(audio_b64: str, transcript: str = "", status: int = 200):
-        body = json.dumps(
-            {
-                "choices": [
-                    {
-                        "message": {
-                            "audio": {"data": audio_b64, "transcript": transcript}
-                        }
-                    }
-                ]
-            }
-        ).encode()
-        return _FakeSession(_FakeJsonResponse(body, status=status))
+    def _capture_warnings(monkeypatch) -> list:
+        captured: list = []
+        monkeypatch.setattr(
+            "agentfield.logger.log_warn",
+            lambda message, **kwargs: captured.append(message),
+        )
+        return captured
+
+    @pytest.mark.parametrize("fmt", [None, "wav", "pcm16", "mp3", "flac", "opus"])
+    @pytest.mark.asyncio
+    async def test_every_format_streams_with_the_requested_wire_format(
+        self, monkeypatch, fmt
+    ):
+        """M1/M2/M10: stream is always True and audio.format is untouched."""
+        self._capture_warnings(monkeypatch)
+        fake_session = self._sse_session(b"ID3\x03\x00\x00\x00\x00lyria")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        call_kwargs = {} if fmt is None else {"format": fmt}
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            await provider.generate_music(prompt="a jingle", **call_kwargs)
+
+        sent = fake_session._last_post_kwargs["json"]
+        assert fake_session._last_post_url.endswith("/chat/completions")
+        assert sent["stream"] is True, "music models reject stream=false"
+        assert sent["audio"]["format"] == (fmt or "wav")
+
+    @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [
+            (b"ID3\x03\x00\x00\x00\x00lyria-mp3-bytes", "mp3"),
+            (b"\xff\xfb\x90\x64frame-sync-mp3", "mp3"),
+            (b"RIFF\x24\x00\x00\x00WAVEfmt payload", "wav"),
+            (b"fLaC\x00\x00\x00\x22flac-bytes", "flac"),
+            (b"OggS\x00\x02\x00\x00ogg-bytes", "ogg"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_detected_container_wins_over_requested_format(
+        self, monkeypatch, payload, expected
+    ):
+        """M4/M6: the container found in the bytes is what gets reported."""
+        warnings = self._capture_warnings(monkeypatch)
+        fake_session = self._sse_session(payload, "take 1")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            # No format -> "wav" is requested; lyria ignores it.
+            result = await provider.generate_music(prompt="a jingle")
+
+        assert result.has_audio
+        assert result.audio.format == expected
+        assert base64.b64decode(result.audio.data) == payload, (
+            "a payload that already has a container must not be re-wrapped"
+        )
+        assert result.text == "take 1"
+
+        if expected == "wav":
+            assert warnings == []
+        else:
+            assert len(warnings) == 1, "exactly one mismatch warning"
+            assert expected in warnings[0]
+            assert "wav" in warnings[0]
 
     @pytest.mark.asyncio
-    async def test_default_format_streams_pcm16_and_returns_wav(self, monkeypatch):
-        """C1: no format -> stream=True, wire pcm16, returned audio is RIFF/WAVE."""
+    async def test_raw_pcm_with_wav_requested_is_wrapped_at_24khz(self, monkeypatch):
+        """M5/M6: no container + wav asked for -> 24 kHz mono RIFF, no warning."""
+        warnings = self._capture_warnings(monkeypatch)
         pcm = b"\x00\x01" * 64
-        fake_session = self._sse_session(base64.b64encode(pcm).decode(), "lyria take 1")
-
+        fake_session = self._sse_session(pcm, "pcm take")
         monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
 
         with patch("aiohttp.ClientSession", return_value=fake_session):
             provider = OpenRouterProvider()
             result = await provider.generate_music(prompt="ambient pads")
 
-        sent = fake_session._last_post_kwargs["json"]
-        assert sent["stream"] is True, "wav must be requested as pcm16 over a stream"
-        assert sent["audio"]["format"] == "pcm16"
-
-        assert result.has_audio
         assert result.audio.format == "wav"
         wav_bytes = base64.b64decode(result.audio.data)
         assert wav_bytes[:4] == b"RIFF"
         assert wav_bytes[8:12] == b"WAVE"
-        assert pcm in wav_bytes, "the streamed pcm payload must survive the re-wrap"
-        assert result.text == "lyria take 1"
+        with wave.open(io.BytesIO(wav_bytes)) as handle:
+            assert handle.getframerate() == 24000
+            assert handle.getnchannels() == 1
+            assert handle.getsampwidth() == 2
+        assert pcm in wav_bytes, "the streamed pcm payload must survive the wrap"
+        assert warnings == [], (
+            "wrapping raw pcm into the requested wav is not a mismatch"
+        )
 
     @pytest.mark.asyncio
-    async def test_pcm16_streams_and_returns_data_untouched(self, monkeypatch):
-        """C2: format=pcm16 -> stream=True and the base64 is returned verbatim."""
-        chunk = base64.b64encode(b"raw-pcm-frames").decode()
-        fake_session = self._sse_session(chunk, "pcm take")
-
+    async def test_raw_pcm_with_pcm16_requested_is_returned_verbatim(self, monkeypatch):
+        """M5/M6: no container + pcm16 asked for -> untouched base64, no warning."""
+        warnings = self._capture_warnings(monkeypatch)
+        pcm = b"\x00\x01" * 64
+        chunk = base64.b64encode(pcm).decode()
+        fake_session = self._sse_session(pcm, "pcm take")
         monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
 
         with patch("aiohttp.ClientSession", return_value=fake_session):
@@ -766,96 +869,74 @@ class TestOpenRouterMusicFormatRouting:
                 prompt="ambient pads", format="pcm16"
             )
 
-        sent = fake_session._last_post_kwargs["json"]
-        assert sent["stream"] is True
-        assert sent["audio"]["format"] == "pcm16"
-
         assert result.audio.format == "pcm16"
         assert result.audio.data == chunk
-        assert result.text == "pcm take"
-
-    @pytest.mark.parametrize("fmt", ["mp3", "flac"])
-    @pytest.mark.asyncio
-    async def test_compressed_formats_use_nonstream_json(self, monkeypatch, fmt):
-        """C3: mp3/flac -> stream=False, parsed from choices[0].message.audio."""
-        audio_b64 = base64.b64encode(f"{fmt}-music-bytes".encode()).decode()
-        fake_session = self._json_session(audio_b64, transcript="a short riff")
-
-        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
-
-        with patch("aiohttp.ClientSession", return_value=fake_session):
-            provider = OpenRouterProvider()
-            result = await provider.generate_music(prompt="a short riff", format=fmt)
-
-        assert fake_session._last_post_url.endswith("/chat/completions")
-        sent = fake_session._last_post_kwargs["json"]
-        assert sent["stream"] is False, f"{fmt} must disable streaming"
-        assert sent["audio"]["format"] == fmt
-
-        assert result.has_audio
-        assert result.audio.format == fmt
-        assert result.audio.data == audio_b64
-        assert result.text == "a short riff"
+        assert warnings == []
 
     @pytest.mark.asyncio
-    async def test_nonstream_http_error_mentions_music_and_status(self, monkeypatch):
-        """C4: an HTTP error on the non-stream music path raises RuntimeError."""
-        body = b'{"error": {"message": "no such model"}}'
-        fake_session = _FakeSession(_FakeJsonResponse(body, status=402))
-
-        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
-
-        with patch("aiohttp.ClientSession", return_value=fake_session):
-            provider = OpenRouterProvider()
-            with pytest.raises(RuntimeError) as excinfo:
-                await provider.generate_music(prompt="a short riff", format="opus")
-
-        message = str(excinfo.value)
-        assert "music" in message
-        assert "402" in message
-        # Pin the transport: opus must have gone down the non-streaming path.
-        assert fake_session._last_post_kwargs["json"]["stream"] is False
-
-    @pytest.mark.parametrize(
-        ("fmt", "expect_stream"),
-        [("wav", True), ("pcm16", True), ("mp3", False)],
-    )
-    @pytest.mark.asyncio
-    async def test_request_shape_is_identical_across_transports(
-        self, monkeypatch, fmt, expect_stream
+    async def test_raw_pcm_with_mp3_requested_passes_through_and_warns(
+        self, monkeypatch
     ):
-        """C5: prompt/messages/model/modalities do not vary with the transport."""
-        if expect_stream:
-            fake_session = self._sse_session(
-                base64.b64encode(b"\x00\x01\x00\x01").decode()
-            )
-        else:
-            fake_session = self._json_session(base64.b64encode(b"mp3").decode())
+        """M5/M6: no container + mp3 asked for -> passthrough plus one warning."""
+        warnings = self._capture_warnings(monkeypatch)
+        pcm = b"\x00\x01" * 64
+        chunk = base64.b64encode(pcm).decode()
+        fake_session = self._sse_session(pcm)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
 
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            result = await provider.generate_music(prompt="a riff", format="mp3")
+
+        assert result.audio.data == chunk, "raw pcm must not be re-encoded"
+        assert result.audio.format == "mp3"
+        assert len(warnings) == 1
+        assert "pcm16" in warnings[0]
+        assert "mp3" in warnings[0]
+
+    @pytest.mark.asyncio
+    async def test_matching_container_logs_nothing(self, monkeypatch):
+        """M6: mp3 asked for and mp3 delivered -> silence."""
+        warnings = self._capture_warnings(monkeypatch)
+        fake_session = self._sse_session(b"ID3\x03\x00\x00\x00\x00lyria-mp3")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            result = await provider.generate_music(prompt="a riff", format="mp3")
+
+        assert result.audio.format == "mp3"
+        assert warnings == []
+
+    @pytest.mark.parametrize("fmt", ["wav", "pcm16", "mp3", "opus"])
+    @pytest.mark.asyncio
+    async def test_request_shape_is_identical_across_formats(self, monkeypatch, fmt):
+        """M7: prompt/messages/model/modalities do not vary with the format."""
+        self._capture_warnings(monkeypatch)
+        fake_session = self._sse_session(b"\x00\x01\x00\x01")
         monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
 
         with patch("aiohttp.ClientSession", return_value=fake_session):
             provider = OpenRouterProvider()
             await provider.generate_music(
                 prompt="lo-fi beats",
-                model="openrouter/google/lyria-3-pro",
+                model="openrouter/google/lyria-3-pro-preview",
                 duration=45,
                 format=fmt,
             )
 
         sent = fake_session._last_post_kwargs["json"]
-        assert sent["model"] == "google/lyria-3-pro"
+        assert sent["model"] == "google/lyria-3-pro-preview"
         assert sent["messages"] == [
             {"role": "user", "content": "lo-fi beats (duration: 45 seconds)"}
         ]
         assert sent["modalities"] == ["text", "audio"]
-        assert sent["stream"] is expect_stream
+        assert sent["stream"] is True
 
     @pytest.mark.asyncio
     async def test_duration_validation_runs_before_any_request(self, monkeypatch):
-        """C5: duration validation is unchanged and still precedes the HTTP call."""
-        fake_session = self._json_session(base64.b64encode(b"mp3").decode())
-
+        """M7: duration validation still precedes the HTTP call."""
+        fake_session = self._sse_session(b"\x00\x01\x00\x01")
         monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
 
         with patch("aiohttp.ClientSession", return_value=fake_session):
@@ -864,6 +945,38 @@ class TestOpenRouterMusicFormatRouting:
                 await provider.generate_music(prompt="x", duration=601, format="mp3")
 
         assert not hasattr(fake_session, "_last_post_kwargs")
+
+    @pytest.mark.asyncio
+    async def test_empty_stream_returns_no_audio(self, monkeypatch):
+        """M8: a stream with no audio deltas yields no audio and does not crash."""
+        self._capture_warnings(monkeypatch)
+        fake_session = _FakeSession(_FakeStreamResponse(_make_sse_lines([])))
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            result = await provider.generate_music(prompt="silence please")
+
+        assert not result.has_audio
+        assert result.audio is None
+        assert result.text == "silence please"
+
+    @pytest.mark.asyncio
+    async def test_http_error_mentions_music_and_status(self, monkeypatch):
+        """M9: a non-200 raises RuntimeError naming the label and the status."""
+        fake_session = _FakeSession(_FakeStreamResponse([], status=402))
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            provider = OpenRouterProvider()
+            with pytest.raises(RuntimeError) as excinfo:
+                await provider.generate_music(prompt="a riff", format="opus")
+
+        message = str(excinfo.value)
+        assert "music" in message
+        assert "402" in message
+        # M1: even the failing request went out as a stream.
+        assert fake_session._last_post_kwargs["json"]["stream"] is True
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

The first version of this PR generalised #962's format-driven transport routing from
`generate_audio` to `generate_music`. A verification round against the **live** OpenRouter
API showed that premise does not hold for music models, and that both halves of the routing
were wrong there:

- **Music models require `stream: true` for *any* audio output.** A non-streaming request is
  answered with `400 {"error":{"message":"Audio output requires stream: true"}}`, so routing
  `mp3`/`flac`/`opus` through the non-streaming JSON path turned a working
  `generate_music(format="mp3")` into a hard failure.
- **Music models ignore `audio.format` entirely.** `google/lyria-3-*` returns MP3 whatever is
  asked for. Requesting `pcm16` on behalf of a `wav` caller and then wrapping the answer in a
  RIFF/PCM16 header produced a `.wav` file with an MP3 inside it — `ffprobe` reports
  `[mp3float] Header missing` on the result.

So this PR now does something different from where it started:

**1. `generate_music` always streams, and labels the result by what actually came back.**
The requested `format` is forwarded as `audio.format` untouched (harmless — the model ignores
it), the transport is always SSE, and the container is sniffed from the decoded bytes:
`ID3` / an MPEG frame sync → `mp3`, `RIFF`+`WAVE` → `wav`, `fLaC` → `flac`, `OggS` → `ogg`.
A payload with no container signature is raw PCM16 and is wrapped in a 24 kHz mono RIFF
container only when `wav` was requested; otherwise it passes through untouched. When the
detected container differs from the requested one, exactly one warning naming both is logged
and `response.audio.format` reports the container that is really there.

**2. The default music model id is fixed.** `google/lyria-3-pro` is not a valid OpenRouter
model ID (`400 "… is not a valid model ID"`), so `generate_music()` with no `model` argument
fails on `main` today. The live id is `google/lyria-3-pro-preview`. The `48kHz stereo` claim
in the docstrings is also wrong (lyria returns 44.1 kHz stereo MP3) and is replaced by
"whatever the model produced, reported on `.audio.format`".

**3. `generate_audio` fails fast instead of spending a request on a guaranteed 400.**
The gateway rejects `stream: false` for *any* audio-output chat request — the 400 comes back
with `provider_name: null`, i.e. from the gateway rather than a model — and the streaming
transport only ever emits `pcm16` deltas. There is therefore no combination that returns
mp3/flac/opus from a chat-audio model, and `_nonstream_openrouter_audio` (added by #962)
could never succeed. `generate_audio` now raises `ValueError` for any chat-audio format other
than `pcm16`/`wav` **before** the request is sent, and `_nonstream_openrouter_audio` is
removed along with its tests. The `/audio/speech` (TTS) route is untouched and still serves
mp3/flac/opus/aac natively; the wav-via-pcm16 behaviour is unchanged.

Everything else about `generate_music` is unchanged — prompt/duration-hint message shape,
`openrouter/` prefix stripping, duration validation, and the returned `MultimodalResponse`
fields — and there are tests pinning that.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] Tests only
- [ ] CI / tooling
- [x] Breaking change

> Breaking-change note: `generate_audio(format="mp3"|"flac"|"opus"|"pcm")` against a
> **chat-audio** model now raises `ValueError` instead of issuing a request. That request
> could only ever return a 400, so the change turns a confusing runtime error into an
> actionable one — but it is a different exception type, hence the flag. TTS models on
> `/audio/speech` are unaffected. Also: `generate_music(...).audio.format` now reports the
> container the model actually returned (today `"mp3"` for `google/lyria-3-*`, whatever was
> requested) instead of echoing the requested format, and raw PCM that is not wrapped as wav
> is labelled `"pcm16"`; code branching on `.audio.format == "wav"` will see the change.

## Validation contract

Behaviours this change must exhibit, and the test each maps to. Music tests live in
`sdk/python/tests/test_openrouter_audio.py::TestOpenRouterMusicTransportAndLabelling`,
sniffing units in `TestSniffAudioContainer` / `TestLabelStreamedAudio`, and the
`generate_audio` guard in `TestOpenRouterChatAudioFormatGuard`.

| # | Behaviour | Test |
|---|---|---|
| M1 | Every music request is POSTed to `/chat/completions` with `stream: true`, for every requested format (default, wav, pcm16, mp3, flac, opus). No music request ever sets `stream: false`. | `test_every_format_streams_with_the_requested_wire_format[...]`, `test_http_error_mentions_music_and_status` |
| M2 | The `audio.format` on the wire is exactly what the caller requested — no pcm16 substitution. | `test_every_format_streams_with_the_requested_wire_format[...]` |
| M3 | With no `model` the wire model is `google/lyria-3-pro-preview`; an `openrouter/` prefix is still stripped from an explicit model. | `test_openrouter_generate_music_default_model`, `test_openrouter_generate_music_strips_prefix` |
| M4 | A payload carrying a known container signature is reported with that container and returned byte-for-byte unchanged. | `test_detected_container_wins_over_requested_format[mp3/mpeg-sync/wav/flac/ogg]` |
| M5 | A payload with no container signature is raw PCM16: wrapped as 24 kHz mono RIFF/WAVE when `wav` was requested, returned unchanged with the requested label otherwise. | `test_raw_pcm_with_wav_requested_is_wrapped_at_24khz`, `test_raw_pcm_with_pcm16_requested_is_returned_verbatim`, `test_raw_pcm_with_mp3_requested_passes_through_and_warns` |
| M6 | A detected/requested mismatch logs exactly one warning naming both; agreement and the raw-PCM→wav wrap log nothing. | the three M5 tests, `test_detected_container_wins_over_requested_format`, `test_matching_container_logs_nothing` |
| M7 | Request shape otherwise unchanged (messages with the duration hint, `modalities`, model stripping) and duration validation still precedes the HTTP call. | `test_request_shape_is_identical_across_formats[wav/pcm16/mp3/opus]`, `test_duration_validation_runs_before_any_request` |
| M8 | An empty stream yields `.audio is None` and does not crash. | `test_empty_stream_returns_no_audio` |
| M9 | A non-200 raises `RuntimeError` naming `"music"` and the status code. | `test_http_error_mentions_music_and_status` |
| A1 | A chat-audio model asked for anything but `wav`/`pcm16` raises `ValueError` **before any generation request** (the model-metadata lookup that picks the route still runs), naming the requested format, saying pcm16 is all that route delivers, and mentioning the client-side wav wrap. An unrecognised format still normalises to `wav` rather than raising. | `test_unsupported_format_raises_before_any_request[mp3/flac/opus/pcm]`, `test_unknown_format_still_falls_back_to_wav` |
| A2 | `format="pcm16"` still streams and returns the concatenated base64 verbatim. | `test_pcm16_format_still_uses_sse_streaming` |
| A3 | `format="wav"` still streams as pcm16 and returns a 24 kHz mono RIFF/WAVE container. | `test_wav_streams_as_pcm16_and_returns_riff` |
| A4 | The `/audio/speech` route is untouched — mp3 still goes out as `response_format: mp3`. | `test_audio_speech_passes_speed_and_extra` |

### Tests that were re-pinned, and why

`TestOpenRouterMusicFormatRouting` (added in the first version of this PR) asserted
`stream is False` for mp3/flac/opus. That is exactly the shape the live API rejects, so the
class is replaced rather than adjusted. `TestOpenRouterNonStreamAudio` (from #962) covered a
helper that can never succeed against the real gateway; its cases become the `ValueError`
cases, and its two still-valid cases (pcm16 SSE, wav re-wrap) are kept.
`tests/test_media_integration.py::TestOpenRouterMusicE2E::test_music_generation_returns_audio`
now uses a decodable base64 body and asserts the wire `audio.format` as well as `stream`.

## Verification round

The first version of this PR was verified live and failed; this version was re-verified the
same way. Three layers:

**1. Fake OpenRouter over real HTTP** — a local `ThreadingHTTPServer` speaking real SSE, with
the SDK's `aiohttp` session rewritten only at the hostname, so real sockets, real aiohttp and
the real SSE parser are exercised. The server mimics the gateway: it answers `stream: false`
with the real `400 "Audio output requires stream: true"`, and its payload depends on the
**model**, not on `audio.format` (a lyria-like model always returns ID3-headed bytes; another
model returns raw PCM16). Result on this branch: **0 failing checks / 6 POSTs, all with
`stream: true`**; `generate_audio(format="mp3")` raised `ValueError` and sent **zero** POSTs.
The same harness run against this PR's previous head produces **11 failures**, including the
`400` for mp3/flac/opus and a `RIFF`-wrapped MP3 for the default `wav` call.

**2. Real OpenRouter API, 2 calls**, `google/lyria-3-pro-preview`, prompt
_"a five second upbeat ukulele jingle"_:

| call | `format=` | wire | result |
|---|---|---|---|
| 1 | `mp3` | `stream: true`, `audio.format: mp3` | 1,149,612 B starting `ID3\x03…`, `.audio.format == "mp3"`, no warning. `ffprobe`: `codec_name=mp3 sample_rate=44100 channels=2` |
| 2 | `wav` | `stream: true`, `audio.format: wav` | 703,232 B starting `ID3\x03…` (**not** RIFF-wrapped), `.audio.format == "mp3"`, one warning: `OpenRouter returned mp3 audio for google/lyria-3-pro-preview but format='wav' was requested; labelling the result as 'mp3'.` `ffprobe`: `codec_name=mp3 sample_rate=44100 channels=2` |

Both files decode cleanly. On the previous head, call 1 was a `400` and call 2 produced a file
`ffprobe` refuses (`[mp3float] Header missing`).

**3. Unit tests** for the sniffer itself, including the negative cases (`RIFF` that is not
`WAVE`, short buffers, raw PCM frames).

## Test plan

All commands run from `sdk/python/`.

- `uvx --from ruff==0.15.22 ruff check .` → `All checks passed!`
- `uvx --from ruff==0.15.22 ruff format --check` on every file this PR touches →
  `4 files already formatted` (`agent.py` carries pre-existing repo-wide `ruff format` drift
  that also exists on `main`; the only change to it here is a docstring, so it is left alone)
- `./scripts/run_pytest.sh` (Python 3.12) → `2037 passed, 4 skipped, 38 deselected, 36 warnings in 120.24s`, exit 0; coverage `TOTAL 2002 stmts / 116 miss / 94%`. Also run on Python 3.10 (`uv run --python 3.10 … --no-cov -q`) → exit 0, 0 failures (this project's `-q` run does not print the trailing counts line under 3.10), and the `websockets-compat` job on 3.11 with `websockets==12.0` and `==15.0.1` → `11 passed` on both
- Targeted: `pytest tests/test_openrouter_audio.py tests/test_media_integration.py` →
  96 passed, exit 0

## Test coverage

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR (no bare additions). Container sniffing,
      the wav wrap, the passthrough branch, the mismatch warning and the `generate_audio`
      guard all have tests.
- [x] If I removed code, I updated `coverage-baseline.json` in this PR *only if* the removal
      caused a legitimate regression and I called it out in the summary above.
      `_nonstream_openrouter_audio` was removed, but `media_providers.py` is not in the
      coverage `--cov` set, so no baseline change is needed.
- [ ] The coverage gate check is green in CI before requesting review.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) (if present) and [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
- [x] Commits are signed and follow conventional-commits style.
- [x] I have linked any related issues (Fixes #123 / Closes #456).

## Related issues / PRs

Refs #584
Refs #962
