### PR TITLE
test(control-plane): make the UI service storage stub safe for concurrent StatusManager calls

### DIFF
--- a/control-plane/internal/services/services95_vc_additional_test.go
+++ b/control-plane/internal/services/services95_vc_additional_test.go
@@ -146,9 +146,9 @@ func TestVCServiceSignatureHelperErrorBranches(t *testing.T) {
 	shortPublicKey := base64.RawURLEncoding.EncodeToString([]byte("short-public-key"))
 
 	signTests := []struct {
-		name      string
-		identity   *types.DIDIdentity
-		wantErr   string
+		name     string
+		identity *types.DIDIdentity
+		wantErr  string
 	}{
 		{name: "invalid private jwk json", identity: &types.DIDIdentity{PrivateKeyJWK: "{not-json}"}, wantErr: "failed to parse private key JWK"},
 		{name: "missing private key d", identity: &types.DIDIdentity{PrivateKeyJWK: `{"kty":"OKP"}`}, wantErr: "missing 'd' parameter"},
@@ -342,13 +342,13 @@ func TestHealthMonitorUnifiedAndFallbackBranches(t *testing.T) {
 		hm := NewHealthMonitor(storageStub, HealthMonitorConfig{}, nil, nil, statusManager, presence)
 
 		hm.markAgentActive("node-1")
-		require.Equal(t, types.HealthStatusActive, storageStub.updatedHealth["node-1"])
-		require.Equal(t, types.AgentStatusReady, storageStub.updatedLifecycle["node-1"])
+		require.Equal(t, types.HealthStatusActive, storageStub.healthFor("node-1"))
+		require.Equal(t, types.AgentStatusReady, storageStub.lifecycleFor("node-1"))
 		require.True(t, presence.HasLease("node-1"))
 
 		hm.markAgentInactive("node-1", 2)
-		require.Equal(t, types.HealthStatusInactive, storageStub.updatedHealth["node-1"])
-		require.Equal(t, types.AgentStatusOffline, storageStub.updatedLifecycle["node-1"])
+		require.Equal(t, types.HealthStatusInactive, storageStub.healthFor("node-1"))
+		require.Equal(t, types.AgentStatusOffline, storageStub.lifecycleFor("node-1"))
 	})
 
 	t.Run("status manager failure falls back to direct health update", func(t *testing.T) {
@@ -362,9 +362,9 @@ func TestHealthMonitorUnifiedAndFallbackBranches(t *testing.T) {
 		hm := NewHealthMonitor(storageStub, HealthMonitorConfig{}, nil, nil, statusManager, nil)
 
 		hm.markAgentActive("node-2")
-		require.Equal(t, types.HealthStatusActive, storageStub.updatedHealth["node-2"])
+		require.Equal(t, types.HealthStatusActive, storageStub.healthFor("node-2"))
 
 		hm.markAgentInactive("node-2", 3)
-		require.Equal(t, types.HealthStatusInactive, storageStub.updatedHealth["node-2"])
+		require.Equal(t, types.HealthStatusInactive, storageStub.healthFor("node-2"))
 	})
 }

--- a/control-plane/internal/services/ui_service_additional_test.go
+++ b/control-plane/internal/services/ui_service_additional_test.go
@@ -15,20 +15,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// uiStorageStub is shared by tests that drive StatusManager and UIService, both of
+// which fan out across goroutines (see UIService.RefreshAllNodeStatus). Every map in
+// the stub is therefore guarded by mu; production storage backends are already safe.
 type uiStorageStub struct {
 	storage.StorageProvider
-	listAgentsResp []*types.AgentNode
-	listAgentsErr  error
-	agentsByID     map[string]*types.AgentNode
-	getAgentErr    error
-	packages       []*types.AgentPackage
-	queryPkgsErr   error
-	updatedHealth  map[string]types.HealthStatus
+
+	mu               sync.Mutex
+	listAgentsResp   []*types.AgentNode
+	listAgentsErr    error
+	agentsByID       map[string]*types.AgentNode
+	getAgentErr      error
+	packages         []*types.AgentPackage
+	queryPkgsErr     error
+	updatedHealth    map[string]types.HealthStatus
 	updatedLifecycle map[string]types.AgentLifecycleStatus
 	updatedHeartbeat map[string]time.Time
 }
 
 func (s *uiStorageStub) ListAgents(_ context.Context, _ types.AgentFilters) ([]*types.AgentNode, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.listAgentsErr != nil {
 		return nil, s.listAgentsErr
 	}
@@ -36,6 +43,8 @@ func (s *uiStorageStub) ListAgents(_ context.Context, _ types.AgentFilters) ([]*
 }
 
 func (s *uiStorageStub) GetAgent(_ context.Context, nodeID string) (*types.AgentNode, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.getAgentErr != nil {
 		return nil, s.getAgentErr
 	}
@@ -46,6 +55,8 @@ func (s *uiStorageStub) GetAgent(_ context.Context, nodeID string) (*types.Agent
 }
 
 func (s *uiStorageStub) QueryAgentPackages(_ context.Context, _ types.PackageFilters) ([]*types.AgentPackage, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.queryPkgsErr != nil {
 		return nil, s.queryPkgsErr
 	}
@@ -53,6 +64,8 @@ func (s *uiStorageStub) QueryAgentPackages(_ context.Context, _ types.PackageFil
 }
 
 func (s *uiStorageStub) UpdateAgentHealth(_ context.Context, nodeID string, health types.HealthStatus) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.updatedHealth == nil {
 		s.updatedHealth = make(map[string]types.HealthStatus)
 	}
@@ -64,6 +77,8 @@ func (s *uiStorageStub) UpdateAgentHealth(_ context.Context, nodeID string, heal
 }
 
 func (s *uiStorageStub) UpdateAgentLifecycleStatus(_ context.Context, nodeID string, lifecycle types.AgentLifecycleStatus) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.updatedLifecycle == nil {
 		s.updatedLifecycle = make(map[string]types.AgentLifecycleStatus)
 	}
@@ -75,6 +90,8 @@ func (s *uiStorageStub) UpdateAgentLifecycleStatus(_ context.Context, nodeID str
 }
 
 func (s *uiStorageStub) UpdateAgentHeartbeat(_ context.Context, nodeID, _ string, heartbeat time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.updatedHeartbeat == nil {
 		s.updatedHeartbeat = make(map[string]time.Time)
 	}
@@ -83,6 +100,26 @@ func (s *uiStorageStub) UpdateAgentHeartbeat(_ context.Context, nodeID, _ string
 		agent.LastHeartbeat = heartbeat
 	}
 	return nil
+}
+
+// healthFor, lifecycleFor and heartbeatFor let assertions read what the stub
+// recorded without racing against in-flight StatusManager goroutines.
+func (s *uiStorageStub) healthFor(nodeID string) types.HealthStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.updatedHealth[nodeID]
+}
+
+func (s *uiStorageStub) lifecycleFor(nodeID string) types.AgentLifecycleStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.updatedLifecycle[nodeID]
+}
+
+func (s *uiStorageStub) heartbeatFor(nodeID string) time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.updatedHeartbeat[nodeID]
 }
 
 type uiAgentServiceStub struct {
@@ -372,7 +409,7 @@ func TestUIServiceUnifiedStatusAndRefreshFlows(t *testing.T) {
 	require.Contains(t, statuses, "node-2")
 
 	require.NoError(t, service.RefreshNodeStatus(context.Background(), "node-1"))
-	require.Equal(t, types.HealthStatusInactive, storageStub.updatedHealth["node-1"])
+	require.Equal(t, types.HealthStatusInactive, storageStub.healthFor("node-1"))
 
 	allStatuses, err := service.RefreshAllNodeStatus(context.Background())
 	require.NoError(t, err)
@@ -448,7 +485,7 @@ func TestStatusManagerCheckTransitionTimeoutsCompletesAndPersists(t *testing.T) 
 	statusManager.checkTransitionTimeouts()
 
 	require.Empty(t, statusManager.activeTransitions)
-	require.Equal(t, types.AgentStatusReady, storageStub.updatedLifecycle["node-2"])
+	require.Equal(t, types.AgentStatusReady, storageStub.lifecycleFor("node-2"))
 }
 
 func TestStatusManagerPersistStatus(t *testing.T) {
@@ -463,9 +500,9 @@ func TestStatusManagerPersistStatus(t *testing.T) {
 		Source:          types.StatusSourceHeartbeat,
 	})
 	require.NoError(t, err)
-	require.Equal(t, types.HealthStatusActive, storageStub.updatedHealth["node-1"])
-	require.Equal(t, types.AgentStatusReady, storageStub.updatedLifecycle["node-1"])
-	require.False(t, storageStub.updatedHeartbeat["node-1"].IsZero())
+	require.Equal(t, types.HealthStatusActive, storageStub.healthFor("node-1"))
+	require.Equal(t, types.AgentStatusReady, storageStub.lifecycleFor("node-1"))
+	require.False(t, storageStub.heartbeatFor("node-1").IsZero())
 
 	err = statusManager.persistStatus(context.Background(), "node-1", "v1", &types.AgentStatus{
 		State:           types.AgentStateStarting,
@@ -475,7 +512,7 @@ func TestStatusManagerPersistStatus(t *testing.T) {
 		Source:          types.StatusSourceManual,
 	})
 	require.NoError(t, err)
-	require.Equal(t, types.AgentStatusStarting, storageStub.updatedLifecycle["node-1"])
+	require.Equal(t, types.AgentStatusStarting, storageStub.lifecycleFor("node-1"))
 
 	err = statusManager.persistStatus(context.Background(), "node-1", "v1", &types.AgentStatus{
 		State:           types.AgentStateInactive,
@@ -485,7 +522,7 @@ func TestStatusManagerPersistStatus(t *testing.T) {
 		Source:          types.StatusSourceManual,
 	})
 	require.NoError(t, err)
-	require.Equal(t, types.AgentStatusOffline, storageStub.updatedLifecycle["node-1"])
+	require.Equal(t, types.AgentStatusOffline, storageStub.lifecycleFor("node-1"))
 }
 
 func syncMap() sync.Map {


### PR DESCRIPTION
## Summary

`UIService.RefreshAllNodeStatus` deliberately fans a node refresh out across up to five goroutines, each calling into storage through `StatusManager`. Production storage backends are safe under that; the `uiStorageStub` test double in `internal/services/ui_service_additional_test.go` was not — it wrote `updatedHealth` / `updatedLifecycle` / `updatedHeartbeat` (including a lazy `make()`) and mutated `agentsByID` entries with no synchronisation at all. That is a real, load-dependent crash of the whole test binary, and it has already taken down an unrelated PR's coverage job.

This adds a `sync.Mutex` to the stub guarding every map read and write and the lazy inits, plus `healthFor` / `lifecycleFor` / `heartbeatFor` accessors so assertions read the recorded values through the same lock instead of reaching into the maps directly. Test-only; no production code is touched.

### CI evidence

From `Coverage Summary → coverage (control-plane)`, run `32987046959` on PR #965 — a PR that does not touch this package:

```
fatal error: concurrent map writes
goroutine 2068 [running]: internal/runtime/maps.fatal
control-plane/internal/services.(*uiStorageStub).UpdateAgentHealth(...)  ui_service_additional_test.go:59
control-plane/internal/services.(*StatusManager).GetAgentStatus(...)      status_manager.go:265
control-plane/internal/services.(*StatusManager).RefreshAgentStatus(...)
(called from TestUIServiceUnifiedStatusAndRefreshFlows and siblings)
```

Reproduced deterministically on `origin/main`: `go test ./internal/services/ -run 'TestUIService' -race -count=20` reports `WARNING: DATA RACE` and `--- FAIL: TestUIServiceUnifiedStatusAndRefreshFlows`. With this change the same command is clean.

I also grepped the package's other test doubles for the same pattern. `uiStorageStub` is the only one reached from the `StatusManager` / health-check fan-out — every other `NewStatusManager` call site in the package passes a real `storage.NewLocalStorage`, and the remaining embedded-`StorageProvider` stubs (`cancel_dispatcher_test.go`, `executions_ui_service*_test.go`, `source_manager_coverage_test.go`, `vc_service_test.go`, `services92_branch_additional_test.go`) are only driven from a single goroutine.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [x] Tests only
- [ ] CI / tooling
- [ ] Breaking change

## Test plan

All from `control-plane/`:

- [x] `go build ./...` — clean
- [x] `go vet ./internal/services/...` — clean
- [x] `gofmt -l ./internal/services` — both files touched by this PR are clean (the other ten entries it lists are pre-existing on `main` and untouched here)
- [x] `golangci-lint run ./internal/services/...` — no new findings; identical 10 pre-existing findings before and after this change, none in the two files touched
- [x] `go test ./internal/services/ -run 'TestUIService' -race -count=20` — clean (fails with `DATA RACE` on `main`)
- [x] `go test ./internal/services/ -run 'TestUIService|TestStatusManager|TestNewUIService' -race -count=20 -gcflags=all=-d=checkptr=0` — clean
- [x] `go test ./internal/services/ -race -count=1 -gcflags=all=-d=checkptr=0` — whole package clean
- [x] `go test ./internal/services/ -count=1` — whole package clean
- [x] `go test ./internal/services/ -run 'TestUIService|TestStatusManager|TestNewUIService' -count=5` — clean

Two pre-existing conditions blocked the literal whole-package `-race -count=3` / `-count=5` runs. Both reproduce unchanged on `origin/main` with this PR reverted, and both are out of scope here:

1. `-race` enables `checkptr`, and `boltdb v1.3.1` (`bucket.go:626`, reached via `storage.(*LocalStorage).initializeMemoryBuckets`) trips `fatal error: checkptr: converted pointer straddles multiple allocations` under Go 1.25. Worked around above with `-gcflags=all=-d=checkptr=0`.
2. The package is not `-count>1` safe: `TestRecordGatewayBackpressure` asserts on a counter that is never reset between runs (`expected: 1, actual: 2`), and `sourceManagerTestLoop.Run` (`source_manager_coverage_test.go:35`) panics with `close of closed channel` on the second iteration.

## Test coverage

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR (no bare additions) — this PR only changes test files; no production line coverage changes.
- [ ] If I removed code, I updated `coverage-baseline.json` — not applicable, no production code removed.
- [ ] The coverage gate check is green in CI before requesting review.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) (if present) and [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
- [x] Commits are signed and follow conventional-commits style.
- [x] I have linked any related issues — none.

## Related issues / PRs

None. PR #965 is only where the crash surfaced; it is not the cause and needs no change.
