### PR TITLE
fix(sdk/python): retry OpenRouter image 404s on the provider path and guard data: URLs in all media outputs

### DIFF
--- a/sdk/python/agentfield/data_url.py
+++ b/sdk/python/agentfield/data_url.py
@@ -7,11 +7,17 @@ rather than as an http(s) URL. Any code path that treats a media URL as
 downloadable has to decode those locally instead of handing them to
 ``requests`` — which raises ``InvalidSchema`` for a ``data:`` URL (issue #587).
 
-Only the base64 form is supported. A ``data:`` URL with a percent-encoded (or
-missing) payload is rejected loudly by :func:`decode_data_url` rather than
-decoded into wrong-but-plausible bytes: silently returning ``b""`` for
-``data:image/png`` would be worse than the ``InvalidSchema`` these helpers
-replaced.
+Only the base64 form is supported. A ``data:`` URL that declares no base64
+payload, or whose payload is empty, is rejected loudly by
+:func:`decode_data_url` rather than decoded into wrong-but-plausible bytes:
+silently returning ``b""`` for ``data:image/png`` or ``data:image/png;base64,``
+would be worse than the ``InvalidSchema`` these helpers replaced.
+
+Decoding is strict about the base64 alphabet but *not* about layout: ASCII
+whitespace is stripped from the payload first, so an RFC 2045 line-wrapped
+payload, a trailing newline, or a space after the comma still decode — those
+are all shapes real producers emit, and the permissive decoder these helpers
+replaced accepted them.
 """
 
 import base64
@@ -22,31 +28,57 @@ from typing import Any
 # payload never reaches the message or the logs.
 _MAX_REPORTED_HEAD = 64
 
+# ASCII whitespace is not part of the base64 alphabet, so ``validate=True``
+# rejects it — but RFC 2045 encoders wrap payloads at 76 columns and some
+# producers pad the comma with a space. Deleting it keeps those decodable
+# while a genuinely corrupt payload still raises.
+_ASCII_WHITESPACE = {ord(c): None for c in " \t\n\r\v\f"}
+
 
 def is_data_url(url: Any) -> bool:
     """Return True if *url* is a ``data:`` URL.
 
     URL schemes are case-insensitive (RFC 3986 §3.1), so ``DATA:`` and
-    ``data:`` are both matched.
+    ``data:`` are both matched. Only the scheme is lower-cased — this runs on
+    every ``get_bytes()`` / ``save()`` call and a media URL can carry a
+    multi-megabyte inline payload, so the whole string is never copied.
     """
-    return isinstance(url, str) and url.lower().startswith("data:")
+    return isinstance(url, str) and url[:5].lower() == "data:"
+
+
+def data_url_mime_type(url: str) -> str:
+    """Return the MIME type declared by a ``data:`` URL, lower-cased.
+
+    Returns ``""`` when the URL declares none (``data:;base64,…``), which per
+    RFC 2397 means ``text/plain;charset=US-ASCII``. Callers that care about the
+    distinction supply their own default.
+    """
+    head = url.partition(",")[0]
+    return head[len("data:") :].partition(";")[0].strip().lower()
 
 
 def decode_data_url(url: str) -> bytes:
     """Return the decoded bytes carried inline by a base64 ``data:`` URL.
 
+    ASCII whitespace in the payload (line wrapping, a trailing newline, a space
+    after the comma) is ignored.
+
     Raises:
-        ValueError: if *url* has no ``,`` separator or its metadata head does
-            not declare ``;base64`` — i.e. it is not a form this helper can
-            decode.
+        ValueError: if *url* has no ``,`` separator, its metadata head does not
+            declare ``;base64``, or the payload is empty — i.e. it is not a
+            form this helper can decode into real bytes.
         binascii.Error: if the payload is declared base64 but is corrupt.
+            (``binascii.Error`` subclasses ``ValueError``.)
     """
     head, sep, payload = url.partition(",")
+    reported = head[:_MAX_REPORTED_HEAD] + (
+        "..." if len(head) > _MAX_REPORTED_HEAD else ""
+    )
     if not sep or ";base64" not in head.lower():
-        reported = head[:_MAX_REPORTED_HEAD] + (
-            "..." if len(head) > _MAX_REPORTED_HEAD else ""
-        )
         raise ValueError(
             f"Unsupported data: URL (expected base64 payload): {reported!r}"
         )
+    payload = payload.translate(_ASCII_WHITESPACE)
+    if not payload:
+        raise ValueError(f"Empty data: URL payload: {reported!r}")
     return base64.b64decode(payload, validate=True)

--- a/sdk/python/agentfield/data_url.py
+++ b/sdk/python/agentfield/data_url.py
@@ -1,0 +1,23 @@
+"""
+Helpers for ``data:`` URLs.
+
+Image / video / file models reached through OpenRouter (Gemini image models in
+particular) return their output inline as ``data:<mime>;base64,<payload>``
+rather than as an http(s) URL. Any code path that treats a media URL as
+downloadable has to decode those locally instead of handing them to
+``requests`` — which raises ``InvalidSchema`` for a ``data:`` URL (issue #587).
+"""
+
+import base64
+from typing import Any
+
+
+def is_data_url(url: Any) -> bool:
+    """Return True if *url* is a ``data:`` URL."""
+    return isinstance(url, str) and url.startswith("data:")
+
+
+def decode_data_url(url: str) -> bytes:
+    """Return the decoded bytes carried inline by a base64 ``data:`` URL."""
+    _, _, payload = url.partition(",")
+    return base64.b64decode(payload)

--- a/sdk/python/agentfield/data_url.py
+++ b/sdk/python/agentfield/data_url.py
@@ -6,18 +6,47 @@ particular) return their output inline as ``data:<mime>;base64,<payload>``
 rather than as an http(s) URL. Any code path that treats a media URL as
 downloadable has to decode those locally instead of handing them to
 ``requests`` — which raises ``InvalidSchema`` for a ``data:`` URL (issue #587).
+
+Only the base64 form is supported. A ``data:`` URL with a percent-encoded (or
+missing) payload is rejected loudly by :func:`decode_data_url` rather than
+decoded into wrong-but-plausible bytes: silently returning ``b""`` for
+``data:image/png`` would be worse than the ``InvalidSchema`` these helpers
+replaced.
 """
 
 import base64
 from typing import Any
 
+# Cap on how much of a rejected URL is echoed back in the error. Only the
+# metadata head (everything before the first comma) is ever reported, so a
+# payload never reaches the message or the logs.
+_MAX_REPORTED_HEAD = 64
+
 
 def is_data_url(url: Any) -> bool:
-    """Return True if *url* is a ``data:`` URL."""
-    return isinstance(url, str) and url.startswith("data:")
+    """Return True if *url* is a ``data:`` URL.
+
+    URL schemes are case-insensitive (RFC 3986 §3.1), so ``DATA:`` and
+    ``data:`` are both matched.
+    """
+    return isinstance(url, str) and url.lower().startswith("data:")
 
 
 def decode_data_url(url: str) -> bytes:
-    """Return the decoded bytes carried inline by a base64 ``data:`` URL."""
-    _, _, payload = url.partition(",")
-    return base64.b64decode(payload)
+    """Return the decoded bytes carried inline by a base64 ``data:`` URL.
+
+    Raises:
+        ValueError: if *url* has no ``,`` separator or its metadata head does
+            not declare ``;base64`` — i.e. it is not a form this helper can
+            decode.
+        binascii.Error: if the payload is declared base64 but is corrupt.
+    """
+    head, sep, payload = url.partition(",")
+    if not sep or ";base64" not in head.lower():
+        reported = head[:_MAX_REPORTED_HEAD] + (
+            "..." if len(head) > _MAX_REPORTED_HEAD else ""
+        )
+        raise ValueError(
+            f"Unsupported data: URL (expected base64 payload): {reported!r}"
+        )
+    return base64.b64decode(payload, validate=True)

--- a/sdk/python/agentfield/media_providers.py
+++ b/sdk/python/agentfield/media_providers.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
 from urllib.parse import quote, urlparse
 
+from agentfield import openrouter_retry
 from agentfield.openrouter_attribution import merge_attribution_headers
 from agentfield.multimodal_response import (
     AudioOutput,
@@ -2275,18 +2276,64 @@ class OpenRouterProvider(MediaProvider):
 
         timeout = aiohttp.ClientTimeout(total=120.0)
         async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.post(
-                "https://openrouter.ai/api/v1/chat/completions",
-                headers=headers,
-                json=body,
-            ) as resp:
-                if resp.status >= 400:
-                    detail = await resp.text()
-                    raise RuntimeError(
-                        f"OpenRouter image generation failed ({resp.status}): "
-                        f"{detail[:500]}"
+
+            async def post(request_body: Dict[str, Any]):
+                """POST once. Returns (ok, status, detail_text, payload)."""
+                async with session.post(
+                    "https://openrouter.ai/api/v1/chat/completions",
+                    headers=headers,
+                    json=request_body,
+                ) as resp:
+                    if resp.status >= 400:
+                        return False, resp.status, await resp.text(), None
+                    return True, resp.status, "", await resp.json()
+
+            def fail(status: int, detail: str) -> RuntimeError:
+                return RuntimeError(
+                    f"OpenRouter image generation failed ({status}): {detail[:500]}"
+                )
+
+            # OpenRouter answers a 404 carrying "No endpoints found that support
+            # the requested output modalities" when routing lands on an upstream
+            # replica without the image modality (transient, issue #588) or when
+            # no upstream provider accepts the requested image_config
+            # (deterministic, issue #586). Retry the transient case; strip
+            # image_config once for the deterministic one. Every other failure
+            # raises on the first response.
+            last_status = 0
+            last_detail = ""
+            for attempt in range(openrouter_retry.NO_ENDPOINTS_TOTAL_ATTEMPTS):
+                ok, status, detail, payload = await post(body)
+                if ok:
+                    break
+                if not (
+                    status == 404 and openrouter_retry.is_no_endpoints_error(detail)
+                ):
+                    raise fail(status, detail)
+                last_status, last_detail = status, detail
+                if attempt < len(openrouter_retry.NO_ENDPOINTS_INTER_SLEEPS):
+                    await openrouter_retry.sleep(
+                        openrouter_retry.NO_ENDPOINTS_INTER_SLEEPS[attempt]
                     )
-                payload = await resp.json()
+            else:
+                # Retries exhausted. A falsy image_config (absent or {}) produces
+                # an identical wire call whether stripped or not, so there is
+                # nothing left to try.
+                if not body.get("image_config"):
+                    raise fail(last_status, last_detail)
+
+                from agentfield.logger import log_warn
+
+                log_warn(
+                    "OpenRouter returned 'No endpoints found' after retries; "
+                    "retrying once with image_config stripped (no upstream "
+                    "provider accepted the requested image_config)."
+                )
+                stripped = {k: v for k, v in body.items() if k != "image_config"}
+                await openrouter_retry.sleep(openrouter_retry.NO_ENDPOINTS_STRIP_SLEEP)
+                ok, status, detail, payload = await post(stripped)
+                if not ok:
+                    raise fail(status, detail)
 
         images: List[ImageOutput] = []
         text_content = ""

--- a/sdk/python/agentfield/multimodal.py
+++ b/sdk/python/agentfield/multimodal.py
@@ -4,7 +4,7 @@ from typing import Literal, Optional, Union
 
 from pydantic import BaseModel, Field
 
-from agentfield.data_url import decode_data_url, is_data_url
+from agentfield.data_url import data_url_mime_type, decode_data_url, is_data_url
 
 
 class Text(BaseModel):
@@ -55,6 +55,22 @@ class Image(BaseModel):
         return cls(image_url={"url": url, "detail": detail})
 
 
+# Audio formats the LiteLLM ``input_audio`` block understands, keyed by the MIME
+# type a ``data:`` URL can declare. Anything unrecognised falls back to
+# ``_DEFAULT_AUDIO_FORMAT``, which is also what an http(s) URL gets when the
+# caller does not say - the URL alone carries no reliable type.
+_DEFAULT_AUDIO_FORMAT = "wav"
+_AUDIO_MIME_FORMATS = {
+    "audio/mpeg": "mp3",
+    "audio/mp3": "mp3",
+    "audio/wav": "wav",
+    "audio/x-wav": "wav",
+    "audio/wave": "wav",
+    "audio/flac": "flac",
+    "audio/ogg": "ogg",
+}
+
+
 class Audio(BaseModel):
     """Represents audio content in a multimodal prompt."""
 
@@ -84,22 +100,30 @@ class Audio(BaseModel):
         return cls(input_audio={"data": audio_data, "format": format})
 
     @classmethod
-    def from_url(cls, url: str, format: str = "wav") -> "Audio":
+    def from_url(cls, url: str, format: Optional[str] = None) -> "Audio":
         """Create Audio from URL.
 
         ``data:`` URLs carry their payload inline and are decoded locally;
-        http(s) URLs are downloaded and converted to base64.
+        their declared MIME type picks the format when *format* is not given
+        (``data:audio/mpeg;base64,...`` -> ``"mp3"``), falling back to
+        ``"wav"`` for a MIME type this SDK does not map. http(s) URLs are
+        downloaded and converted to base64, and default to ``"wav"``. An
+        explicit *format* always wins.
         """
         if is_data_url(url):
             audio_data = base64.b64encode(decode_data_url(url)).decode()
-            return cls(input_audio={"data": audio_data, "format": format})
+            resolved = format or _AUDIO_MIME_FORMATS.get(
+                data_url_mime_type(url), _DEFAULT_AUDIO_FORMAT
+            )
+            return cls(input_audio={"data": audio_data, "format": resolved})
+        resolved = format or _DEFAULT_AUDIO_FORMAT
         try:
             import requests
 
             response = requests.get(url)
             response.raise_for_status()
             audio_data = base64.b64encode(response.content).decode()
-            return cls(input_audio={"data": audio_data, "format": format})
+            return cls(input_audio={"data": audio_data, "format": resolved})
         except ImportError:
             raise ImportError("URL download requires requests: pip install requests")
 
@@ -201,7 +225,7 @@ def audio_from_file(file_path: Union[str, Path], format: Optional[str] = None) -
     return Audio.from_file(file_path, format)
 
 
-def audio_from_url(url: str, format: str = "wav") -> Audio:
+def audio_from_url(url: str, format: Optional[str] = None) -> Audio:
     """Create audio content from URL."""
     return Audio.from_url(url, format)
 

--- a/sdk/python/agentfield/multimodal.py
+++ b/sdk/python/agentfield/multimodal.py
@@ -4,6 +4,8 @@ from typing import Literal, Optional, Union
 
 from pydantic import BaseModel, Field
 
+from agentfield.data_url import decode_data_url, is_data_url
+
 
 class Text(BaseModel):
     """Represents text content in a multimodal prompt."""
@@ -83,7 +85,14 @@ class Audio(BaseModel):
 
     @classmethod
     def from_url(cls, url: str, format: str = "wav") -> "Audio":
-        """Create Audio from URL (downloads and converts to base64)."""
+        """Create Audio from URL.
+
+        ``data:`` URLs carry their payload inline and are decoded locally;
+        http(s) URLs are downloaded and converted to base64.
+        """
+        if is_data_url(url):
+            audio_data = base64.b64encode(decode_data_url(url)).decode()
+            return cls(input_audio={"data": audio_data, "format": format})
         try:
             import requests
 

--- a/sdk/python/agentfield/multimodal_response.py
+++ b/sdk/python/agentfield/multimodal_response.py
@@ -10,6 +10,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
+from agentfield.data_url import decode_data_url, is_data_url
 from agentfield.logger import log_error, log_warn
 from pydantic import BaseModel, Field
 
@@ -100,10 +101,9 @@ class ImageOutput(BaseModel):
         if self.b64_json:
             return base64.b64decode(self.b64_json)
         if self.url:
-            if self.url.startswith("data:"):
+            if is_data_url(self.url):
                 # data:image/jpeg;base64,<payload>
-                _, _, payload = self.url.partition(",")
-                return base64.b64decode(payload)
+                return decode_data_url(self.url)
             try:
                 import requests
             except ImportError:
@@ -148,6 +148,10 @@ class FileOutput(BaseModel):
             file_bytes = base64.b64decode(self.data)
             with open(path, "wb") as f:
                 f.write(file_bytes)
+        elif is_data_url(self.url):
+            # Inline payload - decode locally, never hand a data: URL to requests
+            with open(path, "wb") as f:
+                f.write(decode_data_url(self.url))
         elif self.url:
             # Download from URL
             try:
@@ -168,6 +172,8 @@ class FileOutput(BaseModel):
         """Get raw file bytes."""
         if self.data:
             return base64.b64decode(self.data)
+        elif is_data_url(self.url):
+            return decode_data_url(self.url)
         elif self.url:
             try:
                 import requests
@@ -205,6 +211,10 @@ class VideoOutput(BaseModel):
             video_bytes = base64.b64decode(self.data)
             with open(path, "wb") as f:
                 f.write(video_bytes)
+        elif is_data_url(self.url):
+            # Inline payload - decode locally, never hand a data: URL to requests
+            with open(path, "wb") as f:
+                f.write(decode_data_url(self.url))
         elif self.url:
             try:
                 import requests
@@ -224,6 +234,8 @@ class VideoOutput(BaseModel):
         """Get raw video bytes."""
         if self.data:
             return base64.b64decode(self.data)
+        elif is_data_url(self.url):
+            return decode_data_url(self.url)
         elif self.url:
             try:
                 import requests

--- a/sdk/python/agentfield/multimodal_response.py
+++ b/sdk/python/agentfield/multimodal_response.py
@@ -91,10 +91,14 @@ class ImageOutput(BaseModel):
         """Save image to file."""
         if not self.b64_json and not self.url:
             raise ValueError("No image data or URL available to save")
+        # Resolve the bytes before touching the destination: opening with "wb"
+        # truncates, so a payload that turns out to be undecodable (or a
+        # download that fails) must not destroy an existing file at *path*.
+        image_bytes = self.get_bytes()
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "wb") as f:
-            f.write(self.get_bytes())
+            f.write(image_bytes)
 
     def get_bytes(self) -> bytes:
         """Get raw image bytes from b64_json, a data: URL, or an http(s) URL."""
@@ -140,18 +144,15 @@ class FileOutput(BaseModel):
 
     def save(self, path: Union[str, Path]) -> None:
         """Save file to disk."""
-        path = Path(path)
-        path.parent.mkdir(parents=True, exist_ok=True)
-
+        # Resolve the bytes before touching the destination: opening with "wb"
+        # truncates, so a payload that turns out to be undecodable (or a
+        # download that fails) must not destroy an existing file at *path*.
         if self.data:
             # Save from base64 data
             file_bytes = base64.b64decode(self.data)
-            with open(path, "wb") as f:
-                f.write(file_bytes)
         elif is_data_url(self.url):
             # Inline payload - decode locally, never hand a data: URL to requests
-            with open(path, "wb") as f:
-                f.write(decode_data_url(self.url))
+            file_bytes = decode_data_url(self.url)
         elif self.url:
             # Download from URL
             try:
@@ -159,14 +160,18 @@ class FileOutput(BaseModel):
 
                 response = requests.get(self.url)
                 response.raise_for_status()
-                with open(path, "wb") as f:
-                    f.write(response.content)
+                file_bytes = response.content
             except ImportError:
                 raise ImportError(
                     "URL download requires requests: pip install requests"
                 )
         else:
             raise ValueError("No file data or URL available to save")
+
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "wb") as f:
+            f.write(file_bytes)
 
     def get_bytes(self) -> bytes:
         """Get raw file bytes."""
@@ -204,31 +209,32 @@ class VideoOutput(BaseModel):
 
     def save(self, path: Union[str, Path]) -> None:
         """Save video to file."""
-        path = Path(path)
-        path.parent.mkdir(parents=True, exist_ok=True)
-
+        # Resolve the bytes before touching the destination: opening with "wb"
+        # truncates, so a payload that turns out to be undecodable (or a
+        # download that fails) must not destroy an existing file at *path*.
         if self.data:
             video_bytes = base64.b64decode(self.data)
-            with open(path, "wb") as f:
-                f.write(video_bytes)
         elif is_data_url(self.url):
             # Inline payload - decode locally, never hand a data: URL to requests
-            with open(path, "wb") as f:
-                f.write(decode_data_url(self.url))
+            video_bytes = decode_data_url(self.url)
         elif self.url:
             try:
                 import requests
 
                 response = requests.get(self.url, timeout=120)
                 response.raise_for_status()
-                with open(path, "wb") as f:
-                    f.write(response.content)
+                video_bytes = response.content
             except ImportError:
                 raise ImportError(
                     "URL download requires requests: pip install requests"
                 )
         else:
             raise ValueError("No video data or URL available to save")
+
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "wb") as f:
+            f.write(video_bytes)
 
     def get_bytes(self) -> bytes:
         """Get raw video bytes."""

--- a/sdk/python/agentfield/openrouter_retry.py
+++ b/sdk/python/agentfield/openrouter_retry.py
@@ -1,0 +1,43 @@
+"""
+Shared retry policy for OpenRouter's transient "no endpoints" 404.
+
+OpenRouter occasionally routes an image-generation request to an upstream
+replica that does not expose the image output modality, and answers with a 404
+whose body carries the ``No endpoints found that support the requested output
+modalities`` message (issues #586 and #588). The same 404 is returned
+deterministically when ``image_config`` is set and no upstream provider in the
+model's matrix accepts that parameter.
+
+Both the LiteLLM path (:mod:`agentfield.vision`) and the direct-HTTP provider
+path (:class:`agentfield.media_providers.OpenRouterProvider`) share the marker
+and the backoff schedule defined here.
+"""
+
+import asyncio
+
+# Substring identifying OpenRouter's "no upstream provider" 404. Matched against
+# the exception text on the LiteLLM path and against the response body on the
+# direct-HTTP provider path.
+NO_ENDPOINTS_MARKER = "No endpoints found that support the requested output modalities"
+
+# Sleeps between the 3 in-loop attempts.
+# Sequence: attempt 1 -> sleep 1s -> attempt 2 -> sleep 2s -> attempt 3 -> (sleep
+# 4s -> strip-and-retry) if image_config was set, else give up.
+NO_ENDPOINTS_TOTAL_ATTEMPTS = 3
+NO_ENDPOINTS_INTER_SLEEPS = (1.0, 2.0)
+NO_ENDPOINTS_STRIP_SLEEP = 4.0
+
+
+def is_no_endpoints_error(text: str) -> bool:
+    """Return True if *text* carries OpenRouter's "no endpoints found" marker."""
+    return NO_ENDPOINTS_MARKER in (text or "")
+
+
+async def sleep(seconds: float) -> None:
+    """Back off between retries.
+
+    Indirection kept at module level so tests can patch the backoff
+    (``agentfield.openrouter_retry.sleep``) without patching ``asyncio.sleep``
+    process-wide.
+    """
+    await asyncio.sleep(seconds)

--- a/sdk/python/agentfield/vision.py
+++ b/sdk/python/agentfield/vision.py
@@ -13,11 +13,12 @@ import asyncio
 import os
 from typing import Any, Dict, Optional
 from agentfield.logger import log_error, log_warn
+from agentfield import openrouter_retry
 from agentfield.openrouter_retry import (
     NO_ENDPOINTS_INTER_SLEEPS,
-    NO_ENDPOINTS_MARKER,
     NO_ENDPOINTS_STRIP_SLEEP,
     NO_ENDPOINTS_TOTAL_ATTEMPTS,
+    is_no_endpoints_error,
 )
 
 
@@ -192,11 +193,11 @@ async def generate_image_openrouter(
                 )
                 break
             except Exception as e:
-                if NO_ENDPOINTS_MARKER not in str(e):
+                if not is_no_endpoints_error(str(e)):
                     raise
                 last_exc = e
                 if attempt < len(NO_ENDPOINTS_INTER_SLEEPS):
-                    await asyncio.sleep(NO_ENDPOINTS_INTER_SLEEPS[attempt])
+                    await openrouter_retry.sleep(NO_ENDPOINTS_INTER_SLEEPS[attempt])
         if response is None:
             # All in-loop attempts exhausted. If image_config was set, try once
             # without it before giving up. Falsy check (not `is not None`) is
@@ -209,7 +210,7 @@ async def generate_image_openrouter(
                     "accepted the requested image_config)."
                 )
                 completion_params.pop("image_config", None)
-                await asyncio.sleep(NO_ENDPOINTS_STRIP_SLEEP)
+                await openrouter_retry.sleep(NO_ENDPOINTS_STRIP_SLEEP)
                 response = await asyncio.wait_for(
                     litellm.acompletion(**completion_params),
                     timeout=timeout,

--- a/sdk/python/agentfield/vision.py
+++ b/sdk/python/agentfield/vision.py
@@ -13,17 +13,12 @@ import asyncio
 import os
 from typing import Any, Dict, Optional
 from agentfield.logger import log_error, log_warn
-
-
-# Substring identifying OpenRouter's transient "no upstream provider" 404
-# (issues #3 and #5 in reel-af AGENTFIELD_SDK_ISSUES.md).
-_NO_ENDPOINTS_MARKER = "No endpoints found that support the requested output modalities"
-# Sleeps between the 3 in-loop attempts; index 0 is before the strip attempt.
-# Sequence: attempt 1 → sleep 1s → attempt 2 → sleep 2s → attempt 3 → (sleep 4s
-# → strip-and-retry) if image_config was set, else give up.
-_NO_ENDPOINTS_TOTAL_ATTEMPTS = 3
-_NO_ENDPOINTS_INTER_SLEEPS = (1.0, 2.0)
-_NO_ENDPOINTS_STRIP_SLEEP = 4.0
+from agentfield.openrouter_retry import (
+    NO_ENDPOINTS_INTER_SLEEPS,
+    NO_ENDPOINTS_MARKER,
+    NO_ENDPOINTS_STRIP_SLEEP,
+    NO_ENDPOINTS_TOTAL_ATTEMPTS,
+)
 
 
 async def generate_image_litellm(
@@ -113,6 +108,11 @@ async def generate_image_openrouter(
     the standard chat completions endpoint. This is different from
     LiteLLM's dedicated image generation API.
 
+    Note: ``app.ai_generate_image()`` routes through
+    :meth:`agentfield.media_providers.OpenRouterProvider.generate_image`, which
+    is the supported OpenRouter image path; this function is the older LiteLLM
+    based entry point kept for direct callers.
+
     Supported models:
     - google/gemini-3.1-flash-image-preview
     - And other OpenRouter models with image generation capabilities
@@ -184,7 +184,7 @@ async def generate_image_openrouter(
         timeout = float(os.getenv("AGENTFIELD_LLM_CALL_TIMEOUT", "120.0"))
         response = None
         last_exc: Optional[BaseException] = None
-        for attempt in range(_NO_ENDPOINTS_TOTAL_ATTEMPTS):
+        for attempt in range(NO_ENDPOINTS_TOTAL_ATTEMPTS):
             try:
                 response = await asyncio.wait_for(
                     litellm.acompletion(**completion_params),
@@ -192,11 +192,11 @@ async def generate_image_openrouter(
                 )
                 break
             except Exception as e:
-                if _NO_ENDPOINTS_MARKER not in str(e):
+                if NO_ENDPOINTS_MARKER not in str(e):
                     raise
                 last_exc = e
-                if attempt < len(_NO_ENDPOINTS_INTER_SLEEPS):
-                    await asyncio.sleep(_NO_ENDPOINTS_INTER_SLEEPS[attempt])
+                if attempt < len(NO_ENDPOINTS_INTER_SLEEPS):
+                    await asyncio.sleep(NO_ENDPOINTS_INTER_SLEEPS[attempt])
         if response is None:
             # All in-loop attempts exhausted. If image_config was set, try once
             # without it before giving up. Falsy check (not `is not None`) is
@@ -209,7 +209,7 @@ async def generate_image_openrouter(
                     "accepted the requested image_config)."
                 )
                 completion_params.pop("image_config", None)
-                await asyncio.sleep(_NO_ENDPOINTS_STRIP_SLEEP)
+                await asyncio.sleep(NO_ENDPOINTS_STRIP_SLEEP)
                 response = await asyncio.wait_for(
                     litellm.acompletion(**completion_params),
                     timeout=timeout,

--- a/sdk/python/tests/test_data_url_media_outputs.py
+++ b/sdk/python/tests/test_data_url_media_outputs.py
@@ -1,0 +1,69 @@
+"""``data:`` URL handling for media outputs (issue #587).
+
+Gemini image models reached through OpenRouter return their output inline as a
+``data:<mime>;base64,<payload>`` URL rather than an http(s) URL. Handing such a
+URL to ``requests.get`` raises ``InvalidSchema``, so ``ImageOutput`` has to
+decode inline payloads locally instead of downloading them.
+"""
+
+import base64
+
+import pytest
+import requests
+
+from agentfield.multimodal_response import ImageOutput
+
+
+PAYLOAD = b"foo"
+B64 = base64.b64encode(PAYLOAD).decode()  # "Zm9v"
+
+IMAGE_DATA_URL = f"data:image/png;base64,{B64}"
+
+HTTP_URL = "https://example.test/media.bin"
+
+
+@pytest.fixture
+def no_network(monkeypatch):
+    """Fail loudly if anything tries to download while handling a data: URL."""
+
+    def _boom(*args, **kwargs):
+        raise AssertionError(f"unexpected network call: {args!r}")
+
+    monkeypatch.setattr(requests, "get", _boom)
+
+
+class _FakeResponse:
+    def __init__(self, content):
+        self.content = content
+
+    def raise_for_status(self):
+        return None
+
+
+@pytest.fixture
+def recorded_download(monkeypatch):
+    """Record http(s) downloads instead of performing them."""
+    calls = []
+
+    def _get(url, **kwargs):
+        calls.append((url, kwargs))
+        return _FakeResponse(PAYLOAD)
+
+    monkeypatch.setattr(requests, "get", _get)
+    return calls
+
+
+class TestImageOutputDataUrl:
+    def test_get_bytes_decodes_inline_payload(self, no_network):
+        assert ImageOutput(url=IMAGE_DATA_URL).get_bytes() == PAYLOAD
+
+    def test_save_writes_inline_payload(self, tmp_path, no_network):
+        path = tmp_path / "out.png"
+        ImageOutput(url=IMAGE_DATA_URL).save(path)
+        assert path.read_bytes() == PAYLOAD
+
+    def test_http_url_is_still_downloaded(self, tmp_path, recorded_download):
+        path = tmp_path / "out.png"
+        ImageOutput(url=HTTP_URL).save(path)
+        assert path.read_bytes() == PAYLOAD
+        assert [url for url, _ in recorded_download] == [HTTP_URL]

--- a/sdk/python/tests/test_data_url_media_outputs.py
+++ b/sdk/python/tests/test_data_url_media_outputs.py
@@ -13,6 +13,10 @@ a URL reached ``requests`` and raised ``InvalidSchema``, so silently yielding
 alphabet: whitespace inside the payload (RFC 2045 line wrapping, a trailing
 newline, a space after the comma) is layout, not corruption, and must still
 decode.
+
+Rejecting a payload must also never cost the caller data: ``save()`` resolves
+the bytes before it opens the destination, so a file already at that path
+survives a failed save intact.
 """
 
 import base64
@@ -258,6 +262,58 @@ class TestDataUrlHelper:
         with pytest.raises(ValueError, match="expected base64 payload") as excinfo:
             decode_data_url("data:text/plain,sup3r-s3cret")
         assert "sup3r-s3cret" not in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "make", [cls for _, cls in URL_OUTPUTS], ids=[label for label, _ in URL_OUTPUTS]
+)
+class TestSaveDoesNotDestroyTheDestination:
+    """``save()`` must resolve its bytes before it truncates anything.
+
+    ``open(path, "wb")`` truncates on open, so deciding the payload is
+    undecodable *after* opening turns "this URL is broken" into "your file is
+    gone" — the caller loses data they already had.
+    """
+
+    @pytest.mark.parametrize("bad_url", UNDECODABLE_DATA_URLS)
+    def test_rejected_payload_leaves_an_existing_file_intact(
+        self, tmp_path, no_network, make, bad_url
+    ):
+        path = tmp_path / "existing.bin"
+        path.write_bytes(EXISTING_BYTES)
+        with pytest.raises(ValueError):
+            make(url=bad_url).save(path)
+        assert path.read_bytes() == EXISTING_BYTES
+
+    @pytest.mark.parametrize("bad_url", UNDECODABLE_DATA_URLS)
+    def test_rejected_payload_leaves_no_stub_file_behind(
+        self, tmp_path, no_network, make, bad_url
+    ):
+        path = tmp_path / "new.bin"
+        with pytest.raises(ValueError):
+            make(url=bad_url).save(path)
+        assert not path.exists()
+
+    def test_failed_download_leaves_an_existing_file_intact(
+        self, tmp_path, monkeypatch, make
+    ):
+        def _boom(url, **kwargs):
+            raise requests.exceptions.ConnectionError("network down")
+
+        monkeypatch.setattr(requests, "get", _boom)
+        path = tmp_path / "existing.bin"
+        path.write_bytes(EXISTING_BYTES)
+        with pytest.raises(requests.exceptions.ConnectionError):
+            make(url=HTTP_URL).save(path)
+        assert path.read_bytes() == EXISTING_BYTES
+
+    def test_a_good_payload_still_overwrites_an_existing_file(
+        self, tmp_path, no_network, make
+    ):
+        path = tmp_path / "existing.bin"
+        path.write_bytes(EXISTING_BYTES)
+        make(url=IMAGE_DATA_URL).save(path)
+        assert path.read_bytes() == PAYLOAD
 
 
 class TestWhitespaceInPayloads:

--- a/sdk/python/tests/test_data_url_media_outputs.py
+++ b/sdk/python/tests/test_data_url_media_outputs.py
@@ -27,7 +27,7 @@ import pytest
 import requests
 
 from agentfield.data_url import data_url_mime_type, decode_data_url, is_data_url
-from agentfield.multimodal import Audio
+from agentfield.multimodal import Audio, audio_from_url
 from agentfield.multimodal_response import FileOutput, ImageOutput, VideoOutput
 
 
@@ -380,6 +380,61 @@ class TestEmptyPayloadIsRejected:
     def test_audio_rejects_an_empty_payload(self, no_network):
         with pytest.raises(ValueError, match="Empty data: URL payload"):
             Audio.from_url(EMPTY_PAYLOAD_DATA_URL)
+
+
+class TestAudioFormatFollowsTheDataUrl:
+    """``Audio.from_url`` must not label every inline payload ``wav``.
+
+    The format is handed to the model as the declared encoding of the bytes;
+    calling an MP3 a WAV is a wrong answer, not a cosmetic default.
+    """
+
+    @pytest.mark.parametrize(
+        "mime,expected",
+        [
+            ("audio/mpeg", "mp3"),
+            ("audio/mp3", "mp3"),
+            ("audio/wav", "wav"),
+            ("audio/x-wav", "wav"),
+            ("audio/wave", "wav"),
+            ("audio/flac", "flac"),
+            ("audio/ogg", "ogg"),
+            ("audio/aac", "wav"),  # unmapped -> the historical default
+            ("", "wav"),  # RFC 2397 allows an absent MIME type
+        ],
+    )
+    def test_format_is_derived_from_the_declared_mime_type(
+        self, no_network, mime, expected
+    ):
+        audio = Audio.from_url(f"data:{mime};base64,{B64}")
+        assert audio.input_audio["format"] == expected
+        assert base64.b64decode(audio.input_audio["data"]) == PAYLOAD
+
+    def test_mime_match_ignores_case_and_extra_parameters(self, no_network):
+        assert (
+            Audio.from_url(f"DATA:AUDIO/MPEG;BASE64,{B64}").input_audio["format"]
+            == "mp3"
+        )
+        assert (
+            Audio.from_url(f"data:audio/mpeg;charset=binary;base64,{B64}").input_audio[
+                "format"
+            ]
+            == "mp3"
+        )
+
+    def test_an_explicit_format_always_wins(self, no_network):
+        audio = Audio.from_url(f"data:audio/mpeg;base64,{B64}", format="flac")
+        assert audio.input_audio["format"] == "flac"
+
+    def test_http_urls_keep_the_wav_default(self, recorded_download):
+        assert Audio.from_url(HTTP_URL).input_audio["format"] == "wav"
+        assert Audio.from_url(HTTP_URL, format="mp3").input_audio["format"] == "mp3"
+
+    def test_module_level_helper_derives_the_format_too(self, no_network):
+        assert (
+            audio_from_url(f"data:audio/ogg;base64,{B64}").input_audio["format"]
+            == "ogg"
+        )
 
 
 class TestIsDataUrlCost:

--- a/sdk/python/tests/test_data_url_media_outputs.py
+++ b/sdk/python/tests/test_data_url_media_outputs.py
@@ -4,13 +4,21 @@ Gemini image models reached through OpenRouter return their output inline as a
 ``data:<mime>;base64,<payload>`` URL rather than an http(s) URL. Handing such a
 URL to ``requests.get`` raises ``InvalidSchema``, so every media output that can
 carry a URL has to decode inline payloads locally instead of downloading them.
+
+Only the base64 form is decodable. A ``data:`` URL that carries no payload or
+declares a non-base64 encoding must be rejected loudly rather than decoded into
+wrong-but-plausible bytes — before these helpers existed such a URL reached
+``requests`` and raised ``InvalidSchema``, so silently yielding ``b""`` would be
+a regression in disguise.
 """
 
 import base64
+import binascii
 
 import pytest
 import requests
 
+from agentfield.data_url import decode_data_url, is_data_url
 from agentfield.multimodal import Audio
 from agentfield.multimodal_response import FileOutput, ImageOutput, VideoOutput
 
@@ -24,6 +32,14 @@ VIDEO_DATA_URL = f"data:video/mp4;base64,{B64}"
 AUDIO_DATA_URL = f"data:audio/wav;base64,{B64}"
 
 HTTP_URL = "https://example.test/media.bin"
+
+# Scheme casing is not significant (RFC 3986 3.1) - this must still decode.
+UPPERCASE_DATA_URL = f"DATA:image/png;base64,{B64}"
+
+# Neither of these is decodable: the first carries no payload at all, the second
+# declares a plain-text (percent-encoded) payload rather than base64.
+NO_COMMA_DATA_URL = "data:image/png"
+NOT_BASE64_DATA_URL = "data:text/plain,hello"
 
 
 @pytest.fixture
@@ -72,6 +88,17 @@ class TestImageOutputDataUrl:
         assert path.read_bytes() == PAYLOAD
         assert [url for url, _ in recorded_download] == [HTTP_URL]
 
+    def test_uppercase_scheme_is_still_decoded(self, no_network):
+        assert ImageOutput(url=UPPERCASE_DATA_URL).get_bytes() == PAYLOAD
+
+    def test_data_url_without_a_payload_is_rejected(self, no_network):
+        with pytest.raises(ValueError, match="expected base64 payload"):
+            ImageOutput(url=NO_COMMA_DATA_URL).get_bytes()
+
+    def test_non_base64_data_url_is_rejected(self, no_network):
+        with pytest.raises(ValueError, match="expected base64 payload"):
+            ImageOutput(url=NOT_BASE64_DATA_URL).get_bytes()
+
 
 class TestFileOutputDataUrl:
     def test_get_bytes_decodes_inline_payload(self, no_network):
@@ -93,6 +120,24 @@ class TestFileOutputDataUrl:
         assert FileOutput(url=HTTP_URL).get_bytes() == PAYLOAD
         assert [url for url, _ in recorded_download] == [HTTP_URL, HTTP_URL]
 
+    def test_uppercase_scheme_is_still_decoded(self, tmp_path, no_network):
+        assert FileOutput(url=UPPERCASE_DATA_URL).get_bytes() == PAYLOAD
+        path = tmp_path / "upper.png"
+        FileOutput(url=UPPERCASE_DATA_URL).save(path)
+        assert path.read_bytes() == PAYLOAD
+
+    def test_data_url_without_a_payload_is_rejected(self, tmp_path, no_network):
+        with pytest.raises(ValueError, match="expected base64 payload"):
+            FileOutput(url=NO_COMMA_DATA_URL).get_bytes()
+        with pytest.raises(ValueError, match="expected base64 payload"):
+            FileOutput(url=NO_COMMA_DATA_URL).save(tmp_path / "nope.bin")
+
+    def test_non_base64_data_url_is_rejected(self, tmp_path, no_network):
+        with pytest.raises(ValueError, match="expected base64 payload"):
+            FileOutput(url=NOT_BASE64_DATA_URL).get_bytes()
+        with pytest.raises(ValueError, match="expected base64 payload"):
+            FileOutput(url=NOT_BASE64_DATA_URL).save(tmp_path / "nope.bin")
+
 
 class TestVideoOutputDataUrl:
     def test_get_bytes_decodes_inline_payload(self, no_network):
@@ -113,6 +158,24 @@ class TestVideoOutputDataUrl:
         assert url == HTTP_URL
         assert kwargs["timeout"] == 120
 
+    def test_uppercase_scheme_is_still_decoded(self, tmp_path, no_network):
+        assert VideoOutput(url=UPPERCASE_DATA_URL).get_bytes() == PAYLOAD
+        path = tmp_path / "upper.mp4"
+        VideoOutput(url=UPPERCASE_DATA_URL).save(path)
+        assert path.read_bytes() == PAYLOAD
+
+    def test_data_url_without_a_payload_is_rejected(self, tmp_path, no_network):
+        with pytest.raises(ValueError, match="expected base64 payload"):
+            VideoOutput(url=NO_COMMA_DATA_URL).get_bytes()
+        with pytest.raises(ValueError, match="expected base64 payload"):
+            VideoOutput(url=NO_COMMA_DATA_URL).save(tmp_path / "nope.mp4")
+
+    def test_non_base64_data_url_is_rejected(self, tmp_path, no_network):
+        with pytest.raises(ValueError, match="expected base64 payload"):
+            VideoOutput(url=NOT_BASE64_DATA_URL).get_bytes()
+        with pytest.raises(ValueError, match="expected base64 payload"):
+            VideoOutput(url=NOT_BASE64_DATA_URL).save(tmp_path / "nope.mp4")
+
 
 class TestAudioFromDataUrl:
     def test_from_url_decodes_inline_payload(self, no_network):
@@ -124,3 +187,41 @@ class TestAudioFromDataUrl:
         audio = Audio.from_url(HTTP_URL, format="mp3")
         assert base64.b64decode(audio.input_audio["data"]) == PAYLOAD
         assert [url for url, _ in recorded_download] == [HTTP_URL]
+
+    def test_uppercase_scheme_is_still_decoded(self, no_network):
+        audio = Audio.from_url(UPPERCASE_DATA_URL, format="wav")
+        assert base64.b64decode(audio.input_audio["data"]) == PAYLOAD
+
+    def test_data_url_without_a_payload_is_rejected(self, no_network):
+        with pytest.raises(ValueError, match="expected base64 payload"):
+            Audio.from_url(NO_COMMA_DATA_URL)
+
+    def test_non_base64_data_url_is_rejected(self, no_network):
+        with pytest.raises(ValueError, match="expected base64 payload"):
+            Audio.from_url(NOT_BASE64_DATA_URL)
+
+
+class TestDataUrlHelper:
+    """Direct coverage of the shared helper the four classes above go through."""
+
+    def test_scheme_match_ignores_case(self):
+        assert is_data_url("data:image/png;base64,Zm9v")
+        assert is_data_url("DaTa:image/png;base64,Zm9v")
+
+    def test_non_data_urls_and_non_strings_are_not_matched(self):
+        assert not is_data_url(HTTP_URL)
+        assert not is_data_url(None)
+        assert not is_data_url(b"data:image/png;base64,Zm9v")
+
+    def test_corrupt_base64_payload_raises_instead_of_truncating(self):
+        # "Zm9v!!" is declared base64 but is not - the permissive decoder used
+        # to drop the stray characters and hand back short, wrong bytes.
+        with pytest.raises(binascii.Error):
+            decode_data_url("data:image/png;base64,Zm9v!!")
+
+    def test_rejection_message_never_echoes_the_payload(self):
+        # binascii.Error subclasses ValueError, so the marker is what pins the
+        # *rejection* rather than an incidental decode failure.
+        with pytest.raises(ValueError, match="expected base64 payload") as excinfo:
+            decode_data_url("data:text/plain,sup3r-s3cret")
+        assert "sup3r-s3cret" not in str(excinfo.value)

--- a/sdk/python/tests/test_data_url_media_outputs.py
+++ b/sdk/python/tests/test_data_url_media_outputs.py
@@ -1,9 +1,9 @@
-"""``data:`` URL handling for media outputs (issue #587).
+"""``data:`` URL handling for media outputs (issue #587 and its siblings).
 
 Gemini image models reached through OpenRouter return their output inline as a
 ``data:<mime>;base64,<payload>`` URL rather than an http(s) URL. Handing such a
-URL to ``requests.get`` raises ``InvalidSchema``, so ``ImageOutput`` has to
-decode inline payloads locally instead of downloading them.
+URL to ``requests.get`` raises ``InvalidSchema``, so every media output that can
+carry a URL has to decode inline payloads locally instead of downloading them.
 """
 
 import base64
@@ -11,13 +11,17 @@ import base64
 import pytest
 import requests
 
-from agentfield.multimodal_response import ImageOutput
+from agentfield.multimodal import Audio
+from agentfield.multimodal_response import FileOutput, ImageOutput, VideoOutput
 
 
 PAYLOAD = b"foo"
 B64 = base64.b64encode(PAYLOAD).decode()  # "Zm9v"
 
 IMAGE_DATA_URL = f"data:image/png;base64,{B64}"
+FILE_DATA_URL = f"data:application/pdf;base64,{B64}"
+VIDEO_DATA_URL = f"data:video/mp4;base64,{B64}"
+AUDIO_DATA_URL = f"data:audio/wav;base64,{B64}"
 
 HTTP_URL = "https://example.test/media.bin"
 
@@ -66,4 +70,57 @@ class TestImageOutputDataUrl:
         path = tmp_path / "out.png"
         ImageOutput(url=HTTP_URL).save(path)
         assert path.read_bytes() == PAYLOAD
+        assert [url for url, _ in recorded_download] == [HTTP_URL]
+
+
+class TestFileOutputDataUrl:
+    def test_get_bytes_decodes_inline_payload(self, no_network):
+        assert FileOutput(url=FILE_DATA_URL).get_bytes() == PAYLOAD
+
+    def test_save_writes_inline_payload(self, tmp_path, no_network):
+        path = tmp_path / "out.pdf"
+        FileOutput(url=FILE_DATA_URL).save(path)
+        assert path.read_bytes() == PAYLOAD
+
+    def test_base64_data_field_still_wins_over_url(self, no_network):
+        out = FileOutput(url=FILE_DATA_URL, data=base64.b64encode(b"bar").decode())
+        assert out.get_bytes() == b"bar"
+
+    def test_http_url_is_still_downloaded(self, tmp_path, recorded_download):
+        path = tmp_path / "out.pdf"
+        FileOutput(url=HTTP_URL).save(path)
+        assert path.read_bytes() == PAYLOAD
+        assert FileOutput(url=HTTP_URL).get_bytes() == PAYLOAD
+        assert [url for url, _ in recorded_download] == [HTTP_URL, HTTP_URL]
+
+
+class TestVideoOutputDataUrl:
+    def test_get_bytes_decodes_inline_payload(self, no_network):
+        assert VideoOutput(url=VIDEO_DATA_URL).get_bytes() == PAYLOAD
+
+    def test_save_writes_inline_payload(self, tmp_path, no_network):
+        path = tmp_path / "out.mp4"
+        VideoOutput(url=VIDEO_DATA_URL).save(path)
+        assert path.read_bytes() == PAYLOAD
+
+    def test_http_url_is_still_downloaded_with_timeout(
+        self, tmp_path, recorded_download
+    ):
+        path = tmp_path / "out.mp4"
+        VideoOutput(url=HTTP_URL).save(path)
+        assert path.read_bytes() == PAYLOAD
+        url, kwargs = recorded_download[0]
+        assert url == HTTP_URL
+        assert kwargs["timeout"] == 120
+
+
+class TestAudioFromDataUrl:
+    def test_from_url_decodes_inline_payload(self, no_network):
+        audio = Audio.from_url(AUDIO_DATA_URL, format="wav")
+        assert base64.b64decode(audio.input_audio["data"]) == PAYLOAD
+        assert audio.input_audio["format"] == "wav"
+
+    def test_http_url_is_still_downloaded(self, recorded_download):
+        audio = Audio.from_url(HTTP_URL, format="mp3")
+        assert base64.b64decode(audio.input_audio["data"]) == PAYLOAD
         assert [url for url, _ in recorded_download] == [HTTP_URL]

--- a/sdk/python/tests/test_data_url_media_outputs.py
+++ b/sdk/python/tests/test_data_url_media_outputs.py
@@ -5,20 +5,24 @@ Gemini image models reached through OpenRouter return their output inline as a
 URL to ``requests.get`` raises ``InvalidSchema``, so every media output that can
 carry a URL has to decode inline payloads locally instead of downloading them.
 
-Only the base64 form is decodable. A ``data:`` URL that carries no payload or
-declares a non-base64 encoding must be rejected loudly rather than decoded into
-wrong-but-plausible bytes — before these helpers existed such a URL reached
-``requests`` and raised ``InvalidSchema``, so silently yielding ``b""`` would be
-a regression in disguise.
+Only the base64 form is decodable. A ``data:`` URL that carries no payload, an
+empty payload, or declares a non-base64 encoding must be rejected loudly rather
+than decoded into wrong-but-plausible bytes — before these helpers existed such
+a URL reached ``requests`` and raised ``InvalidSchema``, so silently yielding
+``b""`` would be a regression in disguise. Strictness stops at the base64
+alphabet: whitespace inside the payload (RFC 2045 line wrapping, a trailing
+newline, a space after the comma) is layout, not corruption, and must still
+decode.
 """
 
 import base64
 import binascii
+import tracemalloc
 
 import pytest
 import requests
 
-from agentfield.data_url import decode_data_url, is_data_url
+from agentfield.data_url import data_url_mime_type, decode_data_url, is_data_url
 from agentfield.multimodal import Audio
 from agentfield.multimodal_response import FileOutput, ImageOutput, VideoOutput
 
@@ -36,10 +40,39 @@ HTTP_URL = "https://example.test/media.bin"
 # Scheme casing is not significant (RFC 3986 3.1) - this must still decode.
 UPPERCASE_DATA_URL = f"DATA:image/png;base64,{B64}"
 
-# Neither of these is decodable: the first carries no payload at all, the second
-# declares a plain-text (percent-encoded) payload rather than base64.
+# None of these is decodable: no payload at all, an empty payload, a plain-text
+# (percent-encoded) payload rather than base64, and a payload declared base64
+# that is not.
 NO_COMMA_DATA_URL = "data:image/png"
+EMPTY_PAYLOAD_DATA_URL = "data:image/png;base64,"
 NOT_BASE64_DATA_URL = "data:text/plain,hello"
+CORRUPT_DATA_URL = f"data:image/png;base64,{B64}!!"
+
+UNDECODABLE_DATA_URLS = [
+    NO_COMMA_DATA_URL,
+    EMPTY_PAYLOAD_DATA_URL,
+    NOT_BASE64_DATA_URL,
+    CORRUPT_DATA_URL,
+]
+
+# Whitespace inside a payload is layout, not corruption: RFC 2045 encoders wrap
+# at 76 columns, and a stray leading space or trailing newline is common.
+BIG_PAYLOAD = bytes(range(256)) * 4
+WRAPPED_DATA_URL = "data:image/png;base64," + base64.encodebytes(BIG_PAYLOAD).decode()
+TRAILING_NEWLINE_DATA_URL = f"data:image/png;base64,{B64}\n"
+LEADING_SPACE_DATA_URL = f"data:image/png;base64, {B64}"
+SPLIT_DATA_URL = f"data:image/png;base64,{B64[:2]}\r\n\t{B64[2:]}"
+
+# What an existing file at the save destination holds, so a truncating save is
+# visible as a length change rather than only a content change.
+EXISTING_BYTES = b"x" * 820
+
+# (label, factory) for the three outputs whose save() writes a URL payload.
+URL_OUTPUTS = [
+    ("ImageOutput", ImageOutput),
+    ("FileOutput", FileOutput),
+    ("VideoOutput", VideoOutput),
+]
 
 
 @pytest.fixture
@@ -225,3 +258,110 @@ class TestDataUrlHelper:
         with pytest.raises(ValueError, match="expected base64 payload") as excinfo:
             decode_data_url("data:text/plain,sup3r-s3cret")
         assert "sup3r-s3cret" not in str(excinfo.value)
+
+
+class TestWhitespaceInPayloads:
+    """Layout whitespace decodes; corruption still raises.
+
+    The permissive decoder these helpers replaced accepted line-wrapped
+    payloads, so rejecting them would break callers that work today.
+    """
+
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            (WRAPPED_DATA_URL, BIG_PAYLOAD),
+            (TRAILING_NEWLINE_DATA_URL, PAYLOAD),
+            (LEADING_SPACE_DATA_URL, PAYLOAD),
+            (SPLIT_DATA_URL, PAYLOAD),
+        ],
+        ids=["rfc2045-wrapped", "trailing-newline", "space-after-comma", "cr-lf-tab"],
+    )
+    def test_whitespace_is_not_corruption(self, url, expected):
+        assert decode_data_url(url) == expected
+
+    def test_the_wrapped_fixture_really_is_wrapped(self):
+        # Guards the test above from silently becoming a no-op.
+        assert "\n" in WRAPPED_DATA_URL.partition(",")[2]
+
+    @pytest.mark.parametrize(
+        "make", [cls for _, cls in URL_OUTPUTS], ids=[label for label, _ in URL_OUTPUTS]
+    )
+    def test_media_outputs_accept_wrapped_payloads(self, make, no_network):
+        assert make(url=WRAPPED_DATA_URL).get_bytes() == BIG_PAYLOAD
+
+    def test_audio_accepts_wrapped_payloads(self, no_network):
+        audio = Audio.from_url(WRAPPED_DATA_URL)
+        assert base64.b64decode(audio.input_audio["data"]) == BIG_PAYLOAD
+
+    def test_stripping_whitespace_does_not_rescue_a_corrupt_payload(self):
+        with pytest.raises(binascii.Error):
+            decode_data_url(f"data:image/png;base64,{B64} !!")
+
+    def test_a_whitespace_only_payload_is_empty_not_valid(self):
+        with pytest.raises(ValueError, match="Empty data: URL payload"):
+            decode_data_url("data:image/png;base64, \n ")
+
+
+class TestEmptyPayloadIsRejected:
+    """``data:image/png;base64,`` must not decode to ``b""``.
+
+    Yielding empty bytes is the exact silent-wrong-answer failure the helper
+    exists to prevent; it has to raise like the other undecodable forms.
+    """
+
+    def test_helper_rejects_an_empty_payload(self):
+        with pytest.raises(ValueError, match="Empty data: URL payload"):
+            decode_data_url(EMPTY_PAYLOAD_DATA_URL)
+
+    @pytest.mark.parametrize(
+        "make", [cls for _, cls in URL_OUTPUTS], ids=[label for label, _ in URL_OUTPUTS]
+    )
+    def test_media_outputs_reject_an_empty_payload(self, make, no_network):
+        with pytest.raises(ValueError, match="Empty data: URL payload"):
+            make(url=EMPTY_PAYLOAD_DATA_URL).get_bytes()
+
+    def test_audio_rejects_an_empty_payload(self, no_network):
+        with pytest.raises(ValueError, match="Empty data: URL payload"):
+            Audio.from_url(EMPTY_PAYLOAD_DATA_URL)
+
+
+class TestIsDataUrlCost:
+    def test_detection_does_not_copy_the_url(self):
+        """``is_data_url`` runs on every get_bytes()/save() call.
+
+        An inline image is routinely megabytes, so lower-casing the whole URL
+        to test a 5-character scheme allocates a full copy of the payload for
+        nothing. Measured in allocations rather than wall time so the bound is
+        deterministic.
+        """
+        big = "data:image/png;base64," + "A" * (10 * 1024 * 1024)
+        tracemalloc.start()
+        try:
+            baseline = tracemalloc.get_traced_memory()[0]
+            assert is_data_url(big) is True
+            peak = tracemalloc.get_traced_memory()[1]
+        finally:
+            tracemalloc.stop()
+        # A whole-URL .lower() would add ~10 MB here.
+        assert peak - baseline < 1024 * 1024
+
+    def test_short_strings_do_not_trip_the_scheme_slice(self):
+        assert not is_data_url("")
+        assert not is_data_url("data")
+        assert is_data_url("data:")
+
+
+class TestDataUrlMimeType:
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            (f"data:audio/mpeg;base64,{B64}", "audio/mpeg"),
+            (f"DATA:Audio/MPEG;BASE64,{B64}", "audio/mpeg"),
+            (f"data:;base64,{B64}", ""),
+            (f"data:image/png;charset=binary;base64,{B64}", "image/png"),
+            ("data:image/png", "image/png"),
+        ],
+    )
+    def test_mime_type_is_the_head_before_the_first_parameter(self, url, expected):
+        assert data_url_mime_type(url) == expected

--- a/sdk/python/tests/test_openrouter_image_retry.py
+++ b/sdk/python/tests/test_openrouter_image_retry.py
@@ -1,0 +1,220 @@
+"""OpenRouter image-generation retry behaviour on the provider path.
+
+Issues #586 / #588: OpenRouter answers a 404 carrying "No endpoints found that
+support the requested output modalities" when routing lands on an upstream
+replica without the image modality (transient) or when no upstream provider in
+the model's matrix accepts the requested ``image_config`` (deterministic).
+
+``app.ai_generate_image()`` reaches OpenRouter through
+``OpenRouterProvider.generate_image``, so the retry has to live there — these
+tests exercise that entry point end to end over a fake aiohttp session.
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agentfield import openrouter_retry
+from agentfield.media_providers import OpenRouterProvider
+
+
+NO_ENDPOINTS_BODY = json.dumps(
+    {
+        "error": {
+            "message": (
+                "No endpoints found that support the requested output "
+                "modalities: image, text"
+            ),
+            "code": 404,
+        }
+    }
+)
+
+OTHER_404_BODY = json.dumps(
+    {"error": {"message": "No allowed providers are available", "code": 404}}
+)
+
+SUCCESS_PAYLOAD = {
+    "choices": [
+        {
+            "message": {
+                "content": "here you go",
+                "images": [
+                    {"image_url": {"url": "data:image/png;base64,Zm9v"}},
+                ],
+            }
+        }
+    ]
+}
+
+IMAGE_CONFIG = {"aspect_ratio": "9:16"}
+
+
+def _response(status, *, payload=None, text=""):
+    resp = AsyncMock()
+    resp.status = status
+    resp.json = AsyncMock(return_value=payload if payload is not None else {})
+    resp.text = AsyncMock(return_value=text)
+    return resp
+
+
+def _ok():
+    return _response(200, payload=SUCCESS_PAYLOAD)
+
+
+def _no_endpoints_404():
+    return _response(404, text=NO_ENDPOINTS_BODY)
+
+
+class RecordingSession:
+    """aiohttp.ClientSession double: records POST bodies, replays responses."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.bodies = []
+
+    def post(self, url, **kwargs):
+        # Copy: the provider must be free to reuse/replace the body dict.
+        body = kwargs.get("json")
+        self.bodies.append(dict(body) if isinstance(body, dict) else body)
+        resp = self._responses[len(self.bodies) - 1]
+        cm = AsyncMock()
+        cm.__aenter__ = AsyncMock(return_value=resp)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        return cm
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    """Replace the retry backoff so tests do not wait real seconds."""
+    sleeper = AsyncMock()
+    monkeypatch.setattr(openrouter_retry, "sleep", sleeper)
+    return sleeper
+
+
+async def _generate(session, **kwargs):
+    provider = OpenRouterProvider(api_key="sk-test-key")
+    with patch("aiohttp.ClientSession", return_value=session):
+        return await provider.generate_image(prompt="a vertical portrait", **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_transient_no_endpoints_404_is_retried_until_it_succeeds(no_sleep):
+    session = RecordingSession([_no_endpoints_404(), _no_endpoints_404(), _ok()])
+
+    result = await _generate(session)
+
+    assert result.has_images
+    assert result.images[0].get_bytes() == b"foo"
+    assert len(session.bodies) == 3
+    # Backoff between attempts, not a hot loop.
+    assert [c.args[0] for c in no_sleep.await_args_list] == [1.0, 2.0]
+
+
+@pytest.mark.asyncio
+async def test_first_attempt_success_issues_a_single_request(no_sleep):
+    session = RecordingSession([_ok()])
+
+    result = await _generate(session, image_config=IMAGE_CONFIG)
+
+    assert result.has_images
+    assert len(session.bodies) == 1
+    assert no_sleep.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_exhausted_retries_retry_once_with_image_config_stripped(no_sleep):
+    session = RecordingSession(
+        [_no_endpoints_404(), _no_endpoints_404(), _no_endpoints_404(), _ok()]
+    )
+
+    result = await _generate(session, image_config=IMAGE_CONFIG)
+
+    assert result.has_images
+    assert result.images[0].get_bytes() == b"foo"
+    assert len(session.bodies) == 4
+    # The three retried attempts asked for the caller's image_config...
+    for body in session.bodies[:3]:
+        assert body["image_config"] == IMAGE_CONFIG
+    # ...and only the final fallback drops it.
+    assert "image_config" not in session.bodies[3]
+    # Everything else about the request is unchanged.
+    assert session.bodies[3]["messages"] == session.bodies[0]["messages"]
+    assert session.bodies[3]["modalities"] == ["image"]
+
+
+@pytest.mark.asyncio
+async def test_exhausted_retries_without_image_config_raise(no_sleep):
+    session = RecordingSession(
+        [_no_endpoints_404(), _no_endpoints_404(), _no_endpoints_404()]
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        await _generate(session)
+
+    assert "No endpoints found" in str(exc.value)
+    assert "404" in str(exc.value)
+    assert len(session.bodies) == 3
+
+
+@pytest.mark.asyncio
+async def test_empty_image_config_is_not_worth_a_strip_attempt(no_sleep):
+    """An empty image_config produces an identical request once stripped."""
+    session = RecordingSession(
+        [_no_endpoints_404(), _no_endpoints_404(), _no_endpoints_404()]
+    )
+
+    with pytest.raises(RuntimeError):
+        await _generate(session, image_config={})
+
+    assert len(session.bodies) == 3
+
+
+@pytest.mark.asyncio
+async def test_failure_of_the_stripped_attempt_is_surfaced(no_sleep):
+    session = RecordingSession(
+        [
+            _no_endpoints_404(),
+            _no_endpoints_404(),
+            _no_endpoints_404(),
+            _no_endpoints_404(),
+        ]
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        await _generate(session, image_config=IMAGE_CONFIG)
+
+    assert "No endpoints found" in str(exc.value)
+    assert len(session.bodies) == 4
+
+
+@pytest.mark.asyncio
+async def test_unrelated_404_raises_on_the_first_response(no_sleep):
+    session = RecordingSession([_response(404, text=OTHER_404_BODY), _ok()])
+
+    with pytest.raises(RuntimeError) as exc:
+        await _generate(session, image_config=IMAGE_CONFIG)
+
+    assert "No allowed providers are available" in str(exc.value)
+    assert len(session.bodies) == 1
+    assert no_sleep.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_server_error_raises_on_the_first_response(no_sleep):
+    session = RecordingSession([_response(500, text="upstream exploded"), _ok()])
+
+    with pytest.raises(RuntimeError) as exc:
+        await _generate(session)
+
+    assert "upstream exploded" in str(exc.value)
+    assert "500" in str(exc.value)
+    assert len(session.bodies) == 1
+    assert no_sleep.await_count == 0

--- a/sdk/python/tests/test_openrouter_image_retry.py
+++ b/sdk/python/tests/test_openrouter_image_retry.py
@@ -148,6 +148,7 @@ async def test_exhausted_retries_retry_once_with_image_config_stripped(no_sleep)
     # Everything else about the request is unchanged.
     assert session.bodies[3]["messages"] == session.bodies[0]["messages"]
     assert session.bodies[3]["modalities"] == ["image"]
+    assert [c.args[0] for c in no_sleep.await_args_list] == [1.0, 2.0, 4.0]
 
 
 @pytest.mark.asyncio

--- a/sdk/python/tests/test_vision.py
+++ b/sdk/python/tests/test_vision.py
@@ -315,7 +315,7 @@ async def test_generate_image_openrouter_retries_on_no_endpoints_then_succeeds(
     monkeypatch,
 ):
     """First call hits 'No endpoints found' 404; second call succeeds (issue #5)."""
-    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+    monkeypatch.setattr("agentfield.openrouter_retry.sleep", AsyncMock())
 
     success_response = _build_openrouter_success_response()
     failure = Exception(_NO_ENDPOINTS_MSG)
@@ -343,7 +343,7 @@ async def test_generate_image_openrouter_strips_image_config_after_retries(
     monkeypatch,
 ):
     """All 3 in-loop attempts fail; strip-and-retry succeeds without image_config (issue #3)."""
-    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+    monkeypatch.setattr("agentfield.openrouter_retry.sleep", AsyncMock())
 
     success_response = _build_openrouter_success_response()
     failure = Exception(_NO_ENDPOINTS_MSG)
@@ -378,7 +378,7 @@ async def test_generate_image_openrouter_strips_image_config_after_retries(
 @pytest.mark.asyncio
 async def test_generate_image_openrouter_does_not_retry_on_other_errors(monkeypatch):
     """Generic exceptions propagate immediately; no retry, no strip."""
-    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+    monkeypatch.setattr("agentfield.openrouter_retry.sleep", AsyncMock())
 
     mock_litellm = MagicMock()
     mock_litellm.acompletion = AsyncMock(side_effect=RuntimeError("boom"))
@@ -406,7 +406,7 @@ async def test_generate_image_openrouter_gives_up_after_all_retries_no_image_con
 
     No strip attempt is performed (nothing to strip), so total call count is 3.
     """
-    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+    monkeypatch.setattr("agentfield.openrouter_retry.sleep", AsyncMock())
 
     failure = Exception(_NO_ENDPOINTS_MSG)
     mock_litellm = MagicMock()


### PR DESCRIPTION
## Summary

Two media bugs in the Python SDK, both reported by the `reel-af` consumer.

**OpenRouter image 404s are retried again (#586, #588).** PR #600 added a bounded retry for OpenRouter's `No endpoints found that support the requested output modalities` 404 inside `vision.generate_image_openrouter`. PR #619 then rewrote `OpenRouterProvider.generate_image` as a direct `aiohttp` POST and dropped the delegation to that function, so the retry became dead code on the path users actually hit — `app.ai_generate_image()` → `MediaRouter` → `OpenRouterProvider.generate_image`, which raised `RuntimeError` on the very first 404. The behaviour is now ported to the provider, matching the marker against the 404 **response body** (this path raises `RuntimeError`, not `litellm.NotFoundError`). The marker, attempt count and backoff schedule moved to a new neutral module `agentfield/openrouter_retry.py` shared by both paths; `vision.generate_image_openrouter` behaviour is unchanged.

**`data:` URLs are decoded everywhere, not just in `ImageOutput` (#587).** #587 was fixed for `ImageOutput` but landed without a regression test — deleting the branch left the suite green. The same bug is still live in `FileOutput.save/get_bytes`, `VideoOutput.save/get_bytes` and `multimodal.Audio.from_url`, all of which hand the URL straight to `requests.get` and raise `InvalidSchema` when a model returns its output inline. All of them now decode locally through one shared helper, `agentfield/data_url.py`; the http(s) branches (including `VideoOutput`'s 120s download timeout) are untouched.

**The shared helper rejects `data:` URLs it cannot decode, and only those.** An `is_data_url` that matched *any* `data:` URL paired with a `decode_data_url` that assumed base64 meant a malformed or non-base64 `data:` URL decoded silently to wrong bytes instead of failing: `FileOutput(url="data:image/png").get_bytes()` returned `b""` and `"data:text/plain,hello"` returned garbage, where before this branch both raised a loud `requests.exceptions.InvalidSchema`. Trading a loud error for silently-empty bytes is a worse failure mode than the bug being fixed, so the helper is strict about what it will decode:

- no `,` separator, or a metadata head that does not declare `;base64` → `ValueError("Unsupported data: URL (expected base64 payload): ...")`
- an **empty payload** (`data:image/png;base64,`) → `ValueError("Empty data: URL payload: ...")`, because `b""` is the exact silent-wrong-answer this helper exists to prevent
- a payload declared base64 but corrupt → `binascii.Error` from `b64decode(..., validate=True)`, rather than quietly dropping the stray characters and returning short bytes

Only the metadata head is echoed in the error, never the payload. `is_data_url` matches the scheme case-insensitively (RFC 3986 §3.1), so `DATA:image/png;base64,…` decodes instead of being handed to `requests`, and it lower-cases only the five-character scheme — a media URL routinely carries a multi-megabyte inline payload, and it is called on every `get_bytes()` / `save()`.

Strictness stops at the base64 *alphabet*, not at layout. ASCII whitespace is deleted from the payload before validation, so an RFC 2045 line-wrapped payload, a trailing newline or a space after the comma still decode — all three are shapes real producers emit, the permissive decoder on `main` accepted them, and `vision.py` plus the FAL and MiniMax providers build url-only `ImageOutput`s straight from provider responses.

**`save()` resolves its bytes before it opens the destination.** `ImageOutput.save`, `FileOutput.save` and `VideoOutput.save` opened the target with `"wb"` — which truncates on open — and only then decoded the URL or downloaded it. A rejected payload therefore destroyed whatever the caller already had at that path: saving over an existing 820-byte file left it at 0 bytes. Each `save()` now decodes/downloads first and opens the file only once it holds the bytes, so a failed save leaves an existing file byte-for-byte intact and creates no empty stub where there was no file. The success path is unchanged.

**`Audio.from_url` labels inline audio with the format its URL declares.** It defaulted `format` to `"wav"` and passed it through untouched, so `Audio.from_url("data:audio/mpeg;base64,…")` announced MP3 bytes to the model as a WAV. `format` is now `Optional[str] = None` and, for a `data:` URL, is derived from the declared MIME type (`audio/mpeg`, `audio/mp3` → `mp3`; `audio/wav`, `audio/x-wav`, `audio/wave` → `wav`; `audio/flac` → `flac`; `audio/ogg` → `ogg`), falling back to `"wav"` for an unmapped or absent type. http(s) URLs keep the `"wav"` default — the URL alone carries no reliable type — and an explicit `format` always wins, so existing callers are unaffected.

No new network calls, no new logging of payloads or secrets, no auth changes. `agentfield/multimodal_response.py` has pre-existing `ruff format` drift in `_resolve_cost` (line ~618) that is deliberately left alone; it drifts identically on `origin/main`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] Tests only
- [ ] CI / tooling
- [ ] Breaking change

## Test plan

All commands run from `sdk/python`. Every gate below passed.

- `uvx --from ruff==0.15.22 ruff check .` → `All checks passed!`
- `uvx --from ruff==0.15.22 ruff format --check` on the eight files this PR touches → `2 files would be reformatted, 6 files already formatted`; the two are `media_providers.py` and `multimodal_response.py`, which drift identically on `origin/main` (the only hunk in `multimodal_response.py` is the pre-existing `_resolve_cost` signature, not a line this PR wrote)
- `uv run --extra dev ./scripts/run_pytest.sh -p no:cacheprovider` (coverage on, CI's literal entrypoint, CPython 3.13) → `2102 passed, 4 skipped, 38 deselected in 119.00s`, `TOTAL 2002 116 94%`, exit 0
- `uv run --python 3.10 --extra dev ./scripts/run_pytest.sh -p no:cacheprovider` (CI's oldest interpreter) → `2102 passed, 4 skipped, 38 deselected in 125.70s`, exit 0
- Focused: `./scripts/run_pytest.sh tests/test_data_url_media_outputs.py --no-cov` → `94 passed`

Each new test was also run against the pre-fix code to confirm it fails for the right reason:

- With `media_providers.py` reverted to its parent commit, 5 of the 8 retry tests fail (the three that stay green are the "raise on the first response" and first-attempt-success cases, whose behaviour is intentionally unchanged).
- With `multimodal_response.py` / `multimodal.py` reverted, the `FileOutput`, `VideoOutput` and `Audio` tests fail; additionally deleting the `data:` branch from `ImageOutput.get_bytes` turns the two `ImageOutput` tests red — which is exactly the regression #587 had no coverage for.
- With `data_url.py` reverted to the permissive first cut, 14 of the 15 rejection / case-insensitivity tests fail. The 15th (`test_rejection_message_never_echoes_the_payload`) passed against the old code by accident, because `binascii.Error` subclasses `ValueError`; it now matches on the message marker so it fails for the right reason too.
- With the three source files reverted to the review-round state (helper shimmed only so the module imports), **46** of the tests in `tests/test_data_url_media_outputs.py` fail — every truncation, whitespace, empty-payload, detection-cost and audio-format behaviour below is pinned by a test that is red without its fix.

## Validation contract

Behaviours this PR must exhibit, and the test that pins each.

**`OpenRouterProvider.generate_image` — OpenRouter routing 404s** (`tests/test_openrouter_image_retry.py`)

| Behaviour | Test |
| --- | --- |
| A 404 carrying the "no endpoints" marker is retried; if a later attempt succeeds the caller sees a normal `MultimodalResponse` and no error. Attempts back off (1s, 2s) rather than hot-looping. | `test_transient_no_endpoints_404_is_retried_until_it_succeeds` |
| A request that succeeds first time issues exactly one HTTP request and never sleeps. | `test_first_attempt_success_issues_a_single_request` |
| After 3 marked 404s, when the caller passed a non-empty `image_config`, exactly one more request is sent with `image_config` absent from the body while the first three carried it; the rest of the request is identical. | `test_exhausted_retries_retry_once_with_image_config_stripped` |
| After 3 marked 404s with no `image_config`, the caller gets a `RuntimeError` naming the status and body; exactly 3 requests were sent. | `test_exhausted_retries_without_image_config_raise` |
| An empty `image_config` is not worth a strip attempt (identical wire call once stripped): 3 requests, then raise. | `test_empty_image_config_is_not_worth_a_strip_attempt` |
| If the stripped attempt also fails, that failure reaches the caller; exactly 4 requests. | `test_failure_of_the_stripped_attempt_is_surfaced` |
| A 404 **without** the marker raises on the first response — one request, no sleep. | `test_unrelated_404_raises_on_the_first_response` |
| A non-404 failure (500) raises on the first response — one request, no sleep. | `test_server_error_raises_on_the_first_response` |

**`data:` URLs in media outputs** (`tests/test_data_url_media_outputs.py`; `requests.get` is rigged to raise in every `data:` case, so a download attempt fails the test)

| Behaviour | Test |
| --- | --- |
| `ImageOutput(url="data:image/png;base64,Zm9v").get_bytes() == b"foo"` and `.save(path)` writes those bytes, with no network call. | `TestImageOutputDataUrl::test_get_bytes_decodes_inline_payload`, `::test_save_writes_inline_payload` |
| Same for `FileOutput`. | `TestFileOutputDataUrl::…` |
| Same for `VideoOutput`. | `TestVideoOutputDataUrl::…` |
| `multimodal.Audio.from_url` on a `data:` URL yields the inline payload without downloading. | `TestAudioFromDataUrl::test_from_url_decodes_inline_payload` |
| An explicit base64 `data` field still wins over `url`. | `TestFileOutputDataUrl::test_base64_data_field_still_wins_over_url` |
| http(s) URLs behave exactly as before — still downloaded, and `VideoOutput` still passes `timeout=120`. | `test_http_url_is_still_downloaded` (image/file/audio), `TestVideoOutputDataUrl::test_http_url_is_still_downloaded_with_timeout` |

**`data:` URLs that cannot be decoded are rejected, not guessed at** (one test per consumer — `ImageOutput`, `FileOutput`, `VideoOutput`, `Audio.from_url` — so no class can regress on its own)

| Behaviour | Test |
| --- | --- |
| A `data:` URL with no payload at all (`"data:image/png"`, no `,`) raises `ValueError` naming the expected base64 payload — it must not yield `b""`. Checked on both `get_bytes()` and `save()` for the classes whose `save()` does not delegate to `get_bytes()`. | `test_data_url_without_a_payload_is_rejected` (×4) |
| A `data:` URL whose head does not declare `;base64` (`"data:text/plain,hello"`) raises `ValueError` — it must not return garbage bytes. | `test_non_base64_data_url_is_rejected` (×4) |
| A declared-base64 URL with an **empty** payload (`"data:image/png;base64,"`) raises `ValueError`, on the helper and on all four consumers — `b""` is the silent wrong answer this helper exists to prevent. | `TestEmptyPayloadIsRejected` (×5) |
| The scheme is matched case-insensitively: `"DATA:image/png;base64,Zm9v"` decodes to `b"foo"` and is never handed to `requests`. | `test_uppercase_scheme_is_still_decoded` (×4), `TestDataUrlHelper::test_scheme_match_ignores_case` |
| A payload declared base64 but corrupt (`"…;base64,Zm9v!!"`) raises `binascii.Error` instead of silently dropping the stray characters and returning short bytes. | `TestDataUrlHelper::test_corrupt_base64_payload_raises_instead_of_truncating` |
| The rejection message carries the metadata head only — a payload never reaches the error text or the logs. | `TestDataUrlHelper::test_rejection_message_never_echoes_the_payload` |
| `is_data_url` still returns `False` for http(s) URLs, `None`, non-`str` values, and strings shorter than the scheme. | `TestDataUrlHelper::test_non_data_urls_and_non_strings_are_not_matched`, `TestIsDataUrlCost::test_short_strings_do_not_trip_the_scheme_slice` |

**Layout whitespace is not corruption** (strictness must not reject payloads that worked on `main`)

| Behaviour | Test |
| --- | --- |
| An RFC 2045 line-wrapped payload, a trailing newline, a space after the comma, and an embedded CR/LF/tab all decode to the exact bytes — through the helper and through `ImageOutput` / `FileOutput` / `VideoOutput` / `Audio`. | `TestWhitespaceInPayloads::test_whitespace_is_not_corruption` (×4), `::test_media_outputs_accept_wrapped_payloads` (×3), `::test_audio_accepts_wrapped_payloads` |
| Stripping whitespace does not rescue a payload that is corrupt for another reason. | `TestWhitespaceInPayloads::test_stripping_whitespace_does_not_rescue_a_corrupt_payload` |
| A whitespace-only payload is empty, not valid. | `TestWhitespaceInPayloads::test_a_whitespace_only_payload_is_empty_not_valid` |

**`save()` never costs the caller data it already had**

| Behaviour | Test |
| --- | --- |
| Saving over an existing file with an undecodable `data:` URL (no payload / empty payload / not base64 / corrupt) raises and leaves the file byte-for-byte intact — for all three of `ImageOutput`, `FileOutput`, `VideoOutput`. | `TestSaveDoesNotDestroyTheDestination::test_rejected_payload_leaves_an_existing_file_intact` (3 classes × 4 URLs) |
| The same save to a path that did not exist creates no zero-byte stub. | `::test_rejected_payload_leaves_no_stub_file_behind` (×12) |
| A failed http(s) download likewise leaves an existing file intact. | `::test_failed_download_leaves_an_existing_file_intact` (×3) |
| A good payload still overwrites an existing file with the new bytes. | `::test_a_good_payload_still_overwrites_an_existing_file` (×3) |

**`Audio.from_url` reports the real format**

| Behaviour | Test |
| --- | --- |
| The format follows the `data:` URL's declared MIME type: `audio/mpeg`, `audio/mp3` → `mp3`; `audio/wav`, `audio/x-wav`, `audio/wave` → `wav`; `audio/flac` → `flac`; `audio/ogg` → `ogg`; an unmapped or absent type → `wav`. | `TestAudioFormatFollowsTheDataUrl::test_format_is_derived_from_the_declared_mime_type` (×9) |
| The MIME match ignores case and extra parameters (`data:audio/mpeg;charset=binary;base64,…` → `mp3`). | `::test_mime_match_ignores_case_and_extra_parameters` |
| An explicit `format=` always wins over the declared type. | `::test_an_explicit_format_always_wins` |
| http(s) URLs keep the historical `wav` default, and still honour an explicit format. | `::test_http_urls_keep_the_wav_default` |
| The module-level `audio_from_url` wrapper derives the format too. | `::test_module_level_helper_derives_the_format_too` |

**Detection cost**

| Behaviour | Test |
| --- | --- |
| `is_data_url` on a 10 MB inline image allocates no copy of the payload (measured with `tracemalloc`, bound 1 MB) — lower-casing the whole URL would add ~10 MB and ~10 ms on every `get_bytes()` / `save()`. | `TestIsDataUrlCost::test_detection_does_not_copy_the_url` |

## Verification round

An independent verification round re-ran this branch merged onto `main` against real sockets, then re-ran the same probes after the fixes above. Summary of what was live-tested (not mocked):

- **Retry loop, real aiohttp against a real local HTTP server impersonating OpenRouter** — unchanged by this round and re-confirmed on the fixed tree: two marked 404s then success sends exactly 3 requests with backoff `[1.0, 2.0]` and 3.02s real wall time; a permanently-rejected `image_config` sends 3 + 1 stripped request with `[1.0, 2.0, 4.0]` and 7.01s, the 4th body differing only by the removed `image_config`; an unrelated 404 and a 500 each raise on the first response with no sleep. The returned image decodes to real PNG bytes.
- **A real OpenRouter image generation** (1 call, happy path) confirmed the motivation: the live response carried the image as `data:image/jpeg;base64,…`, not an http(s) URL, and the retry loop correctly did not fire.
- **The five defects this round fixed were each reproduced first and then re-probed.** On the pre-fix branch: `save()` over an existing 820-byte file left it at **0 bytes** for all three classes; all four whitespace shapes were **rejected** (they decode on `main`); `data:image/png;base64,` returned `b""`; `is_data_url` on a 10 MB URL allocated **10 MiB**; `Audio.from_url("data:audio/mpeg;…")` reported `wav`. On the fixed tree the same probe reports 33/33 checks passing: the 820-byte file survives every rejected payload and no stub file is created, all four whitespace shapes decode while a genuinely corrupt payload still raises, the empty payload raises `ValueError`, detection costs well under a millisecond with no payload-sized allocation (against ~10 ms / ~10 MiB for a whole-URL lower-case; exact figures vary by machine), and every MIME mapping and the explicit-format override behave as tabled above.
- **Known, deliberately out of scope:** on the `OpenRouterProvider` path specifically, `add_image_url` pre-fills `ImageOutput.b64_json` from the `data:` URL and `get_bytes()` prefers `b64_json` with a permissive `b64decode`, so a corrupt inline payload from that provider still decodes to short bytes without reaching the strict helper. That is pre-existing code this PR does not touch and `main` behaves identically — no regression here, and it is worth its own change rather than widening this one.

## Test coverage

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR (no bare additions).
- [x] If I removed code, I updated `coverage-baseline.json` in this PR *only if* the removal caused a legitimate regression and I called it out in the summary above. — no code removed; the `sdk-python` surface is computed over the seven modules in the pytest `--cov` list, none of which this PR touches, so the baseline is unaffected (`TOTAL … 94%`, unchanged).
- [ ] The coverage gate check is green in CI before requesting review. — to confirm once CI runs.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) (if present) and [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
- [x] Commits are signed and follow conventional-commits style.
- [x] I have linked any related issues (Fixes #123 / Closes #456).

## Related issues / PRs

Fixes #586
Fixes #588
Refs #587
Refs #600, #619 (the retry this restores, and the rewrite that dropped it)
