### PR TITLE
docs: correct memory scope docs, the app.memory API list, and the exists() promise

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,12 +268,17 @@ Storage interface is unified—services call storage layer methods, storage laye
 - Never direct agent-to-agent HTTP—always through control plane
 
 ### Memory Scopes
-- **Global:** Shared across all agents/sessions
-- **Agent:** Scoped to one agent, all sessions
-- **Session:** Scoped to one session (multi-turn conversation)
-- **Run:** Scoped to single execution/workflow run
 
-Automatically synced by control plane. Agents access via SDK methods: `agent.memory.get/set(scope, key, value)`
+The control plane defines four scopes: `global`, `session`, `actor`, and `workflow`. Other strings (such as `agent` or `run`) are not rejected, but they are stored in a namespace that an unscoped `get` never walks, so a value written there can only be read back with the same explicit scope. Python and TypeScript use these names directly; the Go SDK's constant for the actor scope is `agent.ScopeUser` (`"user"`), which `apiScope` translates to `actor` on the wire (`sdk/go/agent/control_plane_memory_backend.go`).
+
+- **`global`:** Shared by every agent and session; fixed scope id `global`
+- **`session`:** One conversation, keyed by `X-Session-ID`
+- **`actor`:** One actor across all its sessions, keyed by `X-Actor-ID`
+- **`workflow`:** One workflow run, keyed by `X-Workflow-ID`
+
+`session`, `actor` and `workflow` are sibling dimensions, not a nested chain. A read with no explicit scope resolves `workflow -> session -> actor -> global` and returns the first hit. Scope controls lookup and isolation, not lifetime: nothing is purged when a session or run ends — values persist until explicitly deleted.
+
+Agents access via SDK methods: `agent.memory.get/set(scope, key, value)`. See `sdk/python/agentfield/memory.py` for the authoritative description.
 
 ### DID/VC (Cryptographic Identity)
 - Opt-in per agent: Set `app.vc_generator.set_enabled(True)` in Python or equivalent in Go

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,7 +269,7 @@ Storage interface is unified—services call storage layer methods, storage laye
 
 ### Memory Scopes
 
-The control plane defines four scopes: `global`, `session`, `actor`, and `workflow`. Other strings (such as `agent` or `run`) are not rejected, but they are stored in a namespace that an unscoped `get` never walks, so a value written there can only be read back with the same explicit scope. Python and TypeScript use these names directly; the Go SDK's constant for the actor scope is `agent.ScopeUser` (`"user"`), which `apiScope` translates to `actor` on the wire (`sdk/go/agent/control_plane_memory_backend.go`).
+The control plane defines four scopes: `global`, `session`, `actor`, and `workflow`. The HTTP handler does not alias `agent` or `run` to those scopes. Python's `MemoryInterface` rejects any name outside `_VALID_SCOPES = ("global", "session", "actor", "workflow")`. The Go SDK remaps unknown names (including `agent` and `run`) to `global` before they hit the wire; its constant for the actor scope is `agent.ScopeUser` (`"user"`), which `apiScope` translates to `actor` (`sdk/go/agent/control_plane_memory_backend.go`). Do not use `agent` or `run` as scope names.
 
 - **`global`:** Shared by every agent and session; fixed scope id `global`
 - **`session`:** One conversation, keyed by `X-Session-ID`
@@ -278,7 +278,7 @@ The control plane defines four scopes: `global`, `session`, `actor`, and `workfl
 
 `session`, `actor` and `workflow` are sibling dimensions, not a nested chain. A read with no explicit scope resolves `workflow -> session -> actor -> global` and returns the first hit. Scope controls lookup and isolation, not lifetime: nothing is purged when a session or run ends — values persist until explicitly deleted.
 
-Agents access via SDK methods: `agent.memory.get/set(scope, key, value)`. See `sdk/python/agentfield/memory.py` for the authoritative description.
+Agents access via SDK methods: `agent.memory.get(key, default=None, scope=..., scope_id=...)` / `agent.memory.set(key, data, scope=..., scope_id=...)`. See `sdk/python/agentfield/memory.py` for the authoritative description.
 
 ### DID/VC (Cryptographic Identity)
 - Opt-in per agent: Set `app.vc_generator.set_enabled(True)` in Python or equivalent in Go

--- a/control-plane/internal/server/knowledgebase/content.go
+++ b/control-plane/internal/server/knowledgebase/content.go
@@ -76,7 +76,7 @@ When in doubt, use .harness(). Reserve .ai() for gates and classifiers.
 
 	kb.Add(Article{
 		ID: "building/memory-scopes", Topic: "building", Title: "Memory Scopes and Usage",
-		Summary:    "Understanding global, agent, session, and run memory scopes",
+		Summary:    "Understanding global, session, actor, and workflow memory scopes",
 		Difficulty: "beginner",
 		Tags:       []string{"memory", "scopes", "state", "persistence"},
 		Content: `# Memory Scopes
@@ -85,15 +85,17 @@ AgentField provides four memory scopes:
 
 | Scope | Shared Across | Use Case |
 |-------|---------------|----------|
-| global | All agents, all sessions | Shared knowledge base |
-| agent | One agent, all sessions | Agent-specific config |
-| session | One session | Multi-turn conversation state |
-| run | Single execution run | Workflow-scoped data |
+| global | All agents, all sessions (fixed id "global") | Shared knowledge base |
+| session | One conversation (X-Session-ID) | Multi-turn conversation state |
+| actor | One actor, all its sessions (X-Actor-ID) | Actor-specific config and learned data |
+| workflow | One workflow run (X-Workflow-ID) | Workflow-scoped intermediate results |
+
+session, actor, and workflow are sibling dimensions, not a nested chain. A read with no explicit scope walks workflow -> session -> actor -> global and returns the first hit. Values persist until explicitly deleted; there is no TTL or automatic cleanup.
 
 ## Usage (Python SDK)
 ` + "```python" + `
