### PR TITLE
ci(release): retry the multi-arch image builds once and make npm publish re-runnable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -474,7 +474,15 @@ jobs:
         working-directory: sdk/typescript
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --provenance --access public --tag next
+        run: |
+          set -euo pipefail
+          name="$(node -p "require('./package.json').name")"
+          version="$(node -p "require('./package.json').version")"
+          if npm view "${name}@${version}" version >/dev/null 2>&1; then
+            echo "${name}@${version} is already on npm; skipping publish"
+          else
+            npm publish --provenance --access public --tag next
+          fi
 
       - name: Publish to npm (production with @latest tag)
         if: |
@@ -483,7 +491,18 @@ jobs:
         working-directory: sdk/typescript
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --provenance --access public
+        # npm refuses to publish over an existing version, which turned a
+        # re-run of this job after a Docker failure into a guaranteed failure.
+        # PyPI already has --skip-existing above; give npm the same behaviour.
+        run: |
+          set -euo pipefail
+          name="$(node -p "require('./package.json').name")"
+          version="$(node -p "require('./package.json').version")"
+          if npm view "${name}@${version}" version >/dev/null 2>&1; then
+            echo "${name}@${version} is already on npm; skipping publish"
+          else
+            npm publish --provenance --access public
+          fi
 
       - name: Compute Docker metadata
         if: needs.prepare.outputs.publish_docker == 'true'
@@ -519,7 +538,25 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push control plane image
+        id: control_plane_image
         if: needs.prepare.outputs.publish_docker == 'true'
+        continue-on-error: true
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: deployments/docker/Dockerfile.control-plane
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          build-args: |
+            VERSION=${{ needs.prepare.outputs.version }}
+            COMMIT=${{ needs.prepare.outputs.release_sha }}
+            BUILD_DATE=${{ needs.prepare.outputs.build_date }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push control plane image (retry)
+        if: needs.prepare.outputs.publish_docker == 'true' && steps.control_plane_image.outcome == 'failure'
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -535,7 +572,25 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push control plane cloud image
+        id: control_plane_cloud_image
         if: needs.prepare.outputs.publish_docker == 'true'
+        continue-on-error: true
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: deployments/docker/Dockerfile.control-plane-cloud
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.docker_meta.outputs.cloud_tags }}
+          build-args: |
+            VERSION=${{ needs.prepare.outputs.version }}
+            COMMIT=${{ needs.prepare.outputs.release_sha }}
+            BUILD_DATE=${{ needs.prepare.outputs.build_date }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push control plane cloud image (retry)
+        if: needs.prepare.outputs.publish_docker == 'true' && steps.control_plane_cloud_image.outcome == 'failure'
         uses: docker/build-push-action@v5
         with:
           context: .


### PR DESCRIPTION
## Summary

The v0.1.134 release died in the `publish` job when BuildKit raced on its own QEMU emulator while starting the arm64 stages of the cloud image (`exec /dev/.buildkit_qemu_emulator: text file busy`, exit 255). The same Dockerfile at the same commit had built arm64 fine two minutes earlier on the merge-push run — this is a runner-side timing race, not a build problem. By the time it failed, the GitHub release, PyPI and npm had already been published, and "re-run failed jobs" was impossible because npm refuses to publish over an existing version, so the release had to be finished by hand with a `workflow_dispatch` reusing `existing_version` with PyPI/npm off.

## Changes

- **One retry per image build.** Each `docker/build-push-action` step runs with `continue-on-error: true` and is followed by an identical step gated on `steps.<id>.outcome == 'failure'`. The second attempt reuses the gha cache, so it only redoes the stage that died. If the retry fails too, the job fails as before.
- **npm publish is idempotent.** Both npm steps skip when `<name>@<version>` is already on the registry (`npm view`), mirroring PyPI's `--skip-existing`. After a Docker failure, "re-run failed jobs" now walks through the already-published steps and reaches the image builds.

## Not changed

Step order. Docker still runs after PyPI/npm; moving it earlier would change what a partial failure leaves behind and deserves its own discussion.

## Validation

- `.github/workflows/release.yml` parses (PyYAML) and the `publish` step list is the expected sequence with the two retry steps in place.
- Behaviour to confirm on the next release: a green `publish` job shows the retry steps as skipped; a re-run after a Docker failure logs `… is already on npm; skipping publish` and proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)