### PR TITLE
fix(sdk/python): dispatch execution logs without a throwaway loop, and finish AsyncExecutionManager teardown when a cancel raises

### DIFF
--- a/sdk/python/agentfield/async_execution_manager.py
+++ b/sdk/python/agentfield/async_execution_manager.py
@@ -359,9 +359,25 @@ class AsyncExecutionManager:
             self._event_stream_task,
         ]
 
+        # First failure seen while tearing things down. Teardown continues
+        # past it and it is re-raised once everything has been attempted, so
+        # one stubborn task or execution cannot strand the rest.
+        first_error: Optional[BaseException] = None
+
         try:
             for task in tasks_to_cancel:
-                await cancel_and_await_if_same_loop(task, owning_loop)
+                try:
+                    await cancel_and_await_if_same_loop(task, owning_loop)
+                except BaseException as exc:  # noqa: BLE001 - re-raised below
+                    # Keep sweeping. The finally below drops the last
+                    # reference to every task in this list, so a task that
+                    # refuses to die must not leave the ones behind it
+                    # pending and unreachable. BaseException rather than
+                    # Exception on purpose: narrowing it would let a
+                    # CancelledError skip the cleanup, the #909 regression
+                    # this finally-based structure exists to prevent.
+                    if first_error is None:
+                        first_error = exc
         finally:
             self._polling_task = None
             self._cleanup_task = None
@@ -376,21 +392,25 @@ class AsyncExecutionManager:
                 # cancellation on the owning loop instead.
                 if owning_loop is current_loop:
                     async with self._execution_lock:
-                        for execution in self._executions.values():
-                            if execution.is_active:
-                                execution.cancel("Manager shutdown")
-                                self._release_capacity_for_execution(execution)
+                        cancel_error = self._cancel_active_executions(
+                            "Manager shutdown"
+                        )
+                    if first_error is None:
+                        first_error = cancel_error
                 elif owning_loop is not None and not owning_loop.is_closed():
 
                     def _cancel_on_owner():
                         async def _do_cancel():
                             async with self._execution_lock:
-                                for execution in self._executions.values():
-                                    if execution.is_active:
-                                        execution.cancel(
-                                            "Manager shutdown (cross-loop)"
-                                        )
-                                        self._release_capacity_for_execution(execution)
+                                error = self._cancel_active_executions(
+                                    "Manager shutdown (cross-loop)"
+                                )
+                            if error is not None:
+                                # Nobody is waiting on this task, so the
+                                # failure is reported here rather than lost.
+                                logger.debug(
+                                    f"Cross-loop execution cancel failed: {error!r}"
+                                )
 
                         owning_loop.create_task(_do_cancel())
 
@@ -407,7 +427,35 @@ class AsyncExecutionManager:
                 finally:
                     await self.result_cache.stop()
 
+        if first_error is not None:
+            logger.warning(
+                f"AsyncExecutionManager stopped, but teardown reported {first_error!r}"
+            )
+            raise first_error
+
         logger.info("AsyncExecutionManager stopped")