-await agent.memory.set("session", session_id, "user_preference", "dark_mode")
-value = await agent.memory.get("session", session_id, "user_preference")
+await agent.memory.set("user_preference", "dark_mode", scope="session")
+value = await agent.memory.get("user_preference", scope="session")
 ` + "```" + `
 
 ## API Endpoints

--- a/control-plane/internal/skillkit/skill_data/agentfield/references/primitives-snapshot.md
+++ b/control-plane/internal/skillkit/skill_data/agentfield/references/primitives-snapshot.md
@@ -76,7 +76,7 @@ result = await app.ai(
     response_format=None,      # "auto" / "json" / "text" / dict / None
     tools=None,                # list of tool defs, OR "discover" to auto-discover
     context=None,
-    memory_scope=None,         # e.g., ["workflow", "session", "reasoner"]
+    memory_scope=None,         # accepted but not yet applied; scopes are workflow/session/actor/global
     **kwargs,
 )
 ```
@@ -184,22 +184,25 @@ If any of those four are false, refactor to `app.ai(tools=[...])` or a chunked-l
 
 ## Memory
 
-| Scope | Lifetime |
-|---|---|
-| `global` | Cross everything |
-| `agent` | This node, all sessions |
-| `session` | One conversation thread |
-| `run` | Single workflow execution |
+| Scope | Keyed by | Lifetime |
+|---|---|---|
+| `global` | fixed scope id `"global"` | Shared by every agent and session |
+| `session` | `X-Session-ID` | One conversation thread |
+| `actor` | `X-Actor-ID` | One actor across all its sessions |
+| `workflow` | `X-Workflow-ID` (falls back to the run id) | One workflow run |
+
+`session`, `actor` and `workflow` are sibling dimensions, not a nested chain; an unscoped read walks `workflow -> session -> actor -> global`. There is no `agent` or `run` scope.
 
 ```python
-await app.memory.set(key, value, scope="run")
-v = await app.memory.get(key, default=None, scope="run")
-await app.memory.exists(key, scope="run")
-await app.memory.delete(key, scope="run")
-keys = await app.memory.list_keys(scope="agent")
+await app.memory.set(key, value)                       # unscoped: the workflow scope of this run
+v = await app.memory.get(key, default=None)             # unscoped: workflow -> session -> actor -> global
+await app.memory.set(key, value, scope="session")
+v = await app.memory.get(key, default=None, scope="session")
+await app.memory.delete(key, scope="session")
+keys = await app.memory.session(session_id).list_keys()  # list_keys lives on the scoped clients
 ```
 
-Vector memory (`set_vector` / `search_vectors`) and event memory (`app.memory.events.*`) also exist. See live docs for current API.
+Vector memory (`set_vector` / `delete_vector` / `similarity_search`) and change listeners (`@app.memory.on_change(patterns)`) also exist. See live docs for current API.
 
 ---
 

--- a/docs/harness-providers.md
+++ b/docs/harness-providers.md
@@ -118,6 +118,23 @@ envelope. Schema runs use a unique output directory per invocation so parallel
 jobs can safely share a checkout. Set `AFORGE_BIN` to an absolute path when the
 binary is installed somewhere off `PATH`.
 
+### OpenCode concurrency
+
+The OpenCode adapters cap how many `opencode run` subprocesses may be in flight
+at once, so a wide fan-out does not overwhelm the upstream provider with
+parallel requests. Set `OPENCODE_MAX_CONCURRENT` to a positive integer to change
+the cap. The defaults differ per SDK:
+
+| SDK | Default | Source |
+| --- | --- | --- |
+| Go | 4 | `sdk/go/harness/opencode.go` |
+| Python | 10 | `sdk/python/agentfield/harness/providers/opencode.py` |
+
+The value is read once per process — Go reads it the first time the limiter is
+used, Python reads it at import time — so export it before starting the agent
+rather than mutating the environment mid-run. The TypeScript OpenCode provider
+has no limiter and ignores the variable.
+
 ## Model selection and reasoning-effort variants
 
 Every provider accepts a `model` option on `.harness()` calls. Leaving it unset

--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -3690,7 +3690,9 @@ class Agent(FastAPI):
             stream (bool, optional): Enable streaming response.
             response_format (str, optional): Desired response format ('auto', 'json', 'text').
             context (Dict, optional): Additional context data to pass to the LLM.
-            memory_scope (List[str], optional): Memory scopes to inject (e.g., ['workflow', 'session', 'reasoner']).
+            memory_scope (List[str], optional): Memory scopes to inject, drawn from the
+                four real scopes 'workflow', 'session', 'actor' and 'global'. Accepted
+                today but not yet applied to the prompt.
             **kwargs: Additional provider-specific parameters to pass to the LLM.
 
         Returns:

--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -1498,6 +1498,12 @@ class Agent(FastAPI):
         A read with no explicit scope walks the same dimensions in the order
         workflow -> session -> actor -> global and returns the first hit.
 
+        In practice the Python SDK always sends X-Workflow-ID (it falls back to
+        the run id when no workflow id is set), so an unscoped write from a
+        reasoner lands in the workflow scope of that run, and a later run in
+        the same session will not see it. Pass scope="session" (or use
+        app.memory.session(...)) for values that must outlive one run.
+
         The agent's node ID travels with the request as X-Agent-Node-ID, but it is
         attribution on the emitted memory change event - it is not a scope key.
 

--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -1491,11 +1491,15 @@ class Agent(FastAPI):
         agents to store and retrieve data across function calls, workflow steps,
         and even across different agent interactions.
 
-        Memory is automatically scoped by:
-        - Execution context (workflow instance)
-        - Agent node ID
-        - Session information
-        - User context (if available)
+        A write with no explicit scope lands in the most specific scope the current
+        request carries, picked from the execution-context headers the SDK sends:
+        X-Workflow-ID (workflow), then X-Session-ID (session), then X-Actor-ID
+        (actor), falling back to the shared "global" scope when none is present.
+        A read with no explicit scope walks the same dimensions in the order
+        workflow -> session -> actor -> global and returns the first hit.
+
+        The agent's node ID travels with the request as X-Agent-Node-ID, but it is
+        attribution on the emitted memory change event - it is not a scope key.
 
         Returns:
             MemoryInterface: Interface for memory operations if execution context is available.
@@ -1508,16 +1512,16 @@ class Agent(FastAPI):
                 '''Analyze message with conversation history context.'''
 
                 # Store current message in conversation history
-                history = app.memory.get("conversation.history", [])
+                history = await app.memory.get("conversation.history", [])
                 history.append({
                     "message": message,
                     "timestamp": datetime.now().isoformat(),
                     "role": "user"
                 })
-                app.memory.set("conversation.history", history)
+                await app.memory.set("conversation.history", history)
 
                 # Get user preferences for analysis
-                user_prefs = app.memory.get("user.analysis_preferences", {
+                user_prefs = await app.memory.get("user.analysis_preferences", {
                     "sentiment_analysis": True,
                     "topic_extraction": True,
                     "language_detection": False
@@ -1540,16 +1544,16 @@ class Agent(FastAPI):
                 )
 
                 # Store analysis results
-                app.memory.set("conversation.last_analysis", result.model_dump())
+                await app.memory.set("conversation.last_analysis", result.model_dump())
 
                 return result
 
             @app.skill()
-            def get_conversation_summary() -> dict:
+            async def get_conversation_summary() -> dict:
                 '''Get summary of current conversation.'''
 
-                history = app.memory.get("conversation.history", [])
-                last_analysis = app.memory.get("conversation.last_analysis", {})
+                history = await app.memory.get("conversation.history", [])
+                last_analysis = await app.memory.get("conversation.last_analysis", {})
 
                 return {
                     "message_count": len(history),
@@ -1559,12 +1563,31 @@ class Agent(FastAPI):
             ```
 
         Memory Operations:
-            - `app.memory.get(key, default=None)`: Retrieve value by key
-            - `app.memory.set(key, value)`: Store value by key
-            - `app.memory.delete(key)`: Remove value by key
-            - `app.memory.exists(key)`: Check if key exists
-            - `app.memory.keys(pattern="*")`: List keys matching pattern
-            - `app.memory.clear(pattern="*")`: Clear keys matching pattern
+            `app.memory` is a `MemoryInterface`. Every value operation on it is a
+            coroutine and has to be awaited:
+
+            - `await app.memory.get(key, default=None, scope=None, scope_id=None)`:
+              Read a value; with `scope=None` this is the hierarchical lookup above
+            - `await app.memory.set(key, data, scope=None, scope_id=None)`: Store a value
+            - `await app.memory.delete(key, scope=None, scope_id=None)`: Remove a value
+            - `await app.memory.exists(key)`: Present, but it answers True for any key
+              as long as the backend is reachable; compare
+              `await app.memory.get(key, sentinel)` against a sentinel instead
+            - `await app.memory.set_vector(key, embedding, metadata=None)`: Store an embedding
+            - `await app.memory.delete_vector(key)`: Remove an embedding
+            - `await app.memory.similarity_search(query_embedding, top_k=10, filters=None,
+              scope=None, scope_id=None)`: Search stored embeddings
+
+            The scope accessors are ordinary (non-async) calls returning a scoped
+            client whose own methods are coroutines:
+
+            - `app.memory.session(session_id)`, `app.memory.actor(actor_id)`,
+              `app.memory.workflow(workflow_id)`, `app.memory.global_scope`
+            - `await app.memory.global_scope.list_keys()`: List the keys in one scope -
+              `list_keys` lives on the scoped clients, not on `app.memory` itself
+            - `@app.memory.on_change(patterns)`: Register a memory change listener
+
+            There is no `keys()` and no `clear()` method on `app.memory`.
 
         Memory Scopes:
             - Session: One conversation, keyed by X-Session-ID

--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -1567,13 +1567,16 @@ class Agent(FastAPI):
             - `app.memory.clear(pattern="*")`: Clear keys matching pattern
 
         Memory Scopes:
-            - Session: Data persists for the duration of a user session
-            - Workflow: Data persists for the duration of a workflow execution
-            - Agent: Data persists across all executions for this agent
-            - Global: Data shared across all agents (use with caution)
+            - Session: One conversation, keyed by X-Session-ID
+            - Actor: One actor across all its sessions, keyed by X-Actor-ID
+            - Workflow: One workflow run, keyed by X-Workflow-ID
+            - Global: Shared by every agent and session; fixed scope id "global"
+
+            session, actor, and workflow are sibling dimensions, not a nested
+            chain. There is no Agent or Run scope.
 
         Note:
-            - Memory is automatically cleaned up based on retention policies
+            - Values persist until explicitly deleted; scope is lookup/isolation, not lifetime
             - Large objects should be stored efficiently (consider serialization)
             - Memory operations are atomic and thread-safe
             - Memory events can trigger `@on_change` listeners

--- a/sdk/python/agentfield/agent_ai.py
+++ b/sdk/python/agentfield/agent_ai.py
@@ -532,7 +532,9 @@ class AgentAI:
             stream (bool, optional): Enable streaming response.
             response_format (str, optional): Desired response format ('auto', 'json', 'text').
             context (Dict, optional): Additional context data to pass to the LLM.