+
+    def _cancel_active_executions(self, reason: str) -> Optional[BaseException]:
+        """Cancel every active execution, returning the first failure.
+
+        Each execution gets its own try/except so a cancel that raises cannot
+        leave the executions behind it QUEUED forever with their capacity
+        slots held. The failure is returned rather than swallowed; the caller
+        decides whether to re-raise it.
+
+        Callers must already hold ``_execution_lock``.
+        """
+        first_error: Optional[BaseException] = None
+        for execution in list(self._executions.values()):
+            if not execution.is_active:
+                continue
+            try:
+                execution.cancel(reason)
+                self._release_capacity_for_execution(execution)
+            except BaseException as exc:  # noqa: BLE001 - returned to caller
+                if first_error is None:
+                    first_error = exc
+        return first_error
 
     async def submit_execution(
         self,

--- a/sdk/python/agentfield/client.py
+++ b/sdk/python/agentfield/client.py
@@ -142,14 +142,20 @@ class _Submission:
 
 
 def _is_background_dispatch_loop(loop: asyncio.AbstractEventLoop) -> bool:
-    """True when ``loop`` is the SDK's shared background dispatch loop.
+    """True when ``loop`` is one of the SDK's background dispatch loops.
+
+    That is the shared background loop *and* the one-shot fallback loop
+    ``run_async`` falls back to when the shared one cannot be started. The
+    fallback closes as soon as its coroutine finishes, so letting it claim the
+    primary client slot would strand the pool on a dead loop — the very
+    failure this module's loop affinity exists to prevent (#620).
 
     Imported lazily: ``agentfield.run_async`` pulls in this package's logger,
     which type-hints this module.
     """
-    from .run_async import background_dispatch_loop
+    from .run_async import is_background_dispatch_loop
 
-    return background_dispatch_loop() is loop
+    return is_background_dispatch_loop(loop)
 
 
 class AgentFieldClient:

--- a/sdk/python/agentfield/client.py
+++ b/sdk/python/agentfield/client.py
@@ -3,6 +3,7 @@ import datetime
 import importlib
 import random
 import sys
+import threading
 import time
 import weakref
 from dataclasses import dataclass
@@ -140,6 +141,17 @@ class _Submission:
     target_type: Optional[str] = None
 
 
+def _is_background_dispatch_loop(loop: asyncio.AbstractEventLoop) -> bool:
+    """True when ``loop`` is the SDK's shared background dispatch loop.
+
+    Imported lazily: ``agentfield.run_async`` pulls in this package's logger,
+    which type-hints this module.
+    """
+    from .run_async import background_dispatch_loop
+
+    return background_dispatch_loop() is loop
+
+
 class AgentFieldClient:
     # Shared session for sync requests (class-level for reuse)
     _shared_sync_session: Optional[requests.Session] = None
@@ -164,7 +176,10 @@ class AgentFieldClient:
         self.async_config = async_config or AsyncConfig.from_environment()
         self._async_execution_manager: Optional[AsyncExecutionManager] = None
         self._async_http_client: Optional["httpx.AsyncClient"] = None
-        self._async_http_client_lock: Optional[asyncio.Lock] = None
+        # Building a client never awaits, so the guard is a threading.Lock: an
+        # asyncio.Lock would bind to whichever loop reached it first and raise
+        # "bound to a different event loop" for the next one (#620).
+        self._async_http_client_lock = threading.Lock()
         # The loop that created ``_async_http_client``. An httpx.AsyncClient
         # keeps its pooled connections on the loop that opened them, so it
         # must never be handed to a different loop (#620).
@@ -465,6 +480,14 @@ class AgentFieldClient:
         alive. That is the failure behind the sync/async mixing reported in
         #620, so the cache is keyed by loop and a client is only ever reused
         on the loop that created it.
+
+        One loop holds the *primary* client — the one :meth:`aclose` closes —
+        and that loop is deliberately never the SDK's background dispatch
+        loop. A structured log emitted from sync code before the agent's first
+        request runs there; letting it claim the slot would strand the agent's
+        own client (and its live keep-alive pool) on the per-loop path, where
+        ``aclose`` merely drops it. The background loop also never closes, so
+        the reclaim path below could never undo the mistake.
         """
         current_module = sys.modules.get("httpx")
         reload_needed = httpx is None or current_module is not httpx
@@ -473,40 +496,36 @@ class AgentFieldClient:
             raise AgentFieldClientError("httpx is required for async HTTP operations")
 
         loop = asyncio.get_running_loop()
+        with self._async_http_client_lock:
+            return self._http_client_for_loop(loop, httpx_module)
 
-        owning_loop = self._async_http_client_loop
-        if owning_loop is not None and owning_loop.is_closed():
-            # The loop that owned the primary client is gone; neither the
-            # client nor its lock can ever be used again. Free the slot for
-            # the current loop rather than leaving every later caller on the
-            # per-loop path.
-            self._async_http_client = None
-            self._async_http_client_lock = None
-            self._async_http_client_loop = None
-            owning_loop = None
+    def _http_client_for_loop(
+        self, loop: asyncio.AbstractEventLoop, httpx_module: Any
+    ) -> "httpx.AsyncClient":
+        """Pick (or build) the client for ``loop``. Caller holds the lock."""
+        if not _is_background_dispatch_loop(loop):
+            owning_loop = self._async_http_client_loop
+            if owning_loop is not None and owning_loop.is_closed():
+                # The loop that owned the primary client is gone; the client
+                # can never be used again. Free the slot for the current loop
+                # rather than leaving every later caller on the per-loop path.
+                self._async_http_client = None
+                self._async_http_client_loop = None
+                owning_loop = None
 
-        if owning_loop is None or owning_loop is loop:
-            if self._async_http_client and not getattr(
-                self._async_http_client, "is_closed", False
-            ):
-                return self._async_http_client
+            if owning_loop is None or owning_loop is loop:
+                client = self._async_http_client
+                if client is not None and not getattr(client, "is_closed", False):
+                    return client
 
-            if self._async_http_client_lock is None:
-                self._async_http_client_lock = asyncio.Lock()
-
-            async with self._async_http_client_lock:
-                if self._async_http_client and not getattr(
-                    self._async_http_client, "is_closed", False
-                ):
-                    return self._async_http_client
-
-                self._async_http_client = self._build_async_http_client(httpx_module)
+                client = self._build_async_http_client(httpx_module)
+                self._async_http_client = client
                 self._async_http_client_loop = loop
-                return self._async_http_client
+                return client
 
-        # A second loop is driving this client — typically a best-effort
-        # background dispatch while the agent's own loop owns the primary
-        # client. Give it its own client instead of corrupting either pool.
+        # Another loop is driving this client — a best-effort background
+        # dispatch, or a second loop while the agent's own holds the primary.
+        # Give it its own client instead of corrupting either pool.
         existing = self._foreign_loop_http_clients.get(loop)
         if existing is not None and not getattr(existing, "is_closed", False):
             return existing
@@ -620,18 +639,30 @@ class AgentFieldClient:
             finally:
                 self._async_execution_manager = None
 
-        if self._async_http_client is not None:
-            try:
-                await self._async_http_client.aclose()
-            finally:
-                self._async_http_client = None
-                self._async_http_client_lock = None
-                self._async_http_client_loop = None
+        try:
+            loop: Optional[asyncio.AbstractEventLoop] = asyncio.get_running_loop()
+        except RuntimeError:  # pragma: no cover - aclose() is a coroutine
+            loop = None
 
-        # Clients belonging to other loops cannot be closed from here without
-        # the cross-loop await this design exists to avoid; drop the
-        # references and let their loops (and the OS) reclaim them.
-        self._foreign_loop_http_clients.clear()
+        with self._async_http_client_lock:
+            primary = self._async_http_client
+            self._async_http_client = None
+            self._async_http_client_loop = None
+            # A per-loop client handed to *this* loop can be closed here too:
+            # the await stays on the loop that opened its pool.
+            mine = (
+                self._foreign_loop_http_clients.pop(loop, None)
+                if loop is not None
+                else None
+            )
+            # The rest belong to other loops and cannot be closed from here
+            # without the cross-loop await this design exists to avoid; drop
+            # the references and let their loops (and the OS) reclaim them.
+            self._foreign_loop_http_clients.clear()
+
+        for client in (primary, mine):
+            if client is not None:
+                await client.aclose()
 
     def register_node(self, node_data: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/sdk/python/agentfield/client.py
+++ b/sdk/python/agentfield/client.py
@@ -185,8 +185,12 @@ class AgentFieldClient:
         # must never be handed to a different loop (#620).
         self._async_http_client_loop: Optional[asyncio.AbstractEventLoop] = None
         # Per-loop clients for any *other* loop that asks (e.g. a best-effort
-        # log dispatch running on the SDK background loop). Keyed weakly so a
-        # finished loop's client is collected with it.
+        # log dispatch running on the SDK background loop). Keyed weakly, but
+        # that alone frees nothing: an httpx.AsyncClient reaches back to its
+        # own loop through the anyio streams its transport holds, so the value
+        # keeps the key alive and no entry is ever collected on its own.
+        # Entries whose loop has closed are evicted explicitly instead — see
+        # ``_evict_closed_loop_http_clients``.
         self._foreign_loop_http_clients: "weakref.WeakKeyDictionary[Any, Any]" = (
             weakref.WeakKeyDictionary()
         )
@@ -499,6 +503,24 @@ class AgentFieldClient:
         with self._async_http_client_lock:
             return self._http_client_for_loop(loop, httpx_module)
 
+    def _evict_closed_loop_http_clients(self) -> None:
+        """Drop per-loop clients whose loop has closed. Caller holds the lock.
+
+        ``_foreign_loop_http_clients`` is keyed weakly, but weakness buys
+        nothing here: the value (an ``httpx.AsyncClient``) reaches its own loop
+        through the anyio streams its transport holds, so every entry keeps its
+        own key alive and the table would otherwise grow once per short-lived
+        loop for the life of the process.
+
+        The clients are dropped, not closed. ``aclose()`` awaits against the
+        pool, which only the loop that opened it can drive; that loop is gone,
+        so there is nowhere to run the close. Dropping the last reference lets
+        the sockets be reclaimed when the client is collected.
+        """
+        dead = [loop for loop in self._foreign_loop_http_clients if loop.is_closed()]
+        for loop in dead:
+            self._foreign_loop_http_clients.pop(loop, None)
+
     def _http_client_for_loop(
         self, loop: asyncio.AbstractEventLoop, httpx_module: Any
     ) -> "httpx.AsyncClient":
@@ -526,6 +548,7 @@ class AgentFieldClient:
         # Another loop is driving this client — a best-effort background
         # dispatch, or a second loop while the agent's own holds the primary.
         # Give it its own client instead of corrupting either pool.
+        self._evict_closed_loop_http_clients()
         existing = self._foreign_loop_http_clients.get(loop)
         if existing is not None and not getattr(existing, "is_closed", False):
             return existing
@@ -658,6 +681,8 @@ class AgentFieldClient:
             # The rest belong to other loops and cannot be closed from here
             # without the cross-loop await this design exists to avoid; drop
             # the references and let their loops (and the OS) reclaim them.
+            # This also subsumes ``_evict_closed_loop_http_clients``: nothing
+            # per-loop survives an aclose().
             self._foreign_loop_http_clients.clear()
 
         for client in (primary, mine):

--- a/sdk/python/agentfield/client.py
+++ b/sdk/python/agentfield/client.py
@@ -4,6 +4,7 @@ import importlib
 import random
 import sys
 import time
+import weakref
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
@@ -164,6 +165,16 @@ class AgentFieldClient:
         self._async_execution_manager: Optional[AsyncExecutionManager] = None
         self._async_http_client: Optional["httpx.AsyncClient"] = None
         self._async_http_client_lock: Optional[asyncio.Lock] = None
+        # The loop that created ``_async_http_client``. An httpx.AsyncClient
+        # keeps its pooled connections on the loop that opened them, so it
+        # must never be handed to a different loop (#620).
+        self._async_http_client_loop: Optional[asyncio.AbstractEventLoop] = None
+        # Per-loop clients for any *other* loop that asks (e.g. a best-effort
+        # log dispatch running on the SDK background loop). Keyed weakly so a
+        # finished loop's client is collected with it.
+        self._foreign_loop_http_clients: "weakref.WeakKeyDictionary[Any, Any]" = (
+            weakref.WeakKeyDictionary()
+        )
         self._result_cache = ResultCache(self.async_config)
         self._latest_event_stream_headers: Dict[str, str] = {}
         self._current_workflow_context = None
@@ -407,61 +418,102 @@ class AgentFieldClient:
         json_payload = DiscoveryResponse.from_dict(payload)
         return DiscoveryResult(format="json", raw=raw_body, json=json_payload)
 
+    def _build_async_http_client(self, httpx_module: Any) -> "httpx.AsyncClient":
+        """Construct a configured httpx.AsyncClient (no caching)."""
+        client_kwargs = {
+            "headers": {
+                "User-Agent": "AgentFieldSDK/1.0",
+                "Accept": "application/json",
+            }
+        }
+
+        limits_factory = getattr(httpx_module, "Limits", None)
+        if limits_factory:
+            client_kwargs["limits"] = limits_factory(
+                max_connections=self.async_config.connection_pool_size,
+                max_keepalive_connections=self.async_config.connection_pool_per_host,
+            )
+
+        timeout_factory = getattr(httpx_module, "Timeout", None)
+        if timeout_factory:
+            client_kwargs["timeout"] = timeout_factory(10.0, connect=5.0)
+        else:
+            client_kwargs["timeout"] = 10.0
+
+        try:
+            client = httpx_module.AsyncClient(**client_kwargs)
+        except TypeError:
+            # Test doubles may not accept keyword arguments
+            client = httpx_module.AsyncClient()
+            headers = client_kwargs.get("headers")
+            if headers and hasattr(client, "headers"):
+                try:
+                    client.headers.update(headers)
+                except Exception:
+                    pass
+
+        return client
+
     async def get_async_http_client(self) -> "httpx.AsyncClient":
-        """Lazily create and return a shared httpx.AsyncClient."""
+        """Return the shared httpx.AsyncClient for the *current* event loop.
+
+        An httpx.AsyncClient keeps its pooled connections (and the anyio
+        primitives guarding them) on whichever loop opened them. Handing one
+        client to two loops therefore breaks whichever loop did not create the
+        pool: ``RuntimeError: Event loop is closed`` if that loop has since
+        closed, ``... is bound to a different event loop`` if it is still
+        alive. That is the failure behind the sync/async mixing reported in
+        #620, so the cache is keyed by loop and a client is only ever reused
+        on the loop that created it.
+        """
         current_module = sys.modules.get("httpx")
         reload_needed = httpx is None or current_module is not httpx
         httpx_module = _ensure_httpx(force_reload=reload_needed)
         if httpx_module is None:
             raise AgentFieldClientError("httpx is required for async HTTP operations")
 
-        if self._async_http_client and not getattr(
-            self._async_http_client, "is_closed", False
-        ):
-            return self._async_http_client
+        loop = asyncio.get_running_loop()
 
-        if self._async_http_client_lock is None:
-            self._async_http_client_lock = asyncio.Lock()
+        owning_loop = self._async_http_client_loop
+        if owning_loop is not None and owning_loop.is_closed():
+            # The loop that owned the primary client is gone; neither the
+            # client nor its lock can ever be used again. Free the slot for
+            # the current loop rather than leaving every later caller on the
+            # per-loop path.
+            self._async_http_client = None
+            self._async_http_client_lock = None
+            self._async_http_client_loop = None
+            owning_loop = None
 
-        async with self._async_http_client_lock:
+        if owning_loop is None or owning_loop is loop:
             if self._async_http_client and not getattr(
                 self._async_http_client, "is_closed", False
             ):
                 return self._async_http_client
 
-            client_kwargs = {
-                "headers": {
-                    "User-Agent": "AgentFieldSDK/1.0",
-                    "Accept": "application/json",
-                }
-            }
+            if self._async_http_client_lock is None:
+                self._async_http_client_lock = asyncio.Lock()
 
-            limits_factory = getattr(httpx_module, "Limits", None)
-            if limits_factory:
-                client_kwargs["limits"] = limits_factory(
-                    max_connections=self.async_config.connection_pool_size,
-                    max_keepalive_connections=self.async_config.connection_pool_per_host,
-                )
+            async with self._async_http_client_lock:
+                if self._async_http_client and not getattr(
+                    self._async_http_client, "is_closed", False
+                ):
+                    return self._async_http_client
 
-            timeout_factory = getattr(httpx_module, "Timeout", None)
-            if timeout_factory:
-                client_kwargs["timeout"] = timeout_factory(10.0, connect=5.0)
-            else:
-                client_kwargs["timeout"] = 10.0
+                self._async_http_client = self._build_async_http_client(httpx_module)
+                self._async_http_client_loop = loop
+                return self._async_http_client
 
-            try:
-                self._async_http_client = httpx_module.AsyncClient(**client_kwargs)
-            except TypeError:
-                # Test doubles may not accept keyword arguments
-                self._async_http_client = httpx_module.AsyncClient()
-                headers = client_kwargs.get("headers")
-                if headers and hasattr(self._async_http_client, "headers"):
-                    try:
-                        self._async_http_client.headers.update(headers)
-                    except Exception:
-                        pass
+        # A second loop is driving this client — typically a best-effort
+        # background dispatch while the agent's own loop owns the primary
+        # client. Give it its own client instead of corrupting either pool.
+        existing = self._foreign_loop_http_clients.get(loop)
+        if existing is not None and not getattr(existing, "is_closed", False):
+            return existing
 
-            return self._async_http_client
+        client = self._build_async_http_client(httpx_module)
+        self._foreign_loop_http_clients[loop] = client
+        return client
 
     async def _async_request(self, method: str, url: str, **kwargs):
         """Perform an HTTP request using the shared async client with sync fallback."""
@@ -574,6 +626,12 @@ class AgentFieldClient:
             finally:
                 self._async_http_client = None
                 self._async_http_client_lock = None
+                self._async_http_client_loop = None
+
+        # Clients belonging to other loops cannot be closed from here without
+        # the cross-loop await this design exists to avoid; drop the
+        # references and let their loops (and the OS) reclaim them.
+        self._foreign_loop_http_clients.clear()
 
     def register_node(self, node_data: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/sdk/python/agentfield/client.py
+++ b/sdk/python/agentfield/client.py
@@ -691,9 +691,22 @@ class AgentFieldClient:
             # per-loop survives an aclose().
             self._foreign_loop_http_clients.clear()
 
+        first_error: Optional[BaseException] = None
         for client in (primary, mine):
-            if client is not None:
+            if client is None:
+                continue
+            try:
                 await client.aclose()
+            except BaseException as exc:
+                # Every client has to be attempted. The slots above are
+                # already cleared, so a client skipped here is one nothing
+                # will ever close — abandoning ``mine`` because ``primary``
+                # failed leaks the pool this very loop opened.
+                if first_error is None:
+                    first_error = exc
+
+        if first_error is not None:
+            raise first_error
 
     def register_node(self, node_data: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/sdk/python/agentfield/logger.py
+++ b/sdk/python/agentfield/logger.py
@@ -8,7 +8,6 @@ This module provides a centralized logging system for the AgentField SDK that:
 - Preserves stdout mirroring for local developer ergonomics
 """
 
-import asyncio
 import json
 import logging
 import os
@@ -185,36 +184,47 @@ class AgentFieldLogger:
         return record
 
     def _dispatch_to_cp(self, record: Dict[str, Any]) -> None:
-        """Send the structured log record to the control plane (best-effort, non-blocking)."""
+        """Send the structured log record to the control plane (best-effort, non-blocking).
+
+        Delegates to :func:`agentfield.run_async.fire_and_forget` rather than
+        hand-rolling the two branches. That matters twice over (#620):
+
+        * on a running loop the scheduled task is retained until it finishes,
+          so it cannot be garbage-collected mid-flight (#902);
+        * with no running loop the work goes to the SDK's long-lived
+          background loop instead of a fresh loop that is closed again the
+          moment the record is sent — closing that loop used to strand the
+          shared HTTP client's connection pool on a dead loop, and the agent's
+          next request then failed with ``RuntimeError: Event loop is closed``.
+
+        Emitting a log must never fail the caller, so nothing propagates.
+        """
         client = self._cp_client
         if client is None:
             return
         execution_id = record.get("execution_id")
         if not execution_id:
             return
-        try:
-            loop = asyncio.get_running_loop()
-            loop.create_task(client.post_execution_logs(execution_id, record))
-        except RuntimeError:
-            # No running event loop — fire from a background thread
-            threading.Thread(
-                target=self._dispatch_sync,
-                args=(client, execution_id, record),
-                daemon=True,
-            ).start()
 
-    @staticmethod
-    def _dispatch_sync(
-        client: "AgentFieldClient",
-        execution_id: str,
-        record: Dict[str, Any],
-    ) -> None:
+        # Imported here, not at module scope: agentfield.run_async imports
+        # this module for its own logger.
+        from .run_async import fire_and_forget
+
+        coro = None
         try:
-            loop = asyncio.new_event_loop()
-            loop.run_until_complete(client.post_execution_logs(execution_id, record))
-            loop.close()
+            coro = client.post_execution_logs(execution_id, record)
+            fire_and_forget(coro)
         except Exception:
-            pass
+            close = getattr(coro, "close", None)
+            if close is not None:
+                try:
+                    close()
+                except Exception:
+                    pass
+            self.logger.debug(
+                "Failed to dispatch execution log to the control plane",
+                exc_info=True,
+            )
 
     def _emit_plain(
         self,

--- a/sdk/python/agentfield/run_async.py
+++ b/sdk/python/agentfield/run_async.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import contextlib
 import threading
 import weakref
 from typing import Any, Coroutine, Optional, TypeVar
@@ -127,7 +128,14 @@ def _background_loop() -> Optional[asyncio.AbstractEventLoop]:
         def _run() -> None:
             asyncio.set_event_loop(loop)
             loop.call_soon(running.set)
-            loop.run_forever()
+            try:
+                loop.run_forever()
+            finally:
+                # Only reached when something stopped the loop, which today
+                # is the start-timeout path below. Closing it here keeps the
+                # thread from leaving an unclosed loop behind and makes the
+                # next ``_background_loop()`` call build a fresh one.
+                loop.close()
 
         thread = threading.Thread(
             target=_run,
@@ -138,6 +146,13 @@ def _background_loop() -> Optional[asyncio.AbstractEventLoop]:
 
         if not running.wait(timeout=_BACKGROUND_LOOP_START_TIMEOUT):
             logger.debug("Background event loop did not start in time")
+            # Do not leave the loop and its thread behind: ``_BACKGROUND_LOOP``
+            # is never published here, so the next call would create a second
+            # one, and a third, with none of them ever reachable again.
+            # Stopping makes ``run_forever`` return (immediately, if it has
+            # not started yet), which closes the loop and ends the thread.
+            with contextlib.suppress(RuntimeError):
+                loop.call_soon_threadsafe(loop.stop)
             return None
 
         _BACKGROUND_LOOP = loop

--- a/sdk/python/agentfield/run_async.py
+++ b/sdk/python/agentfield/run_async.py
@@ -9,8 +9,8 @@ helpers that detect the situation and handle it correctly:
   already running, schedules the work on a **new thread** with its own loop
   so the caller can safely block without deadlocking the running loop.
 - ``fire_and_forget``: schedules the coroutine without waiting for the
-  result. If a loop is running, creates a task on it; otherwise spawns a
-  daemon thread.
+  result. If a loop is running, creates a task on it; otherwise hands it to
+  a single long-lived background loop shared by the whole process.
 
 Part of #620 (slice 3: asyncio.run() inside a running loop).
 """
@@ -18,8 +18,9 @@ Part of #620 (slice 3: asyncio.run() inside a running loop).
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import threading
-from typing import Any, Coroutine, TypeVar
+from typing import Any, Coroutine, Optional, TypeVar
 
 from .logger import get_logger
 
@@ -31,6 +32,12 @@ T = TypeVar("T")
 # loop. asyncio only keeps a weak reference to a task, so without this the
 # task can be garbage-collected mid-flight and silently never complete.
 _BACKGROUND_TASKS: set[asyncio.Task[Any]] = set()
+
+# The single long-lived loop that serves ``fire_and_forget`` calls made from
+# threads with no running loop. See ``_background_loop``.
+_BACKGROUND_LOOP: Optional[asyncio.AbstractEventLoop] = None
+_BACKGROUND_LOOP_LOCK = threading.Lock()
+_BACKGROUND_LOOP_START_TIMEOUT = 5.0
 
 
 def _has_running_loop() -> bool:
@@ -55,6 +62,75 @@ def _on_background_task_done(task: asyncio.Task[Any]) -> None:
     exc = task.exception()
     if exc is not None:
         logger.debug("fire_and_forget background task failed", exc_info=exc)
+
+
+def _on_background_future_done(
+    future: "concurrent.futures.Future[Any]",
+) -> None:
+    """Retrieve/log the outcome of work submitted to the background loop.
+
+    Mirrors :func:`_on_background_task_done` for the no-running-loop path: an
+    unretrieved failure would otherwise be reported by asyncio's default
+    handler when the future is collected.
+    """
+    if future.cancelled():
+        return
+    exc = future.exception()
+    if exc is not None:
+        logger.debug("fire_and_forget background task failed", exc_info=exc)
+
+
+def _background_loop() -> Optional[asyncio.AbstractEventLoop]:
+    """Return the shared background loop, starting it on first use.
+
+    Every ``fire_and_forget`` call made without a running loop is served by
+    this one loop, which stays open for the life of the process. That matters
+    beyond thread economy: a loop created and *closed* per call leaves
+    whatever the coroutine bound to it — most importantly the SDK's shared
+    ``httpx.AsyncClient`` connection pool — attached to a dead loop, and the
+    next use of that object on the caller's own loop then fails with
+    ``RuntimeError: Event loop is closed`` (#620).
+
+    Returns ``None`` if the loop could not be started, so callers can fall
+    back rather than lose the work.
+    """
+    global _BACKGROUND_LOOP
+
+    loop = _BACKGROUND_LOOP
+    if loop is not None and not loop.is_closed():
+        return loop
+
+    with _BACKGROUND_LOOP_LOCK:
+        loop = _BACKGROUND_LOOP
+        if loop is not None and not loop.is_closed():
+            return loop
+
+        try:
+            loop = asyncio.new_event_loop()
+        except Exception:
+            logger.debug("Could not create the background event loop", exc_info=True)
+            return None
+
+        running = threading.Event()
+
+        def _run() -> None:
+            asyncio.set_event_loop(loop)
+            loop.call_soon(running.set)
+            loop.run_forever()
+
+        thread = threading.Thread(
+            target=_run,
+            name="agentfield-background-loop",
+            daemon=True,
+        )
+        thread.start()
+
+        if not running.wait(timeout=_BACKGROUND_LOOP_START_TIMEOUT):
+            logger.debug("Background event loop did not start in time")
+            return None
+
+        _BACKGROUND_LOOP = loop
+        return loop
 
 
 def run_coroutine(coro: Coroutine[Any, Any, T]) -> T:
@@ -111,8 +187,11 @@ def fire_and_forget(coro: Coroutine[Any, Any, Any]) -> None:
     - **Running loop**: creates a task on the current loop (no new thread).
       The task is retained until it finishes and its failure (if any) is
       logged at debug level.
-    - **No running loop**: spawns a daemon thread that runs the coroutine.
-      Note that a daemon thread is killed at interpreter exit, so callers
+    - **No running loop**: hands the coroutine to the SDK's shared background
+      loop (see :func:`_background_loop`), which runs for the life of the
+      process. The coroutine therefore never runs on a loop that is about to
+      be closed, so anything it binds — connection pools, locks — stays
+      usable. Note the background loop runs on a daemon thread, so callers
       that must see the work complete should not use this helper.
 
     Use this for best-effort background work (sending notes, cleanup) where
@@ -122,19 +201,40 @@ def fire_and_forget(coro: Coroutine[Any, Any, Any]) -> None:
         coro: The coroutine to schedule.
     """
     try:
-        loop = asyncio.get_running_loop()
-        task = loop.create_task(coro)
-        _BACKGROUND_TASKS.add(task)
-        task.add_done_callback(_on_background_task_done)
+        # create_task() is inside the guard as well: a loop that is mid-shutdown
+        # raises here, and the background loop is a better home for the work
+        # than an exception in the caller's face.
+        task = asyncio.get_running_loop().create_task(coro)
     except RuntimeError:
-        # No running loop — run in a background thread with exception
-        # handling so failures are logged cleanly rather than surfacing
-        # as noisy unhandled-thread-exception tracebacks.
-        def _worker() -> None:
-            try:
-                asyncio.run(coro)
-            except Exception:
-                logger.debug("fire_and_forget background task failed", exc_info=True)
+        _submit_to_background_loop(coro)
+        return
 
-        thread = threading.Thread(target=_worker, daemon=True)
-        thread.start()
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_on_background_task_done)
+
+
+def _submit_to_background_loop(coro: Coroutine[Any, Any, Any]) -> None:
+    """Run ``coro`` on the shared background loop, never raising."""
+    loop = _background_loop()
+
+    if loop is not None:
+        try:
+            future = asyncio.run_coroutine_threadsafe(coro, loop)
+        except RuntimeError:
+            # The loop stopped between the lookup and the submit.
+            logger.debug("Could not submit work to the background loop", exc_info=True)
+        else:
+            future.add_done_callback(_on_background_future_done)
+            return
+
+    # Last resort: a one-shot loop on its own thread. Only reached when the
+    # shared loop could not be started at all, in which case dropping the
+    # work outright would be worse than the throwaway loop.
+    def _worker() -> None:
+        try:
+            asyncio.run(coro)
+        except Exception:
+            logger.debug("fire_and_forget background task failed", exc_info=True)
+
+    thread = threading.Thread(target=_worker, daemon=True)
+    thread.start()

--- a/sdk/python/agentfield/run_async.py
+++ b/sdk/python/agentfield/run_async.py
@@ -133,6 +133,21 @@ def _background_loop() -> Optional[asyncio.AbstractEventLoop]:
         return loop
 
 
+def background_dispatch_loop() -> Optional[asyncio.AbstractEventLoop]:
+    """Return the shared background loop, but only if it is already running.
+
+    Unlike :func:`_background_loop` this never starts one. It exists so other
+    modules can *recognise* the loop that best-effort work runs on without
+    bringing a thread to life as a side effect of asking — see
+    ``AgentFieldClient.get_async_http_client``, which must not let this loop
+    take ownership of the agent's shared HTTP client.
+    """
+    loop = _BACKGROUND_LOOP
+    if loop is None or loop.is_closed():
+        return None
+    return loop
+
+
 def run_coroutine(coro: Coroutine[Any, Any, T]) -> T:
     """Run a coroutine from sync code, safe even inside a running loop.
 

--- a/sdk/python/agentfield/run_async.py
+++ b/sdk/python/agentfield/run_async.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import threading
+import weakref
 from typing import Any, Coroutine, Optional, TypeVar
 
 from .logger import get_logger
@@ -38,6 +39,15 @@ _BACKGROUND_TASKS: set[asyncio.Task[Any]] = set()
 _BACKGROUND_LOOP: Optional[asyncio.AbstractEventLoop] = None
 _BACKGROUND_LOOP_LOCK = threading.Lock()
 _BACKGROUND_LOOP_START_TIMEOUT = 5.0
+
+# Every loop that best-effort dispatch runs on: the shared background loop
+# above *and* the one-shot fallback loop ``_submit_to_background_loop`` uses
+# when the shared one cannot be started. Both are loops the caller does not
+# own and (for the fallback) that are about to close, so per-loop resources
+# such as the SDK's shared httpx.AsyncClient must never be handed to them as
+# if they belonged to the agent (#620). Held weakly so a finished fallback
+# loop is not kept alive by the registry itself.
+_DISPATCH_LOOPS: "weakref.WeakSet[asyncio.AbstractEventLoop]" = weakref.WeakSet()
 
 
 def _has_running_loop() -> bool:
@@ -111,6 +121,7 @@ def _background_loop() -> Optional[asyncio.AbstractEventLoop]:
             logger.debug("Could not create the background event loop", exc_info=True)
             return None
 
+        _DISPATCH_LOOPS.add(loop)
         running = threading.Event()
 
         def _run() -> None:
@@ -141,11 +152,27 @@ def background_dispatch_loop() -> Optional[asyncio.AbstractEventLoop]:
     bringing a thread to life as a side effect of asking — see
     ``AgentFieldClient.get_async_http_client``, which must not let this loop
     take ownership of the agent's shared HTTP client.
+
+    Callers that only need the yes/no answer should use
+    :func:`is_background_dispatch_loop`, which also covers the fallback loop.
     """
     loop = _BACKGROUND_LOOP
     if loop is None or loop.is_closed():
         return None
     return loop
+
+
+def is_background_dispatch_loop(loop: asyncio.AbstractEventLoop) -> bool:
+    """True when ``loop`` is a loop this module runs best-effort work on.
+
+    Covers the shared background loop *and* the one-shot fallback loop used
+    when the shared one could not be started — the fallback is the more
+    dangerous of the two, since it closes as soon as its coroutine finishes.
+    A caller that keeps loop-affine state (``AgentFieldClient``'s shared
+    ``httpx.AsyncClient``) uses this to keep dispatch work from taking
+    ownership of it. Asking never starts a loop or a thread.
+    """
+    return loop in _DISPATCH_LOOPS
 
 
 def run_coroutine(coro: Coroutine[Any, Any, T]) -> T:
@@ -245,9 +272,16 @@ def _submit_to_background_loop(coro: Coroutine[Any, Any, Any]) -> None:
     # Last resort: a one-shot loop on its own thread. Only reached when the
     # shared loop could not be started at all, in which case dropping the
     # work outright would be worse than the throwaway loop.
+    async def _dispatch() -> None:
+        # Registered before the first await so that anything the coroutine
+        # touches sees this loop for what it is: a dispatch loop that is
+        # about to close, not a loop worth binding a connection pool to.
+        _DISPATCH_LOOPS.add(asyncio.get_running_loop())
+        await coro
+
     def _worker() -> None:
         try:
-            asyncio.run(coro)
+            asyncio.run(_dispatch())
         except Exception:
             logger.debug("fire_and_forget background task failed", exc_info=True)
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -147,5 +147,5 @@ extend-select = [
 "tests/debug_complex_json.py" = ["ASYNC230", "ASYNC240"]
 "tests/test_cancel.py" = ["ASYNC110"]
 "tests/test_harness_functional.py" = ["ASYNC230", "ASYNC240"]
-"tests/test_harness_runner.py" = ["ASYNC230", "ASYNC240"]
+"tests/test_harness_runner.py" = ["ASYNC230"]
 "tests/test_memory_events.py" = ["ASYNC110"]

--- a/sdk/python/tests/test_approval.py
+++ b/sdk/python/tests/test_approval.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -280,7 +281,7 @@ async def test_aclose_cleans_up_manager_and_http_client(client: AgentFieldClient
     http_client = SimpleNamespace(aclose=AsyncMock())
     client._async_execution_manager = manager
     client._async_http_client = http_client
-    client._async_http_client_lock = object()
+    client._async_http_client_loop = asyncio.get_running_loop()
 
     await client.aclose()
 
@@ -288,4 +289,5 @@ async def test_aclose_cleans_up_manager_and_http_client(client: AgentFieldClient
     http_client.aclose.assert_awaited_once()
     assert client._async_execution_manager is None
     assert client._async_http_client is None
-    assert client._async_http_client_lock is None
+    # The slot is free again: the next loop to ask can own it.
+    assert client._async_http_client_loop is None

--- a/sdk/python/tests/test_async_execution_manager_teardown.py
+++ b/sdk/python/tests/test_async_execution_manager_teardown.py
@@ -1,0 +1,215 @@
+"""AsyncExecutionManager.stop() must finish teardown even when a cancel raises.
+
+stop() wraps its two cancel sweeps — the four background tasks, then the
+active executions — in a single try each. One raising cancel therefore aborted
+the whole sweep while the surrounding ``finally`` went on to drop the last
+reference to every task, leaving the ones behind it pending and unreachable
+and their executions stuck QUEUED with their capacity slots held.
+
+These tests pin the sweeps down by their observable effect: every task is done
+and every other execution is CANCELLED once stop() returns, whatever the first
+cancel did. Companion to test_async_lifecycle_deadlock.py (#623) and the
+finally-based structure from #909 — the cleanup below the sweeps must still
+run, including for a BaseException.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agentfield.async_config import AsyncConfig
+from agentfield.async_execution_manager import AsyncExecutionManager
+from agentfield.execution_state import ExecutionState, ExecutionStatus
+
+
+class _Abort(BaseException):
+    """A BaseException that is not CancelledError."""
+
+
+def _manager() -> AsyncExecutionManager:
+    manager = AsyncExecutionManager(
+        "http://example", AsyncConfig(enable_async_execution=True)
+    )
+    manager.connection_manager = SimpleNamespace(start=AsyncMock(), close=AsyncMock())
+    manager.result_cache = SimpleNamespace(start=AsyncMock(), stop=AsyncMock())
+    manager._loop = asyncio.get_running_loop()
+    manager._shutdown_event = asyncio.Event()
+    return manager
+
+
+async def _idle() -> None:
+    await asyncio.sleep(3600)
+
+
+async def _explodes_on_cancel() -> None:
+    try:
+        await asyncio.sleep(3600)
+    except asyncio.CancelledError:
+        raise RuntimeError("cancel handler exploded")
+
+
+async def _attach_background_tasks(manager, coros):
+    tasks = [asyncio.create_task(coro) for coro in coros]
+    await asyncio.sleep(0)  # let each task reach its first await
+    (
+        manager._polling_task,
+        manager._cleanup_task,
+        manager._metrics_task,
+        manager._event_stream_task,
+    ) = tasks
+    return tasks
+
+
+def _execution(execution_id: str, status: ExecutionStatus) -> ExecutionState:
+    execution = ExecutionState(
+        execution_id=execution_id, target="node.skill", input_data={}
+    )
+    execution.update_status(status)
+    return execution
+
+
+# ---------------------------------------------------------------------------
+# Background-task sweep
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_stop_cancels_every_background_task_when_one_cancel_raises():
+    manager = _manager()
+    tasks = await _attach_background_tasks(
+        manager, [_explodes_on_cancel(), _idle(), _idle(), _idle()]
+    )
+
+    with pytest.raises(RuntimeError, match="cancel handler exploded"):
+        await manager.stop()
+
+    assert all(task.done() for task in tasks), (
+        "a raising cancel left the tasks behind it pending and unreachable"
+    )
+    manager.connection_manager.close.assert_awaited_once()
+    manager.result_cache.stop.assert_awaited_once()
+
+
+@pytest.mark.unit
+async def test_stop_reports_the_first_task_cancel_failure():
+    """Later failures must not mask the one that happened first."""
+    manager = _manager()
+
+    async def _explodes_differently():
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            raise ValueError("second failure")
+
+    tasks = await _attach_background_tasks(
+        manager, [_explodes_on_cancel(), _explodes_differently(), _idle(), _idle()]
+    )
+
+    with pytest.raises(RuntimeError, match="cancel handler exploded"):
+        await manager.stop()
+
+    assert all(task.done() for task in tasks)
+
+
+@pytest.mark.unit
+async def test_stop_without_failures_still_tears_everything_down():
+    manager = _manager()
+    tasks = await _attach_background_tasks(
+        manager, [_idle(), _idle(), _idle(), _idle()]
+    )
+
+    await manager.stop()
+
+    assert all(task.cancelled() for task in tasks)
+    assert manager._polling_task is None
+    assert manager._loop is None
+    manager.connection_manager.close.assert_awaited_once()
+    manager.result_cache.stop.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Execution sweep
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_stop_cancels_remaining_executions_when_one_cancel_raises():
+    manager = _manager()
+
+    stubborn = _execution("exec-stubborn", ExecutionStatus.RUNNING)
+
+    def _refuse(reason=None):
+        raise RuntimeError("cancel refused")
+
+    stubborn.cancel = _refuse
+
+    healthy = _execution("exec-healthy", ExecutionStatus.QUEUED)
+    manager._executions = {
+        "exec-stubborn": stubborn,
+        "exec-healthy": healthy,
+    }
+
+    with pytest.raises(RuntimeError, match="cancel refused"):
+        await manager.stop()
+
+    assert healthy.status == ExecutionStatus.CANCELLED, (
+        "a raising cancel left the executions behind it active"
+    )
+    manager.connection_manager.close.assert_awaited_once()
+    manager.result_cache.stop.assert_awaited_once()
+
+
+@pytest.mark.unit
+async def test_stop_finishes_the_sweep_for_a_base_exception():
+    """#909: cleanup must not be skipped when a cancel raises a BaseException."""
+    manager = _manager()
+
+    stubborn = _execution("exec-stubborn", ExecutionStatus.RUNNING)
+
+    def _abort(reason=None):
+        raise _Abort("not an Exception")
+
+    stubborn.cancel = _abort
+
+    healthy = _execution("exec-healthy", ExecutionStatus.QUEUED)
+    manager._executions = {
+        "exec-stubborn": stubborn,
+        "exec-healthy": healthy,
+    }
+
+    with pytest.raises(_Abort):
+        await manager.stop()
+
+    assert healthy.status == ExecutionStatus.CANCELLED
+    manager.connection_manager.close.assert_awaited_once()
+    manager.result_cache.stop.assert_awaited_once()
+
+
+@pytest.mark.unit
+async def test_stop_leaves_terminal_executions_untouched():
+    manager = _manager()
+    finished = _execution("exec-done", ExecutionStatus.SUCCEEDED)
+    manager._executions = {"exec-done": finished}
+
+    await manager.stop()
+
+    assert finished.status == ExecutionStatus.SUCCEEDED
+
+
+@pytest.mark.unit
+async def test_a_failing_task_cancel_does_not_skip_the_execution_sweep():
+    """The two sweeps are independent: the first must not abort the second."""
+    manager = _manager()
+    tasks = await _attach_background_tasks(
+        manager, [_explodes_on_cancel(), _idle(), _idle(), _idle()]
+    )
+    active = _execution("exec-active", ExecutionStatus.RUNNING)
+    manager._executions = {"exec-active": active}
+
+    with pytest.raises(RuntimeError, match="cancel handler exploded"):
+        await manager.stop()
+
+    assert all(task.done() for task in tasks)
+    assert active.status == ExecutionStatus.CANCELLED

--- a/sdk/python/tests/test_client_laser_push.py
+++ b/sdk/python/tests/test_client_laser_push.py
@@ -260,7 +260,8 @@ async def test_get_async_http_client_typeerror_fallback_and_aclose(monkeypatch, 
 
     assert created.is_closed is True
     assert client._async_http_client is None
-    assert client._async_http_client_lock is None
+    # The slot is free again: the next loop to ask can own it.
+    assert client._async_http_client_loop is None
 
 
 @pytest.mark.asyncio

--- a/sdk/python/tests/test_log_dispatch_loop_safety.py
+++ b/sdk/python/tests/test_log_dispatch_loop_safety.py
@@ -1,0 +1,426 @@
+"""Structured execution logs must never wreck the loop that carries them (#620).
+
+``AgentFieldLogger`` forwards structured records to the control plane in the
+background. It used to hand-roll that dispatch: an un-retained
+``loop.create_task`` when a loop was running, and a daemon thread that built a
+throwaway event loop *per record* when one was not. Both branches were wrong,
+and the second one was actively destructive — the throwaway loop drove the
+client's shared ``httpx.AsyncClient`` and then closed underneath it.
+
+The behaviours asserted here are the contract for that dispatch; the loop
+affinity of the shared HTTP client is asserted alongside them because it is the
+same defect seen from the client's side.
+"""
+
+import asyncio
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from agentfield.client import AgentFieldClient
+from agentfield.execution_context import ExecutionContext
+from agentfield.logger import AgentFieldLogger
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _context(execution_id: str) -> ExecutionContext:
+    return ExecutionContext(
+        workflow_id="wf-1",
+        execution_id=execution_id,
+        run_id="run-1",
+        agent_instance=None,
+        reasoner_name="sample_reasoner",
+        agent_node_id="node-1",
+    )
+
+
+async def _wait_for(predicate, timeout: float = 5.0) -> bool:
+    """Poll ``predicate`` from the running loop until it holds or time runs out."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        await asyncio.sleep(0.01)
+    return bool(predicate())
+
+
+def _emit_from_a_thread_without_a_loop(logger: AgentFieldLogger, execution_id: str):
+    """Emit a structured record from a thread that has no event loop."""
+    finished = threading.Event()
+
+    def _run() -> None:
+        try:
+            logger.log_execution(
+                "record from sync code",
+                event_type="log.info",
+                execution_context=_context(execution_id),
+            )
+        finally:
+            finished.set()
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+    thread.join(timeout=5)
+    return finished
+
+
+class _RecordingCpClient:
+    """Control-plane client double that records where each dispatch ran."""
+
+    def __init__(self):
+        self.calls = []
+        self.loops = []
+        self.gate = None
+
+    async def post_execution_logs(self, execution_id, entries):
+        self.loops.append(asyncio.get_running_loop())
+        if self.gate is not None:
+            await self.gate.wait()
+        self.calls.append((execution_id, entries))
+
+
+class _FailingCpClient:
+    def __init__(self):
+        self.attempts = 0
+
+    async def post_execution_logs(self, execution_id, entries):
+        self.attempts += 1
+        raise RuntimeError("control plane unreachable")
+
+
+class _LoopBoundAsyncClient:
+    """httpx.AsyncClient double that reproduces the real loop affinity.
+
+    Verified against httpx 0.28.1 / httpcore 1.0.9: once a request has been
+    made, the pooled connection lives on the loop that made it. Driving the
+    same client from another loop raises ``Event loop is closed`` when that
+    loop has since closed, and ``... is bound to a different event loop``
+    while it is still alive.
+    """
+
+    def __init__(self, sink, **kwargs):
+        self.headers = dict(kwargs.get("headers") or {})
+        self.is_closed = False
+        self.owning_loop = None
+        self._sink = sink
+
+    async def _bind(self) -> None:
+        loop = asyncio.get_running_loop()
+        if self.owning_loop is None:
+            self.owning_loop = loop
+        elif self.owning_loop is not loop:
+            if self.owning_loop.is_closed():
+                raise RuntimeError("Event loop is closed")
+            raise RuntimeError(
+                "<asyncio.locks.Event object> is bound to a different event loop"
+            )
+
+    async def post(self, url, **kwargs):
+        await self._bind()
+        self._sink.append(url)
+        return SimpleNamespace(status_code=200, text="", json=lambda: {})
+
+    async def aclose(self) -> None:
+        self.is_closed = True
+
+
+class _HttpxStub:
+    """Stand-in ``httpx`` module handing out :class:`_LoopBoundAsyncClient`."""
+
+    def __init__(self):
+        self.requested_urls = []
+        self.clients = []
+
+    def AsyncClient(self, **kwargs):  # noqa: N802 - mirrors the httpx API
+        client = _LoopBoundAsyncClient(self.requested_urls, **kwargs)
+        self.clients.append(client)
+        return client
+
+
+@pytest.fixture
+def httpx_stub(monkeypatch):
+    stub = _HttpxStub()
+    monkeypatch.setattr("agentfield.client.httpx", None)
+    monkeypatch.setattr(
+        "agentfield.client._ensure_httpx", lambda force_reload=False: stub
+    )
+    return stub
+
+
+# ---------------------------------------------------------------------------
+# C1 — a log emitted inside a running loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_log_from_async_context_is_delivered_on_the_running_loop(capsys):
+    cp = _RecordingCpClient()
+    logger = AgentFieldLogger("test.dispatch.async")
+    logger._cp_client = cp
+
+    logger.log_execution(
+        "hello",
+        event_type="log.info",
+        execution_context=_context("exec-async"),
+    )
+
+    assert await _wait_for(lambda: len(cp.calls) == 1)
+    execution_id, record = cp.calls[0]
+    assert execution_id == "exec-async"
+    assert record["message"] == "hello"
+    assert cp.loops[0] is asyncio.get_running_loop()
+    capsys.readouterr()
+
+
+@pytest.mark.unit
+async def test_pending_dispatch_survives_a_garbage_collection(capsys):
+    """The in-flight dispatch must not be collected before it completes (#902)."""
+    import gc
+
+    cp = _RecordingCpClient()
+    cp.gate = asyncio.Event()
+    logger = AgentFieldLogger("test.dispatch.retention")
+    logger._cp_client = cp
+
+    logger.log_execution(
+        "slow record",
+        event_type="log.info",
+        execution_context=_context("exec-retained"),
+    )
+
+    # Let the dispatch start and park on the gate, then collect aggressively.
+    assert await _wait_for(lambda: len(cp.loops) == 1)
+    gc.collect()
+    await asyncio.sleep(0)
+
+    cp.gate.set()
+    assert await _wait_for(lambda: len(cp.calls) == 1)
+    capsys.readouterr()
+
+
+@pytest.mark.unit
+async def test_failed_async_dispatch_is_not_reported_as_unretrieved(capsys):
+    """A dispatch failure must not surface asyncio's unhandled-exception warning."""
+    import gc
+
+    unhandled = []
+    asyncio.get_running_loop().set_exception_handler(
+        lambda _loop, context: unhandled.append(context)
+    )
+
+    cp = _FailingCpClient()
+    logger = AgentFieldLogger("test.dispatch.async.failure")
+    logger._cp_client = cp
+
+    logger.log_execution(
+        "doomed",
+        event_type="log.info",
+        execution_context=_context("exec-doomed"),
+    )
+
+    assert await _wait_for(lambda: cp.attempts == 1)
+    await asyncio.sleep(0.05)
+    gc.collect()
+    await asyncio.sleep(0.05)
+
+    assert unhandled == []
+    capsys.readouterr()
+
+
+# ---------------------------------------------------------------------------
+# C2/C3 — a log emitted with no running loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_log_from_sync_context_is_delivered_without_blocking(capsys):
+    cp = _RecordingCpClient()
+    logger = AgentFieldLogger("test.dispatch.sync")
+    logger._cp_client = cp
+
+    finished = _emit_from_a_thread_without_a_loop(logger, "exec-sync")
+
+    assert finished.is_set(), "emitting a log must not block the calling thread"
+    assert await _wait_for(lambda: len(cp.calls) == 1)
+    assert cp.calls[0][0] == "exec-sync"
+    capsys.readouterr()
+
+
+@pytest.mark.unit
+async def test_sync_context_logs_share_one_loop_that_stays_open(capsys):
+    """No throwaway loop per record: every sync dispatch runs on one live loop."""
+    cp = _RecordingCpClient()
+    logger = AgentFieldLogger("test.dispatch.sync.loops")
+    logger._cp_client = cp
+
+    for index in range(3):
+        _emit_from_a_thread_without_a_loop(logger, f"exec-sync-{index}")
+
+    assert await _wait_for(lambda: len(cp.calls) == 3)
+    assert len(set(id(loop) for loop in cp.loops)) == 1, (
+        "each record got its own event loop"
+    )
+    assert not cp.loops[0].is_closed(), (
+        "the dispatch loop was closed underneath the shared client"
+    )
+    capsys.readouterr()
+
+
+@pytest.mark.unit
+async def test_sync_context_log_leaves_the_agent_loop_able_to_use_the_client(
+    httpx_stub, capsys
+):
+    """The scenario from #620: a log emitted before the agent's first request.
+
+    The dispatch used to run on a throwaway loop that then closed, stranding
+    the shared client's connection pool; the agent's next request on its own
+    loop died with ``RuntimeError: Event loop is closed`` and the call was
+    silently dropped.
+    """
+    cp_client = AgentFieldClient(base_url="http://control-plane.invalid")
+    logger = AgentFieldLogger("test.dispatch.realclient")
+    logger._cp_client = cp_client
+
+    _emit_from_a_thread_without_a_loop(logger, "exec-sync-first")
+    assert await _wait_for(lambda: len(httpx_stub.requested_urls) == 1)
+
+    # Now the agent's own loop posts through the same client.
+    await cp_client.post_execution_logs("exec-main", {"message": "from the agent"})
+
+    assert httpx_stub.requested_urls == [
+        "http://control-plane.invalid/api/v1/executions/exec-sync-first/logs",
+        "http://control-plane.invalid/api/v1/executions/exec-main/logs",
+    ]
+    capsys.readouterr()
+
+
+@pytest.mark.unit
+async def test_sync_context_log_after_the_agent_loop_is_still_delivered(
+    httpx_stub, capsys
+):
+    """The mirror scenario: the agent's loop claims the client first.
+
+    The background dispatch used to die with ``... is bound to a different
+    event loop`` and the record was swallowed by post_execution_logs().
+    """
+    cp_client = AgentFieldClient(base_url="http://control-plane.invalid")
+    logger = AgentFieldLogger("test.dispatch.realclient.reverse")
+    logger._cp_client = cp_client
+
+    await cp_client.post_execution_logs("exec-main", {"message": "from the agent"})
+    assert len(httpx_stub.requested_urls) == 1
+
+    _emit_from_a_thread_without_a_loop(logger, "exec-sync-second")
+
+    assert await _wait_for(lambda: len(httpx_stub.requested_urls) == 2)
+    assert httpx_stub.requested_urls[1] == (
+        "http://control-plane.invalid/api/v1/executions/exec-sync-second/logs"
+    )
+    capsys.readouterr()
+
+
+# ---------------------------------------------------------------------------
+# C4/C5 — failure isolation and no-op cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_dispatch_failure_never_reaches_the_caller(capsys):
+    class _ExplodingCpClient:
+        def post_execution_logs(self, execution_id, entries):
+            raise RuntimeError("client is broken")
+
+    logger = AgentFieldLogger("test.dispatch.explode")
+    logger._cp_client = _ExplodingCpClient()
+
+    record = logger.log_execution(
+        "still returns",
+        event_type="log.info",
+        execution_context=_context("exec-explode"),
+    )
+
+    assert record["message"] == "still returns"
+    capsys.readouterr()
+
+
+@pytest.mark.unit
+async def test_no_dispatch_without_a_client_or_an_execution_id(capsys):
+    cp = _RecordingCpClient()
+
+    detached = AgentFieldLogger("test.dispatch.noclient")
+    detached._cp_client = None
+    detached.log_execution(
+        "nowhere to go",
+        event_type="log.info",
+        execution_context=_context("exec-none"),
+    )
+
+    unscoped = AgentFieldLogger("test.dispatch.nocontext")
+    unscoped._cp_client = cp
+    unscoped.log_execution("no execution", event_type="log.info")
+
+    await asyncio.sleep(0.1)
+    assert cp.calls == []
+    capsys.readouterr()
+
+
+# ---------------------------------------------------------------------------
+# C6 — the shared HTTP client is never handed to a second loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_async_http_client_is_never_shared_across_loops(httpx_stub):
+    cp_client = AgentFieldClient(base_url="http://control-plane.invalid")
+
+    mine = await cp_client.get_async_http_client()
+    assert await cp_client.get_async_http_client() is mine
+
+    from_other_loop = {}
+
+    def _worker() -> None:
+        loop = asyncio.new_event_loop()
+        try:
+            from_other_loop["client"] = loop.run_until_complete(
+                cp_client.get_async_http_client()
+            )
+        finally:
+            loop.close()
+
+    thread = threading.Thread(target=_worker, daemon=True)
+    thread.start()
+    thread.join(timeout=5)
+
+    assert from_other_loop["client"] is not mine
+    # The original loop keeps its own client.
+    assert await cp_client.get_async_http_client() is mine
+
+
+@pytest.mark.unit
+async def test_async_http_client_slot_is_reclaimed_when_its_loop_dies(httpx_stub):
+    """A client whose creating loop has closed is never handed out again."""
+    cp_client = AgentFieldClient(base_url="http://control-plane.invalid")
+
+    orphaned = {}
+
+    def _worker() -> None:
+        loop = asyncio.new_event_loop()
+        try:
+            orphaned["client"] = loop.run_until_complete(
+                cp_client.get_async_http_client()
+            )
+        finally:
+            loop.close()
+
+    thread = threading.Thread(target=_worker, daemon=True)
+    thread.start()
+    thread.join(timeout=5)
+
+    fresh = await cp_client.get_async_http_client()
+    assert fresh is not orphaned["client"]

--- a/sdk/python/tests/test_log_dispatch_loop_safety.py
+++ b/sdk/python/tests/test_log_dispatch_loop_safety.py
@@ -551,3 +551,62 @@ async def test_client_construction_survives_two_loops_arriving_together(httpx_st
     assert "error" not in other, other.get("error")
     assert other["client"] is not None
     assert other["client"] is not mine
+
+
+# ---------------------------------------------------------------------------
+# The per-loop client table must not grow once per short-lived loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_closed_loops_do_not_accumulate_in_the_per_loop_table(httpx_stub):
+    """Dead loops' clients are evicted, not kept for the life of the process.
+
+    The table is keyed weakly, which reads as self-cleaning but is not: an
+    httpx.AsyncClient reaches back to its own loop through the anyio streams
+    its transport opened, so every value keeps its own key alive. Without an
+    explicit eviction the table grows by one entry — one client, one socket
+    pool — for every short-lived loop the process ever runs.
+    """
+    cp_client = AgentFieldClient(base_url="http://control-plane.invalid")
+
+    agent_loop = asyncio.get_running_loop()
+    mine = await cp_client.get_async_http_client()
+    await cp_client.post_execution_logs("exec-agent", {"message": "from the agent"})
+
+    reused_within_one_loop = []
+
+    def _use_a_throwaway_loop() -> None:
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(
+                cp_client.post_execution_logs("exec-throwaway", {"message": "hi"})
+            )
+            first = loop.run_until_complete(cp_client.get_async_http_client())
+            second = loop.run_until_complete(cp_client.get_async_http_client())
+            reused_within_one_loop.append(first is second)
+        finally:
+            loop.close()
+
+    for _ in range(50):
+        thread = threading.Thread(target=_use_a_throwaway_loop, daemon=True)
+        thread.start()
+        thread.join(timeout=10)
+        assert not thread.is_alive()
+
+    assert len(httpx_stub.requested_urls) == 51, "the throwaway loops never posted"
+    # A loop that is still alive keeps its client — eviction is about dead
+    # loops, not about handing out a fresh client per call.
+    assert all(reused_within_one_loop)
+
+    # At most the most recent loop's entry survives: it is dropped by the next
+    # foreign-loop caller, and nothing else is left holding a pool.
+    assert len(cp_client._foreign_loop_http_clients) <= 1
+
+    # Evicting is dropping, never closing: the await would have to run on a
+    # loop that no longer exists.
+    assert all(not client.is_closed for client in httpx_stub.clients)
+
+    # The primary slot is untouched by any of it.
+    assert cp_client._async_http_client_loop is agent_loop
+    assert await cp_client.get_async_http_client() is mine

--- a/sdk/python/tests/test_log_dispatch_loop_safety.py
+++ b/sdk/python/tests/test_log_dispatch_loop_safety.py
@@ -650,3 +650,70 @@ async def test_a_fallback_dispatch_loop_never_claims_the_primary_slot(
     assert agent_client is not fallback_client
     assert cp_client._async_http_client_loop is asyncio.get_running_loop()
     capsys.readouterr()
+
+
+# ---------------------------------------------------------------------------
+# aclose() must attempt every client it dropped
+# ---------------------------------------------------------------------------
+
+
+def _seed_two_clients(cp_client, loop, sink):
+    """Give ``cp_client`` a primary and a per-loop client, both owned by ``loop``."""
+    primary = _LoopBoundAsyncClient(sink)
+    mine = _LoopBoundAsyncClient(sink)
+    cp_client._async_http_client = primary
+    cp_client._async_http_client_loop = loop
+    cp_client._foreign_loop_http_clients[loop] = mine
+    return primary, mine
+
+
+@pytest.mark.unit
+async def test_aclose_closes_the_second_client_when_the_first_raises(httpx_stub):
+    """A failed close must not abandon the pool behind it.
+
+    ``aclose()`` clears both slots before awaiting, so a client it skips is one
+    nothing will ever close again.
+    """
+    cp_client = AgentFieldClient(base_url="http://control-plane.invalid")
+    loop = asyncio.get_running_loop()
+    primary, mine = _seed_two_clients(cp_client, loop, httpx_stub.requested_urls)
+
+    async def _refuse() -> None:
+        raise RuntimeError("primary refuses to close")
+
+    primary.aclose = _refuse
+
+    with pytest.raises(RuntimeError, match="primary refuses to close"):
+        await cp_client.aclose()
+
+    assert mine.is_closed is True
+    assert mine.closed_on_loop is loop
+    assert cp_client._async_http_client is None
+    assert cp_client._async_http_client_loop is None
+    assert len(cp_client._foreign_loop_http_clients) == 0
+
+
+@pytest.mark.unit
+async def test_aclose_reports_the_first_close_failure(httpx_stub):
+    """A later failure must not mask the one that happened first."""
+    cp_client = AgentFieldClient(base_url="http://control-plane.invalid")
+    loop = asyncio.get_running_loop()
+    primary, mine = _seed_two_clients(cp_client, loop, httpx_stub.requested_urls)
+
+    attempted = []
+
+    async def _refuse_primary() -> None:
+        attempted.append("primary")
+        raise RuntimeError("primary refuses to close")
+
+    async def _refuse_mine() -> None:
+        attempted.append("mine")
+        raise RuntimeError("per-loop client refuses to close")
+
+    primary.aclose = _refuse_primary
+    mine.aclose = _refuse_mine
+
+    with pytest.raises(RuntimeError, match="primary refuses to close"):
+        await cp_client.aclose()
+
+    assert attempted == ["primary", "mine"]

--- a/sdk/python/tests/test_log_dispatch_loop_safety.py
+++ b/sdk/python/tests/test_log_dispatch_loop_safety.py
@@ -610,3 +610,43 @@ async def test_closed_loops_do_not_accumulate_in_the_per_loop_table(httpx_stub):
     # The primary slot is untouched by any of it.
     assert cp_client._async_http_client_loop is agent_loop
     assert await cp_client.get_async_http_client() is mine
+
+
+# ---------------------------------------------------------------------------
+# The last-resort dispatch loop must stay a guest
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_a_fallback_dispatch_loop_never_claims_the_primary_slot(
+    httpx_stub, monkeypatch, capsys
+):
+    """When the shared loop cannot start, the loop that replaces it is worse.
+
+    The fallback loop closes as soon as its coroutine finishes. If it is not
+    recognised as a dispatch loop it takes the primary slot on the way past,
+    and the agent's own loop is then permanently on the per-loop path against
+    a client whose loop is already dead — the #620 shape the loop affinity
+    exists to prevent.
+    """
+    from agentfield import run_async
+
+    monkeypatch.setattr(run_async, "_background_loop", lambda: None)
+
+    cp_client = AgentFieldClient(base_url="http://control-plane.invalid")
+    logger = AgentFieldLogger("test.dispatch.fallback")
+    logger._cp_client = cp_client
+
+    _emit_from_a_thread_without_a_loop(logger, "exec-fallback")
+    assert await _wait_for(lambda: len(httpx_stub.requested_urls) == 1)
+    fallback_client = httpx_stub.clients[0]
+
+    assert cp_client._async_http_client is None, "the fallback loop took the slot"
+    assert cp_client._async_http_client_loop is None
+
+    # The agent's own loop can still claim it afterwards, and gets a client of
+    # its own rather than the one the dead loop opened.
+    agent_client = await cp_client.get_async_http_client()
+    assert agent_client is not fallback_client
+    assert cp_client._async_http_client_loop is asyncio.get_running_loop()
+    capsys.readouterr()

--- a/sdk/python/tests/test_log_dispatch_loop_safety.py
+++ b/sdk/python/tests/test_log_dispatch_loop_safety.py
@@ -108,6 +108,7 @@ class _LoopBoundAsyncClient:
         self.headers = dict(kwargs.get("headers") or {})
         self.is_closed = False
         self.owning_loop = None
+        self.closed_on_loop = None
         self._sink = sink
 
     async def _bind(self) -> None:
@@ -127,6 +128,10 @@ class _LoopBoundAsyncClient:
         return SimpleNamespace(status_code=200, text="", json=lambda: {})
 
     async def aclose(self) -> None:
+        # Closing is an await against the same pool, so it is loop-bound too:
+        # httpx tears down the anyio primitives the pool was opened with.
+        await self._bind()
+        self.closed_on_loop = asyncio.get_running_loop()
         self.is_closed = True
 
 
@@ -424,3 +429,125 @@ async def test_async_http_client_slot_is_reclaimed_when_its_loop_dies(httpx_stub
 
     fresh = await cp_client.get_async_http_client()
     assert fresh is not orphaned["client"]
+
+
+# ---------------------------------------------------------------------------
+# C12-C14 — the agent's loop, not the background dispatch loop, owns the client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_agent_loop_owns_the_shared_client_after_a_sync_log(httpx_stub, capsys):
+    """A log emitted before the agent's first request must not take the slot.
+
+    The background dispatch loop lives for the whole process. If it claims
+    ownership of the shared client, the agent's own loop is stuck on the
+    per-loop path forever — nothing can hand the slot back, because the
+    reclaim path only triggers when the owning loop closes.
+    """
+    cp_client = AgentFieldClient(base_url="http://control-plane.invalid")
+    logger = AgentFieldLogger("test.dispatch.ownership")
+    logger._cp_client = cp_client
+
+    _emit_from_a_thread_without_a_loop(logger, "exec-sync-first")
+    assert await _wait_for(lambda: len(httpx_stub.requested_urls) == 1)
+    background_client = httpx_stub.clients[0]
+
+    agent_client = await cp_client.get_async_http_client()
+
+    assert agent_client is not background_client
+    assert cp_client._async_http_client is agent_client
+    assert cp_client._async_http_client_loop is asyncio.get_running_loop()
+
+    # A second sync-context log reuses the background loop's own client
+    # rather than building one per record.
+    _emit_from_a_thread_without_a_loop(logger, "exec-sync-second")
+    assert await _wait_for(lambda: len(httpx_stub.requested_urls) == 2)
+    assert len(httpx_stub.clients) == 2
+    capsys.readouterr()
+
+
+@pytest.mark.unit
+async def test_aclose_closes_the_client_the_agent_loop_was_given(httpx_stub, capsys):
+    """aclose() must close the pool the agent's loop actually opened.
+
+    Closing some other loop's client is both a cross-loop await and a leak:
+    the agent's client — the one holding the live keep-alive connections —
+    would only be dropped, never closed.
+    """
+    cp_client = AgentFieldClient(base_url="http://control-plane.invalid")
+    logger = AgentFieldLogger("test.dispatch.aclose")
+    logger._cp_client = cp_client
+
+    _emit_from_a_thread_without_a_loop(logger, "exec-sync-first")
+    assert await _wait_for(lambda: len(httpx_stub.requested_urls) == 1)
+    background_client = httpx_stub.clients[0]
+
+    await cp_client.post_execution_logs("exec-main", {"message": "from the agent"})
+    agent_client = await cp_client.get_async_http_client()
+    assert agent_client.owning_loop is asyncio.get_running_loop()
+
+    await cp_client.aclose()
+
+    assert agent_client.is_closed is True
+    assert agent_client.closed_on_loop is asyncio.get_running_loop()
+    # The background loop's client is dropped, never awaited from here.
+    assert background_client.is_closed is False
+    assert background_client.closed_on_loop is None
+    capsys.readouterr()
+
+
+@pytest.mark.unit
+async def test_client_construction_survives_two_loops_arriving_together(httpx_stub):
+    """Two loops may reach the first construction at once.
+
+    Guarding it with an ``asyncio.Lock`` binds the lock to whichever loop got
+    there first; the next loop to contend for it fails with ``... is bound to
+    a different event loop``. Both loops must come away with a client of
+    their own instead.
+    """
+    cp_client = AgentFieldClient(base_url="http://control-plane.invalid")
+
+    build = cp_client._build_async_http_client
+    in_build = threading.Event()
+    release = threading.Event()
+
+    def _blocking_build(httpx_module):
+        # Hold the construction window open so the other loop arrives while
+        # this one is still inside it.
+        in_build.set()
+        release.wait(timeout=5)
+        return build(httpx_module)
+
+    cp_client._build_async_http_client = _blocking_build
+
+    other = {}
+
+    def _worker() -> None:
+        loop = asyncio.new_event_loop()
+        try:
+            other["client"] = loop.run_until_complete(cp_client.get_async_http_client())
+        except BaseException as exc:  # noqa: BLE001 - reported by the assert
+            other["error"] = exc
+        finally:
+            loop.close()
+
+    thread = threading.Thread(target=_worker, daemon=True)
+    thread.start()
+    assert in_build.wait(timeout=5)
+
+    # Released from a third thread: a guard that blocks this thread while the
+    # other loop builds must not deadlock the test.
+    threading.Timer(0.2, release.set).start()
+
+    try:
+        # Bounded: a loop parked on another loop's asyncio.Lock never wakes,
+        # so without this the regression is a hang rather than a failure.
+        mine = await asyncio.wait_for(cp_client.get_async_http_client(), timeout=5)
+    finally:
+        release.set()
+        thread.join(timeout=5)
+
+    assert "error" not in other, other.get("error")
+    assert other["client"] is not None
+    assert other["client"] is not mine

--- a/sdk/python/tests/test_run_async.py
+++ b/sdk/python/tests/test_run_async.py
@@ -225,3 +225,43 @@ async def test_fire_and_forget_running_loop_task_is_retained_until_done():
 
     assert finished["value"] is True
     assert task not in run_async._BACKGROUND_TASKS
+
+
+def test_fire_and_forget_without_a_running_loop_reuses_one_open_loop():
+    """Work scheduled from sync code shares one loop that is never closed.
+
+    A loop created and closed per call strands anything the coroutine bound to
+    it — notably the SDK's shared httpx.AsyncClient connection pool — so the
+    next use on the caller's own loop fails with ``Event loop is closed``.
+    """
+    loops = []
+    ran = threading.Semaphore(0)
+
+    async def record():
+        loops.append(asyncio.get_running_loop())
+        ran.release()
+
+    fire_and_forget(record())
+    fire_and_forget(record())
+
+    assert ran.acquire(timeout=5)
+    assert ran.acquire(timeout=5)
+
+    assert loops[0] is loops[1], "each call got its own event loop"
+    assert not loops[0].is_closed(), "the background loop was closed after use"
+
+
+def test_fire_and_forget_without_a_running_loop_survives_a_failure():
+    """A failing coroutine must not stop later work from running."""
+    ran = threading.Semaphore(0)
+
+    async def fail():
+        raise ValueError("boom")
+
+    async def ok():
+        ran.release()
+
+    fire_and_forget(fail())
+    fire_and_forget(ok())
+
+    assert ran.acquire(timeout=5)

--- a/sdk/python/tests/test_run_async.py
+++ b/sdk/python/tests/test_run_async.py
@@ -361,3 +361,61 @@ def test_recognising_a_dispatch_loop_starts_nothing(monkeypatch):
         loop.close()
 
     assert {thread.ident for thread in threading.enumerate()} - before == set()
+
+
+# ---------------------------------------------------------------------------
+# A background loop that never signals readiness is not left running
+# ---------------------------------------------------------------------------
+
+
+def test_background_loop_that_never_starts_is_not_left_behind(monkeypatch):
+    """A start that times out must not strand its loop and thread.
+
+    ``_BACKGROUND_LOOP`` is only published on success, so a loop left running
+    after a timeout is unreachable forever — and the next call builds another
+    one beside it.
+    """
+    monkeypatch.setattr(run_async, "_BACKGROUND_LOOP", None)
+    monkeypatch.setattr(run_async, "_BACKGROUND_LOOP_START_TIMEOUT", 0.25)
+
+    real_new_event_loop = asyncio.new_event_loop
+    park = threading.Event()
+    arm = {"on": False}
+
+    def _stalled_loop():
+        loop = real_new_event_loop()
+        if arm["on"]:
+            arm["on"] = False
+            # Queued ahead of the readiness callback, so the loop is busy
+            # here when the start timeout expires.
+            loop.call_soon_threadsafe(lambda: park.wait(timeout=10))
+        return loop
+
+    monkeypatch.setattr(asyncio, "new_event_loop", _stalled_loop)
+
+    before = {
+        t for t in threading.enumerate() if t.name == "agentfield-background-loop"
+    }
+
+    started = []
+    try:
+        for _ in range(3):
+            arm["on"] = True
+            assert run_async._background_loop() is None
+            started = [
+                t
+                for t in threading.enumerate()
+                if t.name == "agentfield-background-loop" and t not in before
+            ]
+    finally:
+        park.set()
+
+    assert started, "the test never created a background-loop thread to strand"
+
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and any(t.is_alive() for t in started):
+        time.sleep(0.01)
+
+    assert not [t for t in started if t.is_alive()], (
+        "a background loop that failed to start was left running"
+    )

--- a/sdk/python/tests/test_run_async.py
+++ b/sdk/python/tests/test_run_async.py
@@ -265,3 +265,33 @@ def test_fire_and_forget_without_a_running_loop_survives_a_failure():
     fire_and_forget(ok())
 
     assert ran.acquire(timeout=5)
+
+
+def test_background_dispatch_loop_names_the_loop_sync_work_runs_on():
+    """Callers can recognise the loop best-effort work is running on.
+
+    ``AgentFieldClient`` uses this to keep the background loop from taking
+    ownership of the agent's shared HTTP client.
+    """
+    loops = []
+    ran = threading.Semaphore(0)
+
+    async def record():
+        loops.append(asyncio.get_running_loop())
+        ran.release()
+
+    fire_and_forget(record())
+    assert ran.acquire(timeout=5)
+
+    assert run_async.background_dispatch_loop() is loops[0]
+
+
+def test_background_dispatch_loop_does_not_start_one(monkeypatch):
+    """Asking must never be what brings the background thread to life."""
+    monkeypatch.setattr(run_async, "_BACKGROUND_LOOP", None)
+
+    before = {thread.ident for thread in threading.enumerate()}
+    assert run_async.background_dispatch_loop() is None
+    after = {thread.ident for thread in threading.enumerate()}
+
+    assert after - before == set(), "asking started a thread"

--- a/sdk/python/tests/test_run_async.py
+++ b/sdk/python/tests/test_run_async.py
@@ -295,3 +295,69 @@ def test_background_dispatch_loop_does_not_start_one(monkeypatch):
     after = {thread.ident for thread in threading.enumerate()}
 
     assert after - before == set(), "asking started a thread"
+
+
+# ---------------------------------------------------------------------------
+# The fallback loop must be recognisable too
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_dispatch_loop_is_recognised_as_a_dispatch_loop(monkeypatch):
+    """The last-resort loop is a dispatch loop, and the loudest kind.
+
+    When the shared loop cannot be started, ``fire_and_forget`` runs the work
+    on a one-shot loop that closes the moment it finishes. A caller that keeps
+    loop-affine state must be able to tell — otherwise that loop looks like an
+    ordinary caller, claims the state, and takes it to the grave (#620).
+    """
+    monkeypatch.setattr(run_async, "_background_loop", lambda: None)
+
+    seen = {}
+    ran = threading.Semaphore(0)
+
+    async def record():
+        loop = asyncio.get_running_loop()
+        seen["loop"] = loop
+        seen["is_dispatch"] = run_async.is_background_dispatch_loop(loop)
+        ran.release()
+
+    fire_and_forget(record())
+
+    assert ran.acquire(timeout=5), "the fallback path never ran the work"
+    assert seen["is_dispatch"] is True
+
+
+def test_the_shared_background_loop_is_recognised_as_a_dispatch_loop():
+    loops = []
+    ran = threading.Semaphore(0)
+
+    async def record():
+        loops.append(asyncio.get_running_loop())
+        ran.release()
+
+    fire_and_forget(record())
+    assert ran.acquire(timeout=5)
+
+    assert run_async.is_background_dispatch_loop(loops[0]) is True
+
+
+def test_an_ordinary_loop_is_not_a_dispatch_loop():
+    loop = asyncio.new_event_loop()
+    try:
+        assert run_async.is_background_dispatch_loop(loop) is False
+    finally:
+        loop.close()
+
+
+def test_recognising_a_dispatch_loop_starts_nothing(monkeypatch):
+    """The yes/no answer must not be what brings a thread to life."""
+    monkeypatch.setattr(run_async, "_BACKGROUND_LOOP", None)
+
+    loop = asyncio.new_event_loop()
+    before = {thread.ident for thread in threading.enumerate()}
+    try:
+        assert run_async.is_background_dispatch_loop(loop) is False
+    finally:
+        loop.close()
+
+    assert {thread.ident for thread in threading.enumerate()} - before == set()


### PR DESCRIPTION
## Summary

Two latent async defects in the Python SDK, both from the #620 family, plus one
lint-config tidy.

`AgentFieldLogger._dispatch_to_cp` hand-rolled both halves of
`run_async.fire_and_forget` and got both wrong. On a running loop it used a bare
`loop.create_task()` with no reference kept — asyncio holds only a weak
reference, so the dispatch could be collected mid-flight (the bug #902 fixed
everywhere else). With no running loop it spawned a daemon thread that built a
**fresh event loop per log record**, drove the client's shared
`httpx.AsyncClient` on it, and closed it, stranding the shared connection pool
on a dead loop. The dispatch now goes through `fire_and_forget`, whose
no-running-loop branch hands work to one long-lived background loop instead of
creating and closing one per call, and `get_async_http_client()` became
loop-affine so a client is only ever reused on the loop that created it.

Two review rounds then found that "loop-affine" was not enough on its own. See
"Review follow-up" and "Second review follow-up" below.

`AsyncExecutionManager.stop()` wrapped each of its two cancel sweeps in a single
`try`, so the first cancel that raised abandoned the rest of its sweep while the
surrounding `finally` nulled the task references — leaving the tasks behind it
pending *and* unreachable and the executions behind it stuck `QUEUED` with their
capacity slots held. Each iteration now has its own guard; the first failure is
re-raised once both sweeps and the downstream teardown have been attempted.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] Tests only
- [ ] CI / tooling
- [ ] Breaking change

## What the log dispatch actually did

Reproduced against the versions the SDK resolves today (httpx 0.28.1,
httpcore 1.0.9), with a real local HTTP server so a keep-alive connection stays
in the pool:

| order | what happened |
| --- | --- |
| a log from sync code, then the agent's own loop | the agent's next request raised `RuntimeError: Event loop is closed` — the agent's real work, not the log, is what broke |
| the agent's own loop, then a log from sync code | the dispatch raised `... is bound to a different event loop`; `post_execution_logs` swallows everything, so the record was dropped silently |

Both are the same root cause: one `httpx.AsyncClient` driven by two event loops.
A shared background loop alone does **not** fix it — it only swaps the first
error for the second — which is why `get_async_http_client()` is now keyed by
loop. The primary client and its lock keep their existing single-loop behaviour;
a second loop gets its own client, and a client whose creating loop has closed is
never handed out again.

## Review follow-up: who owns the shared client

Making `get_async_http_client()` loop-affine fixed the crash but left ownership
to a race. Two problems, both reproduced against the code as it stood:

**The background loop could claim the primary slot.** In exactly the scenario
this PR is about — a structured log emitted from sync code *before* the agent's
first async request — the background dispatch loop got there first and became
the owner. From then on the agent's own loop was permanently on the per-loop
path: `aclose()` was a cross-loop `aclose()` against the background loop's
client, the agent's real client (the one holding the live keep-alive pool) was
never closed, only dropped by `.clear()`, and the reclaim branch keyed on
`owning_loop.is_closed()` could never fire because the background loop is
immortal. Ownership is now deliberate: `run_async` exposes
`background_dispatch_loop()` — which reports the shared loop *only if it is
already running*, and never starts one — and `get_async_http_client()` skips the
primary branch when the caller is that loop, so background dispatch always lands
in the per-loop table. `aclose()` additionally closes the per-loop client
belonging to the loop it is called on, which is a same-loop await.

**The construction guard could be created by one loop and awaited by another.**
The `asyncio.Lock` in the "nobody owns the slot yet" branch binds to whichever
loop first contends for it; the next loop to arrive dies with `... is bound to a
different event loop`. Building a client never awaits, so the guard is now a
plain `threading.Lock` held across the whole pick-or-build. In the pre-fix run
the new test for this did not even get as far as that error — the two loops were
handed **the same client object**, which is the corruption the loop-affinity
work exists to prevent.

`_async_http_client_lock` is therefore a `threading.Lock` created in `__init__`
and never replaced, so the two pre-existing `assert ... _async_http_client_lock
is None` post-`aclose()` assertions (`tests/test_approval.py`,
`tests/test_client_laser_push.py`) no longer describe anything real. They are
replaced with `assert client._async_http_client_loop is None` — the slot is free
again for the next loop to own, which is what those assertions were reaching
for.

## Second review follow-up: four defects in the new code

An independent verification round confirmed the fix end-to-end against a live
control plane and then found four defects **in the code this PR adds**. All four
are fixed here, each with a test that fails without it.

**1. The per-loop client table never shed anything.** `_foreign_loop_http_clients`
is a `WeakKeyDictionary` keyed by event loop, with a comment claiming "a finished
loop's client is collected with it". That is simply untrue: an
`httpx.AsyncClient` reaches back to the loop it opened its pool on through the
anyio streams its transport holds, so every *value* keeps its own weak *key*
alive and nothing is ever collected. Every short-lived loop that touched the
client left a client and its keep-alive sockets behind for the life of the
process. Measured against a live control plane with real `httpx`, 50 throwaway
loops: **50 entries retained and 60 open file descriptors**, versus **1 entry and
11 fds** after the fix. Dead loops' entries are now dropped on the ordinary path
— the next foreign-loop caller sweeps them — and the comment says what the table
really does. They are dropped, not closed: `aclose()` awaits against a pool only
the loop that opened it can drive, and that loop is gone.

**2. The last-resort dispatch loop was not recognised as one.** When the shared
background loop cannot be started at all, `_submit_to_background_loop` runs the
work on a one-shot loop of its own. `get_async_http_client()` only knew about the
*shared* loop, so the fallback looked like an ordinary caller: it could claim the
primary slot on its way past and then close — leaving the agent's own loop
permanently bound to a client whose loop is dead. That is #620 again, inside the
branch added to fix it. `run_async` now keeps a `WeakSet` of every loop it
dispatches best-effort work on (the shared loop, and any fallback loop,
registered before its first await) and exposes `is_background_dispatch_loop()`;
asking still never starts a loop. `client.py` asks that instead.

**3. `aclose()` could abandon the second client.** It ended with
`for client in (primary, mine): await client.aclose()`. Both slots are cleared
under the lock beforehand, so a client the loop never reaches is one nothing will
ever close — if the primary's `aclose()` raised, the per-loop client belonging to
the very loop calling `aclose()` was left with its pool open. Each close is now
attempted on its own and the **first** failure is re-raised once both have been
tried.

**4. A background loop that never signalled readiness was left running.**
`_background_loop()` publishes `_BACKGROUND_LOOP` only after the loop reports
ready. On timeout it returned `None` and walked away from a loop and thread
nobody held a reference to any more — and the next call created another beside
it. On timeout the loop is now stopped (best effort), which makes `run_forever`
return and its new `finally` close the loop, so the thread ends. Callers still
get `None` and fall back exactly as before.

## Validation contract

Behaviours the change must exhibit, and the test that covers each. All new tests
were confirmed to **fail** on the pre-fix code (see "Red/green" below).

**Execution-log dispatch** — `sdk/python/tests/test_log_dispatch_loop_safety.py`

| # | Behaviour | Test |
| --- | --- | --- |
| C1 | A structured log emitted inside a running loop is delivered once, on that loop, with the right execution id and record | `test_log_from_async_context_is_delivered_on_the_running_loop` |
| C2 | An in-flight dispatch survives a garbage collection before it completes | `test_pending_dispatch_survives_a_garbage_collection` |
| C3 | A failing dispatch never surfaces asyncio's "Task exception was never retrieved" | `test_failed_async_dispatch_is_not_reported_as_unretrieved` |
| C4 | A log emitted with no running loop is still delivered, and the emitting thread is not blocked on it | `test_log_from_sync_context_is_delivered_without_blocking` |
| C5 | Repeated sync-context logs share one event loop, and that loop is not closed afterwards | `test_sync_context_logs_share_one_loop_that_stays_open` |
| C6 | After a sync-context log, the agent's own loop can still use the shared client (scenario (a) above) | `test_sync_context_log_leaves_the_agent_loop_able_to_use_the_client` |
| C7 | A sync-context log fired after the agent's loop claimed the client is still delivered (scenario (b)) | `test_sync_context_log_after_the_agent_loop_is_still_delivered` |
| C8 | A control-plane client that raises does not fail the `log_execution` call | `test_dispatch_failure_never_reaches_the_caller` |
| C9 | No client, or a record with no execution id, dispatches nothing | `test_no_dispatch_without_a_client_or_an_execution_id` |
| C10 | `get_async_http_client()` never hands one client to two loops, and each loop keeps its own | `test_async_http_client_is_never_shared_across_loops` |
| C11 | A client whose creating loop has closed is never handed out again | `test_async_http_client_slot_is_reclaimed_when_its_loop_dies` |
| C12 | After a sync-context log, the agent's own loop — not the background dispatch loop — owns the shared client, and further sync-context logs reuse the background loop's own client | `test_agent_loop_owns_the_shared_client_after_a_sync_log` |
| C13 | `aclose()` closes the client the agent's loop was handed, on that loop; the background loop's client is dropped, never awaited cross-loop | `test_aclose_closes_the_client_the_agent_loop_was_given` |
| C14 | Two loops arriving at the first construction together each come away with their own client — no `RuntimeError`, no deadlock | `test_client_construction_survives_two_loops_arriving_together` |
| C27 | Clients belonging to loops that have closed do not accumulate: after 50 short-lived loops at most one entry survives, a still-open loop keeps its own client, evicted clients are dropped rather than closed, and the primary slot is untouched | `test_closed_loops_do_not_accumulate_in_the_per_loop_table` |
| C28 | Work that lands on the last-resort dispatch loop does not claim the primary slot, and the agent's own loop can still take it afterwards | `test_a_fallback_dispatch_loop_never_claims_the_primary_slot` |
| C29 | If the primary client's `aclose()` raises, the per-loop client for the calling loop is still closed and both slots end up cleared | `test_aclose_closes_the_second_client_when_the_first_raises` |
| C30 | When both closes fail, the caller sees the **first** failure and both were attempted | `test_aclose_reports_the_first_close_failure` |

**`fire_and_forget` without a running loop** — `sdk/python/tests/test_run_async.py`

| # | Behaviour | Test |
| --- | --- | --- |
| C15 | Successive calls share one loop, and that loop is never closed | `test_fire_and_forget_without_a_running_loop_reuses_one_open_loop` |
| C16 | A failing coroutine does not stop later work from running | `test_fire_and_forget_without_a_running_loop_survives_a_failure` |
| C17 | `background_dispatch_loop()` names the loop sync-context work actually ran on | `test_background_dispatch_loop_names_the_loop_sync_work_runs_on` |
| C18 | Asking is never what starts the background loop | `test_background_dispatch_loop_does_not_start_one` |
| C19 (existing) | On a running loop the task is retained while pending and released when done | `test_fire_and_forget_running_loop_task_is_retained_until_done` |
| C31 | When the shared loop cannot be started the work still runs, and the loop it runs on reports itself as a dispatch loop | `test_fallback_dispatch_loop_is_recognised_as_a_dispatch_loop` |
| C32 | The shared background loop reports itself as a dispatch loop | `test_the_shared_background_loop_is_recognised_as_a_dispatch_loop` |
| C33 | An ordinary loop does not | `test_an_ordinary_loop_is_not_a_dispatch_loop` |
| C34 | Asking the recogniser starts no loop and no thread | `test_recognising_a_dispatch_loop_starts_nothing` |
| C35 | A background loop that never signals readiness is stopped, so repeated failures leave no `agentfield-background-loop` threads behind | `test_background_loop_that_never_starts_is_not_left_behind` |

C19 is the deterministic guard for task retention; the logger now routes through
that code path, and C2 covers it end-to-end from the logger's side.

**`AsyncExecutionManager.stop()`** — `sdk/python/tests/test_async_execution_manager_teardown.py`

| # | Behaviour | Test |
| --- | --- | --- |
| C20 | When one background task's cancel raises, every task is `done()` once `stop()` returns, and the downstream teardown still ran | `test_stop_cancels_every_background_task_when_one_cancel_raises` |
| C21 | The **first** failure is the one the caller sees; a later one does not mask it | `test_stop_reports_the_first_task_cancel_failure` |
| C22 | A clean stop still cancels everything and clears the manager's state | `test_stop_without_failures_still_tears_everything_down` |
| C23 | When one `execution.cancel()` raises, the other executions end `CANCELLED` | `test_stop_cancels_remaining_executions_when_one_cancel_raises` |
| C24 | A `BaseException` from a cancel does not skip the cleanup below it (the #909 structure) | `test_stop_finishes_the_sweep_for_a_base_exception` |
| C25 | Terminal executions are left alone | `test_stop_leaves_terminal_executions_untouched` |
| C26 | A failing task sweep does not abort the execution sweep | `test_a_failing_task_cancel_does_not_skip_the_execution_sweep` |

C20/C21/C23/C26 assert on captured task handles and execution status, not on the
manager attributes being `None` — the attributes were already nulled by the
buggy code, which is precisely how the orphaned tasks became unreachable.

### Red/green

Run against the pre-fix sources (tests unchanged), 6/11 and 5/7 fail:

```
FAILED tests/test_log_dispatch_loop_safety.py::test_failed_async_dispatch_is_not_reported_as_unretrieved
FAILED tests/test_log_dispatch_loop_safety.py::test_sync_context_logs_share_one_loop_that_stays_open
FAILED tests/test_log_dispatch_loop_safety.py::test_sync_context_log_leaves_the_agent_loop_able_to_use_the_client
FAILED tests/test_log_dispatch_loop_safety.py::test_sync_context_log_after_the_agent_loop_is_still_delivered
FAILED tests/test_log_dispatch_loop_safety.py::test_async_http_client_is_never_shared_across_loops
FAILED tests/test_log_dispatch_loop_safety.py::test_async_http_client_slot_is_reclaimed_when_its_loop_dies

FAILED tests/test_async_execution_manager_teardown.py::test_stop_cancels_every_background_task_when_one_cancel_raises
FAILED tests/test_async_execution_manager_teardown.py::test_stop_reports_the_first_task_cancel_failure
FAILED tests/test_async_execution_manager_teardown.py::test_stop_cancels_remaining_executions_when_one_cancel_raises
FAILED tests/test_async_execution_manager_teardown.py::test_stop_finishes_the_sweep_for_a_base_exception
FAILED tests/test_async_execution_manager_teardown.py::test_a_failing_task_cancel_does_not_skip_the_execution_sweep
```

The three review-follow-up tests, run against the branch as it stood *before*
the ownership/lock commit, all fail:

```
FAILED tests/test_log_dispatch_loop_safety.py::test_agent_loop_owns_the_shared_client_after_a_sync_log
FAILED tests/test_log_dispatch_loop_safety.py::test_aclose_closes_the_client_the_agent_loop_was_given
FAILED tests/test_log_dispatch_loop_safety.py::test_client_construction_survives_two_loops_arriving_together
```

`test_client_construction_survives_two_loops_arriving_together` fails on
`assert other["client"] is not mine` — pre-fix both loops were handed the same
`AsyncClient`. Its `await` is wrapped in `asyncio.wait_for(..., timeout=5)` on
purpose: a loop parked on another loop's `asyncio.Lock` is woken by a
cross-thread `set_result` that never reaches the selector, so without the bound
the regression presents as a hang instead of a failure.

The nine tests for the second review follow-up, run against the branch as it
stood before those four commits, all fail (`9 failed, 29 passed`):

```
FAILED tests/test_log_dispatch_loop_safety.py::test_closed_loops_do_not_accumulate_in_the_per_loop_table
FAILED tests/test_log_dispatch_loop_safety.py::test_a_fallback_dispatch_loop_never_claims_the_primary_slot
FAILED tests/test_log_dispatch_loop_safety.py::test_aclose_closes_the_second_client_when_the_first_raises
FAILED tests/test_log_dispatch_loop_safety.py::test_aclose_reports_the_first_close_failure
FAILED tests/test_run_async.py::test_fallback_dispatch_loop_is_recognised_as_a_dispatch_loop
FAILED tests/test_run_async.py::test_the_shared_background_loop_is_recognised_as_a_dispatch_loop
FAILED tests/test_run_async.py::test_an_ordinary_loop_is_not_a_dispatch_loop
FAILED tests/test_run_async.py::test_recognising_a_dispatch_loop_starts_nothing
FAILED tests/test_run_async.py::test_background_loop_that_never_starts_is_not_left_behind
```

## Verification round

Everything below was exercised against a locally built control plane (built from
this branch) and a real agent node, not just the test doubles.

- **Execution-log delivery, scenarios (a)–(d).** A live agent emitting structured
  logs from inside the async reasoner, from a plain `threading.Thread` and an
  `asyncio.to_thread` worker while the reasoner awaits, from a task that runs
  after the reasoner returned, and 200 logs in a tight loop from both a running
  loop and a worker thread. All delivered in full — **5/5, 5/5 + 5/5, 4/4,
  200/200, 200/200** — every execution reaching `succeeded`, and zero
  `Event loop is closed` / `bound to a different event loop` / `ResourceWarning` /
  traceback / "Task exception was never retrieved" lines across the agent's
  whole stderr. On `origin/main` the same harness loses most or all worker-thread
  records and leaves the executions stuck `running`.
- **Sync-context dispatch.** A plain synchronous script with no event loop at
  all, emitting 5 records and exiting: **5/5 on three consecutive runs**, process
  exit 0 in ~2.4 s (2 s of which is a deliberate sleep), no `ResourceWarning`.
  On `origin/main` the same script delivers 1 of 5.
- **The per-loop client leak (defect 1), with real `httpx` against the live
  control plane.** 50 throwaway loops, each opening a real connection pool:
  with the eviction, 1 retained entry and 11 open file descriptors; with the
  eviction neutered (the pre-fix behaviour), 50 retained entries and 60 open file
  descriptors. The primary slot still belongs to the agent's loop and still hands
  back the same client in both runs.
- **`AsyncExecutionManager.stop()` (the #909 half)** was exercised against real
  queued executions with an injected raising `cancel()`: every background task
  ends `done()`, the remaining executions end `CANCELLED` with their capacity
  slots released, and the injected error is logged once and re-raised once. On
  `origin/main` the tasks behind the failure stay pending and unreachable and 3 of
  3 executions stay active holding capacity.

## A note on the lint-config commit

The lint tidy is smaller than it looks. `ASYNC240` left preview in ruff 0.15.0
and CI pins `ruff==0.15.22`, so under the pinned linter those `per-file-ignores`
are live, not dead weight — removing them all reintroduces 12 errors
(`agentfield/agent_ai.py` 2, `agentfield/harness/_runner.py` 3,
`agentfield/harness/providers/opencode.py` 1, `agentfield/media_providers.py` 1,
`tests/debug_complex_json.py` 4, `tests/test_harness_functional.py` 1). Only
`tests/test_harness_runner.py`'s `ASYNC240` suppresses nothing today, so that is
the only entry removed; its `ASYNC230` stays (five blocking `open()` calls).

## Test plan

Gates from `.github/workflows/sdk-python.yml`, run literally. Only Python SDK
files changed, so the control-plane / sdk-go / sdk-typescript workflows do not
trigger (path filters) and were not run.

- [x] `cd sdk/python && ruff check .` on the pinned `ruff==0.15.22` → `All checks passed!`
- [x] `cd sdk/python && ./scripts/run_pytest.sh -p no:cacheprovider` (CPython 3.12, coverage on) → `2034 passed, 4 skipped, 38 deselected, 33 warnings in 113.79s` (exit 0)
- [x] Same suite on CI's pinned matrix → `2034 passed, 4 skipped, 38 deselected` on **3.10**, **3.11** and **3.12**, exit 0 on each
- [x] `websockets-compat`: `./scripts/run_pytest.sh tests/test_memory_events.py -v --no-cov` under `websockets==12.0` and `websockets==15.0.1` on Python 3.11 → `11 passed` each
- [x] sdk-python coverage surface — the coverage-enabled run reports `TOTAL 2046 115 94%` against a `coverage-baseline.json` of **93.73** for this surface, so no baseline change is needed. `agentfield/client.py` is at 96% with no newly uncovered lines.
- [x] Each of the four follow-up commits was checked out on its own and the four
      affected test files run against it — all green, so the branch is bisectable.
- [x] `ruff format --check` on the changed files: `agentfield/logger.py`, `agentfield/run_async.py`, `agentfield/async_execution_manager.py`, `tests/test_log_dispatch_loop_safety.py` and `tests/test_async_execution_manager_teardown.py` are clean. `agentfield/client.py`, `tests/test_run_async.py`, `tests/test_approval.py` and `tests/test_client_laser_push.py` still report `Would reformat` — that drift is **pre-existing**: `ruff format --diff` on `client.py` produces a byte-identical hunk set before and after this PR, and every remaining hunk in `tests/test_run_async.py` is above the lines this PR adds. (CI's `ruff format` step is `continue-on-error: true` and asserts nothing.)

Behaviour was also confirmed against real `httpx` (not just the test double) with
a throwaway local HTTP server, which is where the `Event loop is closed` and
`bound to a different event loop` strings in the table above come from, and
against a locally built control plane — see "Verification round".

## Test coverage

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR (no bare additions).
- [x] If I removed code, I updated `coverage-baseline.json` in this PR *only if* the removal caused a legitimate regression and I called it out in the summary above — no baseline change is needed here.
- [ ] The coverage gate check is green in CI before requesting review.

## Checklist

- [x] I have read [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) (there is no `CONTRIBUTING.md` in the repo).
- [x] Commits follow conventional-commits style. (Not GPG-signed — eight commits: the log dispatch fix, the teardown fix, the lint-config tidy, the first review follow-up on client ownership / construction locking, and four more from the second review round: per-loop client eviction, fallback-dispatch-loop recognition, the background-loop start timeout, and `aclose()` attempting every client.)
- [x] I have linked the related issues below. Deliberately `Refs`, not `Fixes` — #620 is broader than these two slices.

## Related issues / PRs

Refs #620 — this is two more slices of the sync/async mixing report, not the
whole of it, so it is deliberately not marked as closing the issue.
Refs #902 (un-retained `create_task`, fixed elsewhere and now fixed here too).
Refs #909 (the `finally`-based teardown structure this PR preserves).