-            memory_scope (List[str], optional): Memory scopes to inject (e.g., ['workflow', 'session', 'reasoner']).
+            memory_scope (List[str], optional): Memory scopes to inject, drawn from the
+                four real scopes 'workflow', 'session', 'actor' and 'global'. Accepted
+                today but not yet applied to the prompt.
             tools: Tool definitions for LLM tool calling. Accepts:
                 - "discover": auto-discover all tools from the control plane
                 - DiscoveryResponse: use pre-fetched discovery results

--- a/sdk/python/agentfield/memory.py
+++ b/sdk/python/agentfield/memory.py
@@ -385,12 +385,18 @@ class MemoryClient:
         """
         Check if a memory key exists.
 
+        Known limitation: ``get`` returns ``default`` rather than raising when the
+        key is absent, so this answers ``True`` for any key as long as the memory
+        backend is reachable. Only a transport or backend failure yields ``False``.
+        For a real existence test, compare ``get(key, sentinel)`` against a
+        sentinel of your own.
+
         Args:
             key: The memory key
             scope: Optional explicit scope override
 
         Returns:
-            True if key exists, False otherwise
+            True unless the lookup itself failed.
         """
         try:
             await self.get(key, scope=scope, scope_id=scope_id)
@@ -573,7 +579,11 @@ class ScopedMemoryClient:
         )
 
     async def exists(self, key: str) -> bool:
-        """Check if a key exists in this specific scope."""
+        """Check if a key exists in this specific scope.
+
+        Carries the same limitation as ``MemoryClient.exists``: it answers ``True``
+        whenever the backend is reachable.
+        """
         return await self.memory_client.exists(
             key, scope=self.scope, scope_id=self.scope_id
         )
@@ -667,7 +677,11 @@ class GlobalMemoryClient:
         return await self.memory_client.get(key, default=default, scope="global")
 
     async def exists(self, key: str) -> bool:
-        """Check if a key exists in global scope."""
+        """Check if a key exists in global scope.
+
+        Carries the same limitation as ``MemoryClient.exists``: it answers ``True``
+        whenever the backend is reachable.
+        """
         return await self.memory_client.exists(key, scope="global")
 
     async def delete(self, key: str) -> None:
@@ -919,11 +933,17 @@ class MemoryInterface:
         """
         Check if a memory key exists in any scope.
 
+        Known limitation: this answers ``True`` for any key as long as the memory
+        backend is reachable - a missing key is not distinguished from a stored one
+        (see ``MemoryClient.exists``). Compare
+        ``await app.memory.get(key, sentinel)`` against a sentinel of your own
+        instead.
+
         Args:
             key: The memory key
 
         Returns:
-            True if key exists in any scope, False otherwise
+            True unless the lookup itself failed.
         """
         return await self.memory_client.exists(key)
 

--- a/sdk/python/agentfield/memory.py
+++ b/sdk/python/agentfield/memory.py
@@ -4,63 +4,85 @@ Cross-Agent Persistent Memory Client for AgentField SDK.
 Memory Scope Hierarchy
 ======================
 
-AgentField provides four memory scopes for storing agent data:
+AgentField provides four memory scopes for storing agent data. A scope
+controls *where a value is looked up and who can see it* — it does not control
+how long the value lives. Values in every scope persist until they are
+explicitly deleted (see "Lifecycle and Data Retention" below).
 
 Global Scope
 ------------
 - Shared across all agents and sessions.
-- Persists until explicitly deleted.
+- Addressed by the fixed scope id ``"global"``.
 - Use for: configuration, shared knowledge bases, cross-agent state.
 
 Session Scope
 -------------
-- Scoped to a single user session (conversation).
-- Cleared when the session ends.
+- Scoped to a single user session (conversation), keyed by ``X-Session-ID``.
+- Isolated from other sessions; invisible to actor- and workflow-scoped reads.
 - Use for: conversation context, user preferences within a session.
 
 Actor Scope
 -----------
-- Scoped to a single actor across all sessions.
-- Persists across sessions.
+- Scoped to a single actor across all sessions, keyed by ``X-Actor-ID``.
+- Independent of the session dimension, not nested inside it.
 - Use for: actor-specific learned data, actor configuration.
 
 Workflow Scope (Run Scope)
 --------------------------
-- Scoped to a single workflow execution.
-- Cleared when the workflow run completes.
+- Scoped to a single workflow execution, keyed by ``X-Workflow-ID``.
+- Isolated from other runs.
 - Use for: intermediate results, execution-specific state.
 
 Scope Relationship
 ------------------
-Conceptually, scope moves from widest to narrowest:
+``session``, ``actor`` and ``workflow`` are **sibling** dimensions, not a
+nested chain. Each is keyed by its own request header, so a value written under
+one is invisible to the other two. ``global`` is the shared fallback for
+all three:
 
 ::
 
-    Global (widest)
-        |
-    Session
-        |
-    Actor
-        |
-    Workflow/Run (narrowest)
+                             global
+                        (scope id "global",
+                       shared by every agent)
+                                |
+          +---------------------+---------------------+
+          |                     |                     |
+       session                actor                workflow
+    X-Session-ID           X-Actor-ID           X-Workflow-ID
+    one conversation     one actor, across        one run
+                           all sessions
 
 Lookup Behavior
 ---------------
-When calling ``memory.get(...)`` without an explicit scope, AgentField resolves
-values from most specific to least specific and returns the first match:
+A read with an explicit ``scope`` looks in that one dimension only. A read
+without a scope — ``memory.get(...)`` — walks the dimensions in this fixed
+order and returns the first match:
 
 ::
 
     workflow -> session -> actor -> global
 
-In other words, values in narrower scopes override broader scopes for reads.
+Only dimensions whose header is present on the request are consulted; ``global``
+is always tried last. Because the order is fixed, a workflow value shadows a
+session value of the same key, a session value shadows an actor value, and any
+of them shadows ``global``.
 
 Lifecycle and Data Retention
 ----------------------------
-- ``global``: retained until explicitly removed (for example via ``delete``).
-- ``session``: removed when the conversation/session ends.
-- ``actor``: retained across sessions for that actor until explicitly removed.
-- ``workflow``: removed automatically when that run completes.
+**All four scopes persist until the value is explicitly deleted.** AgentField
+does not expire, purge or garbage-collect memory:
+
+- There is no TTL or expiry on stored values in any storage backend.
+- Ending a conversation does **not** remove ``session``-scoped values.
+- Completing a workflow run does **not** remove ``workflow``-scoped values.
+  (The workflow-cleanup API deletes run, execution, webhook and
+  verifiable-credential records; it does not touch memory.)
+- The only removal path is an explicit ``delete`` from the SDK or the
+  corresponding control-plane endpoint.
+
+Pick a scope for isolation and lookup, not for cleanup: if a key should not
+outlive a session or a run, delete it yourself when you are done with it.
 
 Example Usage
 -------------
@@ -72,7 +94,7 @@ Example Usage
     # Store per-session context.
     await agent.memory.session(session_id).set("context", {"topic": "billing"})
 
-    # Store actor preferences that survive across sessions.
+    # Store actor preferences that are independent of any session.
     await agent.memory.actor(actor_id).set("preferences", {"tone": "concise"})
 
     # Store workflow-local intermediate results.
@@ -90,12 +112,19 @@ Example Usage
         scope_id=session_id,
     )
 
+    # Nothing reclaims this automatically — delete it when the run is done.
+    await memory_client.delete(
+        "step1_output",
+        scope="workflow",
+        scope_id=workflow_id,
+    )
+
 Use Scope Selection as a Design Tool
 ------------------------------------
 - Use ``global`` for organization-wide or system-wide defaults.
-- Use ``session`` for temporary conversation state.
+- Use ``session`` for state that must not leak between conversations.
 - Use ``actor`` for long-lived persona or agent specialization.
-- Use ``workflow`` for transient, per-run computation artifacts.
+- Use ``workflow`` for per-run computation artifacts.
 """
 
 import asyncio

--- a/skills/agentfield/references/primitives-snapshot.md
+++ b/skills/agentfield/references/primitives-snapshot.md
@@ -76,7 +76,7 @@ result = await app.ai(
     response_format=None,      # "auto" / "json" / "text" / dict / None
     tools=None,                # list of tool defs, OR "discover" to auto-discover
     context=None,
-    memory_scope=None,         # e.g., ["workflow", "session", "reasoner"]
+    memory_scope=None,         # accepted but not yet applied; scopes are workflow/session/actor/global
     **kwargs,
 )
 ```
@@ -184,22 +184,25 @@ If any of those four are false, refactor to `app.ai(tools=[...])` or a chunked-l
 
 ## Memory
 
-| Scope | Lifetime |
-|---|---|
-| `global` | Cross everything |
-| `agent` | This node, all sessions |
-| `session` | One conversation thread |
-| `run` | Single workflow execution |
+| Scope | Keyed by | Lifetime |
+|---|---|---|
+| `global` | fixed scope id `"global"` | Shared by every agent and session |
+| `session` | `X-Session-ID` | One conversation thread |
+| `actor` | `X-Actor-ID` | One actor across all its sessions |
+| `workflow` | `X-Workflow-ID` (falls back to the run id) | One workflow run |
+
+`session`, `actor` and `workflow` are sibling dimensions, not a nested chain; an unscoped read walks `workflow -> session -> actor -> global`. There is no `agent` or `run` scope.
 
 ```python
-await app.memory.set(key, value, scope="run")
-v = await app.memory.get(key, default=None, scope="run")
-await app.memory.exists(key, scope="run")
-await app.memory.delete(key, scope="run")
-keys = await app.memory.list_keys(scope="agent")
+await app.memory.set(key, value)                       # unscoped: the workflow scope of this run
+v = await app.memory.get(key, default=None)             # unscoped: workflow -> session -> actor -> global
+await app.memory.set(key, value, scope="session")
+v = await app.memory.get(key, default=None, scope="session")
+await app.memory.delete(key, scope="session")
+keys = await app.memory.session(session_id).list_keys()  # list_keys lives on the scoped clients
 ```
 
-Vector memory (`set_vector` / `search_vectors`) and event memory (`app.memory.events.*`) also exist. See live docs for current API.
+Vector memory (`set_vector` / `delete_vector` / `similarity_search`) and change listeners (`@app.memory.on_change(patterns)`) also exist. See live docs for current API.
 
 ---
 


### PR DESCRIPTION
## Summary

The `agentfield.memory` module docstring described the memory model in two ways that do not match the control plane. Its "Scope Relationship" diagram drew `global -> session -> actor -> workflow` as a single nested chain, and its "Lifecycle and Data Retention" section promised automatic cleanup that does not exist. This PR rewrites both against the actual implementation, corrects the scope names in `CLAUDE.md` (the wrong wording there is what seeded #93) and in the shipped knowledge-base article, replaces the `app.memory` method list on `Agent.memory` with the API that actually exists, and documents the previously-undocumented `OPENCODE_MAX_CONCURRENT` knob.

Docs only — every changed line is a docstring, a Markdown file, or the Markdown string constant of a knowledge-base article. No code path, signature or behaviour changes.

**What was wrong, and what the source says:**

1. **The scopes are not nested.** `session`, `actor` and `workflow` are sibling dimensions keyed by three different request headers — `X-Session-ID`, `X-Actor-ID`, `X-Workflow-ID` (`resolveScope` / `getScopeID`, `control-plane/internal/handlers/memory.go:401-433`; the same three headers are set by `sdk/python/agentfield/memory.py:190-194` and `sdk/go/agent/control_plane_memory_backend.go:374-386`). A value written under one is invisible to the other two. `global` is the shared fallback, addressed by the fixed scope id `"global"`. The diagram is now a tree with `global` at the root and the three dimensions as siblings, each labelled with its header.

2. **Read precedence is now stated explicitly.** An unscoped `get` walks `workflow -> session -> actor -> global` and returns the first hit — `GetMemoryHandler`, `control-plane/internal/handlers/memory.go:273` (`scopes := []string{"workflow", "session", "actor", "global"}`), skipping any dimension whose header is absent and always falling back to `global` last.

3. **Nothing is purged automatically.** The docstring claimed session values are "removed when the conversation/session ends" and workflow values "removed automatically when that run completes". Neither is true:
   - There is no TTL or expiry field in either backend. Local mode stores memory in per-scope BoltDB buckets keyed `scopeID:key` (`internal/storage/local.go:3606-3612`, `:3689-3696`); postgres mode uses `kv_store(scope, scope_id, key, value, updated_at)` with no expiry column (`internal/storage/local.go:586-596`).
   - `CleanupWorkflow` deletes execution VCs, workflow VCs, execution webhook events, execution webhooks, executions, workflow executions, workflow runs and workflow definitions — and no memory rows (`performWorkflowCleanup`, `internal/storage/local.go:2829-2864`). It is also not automatic: it is reached only through the explicit, confirmation-gated `CleanupWorkflowHandler`.
   - A repo-wide grep for a memory purge/TTL/reaper found only `DeleteMemory` (the explicit endpoint) plus unrelated `memory_vectors` / `memory_events` deletes.

   The retention section now says what actually happens: values in all four scopes persist until explicitly deleted, scope controls lookup and isolation rather than lifetime, and callers who do not want a key to outlive a run must delete it themselves. An example `delete` call was added to make that concrete.

4. **`CLAUDE.md` named scopes that do not exist.** It listed Global / **Agent** / Session / **Run**. The scopes the control plane actually knows are `global` / `session` / `actor` / `workflow`; Python (`memory.py`) and TypeScript (`MemoryScope = 'workflow' | 'session' | 'actor' | 'global'`, `sdk/typescript/src/types/agent.ts:91`) use those names directly. One deliberate wrinkle is documented rather than glossed over: the Go SDK's constant is `agent.ScopeUser = "user"` (`sdk/go/agent/memory.go:20`), which `apiScope` translates to `actor` before it hits the wire (`sdk/go/agent/control_plane_memory_backend.go:391-405`). The section is corrected, kept short, and points at `memory.py` as the source of truth.

5. **The shipped knowledge-base article said the same wrong thing.** `control-plane/internal/server/knowledgebase/content.go` holds the Markdown for `building/memory-scopes`, served over HTTP from the server binary. It advertised `agent` and `run` as scopes, and its Python sample used a four-positional-argument call (`memory.set("session", session_id, key, value)`) that no longer exists. Both are corrected; the scope table now carries each scope's header, and the sample matches today's `set(key, data, scope=...)` signature.

6. **`Agent.memory` advertised two methods that do not exist.** Its "Memory Operations" block listed `app.memory.keys(pattern="*")` and `app.memory.clear(pattern="*")`. The property returns a `MemoryInterface`, which has neither. The block now lists the real surface — `get` / `set` / `delete` / `exists` / `set_vector` / `delete_vector` / `similarity_search`, the `session()` / `actor()` / `workflow()` / `global_scope` accessors and `on_change` — with the signatures `inspect.signature` reports (`set`'s second parameter is `data`, not `value`; `get`/`set`/`delete` all take `scope` and `scope_id`). `list_keys` is shown through an accessor because it lives on the scoped clients, not on `app.memory`. Every one of these is a coroutine, so the list and the runnable Example block in the same docstring now `await` them, and the example skill is `async def`.

   The same docstring's preamble claimed memory is "automatically scoped by ... Agent node ID", contradicting its own "There is no Agent or Run scope" a few lines further down. `X-Agent-Node-ID` is attribution on the emitted memory change event (`control-plane/internal/handlers/memory.go:188`, `:337`); `getScopeID` never reads it. Replaced with the headers that do select a scope.

7. **`exists()` cannot detect a missing key.** `MemoryClient.exists` is "call `get()`, return `False` if it raised", but `MemoryClient.get` returns the caller's default on a 404 rather than raising (`memory.py`, the `if response.status_code == 404: return default` branch). So `exists()` answers `True` for any key the control plane can be reached for. The four `exists()` docstrings promised the opposite; they now state the real behaviour and point at the `get(key, sentinel)` workaround. The existing unit tests miss this because they monkeypatch `get()` to raise on a miss, which the real `get()` never does. **This is a documentation change only — the implementation fix belongs in its own PR.**

8. **`memory_scope` documented a scope that is not in the contract.** `Agent.ai` and `AgentAI.ai` both used `e.g., ['workflow', 'session', 'reasoner']`. There is no `reasoner` scope: `_VALID_SCOPES` is `('global', 'session', 'actor', 'workflow')` and `getScopeID` has no case for it. (Local storage does pre-create a vestigial `reasoner` BoltDB bucket, but it has no header case, is never walked by a hierarchical read, and is rejected by the SDK.) Both docstrings now name the four real scopes, and note that `memory_scope` is accepted but not yet applied — `agent_ai.py` still carries the `TODO: Integrate memory injection based on memory_scope` placeholder and never reads the argument.

9. **`OPENCODE_MAX_CONCURRENT`** was implemented in two SDKs but documented in neither. Added to `docs/harness-providers.md` alongside the existing `AFORGE_MAX_CONCURRENT` note, with the real defaults read from source: Go `defaultMaxConcurrent = 4` (`sdk/go/harness/opencode.go:33`), Python `_MAX_CONCURRENT` default `"10"` (`sdk/python/agentfield/harness/providers/opencode.py:178-182`). The doc also records that the value is read once per process (Go via `sync.Once` on first use, Python at import time) and that the TypeScript OpenCode provider has no limiter.

The `memory.py` docstring stays a valid reST literal-block layout, so the diagram still renders through `help()` / `pydoc`.

**Files touched**

| File | Kind |
| --- | --- |
| `CLAUDE.md` | Markdown |
| `docs/harness-providers.md` | Markdown |
| `sdk/python/agentfield/memory.py` | Python docstrings |
| `sdk/python/agentfield/agent.py` | Python docstrings |
| `sdk/python/agentfield/agent_ai.py` | Python docstring |
| `control-plane/internal/server/knowledgebase/content.go` | Go — the Markdown string constant of one KB article |

`content.go` is a Go file, so `control-plane.yml` and the control-plane coverage surface fire in CI; those gates were run locally and are listed below. No TypeScript source and no Go SDK source is touched, so `sdk-typescript.yml` and `sdk-go.yml` do not fire.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Docs only
- [ ] Tests only
- [ ] CI / tooling
- [ ] Breaking change

## Test plan

Python SDK gates, run from `sdk/python` (CI pins ruff 0.15.22 and runs `./scripts/run_pytest.sh`):

- `uvx --from ruff==0.15.22 ruff check .` → `All checks passed!` (exit 0)
- `uvx --from ruff==0.15.22 ruff format --check agentfield/agent.py agentfield/agent_ai.py agentfield/memory.py` → `memory.py` and `agent_ai.py` already formatted. `agent.py` reports drift, but the identical 23 hunks are reported on `origin/main` for the same file and none of them fall inside the regions this PR edits, so no new drift is introduced. (`ruff format` is `continue-on-error` in CI.)
- `uv run --extra dev ./scripts/run_pytest.sh -p no:cacheprovider` → `2000 passed, 4 skipped, 38 deselected`, coverage `TOTAL 2002 116 94%`, exit 0
- `uv run --extra dev python -c "import agentfield.agent, agentfield.agent_ai, agentfield.memory"` → imports clean
- `uv run --extra dev python -c "import pydoc; ..."` → `pydoc.render_doc` of `Agent.memory` renders, and the `memory.py` sibling-tree diagram, the `workflow -> session -> actor -> global` precedence block and the retention section all render intact under `DESCRIPTION`.

Control-plane gates (fired because `content.go` is a Go source file), run from `control-plane`:

- `go build ./...` → exit 0
- `go vet ./...` → exit 0
- `go test ./internal/server/knowledgebase/...` → `ok`, exit 0
- `go test -tags sqlite_fts5 ./...` → 62 packages, no `FAIL`, exit 0
- `golangci-lint run ./internal/server/knowledgebase/...` → no findings

- [x] Python SDK lint (`ruff check`, ruff 0.15.22) clean
- [x] Python SDK formatting clean for the changed files (no new drift on the one file that already drifts on main)
- [x] Full Python SDK suite green
- [x] control-plane build / vet / tests green
- [x] `help()` / `pydoc` rendering of the rewritten docstrings verified by hand

## Verification round

Every factual claim in the new text was checked against a **live isolated control plane built from this branch** (its own `HOME`/`AGENTFIELD_HOME`, its own SQLite file — the developer's real database was never touched), not just against source.

- **Scope model — 16/16 checks.** With only one of the three headers present, an unscoped read falls back to `global`; a value written under `session` is invisible to explicit `actor` and `workflow` reads and to a different session id; an *explicit* scoped read does not fall back at all (404). Setting all four and deleting one layer at a time returned `workflow -> session -> actor -> global` in exactly that order.
- **Retention — 7/7 checks.** The control plane was stopped and restarted; `global`, `session` and `workflow` values all survived. An explicit `delete` removed one value and left its siblings untouched. Nothing purges memory on its own.
- **Unknown scope names.** In local mode an unknown scope cannot even be written — buckets are pre-created for a fixed list, so `agent`, `run` and any other name hard-fail. The Python SDK rejects them earlier with `ValueError`. This is what makes the corrected `CLAUDE.md` and KB wording accurate.
- **The rewritten `Agent.memory` API list — 21/21 checks.** Every method the new "Memory Operations" block cites was exercised end-to-end against the live control plane: awaited `get`/`set` round-trip (including the docstring's own Example sequence), `set_vector` + `similarity_search` + `delete_vector`, `delete(key, scope=, scope_id=)`, and `list_keys()` through `global_scope` and `session(sid)` — including that a session's `list_keys` does not leak the global key. A separate contract check asserts, for every name in the block, that `hasattr(MemoryInterface, name)` is true, that the cited parameter list equals `inspect.signature`, and that the `await` marker matches `inspect.iscoroutinefunction`. `keys` and `clear` are confirmed absent; `list_keys` is confirmed absent from `MemoryInterface` and present on both scoped clients.
- **`exists()`.** The live run is what surfaced item 7: `exists()` on a key that was never written returned `True`, while `get(key, sentinel)` correctly returned the sentinel. Documented rather than silently left wrong.
- **The KB article.** `GET /api/v1/agentic/kb/articles/building/memory-scopes` on a binary built from this branch returns the new text, and its Python sample was run **verbatim** against the live control plane and round-tripped correctly. The four endpoints the article lists all respond.
- **`OPENCODE_MAX_CONCURRENT`.** Go default measured at 4 and Python at 10 with the variable unset; setting it changed the cap in both; mutating it after first use (Go) or after import (Python) did not — matching the "read once per process" sentence. `grep` confirms the TypeScript provider never reads it.
- **Negative control on `origin/main`.** The old text was run against the same live control plane: main's `CLAUDE.md` call shape and main's KB code sample both raise `ValueError`; `agent` and `run` fail at the storage layer; a workflow-scoped value survived a full restart, falsifying main's "removed automatically when that run completes"; and an actor-scoped read could not see a session-scoped key, falsifying main's nested chain. main's shipped binary serves the wrong article. So the tests do exercise the change.

No LLM provider was contacted at any point; this PR needs no API key.

## Validation contract

Behaviours this change must exhibit, and what covers each:

| # | Behaviour | Covered by |
| --- | --- | --- |
| 1 | The module docstring must not present `session`, `actor` and `workflow` as a nested chain; a reader must be able to see they are independent dimensions. | Live: a value written under one dimension is invisible to the other two, and to a different id in the same dimension (6 checks). |
| 2 | Each scope's identifying request header must be named: `X-Session-ID`, `X-Actor-ID`, `X-Workflow-ID`; `global` must be identified by its fixed scope id `"global"`. | Cross-checked against `resolveScope`/`getScopeID` and the header map in `memory.py`; live, an unscoped read with only one header present falls back to `global` (3 checks). |
| 3 | The docstring must state the unscoped read order as `workflow -> session -> actor -> global`, with `global` last. | Live: all four scopes populated, then deleted one layer at a time — the returned value stepped through in exactly that order (4 checks). |
| 4 | The docstring must not claim any automatic removal on session end or run completion. | Live: stop + restart of the control plane; all values survived. Plus reading every memory delete path in the control plane (only `DeleteMemory`). |
| 5 | The docstring must state that values persist until explicitly deleted, in all four scopes, and that scope governs lookup/isolation rather than lifetime. | Same live restart test; an explicit `delete` removes one value and leaves its siblings intact. |
| 6 | Importing the SDK must still work and `help()`/`pydoc` must render the diagram without mangling it. | `pydoc.render_doc` run on the module and on `Agent.memory`; full Python suite (which imports the modules everywhere) green. |
| 7 | `CLAUDE.md` must list the four real scope names and no invented ones, and must not overstate cross-SDK uniformity. | Live: `agent`/`run` are rejected by the SDK and fail at the storage layer; the Go `ScopeUser -> actor` translation was proven with a temporary in-package test of `apiScope`. |
| 8 | `docs/harness-providers.md` must state the correct per-SDK `OPENCODE_MAX_CONCURRENT` defaults. | Measured live in both SDKs with the variable unset, set, and mutated after first read. |
| 9 | Every `app.memory.<name>` cited by the `Agent.memory` docstring must exist on the object the property returns. | `hasattr(MemoryInterface, name)` asserted for every cited name; `keys` and `clear` asserted absent. |
| 10 | Each cited call shape must equal the real signature, and the `await` marker must match whether the method is a coroutine. | `inspect.signature` compared per method; `inspect.iscoroutinefunction` compared against the presence of `await` in the docstring. |
| 11 | `list_keys` must be documented on the object that actually offers it. | Asserted absent from `MemoryInterface`, present on `ScopedMemoryClient` and `GlobalMemoryClient`; exercised live through both accessors. |
| 12 | No docstring may present `reasoner` as a memory scope, and the `Agent.memory` docstring may not claim an "Agent node ID" scope while also stating there is no Agent scope. | Asserted against the rendered docstrings of `Agent.ai`, `AgentAI.ai` and `Agent.memory`; `getScopeID` confirmed never to read `X-Agent-Node-ID`. |
| 13 | No documented behaviour may be contradicted by the live system. | The `exists()` claim was the one that failed this check; the docs were corrected to match the implementation rather than the reverse. |

No new tests: the change is documentation only and adds no code paths. Existing `tests/test_memory*.py` serve as the regression guard that the described client behaviour is unchanged.

## Test coverage

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR (no bare additions). — N/A: no new code paths; docstrings and Markdown only.
- [x] If I removed code, I updated `coverage-baseline.json` in this PR *only if* the removal caused a legitimate regression and I called it out in the summary above. — N/A: no code removed; Python SDK coverage unchanged at 94%.
- [ ] The coverage gate check is green in CI before requesting review.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) (if present) and [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
- [x] Commits are signed and follow conventional-commits style.
- [x] I have linked any related issues (Fixes #123 / Closes #456).

## Follow-ups this PR deliberately does not do

- **Fix `exists()`.** `MemoryClient.exists` needs to distinguish a 404 from a hit (for example by having `get` signal absence to its caller) and the two unit tests that monkeypatch `get` to raise need to be rewritten against real 404 behaviour. That is a code change with its own test story; this PR only stops the docstrings from promising what it does not do.
- **Remove or document the vestigial `reasoner` storage bucket.** `initializeMemoryBuckets` pre-creates `{workflow, session, actor, reasoner, global}`. `reasoner` has no header case, is never walked by a hierarchical read and is rejected by the SDK — it is dead weight, but removing it is a storage change, not a docs change.
- **Implement `memory_scope`.** It is accepted and ignored. This PR documents that fact rather than hiding it.
- **Return 400 instead of 500 for an unknown scope name.** Writing an unknown scope surfaces a raw storage error as a 500; a validation error would be more correct. Pre-existing, unrelated to this PR.

## Related issues / PRs

Refs #121 — the memory-scope documentation this docstring was written for; this corrects it against the implementation.
Refs #93 — the scope-naming mismatch that the wrong `CLAUDE.md` wording seeded.
