### PR TITLE
desktop: make Railway image auto-updates real — set the policy through the environment config and show Railway's live state

### DIFF
--- a/deployments/railway/README.md
+++ b/deployments/railway/README.md
@@ -25,20 +25,42 @@ control-plane databases, credentials, package registry, and installed agents.
 
 ## Control-plane image updates
 
-After a successful deploy, Desktop enables Railway Image Auto Updates with the
-**Nightly** window: every day from 02:00 to 06:00 UTC. You can choose **Off**,
-**Nightly**, **Weekends**, or **Anytime** in Desktop's Cloud settings.
+After the first successful deploy, Desktop enables Railway Image Auto Updates
+with the **patch** policy and the **Nightly** window: every day from 02:00 to
+06:00 UTC. The concrete `vX.Y.Z` image tag therefore follows patch releases
+without jumping to a new minor release. On later deploys, Desktop keeps any
+policy already present in Railway; it seeds the saved Desktop window only when
+Railway has no policy. Desktop's Cloud settings map to Railway as follows:
 
-You can also change the schedule directly in Railway:
+- **Off** disables the auto-update policy and has no maintenance window.
+- **Nightly** uses the patch policy every day from 02:00 to 06:00 UTC.
+- **Weekends** uses the patch policy all day Saturday and Sunday UTC.
+- **Anytime** uses the patch policy all day, every day.
+
+If the service already uses Railway's **minor** policy, Desktop preserves it
+when changing to an enabled window; Railway will then apply minor updates and
+patches. Choosing **Off** replaces it with the disabled policy. Otherwise,
+Desktop uses the patch policy described above.
+
+Desktop shows Railway's current value whenever it can read it. While that read
+is in progress, the control is disabled, retains the last known window for that
+service, and says **Checking Railway…**; loading is never presented as **Not set**.
+If the read fails, the select shows **Current window unknown — choose one to set
+it** with **Last known window: Nightly** (or the applicable cached window) in the
+note, not as the selected option. **Not set — choose a window** appears only
+after Railway successfully reports that the service has no policy. A window set
+to something else in Railway appears as **Custom**; choosing one of the Desktop
+options replaces that custom value while preserving a live minor policy unless
+you choose **Off**. The same setting is visible and editable directly in Railway:
 
 1. Open the control-plane service.
 2. Open **Settings**.
 3. Under **Source**, select **Configure Auto Updates**.
 4. Choose the update policy and maintenance window, or disable auto updates.
 
-Railway checks the semantic image tag for a newer stable release and redeploys
-the service during the selected window. Its maintenance schedules use UTC.
-Because the service has an attached volume, allow for a brief interruption
+Railway checks the semantic image tag according to the selected policy and
+redeploys the service during the selected window. Its maintenance schedules use
+UTC. Because the service has an attached volume, allow for a brief interruption
 during replacement. See [Railway Image Auto Updates](https://docs.railway.com/deployments/image-auto-updates)
 for Railway's update, backup, and notification behavior.
 
@@ -55,9 +77,10 @@ To manage the Railway service yourself:
 6. Generate a public domain under **Settings** → **Networking**.
 7. Set the health-check path to `/health`.
 
-The mutable `latest` tag tracks the latest stable control-plane release. A
-Railway auto-update schedule for this tag redeploys the service when the image
-digest changes. For repeatable rollbacks, use a concrete `vX.Y.Z` tag instead.
+The mutable `latest` tag tracks the latest stable control-plane release. When
+Railway Image Auto Updates are enabled with an update policy and window, the
+service is redeployed after that tag's image digest changes. For repeatable
+rollbacks, use a concrete `vX.Y.Z` tag instead.
 
 The default local storage backend works when `/data` is persistent. A separate
 PostgreSQL service is optional; configure it with the normal AgentField storage

--- a/desktop/src/main/cloudUpdate.test.ts
+++ b/desktop/src/main/cloudUpdate.test.ts
@@ -2,16 +2,24 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ControlPlaneVersion, PackageMaintenanceStatus } from '../shared/types'
 import { CpApiError } from './cpClient'
 import {
+  applyCloudAutoUpdateAfterDeploy,
   applyCloudUpdate,
   applyCloudUpdateWithRailwayToken,
   autoUpdateModeAfterDeploy,
   checkCloudUpdate,
+  classifyAutoUpdates,
+  cloudAutoUpdatePreferenceAfterReconcile,
+  cloudAutoUpdatePreferenceAfterSet,
+  cloudAutoUpdateReconcileDecision,
   cloudUpdateApplyPath,
   cloudUpdateMaintenanceMessage,
   cloudUpdateRailwayControlsAvailable,
   CloudUpdateChecker,
+  getCloudAutoUpdateState,
+  railwaySettingsUrl,
   setCloudAutoUpdateSchedule
 } from './cloudUpdate'
+import { imageAutoUpdatesPatch } from './railwayApi'
 
 function running(version: string, hosting: ControlPlaneVersion['hosting'] = { platform: 'railway' }): ControlPlaneVersion {
   return { version, commit: 'abc123', build_date: '2026-08-24T00:00:00Z', hosting, features: [] }
@@ -703,12 +711,13 @@ describe('six-minute apply polling', () => {
 })
 
 describe('Railway auto-update preference effects', () => {
-  it('falls back to URL-matched tfstate when the version request times out', async () => {
-    const setSchedule = vi.fn(async () => {})
+  it('D4 — falls back to URL-matched tfstate when the version request times out', async () => {
+    const setImageAutoUpdates = vi.fn(async () => {})
     await expect(setCloudAutoUpdateSchedule({
       mode: 'weekends',
       connectedServerUrl: 'https://cp.example/',
       tfstate: {
+        projectId: 'state-project',
         serviceId: 'state-service',
         environmentId: 'state-environment',
         url: 'https://cp.example'
@@ -716,19 +725,21 @@ describe('Railway auto-update preference effects', () => {
     }, {
       getAccessToken: vi.fn(async () => 'token'),
       getVersion: vi.fn(async () => { throw new Error('timeout') }),
-      setSchedule
+      getAutoUpdates: vi.fn(async () => null),
+      setImageAutoUpdates
     })).resolves.toMatchObject({ ok: true, serviceId: 'state-service' })
-    expect(setSchedule).toHaveBeenCalledWith(
-      'token', 'state-service', 'state-environment', 'weekends'
+    expect(setImageAutoUpdates).toHaveBeenCalledWith(
+      'token', 'state-environment', 'state-service', 'weekends', 'patch'
     )
   })
 
-  it('falls back to URL-matched tfstate for a running non-Railway control plane', async () => {
-    const setSchedule = vi.fn(async () => {})
+  it('D4 — falls back to URL-matched tfstate for a running non-Railway control plane', async () => {
+    const setImageAutoUpdates = vi.fn(async () => {})
     await expect(setCloudAutoUpdateSchedule({
       mode: 'nightly',
       connectedServerUrl: 'https://cp.example',
       tfstate: {
+        projectId: null,
         serviceId: 'state-service',
         environmentId: 'state-environment',
         url: 'https://cp.example/'
@@ -736,15 +747,230 @@ describe('Railway auto-update preference effects', () => {
     }, {
       getAccessToken: vi.fn(async () => 'token'),
       getVersion: vi.fn(async () => running('0.1.135', { platform: 'docker' })),
-      setSchedule
+      getAutoUpdates: vi.fn(async () => null),
+      setImageAutoUpdates
     })).resolves.toMatchObject({ ok: true, serviceId: 'state-service' })
-    expect(setSchedule).toHaveBeenCalledWith(
-      'token', 'state-service', 'state-environment', 'nightly'
+    expect(setImageAutoUpdates).toHaveBeenCalledWith(
+      'token', 'state-environment', 'state-service', 'nightly', 'patch'
     )
   })
 
-  it('always returns a failure result when Railway rejects the schedule', async () => {
+  it('C1 — a missing Railway autoUpdates object reads as not set', async () => {
+    await expect(getCloudAutoUpdateState({
+      connectedServerUrl: 'https://cp.example',
+      tfstate: null
+    }, {
+      getAccessToken: vi.fn(async () => 'token'),
+      getVersion: vi.fn(async () => running('0.1.135', {
+        platform: 'railway', service_id: 'service', environment_id: 'environment'
+      })),
+      getAutoUpdates: vi.fn(async () => null)
+    })).resolves.toMatchObject({ ok: true, mode: null, policy: null })
+  })
+
+  it('C2 — classifies every owned window, custom windows, and minor policy', () => {
+    const nightly = Array.from(
+      { length: 7 },
+      (_, day) => ({ day, startHour: 2, endHour: 6 })
+    )
+    const anytime = Array.from(
+      { length: 7 },
+      (_, day) => ({ day, startHour: 0, endHour: 24 })
+    )
+    expect(classifyAutoUpdates({ type: 'patch', schedule: nightly }))
+      .toEqual({ mode: 'nightly', policy: 'patch' })
+    expect(classifyAutoUpdates({ type: 'disabled' }))
+      .toEqual({ mode: 'off', policy: 'disabled' })
+    expect(classifyAutoUpdates({
+      type: 'patch',
+      schedule: [
+        { day: 6, startHour: 0, endHour: 24 },
+        { day: 0, startHour: 0, endHour: 24 }
+      ]
+    })).toEqual({ mode: 'weekends', policy: 'patch' })
+    expect(classifyAutoUpdates({ type: 'patch', schedule: anytime }))
+      .toEqual({ mode: 'anytime', policy: 'patch' })
+    expect(classifyAutoUpdates({ type: 'patch', schedule: nightly.slice(0, 3) }))
+      .toEqual({ mode: 'custom', policy: 'patch' })
+    expect(classifyAutoUpdates({ type: 'minor', schedule: nightly }))
+      .toEqual({ mode: 'nightly', policy: 'minor' })
+  })
+
+  it('C5 — commit failures include Railway detail and the best settings deep link', async () => {
+    const withProject = await setCloudAutoUpdateSchedule({
+      mode: 'off',
+      connectedServerUrl: 'https://cp.example',
+      tfstate: {
+        projectId: 'project',
+        serviceId: 'service',
+        environmentId: 'environment',
+        url: 'https://cp.example'
+      }
+    }, {
+      getAccessToken: vi.fn(async () => 'token'),
+      getVersion: vi.fn(async () => running('0.1.135', {
+        platform: 'railway',
+        service_id: 'service',
+        environment_id: 'environment'
+      })),
+      getAutoUpdates: vi.fn(async () => null),
+      setImageAutoUpdates: vi.fn(async () => { throw new Error('mutation denied') })
+    })
+    const serviceUrl = 'https://railway.com/project/project/service/service/settings'
+    expect(withProject).toMatchObject({ ok: false, settingsUrl: serviceUrl })
+    expect(withProject.message).toContain('mutation denied')
+    expect(withProject.message).toContain(serviceUrl)
+    expect(cloudAutoUpdatePreferenceAfterSet(withProject, 'off')).toBeNull()
+
+    const withoutProject = await setCloudAutoUpdateSchedule({
+      mode: 'nightly',
+      connectedServerUrl: 'https://cp.example',
+      tfstate: null
+    }, {
+      getAccessToken: vi.fn(async () => 'token'),
+      getVersion: vi.fn(async () => running('0.1.135', {
+        platform: 'railway', service_id: 'service', environment_id: 'environment'
+      })),
+      getAutoUpdates: vi.fn(async () => null),
+      setImageAutoUpdates: vi.fn(async () => { throw new Error('network down') })
+    })
+    expect(withoutProject.settingsUrl).toBe('https://railway.com/dashboard')
+    expect(withoutProject.message).toContain('https://railway.com/dashboard')
+  })
+
+  it('C7 / D5 — read failures retain Railway detail and a known service link', async () => {
+    const result = await getCloudAutoUpdateState({
+      connectedServerUrl: 'https://cp.example',
+      tfstate: {
+        projectId: 'project',
+        serviceId: 'service',
+        environmentId: 'environment',
+        url: 'https://cp.example'
+      }
+    }, {
+      getAccessToken: vi.fn(async () => 'token'),
+      getVersion: vi.fn(async () => running('0.1.135', {
+        platform: 'railway',
+        service_id: 'service',
+        environment_id: 'environment'
+      })),
+      getAutoUpdates: vi.fn(async () => { throw new Error('config query denied') })
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      mode: null,
+      policy: null,
+      serviceId: 'service',
+      message: 'Railway could not read image auto-updates: config query denied. https://railway.com/project/project/service/service/settings',
+      settingsUrl: 'https://railway.com/project/project/service/service/settings'
+    })
+  })
+
+  it('C8 — read IPC state contains no config or variables keys', async () => {
+    const result = await getCloudAutoUpdateState({
+      connectedServerUrl: 'https://cp.example',
+      tfstate: null
+    }, {
+      getAccessToken: vi.fn(async () => 'token'),
+      getVersion: vi.fn(async () => running('0.1.135', {
+        platform: 'railway',
+        project_id: 'project',
+        service_id: 'service',
+        environment_id: 'environment'
+      })),
+      getAutoUpdates: vi.fn(async () => ({
+        type: 'disabled',
+        variables: { SECRET: 'do-not-forward' },
+        config: { services: {} }
+      } as never))
+    })
+    expect(result).toEqual({
+      ok: true,
+      mode: 'off',
+      policy: 'disabled',
+      serviceId: 'service',
+      settingsUrl: railwaySettingsUrl('project', 'service')
+    })
+    expect(result).not.toHaveProperty('variables')
+    expect(result).not.toHaveProperty('config')
+  })
+
+  it('G1 / H4 — failed advisory reads report the policy actually written', async () => {
+    const patches: Record<string, unknown>[] = []
+    const setImageAutoUpdates = vi.fn(async (
+      _token: string,
+      _environmentId: string,
+      serviceId: string,
+      mode: 'off' | 'nightly' | 'weekends' | 'anytime',
+      policy: 'patch' | 'minor'
+    ) => {
+      patches.push(imageAutoUpdatesPatch(serviceId, mode, policy))
+    })
+    const deps = {
+      getAccessToken: vi.fn(async () => 'token'),
+      getVersion: vi.fn(async () => running('0.1.135', {
+        platform: 'railway', service_id: 'service', environment_id: 'environment'
+      })),
+      getAutoUpdates: vi.fn(async () => { throw new Error('read timed out') }),
+      setImageAutoUpdates
+    }
+
+    const nightly = await setCloudAutoUpdateSchedule({
+      mode: 'nightly', connectedServerUrl: 'https://cp.example', tfstate: null
+    }, deps)
+    const off = await setCloudAutoUpdateSchedule({
+      mode: 'off', connectedServerUrl: 'https://cp.example', tfstate: null
+    }, deps)
+
+    expect(setImageAutoUpdates).toHaveBeenNthCalledWith(
+      1, 'token', 'environment', 'service', 'nightly', 'patch'
+    )
+    expect(setImageAutoUpdates).toHaveBeenNthCalledWith(
+      2, 'token', 'environment', 'service', 'off', 'patch'
+    )
+    expect(patches[0]).toMatchObject({
+      services: { service: { source: { autoUpdates: { type: 'patch' } } } }
+    })
+    expect(patches[1]).toEqual({
+      services: { service: { source: { autoUpdates: { type: 'disabled' } } } }
+    })
+    expect(nightly.ok).toBe(true)
+    expect(nightly.message).toContain(
+      "Railway's current policy could not be read first; the patch policy was written."
+    )
+    expect(off.ok).toBe(true)
+    expect(off.message).toContain("Railway's current policy could not be read first.")
+    expect(off.message).not.toContain('patch policy was written')
+  })
+
+  it('F9 — set preserves a live Railway minor policy', async () => {
+    const setImageAutoUpdates = vi.fn(async () => {})
     await expect(setCloudAutoUpdateSchedule({
+      mode: 'anytime',
+      connectedServerUrl: 'https://cp.example',
+      tfstate: null
+    }, {
+      getAccessToken: vi.fn(async () => 'token'),
+      getVersion: vi.fn(async () => running('0.1.135', {
+        platform: 'railway', service_id: 'service', environment_id: 'environment'
+      })),
+      getAutoUpdates: vi.fn(async () => ({
+        type: 'minor',
+        schedule: Array.from(
+          { length: 7 },
+          (_, day) => ({ day, startHour: 2, endHour: 6 })
+        )
+      })),
+      setImageAutoUpdates
+    })).resolves.toMatchObject({ ok: true })
+    expect(setImageAutoUpdates).toHaveBeenCalledWith(
+      'token', 'environment', 'service', 'anytime', 'minor'
+    )
+  })
+
+  it("I5 — Off explains that a live minor policy was replaced", async () => {
+    const result = await setCloudAutoUpdateSchedule({
       mode: 'off',
       connectedServerUrl: 'https://cp.example',
       tfstate: null
@@ -753,31 +979,299 @@ describe('Railway auto-update preference effects', () => {
       getVersion: vi.fn(async () => running('0.1.135', {
         platform: 'railway', service_id: 'service', environment_id: 'environment'
       })),
-      setSchedule: vi.fn(async () => { throw new Error('mutation denied') })
-    })).resolves.toEqual({
-      ok: false,
-      message: 'Railway could not save that schedule: mutation denied. Check your Railway access and try again.'
+      getAutoUpdates: vi.fn(async () => ({
+        type: 'minor',
+        schedule: Array.from(
+          { length: 7 },
+          (_, day) => ({ day, startHour: 2, endHour: 6 })
+        )
+      })),
+      setImageAutoUpdates: vi.fn(async () => {})
     })
+
+    expect(result.ok).toBe(true)
+    expect(result.message).toContain(
+      "Railway's minor-update policy was replaced by Off; enabling a window again uses the patch policy."
+    )
   })
 
-  it('defaults only first deploys and re-applies only a stored same-service mode', () => {
-    expect(autoUpdateModeAfterDeploy({
+  it('F3 — pure reconcile rule writes only when Railway has no policy', () => {
+    const liveNotSet = { ok: true, mode: null, policy: null } as const
+    expect(cloudAutoUpdateReconcileDecision({
       firstDeploy: true,
       serviceId: 'new',
       storedMode: 'off',
-      storedServiceId: 'old'
-    })).toBe('nightly')
-    expect(autoUpdateModeAfterDeploy({
+      storedServiceId: 'old',
+      live: liveNotSet
+    })).toMatchObject({ writeMode: 'nightly', autoUpdateOk: true })
+    expect(cloudAutoUpdateReconcileDecision({
+      firstDeploy: false,
+      serviceId: 'same',
+      storedMode: 'weekends',
+      storedServiceId: 'same',
+      live: liveNotSet
+    })).toMatchObject({ writeMode: 'weekends', autoUpdateOk: true })
+
+    const livePresent = cloudAutoUpdateReconcileDecision({
       firstDeploy: false,
       serviceId: 'same',
       storedMode: 'off',
-      storedServiceId: 'same'
-    })).toBe('off')
+      storedServiceId: 'same',
+      live: { ok: true, mode: 'nightly', policy: 'minor' }
+    })
+    expect(livePresent).toMatchObject({ writeMode: null, autoUpdateOk: true })
+    expect(livePresent.autoUpdateMessage).toContain('Railway image auto-updates: Nightly')
+
+    const readFailure = cloudAutoUpdateReconcileDecision({
+      firstDeploy: false,
+      serviceId: 'new',
+      storedMode: null,
+      storedServiceId: null,
+      live: {
+        ok: false,
+        mode: null,
+        policy: null,
+        message: 'read denied. https://railway.com/project/p/service/s/settings',
+        settingsUrl: 'https://railway.com/project/p/service/s/settings'
+      }
+    })
+    expect(readFailure).toEqual({
+      writeMode: null,
+      autoUpdateOk: false,
+      autoUpdateMessage: 'read denied. https://railway.com/project/p/service/s/settings'
+    })
+  })
+
+  it('G2 — first-deploy read failure writes Nightly while reconcile read failure does not write', async () => {
+    const failedLiveRead = {
+      ok: false,
+      mode: null,
+      policy: null,
+      message: 'read failed',
+      settingsUrl: 'https://railway.com/dashboard'
+    } as const
+    expect(cloudAutoUpdateReconcileDecision({
+      firstDeploy: true,
+      serviceId: 'new',
+      storedMode: 'off',
+      storedServiceId: 'old',
+      live: failedLiveRead
+    })).toMatchObject({
+      writeMode: 'nightly',
+      autoUpdateOk: true
+    })
+    expect(cloudAutoUpdateReconcileDecision({
+      firstDeploy: false,
+      serviceId: 'existing',
+      storedMode: 'weekends',
+      storedServiceId: 'existing',
+      live: failedLiveRead
+    })).toEqual({
+      writeMode: null,
+      autoUpdateOk: false,
+      autoUpdateMessage: 'read failed'
+    })
+
+    const setImageAutoUpdates = vi.fn(async () => {})
+    const result = await applyCloudAutoUpdateAfterDeploy({
+      firstDeploy: true,
+      projectId: 'project',
+      environmentId: 'environment',
+      serviceId: 'new',
+      storedMode: null,
+      storedServiceId: null
+    }, {
+      getAutoUpdates: vi.fn(async () => { throw new Error('read timed out') }),
+      setImageAutoUpdates
+    })
+    expect(setImageAutoUpdates).toHaveBeenCalledWith(
+      'environment', 'new', 'nightly', 'patch'
+    )
+    expect(result).toMatchObject({
+      appliedMode: 'nightly',
+      liveMode: null,
+      autoUpdateOk: true
+    })
+    expect(result.autoUpdateMessage).toContain("current policy could not be read")
+  })
+
+  it('F3 — live policy or non-first reconcile read failure never triggers a write', async () => {
+    const setImageAutoUpdates = vi.fn(async () => {})
+    const liveResult = await applyCloudAutoUpdateAfterDeploy({
+      firstDeploy: false,
+      projectId: 'project',
+      environmentId: 'environment',
+      serviceId: 'service',
+      storedMode: 'off',
+      storedServiceId: 'service'
+    }, {
+      getAutoUpdates: vi.fn(async () => ({
+        type: 'patch',
+        schedule: Array.from(
+          { length: 7 },
+          (_, day) => ({ day, startHour: 0, endHour: 24 })
+        )
+      })),
+      setImageAutoUpdates
+    })
+    expect(liveResult.autoUpdateMessage).toContain('Railway image auto-updates: Anytime')
+    expect(setImageAutoUpdates).not.toHaveBeenCalled()
+
+    const failedResult = await applyCloudAutoUpdateAfterDeploy({
+      firstDeploy: false,
+      projectId: 'project',
+      environmentId: 'environment',
+      serviceId: 'service',
+      storedMode: null,
+      storedServiceId: null
+    }, {
+      getAutoUpdates: vi.fn(async () => { throw new Error('read failed') }),
+      setImageAutoUpdates
+    })
+    expect(failedResult).toMatchObject({
+      autoUpdateOk: false,
+      autoUpdateSettingsUrl: 'https://railway.com/project/project/service/service/settings'
+    })
+    expect(failedResult.autoUpdateMessage).toContain('read failed')
+    expect(setImageAutoUpdates).not.toHaveBeenCalled()
+  })
+
+  it('G5 — post-deploy persistence follows live classification when reconcile did not write', async () => {
+    const liveResult = await applyCloudAutoUpdateAfterDeploy({
+      firstDeploy: false,
+      projectId: 'project',
+      environmentId: 'environment',
+      serviceId: 'service',
+      storedMode: 'off',
+      storedServiceId: 'service'
+    }, {
+      getAutoUpdates: vi.fn(async () => ({
+        type: 'patch',
+        schedule: [
+          { day: 6, startHour: 0, endHour: 24 },
+          { day: 0, startHour: 0, endHour: 24 }
+        ]
+      })),
+      setImageAutoUpdates: vi.fn(async () => {})
+    })
+    expect(liveResult).toMatchObject({ appliedMode: null, liveMode: 'weekends' })
+    expect(cloudAutoUpdatePreferenceAfterReconcile(liveResult, 'off')).toBe('weekends')
+    expect(cloudAutoUpdatePreferenceAfterReconcile({
+      appliedMode: null, liveMode: 'custom', liveOk: true
+    }, 'off')).toBeNull()
+    expect(cloudAutoUpdatePreferenceAfterReconcile({
+      appliedMode: null, liveMode: null, liveOk: true
+    }, 'off')).toBeNull()
+    expect(cloudAutoUpdatePreferenceAfterReconcile({
+      appliedMode: 'nightly', liveMode: null, liveOk: false
+    }, null)).toBe('nightly')
+  })
+
+  it('H2 — a failed or skipped live read preserves the same-service cached preference', async () => {
+    const failedRead = await applyCloudAutoUpdateAfterDeploy({
+      firstDeploy: false,
+      projectId: 'project',
+      environmentId: 'environment',
+      serviceId: 'service',
+      storedMode: 'weekends',
+      storedServiceId: 'service'
+    }, {
+      getAutoUpdates: vi.fn(async () => { throw new Error('read timed out') }),
+      setImageAutoUpdates: vi.fn(async () => {})
+    })
+
+    expect(failedRead).toMatchObject({
+      appliedMode: null,
+      liveMode: null,
+      liveOk: false
+    })
+    expect(cloudAutoUpdatePreferenceAfterReconcile(failedRead, 'weekends'))
+      .toBe('weekends')
+    expect(cloudAutoUpdatePreferenceAfterReconcile(null, 'anytime'))
+      .toBe('anytime')
+    expect(cloudAutoUpdatePreferenceAfterReconcile({
+      appliedMode: null,
+      liveMode: 'custom',
+      liveOk: true
+    }, 'weekends')).toBeNull()
+    expect(cloudAutoUpdatePreferenceAfterReconcile({
+      appliedMode: null,
+      liveMode: null,
+      liveOk: true
+    }, 'weekends')).toBeNull()
+  })
+
+  it('F1 — a rejected post-deploy patch returns renderer-facing feedback and link', async () => {
+    const result = await applyCloudAutoUpdateAfterDeploy({
+      firstDeploy: true,
+      projectId: 'project',
+      environmentId: 'environment',
+      serviceId: 'service',
+      storedMode: null,
+      storedServiceId: null
+    }, {
+      getAutoUpdates: vi.fn(async () => null),
+      setImageAutoUpdates: vi.fn(async () => { throw new Error('patch commit rejected') })
+    })
+
+    expect(result).toMatchObject({
+      appliedMode: null,
+      autoUpdateOk: false,
+      autoUpdateSettingsUrl: 'https://railway.com/project/project/service/service/settings'
+    })
+    expect(result.autoUpdateMessage).toContain('patch commit rejected')
+  })
+
+  it('C9 — first deploy applies Nightly through the shared patch-commit path', async () => {
+    const setImageAutoUpdates = vi.fn(async () => {})
+    await expect(applyCloudAutoUpdateAfterDeploy({
+      firstDeploy: true,
+      projectId: 'project',
+      environmentId: 'environment',
+      serviceId: 'new',
+      storedMode: 'off',
+      storedServiceId: 'old'
+    }, {
+      getAutoUpdates: vi.fn(async () => null),
+      setImageAutoUpdates
+    })).resolves.toMatchObject({ appliedMode: 'nightly', autoUpdateOk: true })
+    expect(setImageAutoUpdates).toHaveBeenCalledWith(
+      'environment', 'new', 'nightly', 'patch'
+    )
+  })
+
+  it('I1 / H7 — a retried deploy with no usable stored mode seeds Nightly', async () => {
+    const setImageAutoUpdates = vi.fn(async () => {})
+    const result = await applyCloudAutoUpdateAfterDeploy({
+      firstDeploy: false,
+      serviceId: 'new',
+      projectId: 'project',
+      environmentId: 'environment',
+      storedMode: null,
+      storedServiceId: 'new'
+    }, {
+      getAutoUpdates: vi.fn(async () => null),
+      setImageAutoUpdates
+    })
+
     expect(autoUpdateModeAfterDeploy({
       firstDeploy: false,
       serviceId: 'new',
-      storedMode: 'weekends',
-      storedServiceId: 'old'
-    })).toBeNull()
+      storedMode: null,
+      storedServiceId: 'new'
+    })).toBe('nightly')
+    expect(result).toMatchObject({
+      appliedMode: 'nightly',
+      liveMode: null,
+      liveOk: true,
+      autoUpdateOk: true
+    })
+    expect(setImageAutoUpdates).toHaveBeenCalledWith(
+      'environment', 'new', 'nightly', 'patch'
+    )
+  })
+
+  it('I7 — a skipped reconcile without environmentId keeps the stored preference', () => {
+    expect(cloudAutoUpdatePreferenceAfterReconcile(null, 'nightly')).toBe('nightly')
   })
 })

--- a/desktop/src/main/cloudUpdate.ts
+++ b/desktop/src/main/cloudUpdate.ts
@@ -1,5 +1,8 @@
 import type {
+  CloudAutoUpdateLiveMode,
   CloudAutoUpdateMode,
+  CloudAutoUpdatePolicy,
+  CloudAutoUpdateStateResult,
   CloudUpdateApplyResult,
   CloudUpdateCheck,
   CloudUpdateStatus,
@@ -8,6 +11,10 @@ import type {
 } from '../shared/types'
 import { CpApiError } from './cpClient'
 import { resolveCloudImage } from './deployEngine'
+import type {
+  RailwayEnabledAutoUpdatePolicy,
+  RailwayImageAutoUpdates
+} from './railwayApi'
 import { compareAppVersions } from './updates'
 
 const APPLY_TIMEOUT_MS = 6 * 60_000
@@ -449,6 +456,7 @@ export async function applyCloudUpdateWithRailwayToken(
 }
 
 export interface CloudAutoUpdateStateIdentity {
+  projectId: string | null
   serviceId: string | null
   environmentId: string | null
   url: string | null
@@ -463,11 +471,17 @@ export interface SetCloudAutoUpdateOptions {
 export interface SetCloudAutoUpdateDeps {
   getAccessToken: () => Promise<string | null>
   getVersion: () => Promise<ControlPlaneVersion | null>
-  setSchedule: (
+  getAutoUpdates: (
     token: string,
-    serviceId: string,
     environmentId: string,
-    mode: CloudAutoUpdateMode
+    serviceId: string
+  ) => Promise<RailwayImageAutoUpdates | null>
+  setImageAutoUpdates: (
+    token: string,
+    environmentId: string,
+    serviceId: string,
+    mode: CloudAutoUpdateMode,
+    policy: RailwayEnabledAutoUpdatePolicy
   ) => Promise<void>
 }
 
@@ -475,6 +489,16 @@ export interface SetCloudAutoUpdateResult {
   ok: boolean
   message: string
   serviceId?: string
+  settingsUrl?: string
+}
+
+/** Main persists a preference only after Railway accepted it and returned the
+ * concrete service identity. */
+export function cloudAutoUpdatePreferenceAfterSet(
+  result: SetCloudAutoUpdateResult,
+  mode: CloudAutoUpdateMode
+): { mode: CloudAutoUpdateMode; serviceId: string } | null {
+  return result.ok && result.serviceId ? { mode, serviceId: result.serviceId } : null
 }
 
 const AUTO_UPDATE_LABELS: Record<CloudAutoUpdateMode, string> = {
@@ -484,70 +508,412 @@ const AUTO_UPDATE_LABELS: Record<CloudAutoUpdateMode, string> = {
   anytime: 'Anytime'
 }
 
+interface ResolvedCloudAutoUpdateIdentity {
+  projectId: string | null
+  serviceId: string
+  environmentId: string
+}
+
+async function resolveCloudAutoUpdateIdentity(
+  options: Pick<SetCloudAutoUpdateOptions, 'connectedServerUrl' | 'tfstate'>,
+  getVersion: () => Promise<ControlPlaneVersion | null>
+): Promise<ResolvedCloudAutoUpdateIdentity | null> {
+  let running: ControlPlaneVersion | null = null
+  try {
+    running = await getVersion()
+  } catch {
+    // A transient CP timeout may safely fall back to URL-matched tfstate.
+  }
+
+  if (running?.hosting.platform === 'railway') {
+    if (running.hosting.service_id && running.hosting.environment_id) {
+      const matchingState = options.tfstate?.serviceId === running.hosting.service_id
+        ? options.tfstate
+        : null
+      return {
+        projectId: running.hosting.project_id ?? matchingState?.projectId ?? null,
+        serviceId: running.hosting.service_id,
+        environmentId: running.hosting.environment_id
+      }
+    }
+    return null
+  }
+
+  if (
+    !running?.hosting.service_id &&
+    options.tfstate?.serviceId &&
+    options.tfstate.environmentId &&
+    sameUrl(options.connectedServerUrl, options.tfstate.url)
+  ) {
+    return {
+      projectId: options.tfstate.projectId,
+      serviceId: options.tfstate.serviceId,
+      environmentId: options.tfstate.environmentId
+    }
+  }
+  return null
+}
+
+export function railwaySettingsUrl(
+  projectId: string | null | undefined,
+  serviceId: string | null | undefined
+): string {
+  if (projectId && serviceId) {
+    return `https://railway.com/project/${encodeURIComponent(projectId)}/service/${encodeURIComponent(serviceId)}/settings`
+  }
+  return 'https://railway.com/dashboard'
+}
+
+function matchesSchedule(
+  schedule: RailwayImageAutoUpdates['schedule'],
+  days: number[],
+  startHour: number,
+  endHour: number
+): boolean {
+  if (!schedule || schedule.length !== days.length) return false
+  const expectedDays = new Set(days)
+  const actualDays = new Set(schedule.map((window) => window.day))
+  return actualDays.size === expectedDays.size && schedule.every((window) =>
+    typeof window.day === 'number' &&
+    expectedDays.has(window.day) &&
+    window.startHour === startHour &&
+    window.endHour === endHour
+  )
+}
+
+/** Classify only the windows Desktop owns; every other Railway configuration
+ * remains visible as custom and can be replaced explicitly by the user. */
+export function classifyAutoUpdates(
+  autoUpdates: RailwayImageAutoUpdates | null
+): { mode: CloudAutoUpdateMode | 'custom' | null; policy: CloudAutoUpdatePolicy } {
+  if (!autoUpdates) return { mode: null, policy: null }
+  const policy = autoUpdates.type === 'disabled' ||
+      autoUpdates.type === 'patch' ||
+      autoUpdates.type === 'minor'
+    ? autoUpdates.type
+    : null
+  if (policy === 'disabled') return { mode: 'off', policy }
+  if (policy === 'patch' || policy === 'minor') {
+    if (matchesSchedule(autoUpdates.schedule, [0, 1, 2, 3, 4, 5, 6], 2, 6)) {
+      return { mode: 'nightly', policy }
+    }
+    if (matchesSchedule(autoUpdates.schedule, [0, 6], 0, 24)) {
+      return { mode: 'weekends', policy }
+    }
+    if (matchesSchedule(autoUpdates.schedule, [0, 1, 2, 3, 4, 5, 6], 0, 24)) {
+      return { mode: 'anytime', policy }
+    }
+  }
+  return { mode: 'custom', policy }
+}
+
+async function readRailwayAutoUpdateState(
+  getAutoUpdates: () => Promise<RailwayImageAutoUpdates | null>,
+  settingsUrl: string
+): Promise<CloudAutoUpdateStateResult> {
+  try {
+    const autoUpdates = await getAutoUpdates()
+    return { ok: true, ...classifyAutoUpdates(autoUpdates), settingsUrl }
+  } catch (error) {
+    return {
+      ok: false,
+      mode: null,
+      policy: null,
+      message: `Railway could not read image auto-updates: ${errorText(error)}. ${settingsUrl}`,
+      settingsUrl
+    }
+  }
+}
+
+export interface GetCloudAutoUpdateOptions {
+  connectedServerUrl: string
+  tfstate: CloudAutoUpdateStateIdentity | null
+}
+
+export interface GetCloudAutoUpdateDeps {
+  getAccessToken: () => Promise<string | null>
+  getVersion: () => Promise<ControlPlaneVersion | null>
+  getAutoUpdates: (
+    token: string,
+    environmentId: string,
+    serviceId: string
+  ) => Promise<RailwayImageAutoUpdates | null>
+}
+
+/** Read only the sanitized autoUpdates subset from Railway; no environment
+ * config document is ever returned to the caller or renderer. */
+export async function getCloudAutoUpdateState(
+  options: GetCloudAutoUpdateOptions,
+  deps: GetCloudAutoUpdateDeps
+): Promise<CloudAutoUpdateStateResult> {
+  const token = await deps.getAccessToken().catch(() => null)
+  const identity = await resolveCloudAutoUpdateIdentity(options, deps.getVersion)
+  if (!token) {
+    const settingsUrl = railwaySettingsUrl(identity?.projectId, identity?.serviceId)
+    return {
+      ok: false,
+      mode: null,
+      policy: null,
+      ...(identity ? { serviceId: identity.serviceId } : {}),
+      message: `Sign in to Railway to read image auto-updates. ${settingsUrl}`,
+      settingsUrl
+    }
+  }
+  if (!identity) {
+    const settingsUrl = railwaySettingsUrl(null, null)
+    return {
+      ok: false,
+      mode: null,
+      policy: null,
+      message: `The connected control plane could not be matched to a Railway service. ${settingsUrl}`,
+      settingsUrl
+    }
+  }
+  const settingsUrl = railwaySettingsUrl(identity.projectId, identity.serviceId)
+  return {
+    ...await readRailwayAutoUpdateState(
+      () => deps.getAutoUpdates(
+        token,
+        identity.environmentId,
+        identity.serviceId
+      ),
+      settingsUrl
+    ),
+    serviceId: identity.serviceId
+  }
+}
+
 /** Apply a Railway schedule without leaking getVersion failures through IPC.
  * A transient version timeout falls back only to URL-matched tfstate. */
 export async function setCloudAutoUpdateSchedule(
   options: SetCloudAutoUpdateOptions,
   deps: SetCloudAutoUpdateDeps
 ): Promise<SetCloudAutoUpdateResult> {
+  let identity: ResolvedCloudAutoUpdateIdentity | null = null
   try {
     const token = await deps.getAccessToken()
     if (!token) {
-      return { ok: false, message: 'Sign in to Railway, then choose the schedule again.' }
-    }
-
-    let running: ControlPlaneVersion | null = null
-    try {
-      running = await deps.getVersion()
-    } catch {
-      // A transient CP timeout must not reject IPC. URL-matched tfstate below
-      // remains a safe identity fallback for Desktop-managed deployments.
-    }
-
-    let serviceId: string | null = null
-    let environmentId: string | null = null
-    if (running?.hosting.platform === 'railway') {
-      serviceId = running.hosting.service_id ?? null
-      environmentId = running.hosting.environment_id ?? null
-    } else if (
-      !running?.hosting.service_id &&
-      options.tfstate &&
-      sameUrl(options.connectedServerUrl, options.tfstate.url)
-    ) {
-      serviceId = options.tfstate.serviceId
-      environmentId = options.tfstate.environmentId
-    }
-    if (!serviceId || !environmentId) {
+      const settingsUrl = railwaySettingsUrl(null, null)
       return {
         ok: false,
-        message: 'The connected control plane could not be matched to a Railway service. Reconnect the matching Railway control plane, then choose the schedule again.'
+        message: `Sign in to Railway, then choose the schedule again. ${settingsUrl}`,
+        settingsUrl
+      }
+    }
+    identity = await resolveCloudAutoUpdateIdentity(options, deps.getVersion)
+    if (!identity) {
+      const settingsUrl = railwaySettingsUrl(null, null)
+      return {
+        ok: false,
+        message: `The connected control plane could not be matched to a Railway service. Reconnect the matching Railway control plane, then choose the schedule again. ${settingsUrl}`,
+        settingsUrl
       }
     }
 
-    await deps.setSchedule(token, serviceId, environmentId, options.mode)
+    const {
+      projectId,
+      environmentId,
+      serviceId
+    } = identity
+    const settingsUrl = railwaySettingsUrl(projectId, serviceId)
+    const live = await readRailwayAutoUpdateState(
+      () => deps.getAutoUpdates(
+        token,
+        environmentId,
+        serviceId
+      ),
+      settingsUrl
+    )
+    const readFailed = !live.ok
+    const policy: RailwayEnabledAutoUpdatePolicy = live.policy === 'minor'
+      ? 'minor'
+      : 'patch'
+
+    await deps.setImageAutoUpdates(
+      token,
+      environmentId,
+      serviceId,
+      options.mode,
+      policy
+    )
     return {
       ok: true,
       serviceId,
-      message: `Railway image auto-updates set to ${AUTO_UPDATE_LABELS[options.mode]}.`
+      settingsUrl,
+      message: `Railway image auto-updates set to ${AUTO_UPDATE_LABELS[options.mode]}.` +
+        (readFailed
+          ? options.mode === 'off'
+            ? " Railway's current policy could not be read first."
+            : " Railway's current policy could not be read first; the patch policy was written."
+          : live.policy === 'minor' && options.mode === 'off'
+            ? " Railway's minor-update policy was replaced by Off; enabling a window again uses the patch policy."
+            : '')
     }
   } catch (error) {
+    const settingsUrl = railwaySettingsUrl(identity?.projectId, identity?.serviceId)
     return {
       ok: false,
-      message: `Railway could not save that schedule: ${errorText(error)}. Check your Railway access and try again.`
+      message: `Railway could not save that schedule: ${errorText(error)}. You can also set it in Railway → Settings → Source → Configure Auto Updates. ${settingsUrl}`,
+      settingsUrl
     }
   }
 }
 
-/** First deploys get the Nightly default. Reconciles preserve only a mode
- * already applied to this same service. */
+/** First deploys and retried deploys without a usable cached preference get the
+ * Nightly default. Reconciles preserve a mode already applied to this service. */
 export function autoUpdateModeAfterDeploy(input: {
   firstDeploy: boolean
   serviceId: string
   storedMode: CloudAutoUpdateMode | null
   storedServiceId: string | null
 }): CloudAutoUpdateMode | null {
-  if (input.firstDeploy) return 'nightly'
-  return input.storedServiceId === input.serviceId ? input.storedMode : null
+  if (
+    input.firstDeploy ||
+    input.storedServiceId !== input.serviceId ||
+    input.storedMode === null
+  ) return 'nightly'
+  return input.storedMode
+}
+
+export interface CloudAutoUpdateReconcileDecision {
+  writeMode: CloudAutoUpdateMode | null
+  autoUpdateOk: boolean
+  autoUpdateMessage: string
+}
+
+function classifiedAutoUpdateLabel(mode: Exclude<CloudAutoUpdateLiveMode, null>): string {
+  if (mode === 'custom') return 'Custom (set in Railway)'
+  return AUTO_UPDATE_LABELS[mode]
+}
+
+/** Decide whether post-deploy reconciliation may write. A live Railway policy,
+ * including a custom window, is authoritative. A first deploy owns its newly
+ * created service, so it can safely write Nightly even when the read failed. */
+export function cloudAutoUpdateReconcileDecision(input: {
+  firstDeploy: boolean
+  serviceId: string
+  storedMode: CloudAutoUpdateMode | null
+  storedServiceId: string | null
+  live: CloudAutoUpdateStateResult
+}): CloudAutoUpdateReconcileDecision {
+  if (!input.live.ok) {
+    if (input.firstDeploy) {
+      return {
+        writeMode: 'nightly',
+        autoUpdateOk: true,
+        autoUpdateMessage: `Railway image auto-updates set to ${AUTO_UPDATE_LABELS.nightly}. Railway's current policy could not be read after the first deploy; the patch policy was written.`
+      }
+    }
+    return {
+      writeMode: null,
+      autoUpdateOk: false,
+      autoUpdateMessage: input.live.message ?? 'Railway could not read image auto-updates.'
+    }
+  }
+  if (input.live.mode !== null) {
+    const policy = input.live.policy === 'minor' ? ' (minor policy)' : ''
+    return {
+      writeMode: null,
+      autoUpdateOk: true,
+      autoUpdateMessage: `Railway image auto-updates: ${classifiedAutoUpdateLabel(input.live.mode)}${policy}.`
+    }
+  }
+  const writeMode = autoUpdateModeAfterDeploy(input)
+  return {
+    writeMode,
+    autoUpdateOk: true,
+    autoUpdateMessage: writeMode
+      ? `Railway image auto-updates set to ${AUTO_UPDATE_LABELS[writeMode]}.`
+      : 'Railway image auto-updates are not set; choose a window below.'
+  }
+}
+
+export interface CloudDeployAutoUpdateResult {
+  appliedMode: CloudAutoUpdateMode | null
+  liveMode: CloudAutoUpdateLiveMode
+  liveOk: boolean
+  autoUpdateOk: boolean
+  autoUpdateMessage: string
+  autoUpdateSettingsUrl: string
+}
+
+/** Convert the reconcile result into Desktop's cached fallback. A successful
+ * write wins. A failed or skipped read preserves the same-service fallback;
+ * successful custom and unknown live states deliberately clear it. */
+export function cloudAutoUpdatePreferenceAfterReconcile(
+  result: Pick<CloudDeployAutoUpdateResult, 'appliedMode' | 'liveMode' | 'liveOk'> | null,
+  storedModeForService: CloudAutoUpdateMode | null
+): CloudAutoUpdateMode | null {
+  if (!result) return storedModeForService
+  if (result.appliedMode) return result.appliedMode
+  if (!result.liveOk) return storedModeForService
+  return result.liveMode === 'custom' ? null : result.liveMode
+}
+
+export interface ApplyCloudAutoUpdateAfterDeployDeps {
+  getAutoUpdates: (
+    environmentId: string,
+    serviceId: string
+  ) => Promise<RailwayImageAutoUpdates | null>
+  setImageAutoUpdates: (
+    environmentId: string,
+    serviceId: string,
+    mode: CloudAutoUpdateMode,
+    policy: RailwayEnabledAutoUpdatePolicy
+  ) => Promise<void>
+}
+
+/** Read Railway first, then apply a default/cached policy only when the service
+ * has no policy at all. Returns fields that are sent directly to the renderer. */
+export async function applyCloudAutoUpdateAfterDeploy(input: {
+  firstDeploy: boolean
+  projectId: string | null
+  environmentId: string
+  serviceId: string
+  storedMode: CloudAutoUpdateMode | null
+  storedServiceId: string | null
+}, deps: ApplyCloudAutoUpdateAfterDeployDeps): Promise<CloudDeployAutoUpdateResult> {
+  const settingsUrl = railwaySettingsUrl(input.projectId, input.serviceId)
+  const live = await readRailwayAutoUpdateState(
+    () => deps.getAutoUpdates(input.environmentId, input.serviceId),
+    settingsUrl
+  )
+  const decision = cloudAutoUpdateReconcileDecision({ ...input, live })
+  if (!decision.writeMode) {
+    return {
+      appliedMode: null,
+      liveMode: live.mode,
+      liveOk: live.ok,
+      autoUpdateOk: decision.autoUpdateOk,
+      autoUpdateMessage: decision.autoUpdateMessage,
+      autoUpdateSettingsUrl: settingsUrl
+    }
+  }
+  try {
+    await deps.setImageAutoUpdates(
+      input.environmentId,
+      input.serviceId,
+      decision.writeMode,
+      'patch'
+    )
+    return {
+      appliedMode: decision.writeMode,
+      liveMode: live.mode,
+      liveOk: live.ok,
+      autoUpdateOk: true,
+      autoUpdateMessage: decision.autoUpdateMessage,
+      autoUpdateSettingsUrl: settingsUrl
+    }
+  } catch (error) {
+    return {
+      appliedMode: null,
+      liveMode: live.mode,
+      liveOk: live.ok,
+      autoUpdateOk: false,
+      autoUpdateMessage: `Automatic updates could not be scheduled: ${errorText(error)}. The deployment is healthy; choose a window below to retry or configure it in Railway → Settings → Source → Configure Auto Updates.`,
+      autoUpdateSettingsUrl: settingsUrl
+    }
+  }
 }
 
 export interface CloudUpdateCheckerDeps {

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -7,6 +7,7 @@ import { RAILWAY_TEMPLATE_URL } from '../shared/cloudLinks'
 import { DEEP_LINK_SCHEME, type View, deepLinkFromArgv, parseDeepLink } from '../shared/deeplink'
 import type {
   CloudAutoUpdateMode,
+  CloudDeployResult,
   DesktopSettings,
   LocalControlPlaneRestartStatus
 } from '../shared/types'
@@ -57,11 +58,15 @@ import { setupTray } from './tray'
 import { syncTrayCompanion } from './tray-companion'
 import { AppUpdater } from './updates'
 import {
+  applyCloudAutoUpdateAfterDeploy,
   applyCloudUpdateWithRailwayToken,
-  autoUpdateModeAfterDeploy,
+  cloudAutoUpdatePreferenceAfterReconcile,
+  cloudAutoUpdatePreferenceAfterSet,
   cloudUpdateApplyPath,
   cloudUpdateRailwayControlsAvailable,
   CloudUpdateChecker,
+  getCloudAutoUpdateState,
+  railwaySettingsUrl,
   setCloudAutoUpdateSchedule
 } from './cloudUpdate'
 import {
@@ -890,6 +895,28 @@ function main(): void {
       settings = settingsWithDismissedCloudUpdate(settings, version)
       await saveSettings(settingsFile(), settings)
     })
+    ipcMain.handle('agentfield:cloud-auto-update-get', async () => {
+      const state = deploymentStateInfo(deployPaths().workspaceDir)
+      return getCloudAutoUpdateState({
+        connectedServerUrl: settings.cloud.serverUrl,
+        tfstate: state
+          ? {
+              projectId: state.projectId,
+              serviceId: state.serviceId,
+              environmentId: state.environmentId,
+              url: state.url
+            }
+          : null
+      }, {
+        getAccessToken: () => getFreshAccessToken(authDeps()),
+        getVersion: () => createCpClient().getVersion(),
+        getAutoUpdates: (token, environmentId, serviceId) =>
+          createRailwayApi(token).getEnvironmentConfigAutoUpdates(
+            environmentId,
+            serviceId
+          )
+      })
+    })
     ipcMain.handle(
       'agentfield:cloud-auto-update-set',
       async (_event, mode: unknown) => {
@@ -905,6 +932,7 @@ function main(): void {
           connectedServerUrl: settings.cloud.serverUrl,
           tfstate: state
             ? {
+                projectId: state.projectId,
                 serviceId: state.serviceId,
                 environmentId: state.environmentId,
                 url: state.url
@@ -913,29 +941,50 @@ function main(): void {
         }, {
           getAccessToken: () => getFreshAccessToken(authDeps()),
           getVersion: () => createCpClient().getVersion(),
-          setSchedule: (token, serviceId, environmentId, selectedMode) =>
-            createRailwayApi(token).setAutoUpdateSchedule(
-              serviceId,
+          getAutoUpdates: (token, environmentId, serviceId) =>
+            createRailwayApi(token).getEnvironmentConfigAutoUpdates(
               environmentId,
-              selectedMode
+              serviceId
+            ),
+          setImageAutoUpdates: (
+            token,
+            environmentId,
+            serviceId,
+            selectedMode,
+            policy
+          ) =>
+            createRailwayApi(token).setImageAutoUpdates(
+              environmentId,
+              serviceId,
+              selectedMode,
+              policy
             )
         })
-        if (result.ok && result.serviceId) {
+        const preference = cloudAutoUpdatePreferenceAfterSet(
+          result,
+          mode as CloudAutoUpdateMode
+        )
+        if (preference) {
           try {
             settings = await persistCloudAutoUpdatePreference(
               settings,
-              mode as CloudAutoUpdateMode,
-              result.serviceId,
+              preference.mode,
+              preference.serviceId,
               (next) => saveSettings(settingsFile(), next)
             )
           } catch (error) {
             return {
               ok: false,
-              message: `Railway saved the schedule, but Desktop could not persist the preference: ${error instanceof Error ? error.message : String(error)}.`
+              message: `Railway saved the schedule, but Desktop could not persist the preference: ${error instanceof Error ? error.message : String(error)}.`,
+              settingsUrl: result.settingsUrl
             }
           }
         }
-        return { ok: result.ok, message: result.message }
+        return {
+          ok: result.ok,
+          message: result.message,
+          settingsUrl: result.settingsUrl
+        }
       }
     )
     cloudUpdater.startAutoCheck()
@@ -971,12 +1020,14 @@ function main(): void {
     ipcMain.handle('agentfield:railway-status', async () => {
       const deps = authDeps()
       const { workspaceDir, binaryDir } = deployPaths()
+      const deployment = deploymentStateInfo(workspaceDir)
       const token = isLoggedIn(deps) ? await getFreshAccessToken(deps) : null
       return loadRailwayStatus({
         token,
         engineAvailable: resolveTofuBinary(binaryDir) !== null,
         hasDeployment: hasDeployment(workspaceDir),
-        deploymentWorkspaceId: deploymentStateInfo(workspaceDir)?.workspaceId ?? null,
+        deploymentWorkspaceId: deployment?.workspaceId ?? null,
+        deploymentServiceId: deployment?.serviceId ?? null,
         listWorkspaces: (accessToken) => listWorkspaces(accessToken)
       })
     })
@@ -988,7 +1039,7 @@ function main(): void {
       return { ...result, workspaces: token ? await listWorkspaces(token) : [] }
     })
     ipcMain.handle('agentfield:railway-logout', () => logout(authDeps()))
-    ipcMain.handle('agentfield:cloud-deploy', async (event, workspaceId: unknown) => {
+    ipcMain.handle('agentfield:cloud-deploy', async (event, workspaceId: unknown): Promise<CloudDeployResult> => {
       if (typeof workspaceId !== 'string' || workspaceId === '') {
         return { ok: false, message: 'Choose a Railway workspace first' }
       }
@@ -1007,37 +1058,53 @@ function main(): void {
             }
           }
         })
-        let deployMessage = result.message
+        let autoUpdateOk: boolean | undefined
+        let autoUpdateMessage: string | undefined
+        let autoUpdateSettingsUrl: string | undefined
         if (result.ok && result.url && result.apiKey) {
           const serviceId = result.serviceId ?? null
-          let appliedMode =
-            serviceId && settings.cloud.autoUpdateServiceId === serviceId
+          const storedAutoUpdateMode =
+            serviceId !== null && settings.cloud.autoUpdateServiceId === serviceId
               ? settings.cloud.autoUpdate
               : null
+          let cachedAutoUpdateMode = cloudAutoUpdatePreferenceAfterReconcile(
+            null,
+            storedAutoUpdateMode
+          )
           if (result.serviceId && result.environmentId) {
-            const scheduleMode = autoUpdateModeAfterDeploy({
+            const railwayApi = createRailwayApi(token)
+            const reconciled = await applyCloudAutoUpdateAfterDeploy({
               firstDeploy: result.firstDeploy === true,
+              projectId: result.projectId ?? null,
+              environmentId: result.environmentId,
               serviceId: result.serviceId,
               storedMode: settings.cloud.autoUpdate,
               storedServiceId: settings.cloud.autoUpdateServiceId
-            })
-            if (scheduleMode) {
-              try {
-                await createRailwayApi(token).setAutoUpdateSchedule(
-                  result.serviceId,
-                  result.environmentId,
-                  scheduleMode
+            }, {
+              getAutoUpdates: (environmentId, targetServiceId) =>
+                railwayApi.getEnvironmentConfigAutoUpdates(
+                  environmentId,
+                  targetServiceId
+                ),
+              setImageAutoUpdates: (environmentId, targetServiceId, mode, policy) =>
+                railwayApi.setImageAutoUpdates(
+                  environmentId,
+                  targetServiceId,
+                  mode,
+                  policy
                 )
-                appliedMode = scheduleMode
-                deployMessage = `${deployMessage} Railway image auto-updates are set to ${scheduleMode === 'nightly' ? 'Nightly (02:00–06:00 UTC every day)' : scheduleMode}.`
-              } catch (error) {
-                deployMessage = `${deployMessage} Automatic updates could not be scheduled: ${error instanceof Error ? error.message : String(error)}. The deployment is healthy; choose a window below to retry.`
-              }
-            } else {
-              deployMessage = `${deployMessage} Railway image auto-updates are not set; choose a window below.`
-            }
+            })
+            cachedAutoUpdateMode = cloudAutoUpdatePreferenceAfterReconcile(
+              reconciled,
+              storedAutoUpdateMode
+            )
+            autoUpdateOk = reconciled.autoUpdateOk
+            autoUpdateMessage = reconciled.autoUpdateMessage
+            autoUpdateSettingsUrl = reconciled.autoUpdateSettingsUrl
           } else {
-            deployMessage = `${deployMessage} Automatic updates could not be scheduled because Railway service outputs were missing. Re-run deploy to reconcile them.`
+            autoUpdateOk = false
+            autoUpdateMessage = 'Automatic updates could not be scheduled because Railway service outputs were missing. Re-run deploy to reconcile them.'
+            autoUpdateSettingsUrl = railwaySettingsUrl(result.projectId, result.serviceId)
           }
           settings = mergeSettings(settings, {
             cloud: {
@@ -1045,7 +1112,7 @@ function main(): void {
               enabled: true,
               serverUrl: result.url,
               apiKey: result.apiKey,
-              autoUpdate: appliedMode,
+              autoUpdate: cachedAutoUpdateMode,
               autoUpdateServiceId: serviceId
             }
           })
@@ -1056,7 +1123,10 @@ function main(): void {
           ok: result.ok,
           url: result.url,
           furrowAddress: result.furrowAddress,
-          message: deployMessage
+          message: result.message,
+          autoUpdateOk,
+          autoUpdateMessage,
+          autoUpdateSettingsUrl
         }
       } finally {
         cloudDeployInFlight = false

--- a/desktop/src/main/railwayApi.test.ts
+++ b/desktop/src/main/railwayApi.test.ts
@@ -1,16 +1,20 @@
 import { describe, expect, it, vi } from 'vitest'
+import { classifyAutoUpdates } from './cloudUpdate'
+import * as railwayApiModule from './railwayApi'
 import {
-  AUTO_UPDATE_MUTATION,
+  autoUpdateSchedule,
   createRailwayApi,
+  ENVIRONMENT_CONFIG_QUERY,
+  ENVIRONMENT_PATCH_COMMIT_MUTATION,
   REDEPLOY_MUTATION,
   SERVICE_IMAGE_MUTATION
 } from './railwayApi'
 
-function graphqlHarness() {
+function graphqlHarness(data: Record<string, unknown> = { ok: true }) {
   const calls: Array<{ query: string; variables: Record<string, unknown> }> = []
   const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
     calls.push(JSON.parse(String(init?.body)) as (typeof calls)[number])
-    return new Response(JSON.stringify({ data: { ok: true } }), {
+    return new Response(JSON.stringify({ data }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' }
     })
@@ -51,42 +55,210 @@ describe('Railway service mutations', () => {
 
     await expect(api.redeploy('service', 'environment')).rejects.toThrow('service update denied')
   })
-})
 
-describe('Railway image auto-update schedules', () => {
-  const expected = {
-    off: [],
-    nightly: Array.from({ length: 7 }, (_, day) => ({ day, startHour: 2, endHour: 6 })),
-    weekends: [
-      { day: 6, startHour: 0, endHour: 24 },
-      { day: 0, startHour: 0, endHour: 24 }
-    ],
-    anytime: Array.from({ length: 7 }, (_, day) => ({ day, startHour: 0, endHour: 24 }))
-  } as const
+  it('G7 — a stalled Railway request times out instead of waiting forever', async () => {
+    vi.useFakeTimers()
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockImplementation((milliseconds) => {
+      const controller = new AbortController()
+      setTimeout(() => controller.abort(new DOMException(
+        'The operation was aborted due to timeout',
+        'TimeoutError'
+      )), milliseconds)
+      return controller.signal
+    })
+    try {
+      const fetchImpl = vi.fn((_url: string | URL | Request, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal
+          if (!signal) {
+            reject(new Error('missing abort signal'))
+            return
+          }
+          const abort = () => reject(signal.reason)
+          if (signal.aborted) abort()
+          else signal.addEventListener('abort', abort, { once: true })
+        })) as typeof fetch
+      const api = createRailwayApi('railway-token', fetchImpl)
 
-  it('declares Railway\'s schedule input as a non-null list of non-null windows', () => {
-    expect(AUTO_UPDATE_MUTATION).toContain(
-      '$schedule: [AutoUpdateScheduleWindowInput!]!'
-    )
+      const request = api.listWorkspaces()
+      const rejected = expect(request).rejects.toThrow('timed out')
+      await vi.advanceTimersByTimeAsync(20_000)
+      await rejected
+    } finally {
+      timeout.mockRestore()
+      vi.useRealTimers()
+    }
   })
 
-  it.each(Object.entries(expected))('sends the exact %s schedule', async (mode, schedule) => {
+  it('H8 — an abort while reading the response body is reported as timed out', async () => {
+    vi.useFakeTimers()
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockImplementation((milliseconds) => {
+      const controller = new AbortController()
+      setTimeout(() => controller.abort(new DOMException(
+        'The operation was aborted due to timeout',
+        'TimeoutError'
+      )), milliseconds)
+      return controller.signal
+    })
+    try {
+      const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => ({
+        ok: true,
+        status: 200,
+        json: () => new Promise((_resolve, reject) => {
+          const signal = init?.signal
+          if (!signal) {
+            reject(new Error('missing abort signal'))
+            return
+          }
+          const abort = () => reject(signal.reason)
+          if (signal.aborted) abort()
+          else signal.addEventListener('abort', abort, { once: true })
+        })
+      }) as Response) as typeof fetch
+      const api = createRailwayApi('railway-token', fetchImpl)
+
+      const request = api.listWorkspaces()
+      const rejected = expect(request).rejects.toThrow('timed out')
+      await vi.advanceTimersByTimeAsync(20_000)
+      await rejected
+    } finally {
+      timeout.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('Railway image auto-update policy', () => {
+  it('C3 — setting nightly sends one exact environment patch commit', async () => {
     const { api, calls } = graphqlHarness()
-    await api.setAutoUpdateSchedule(
-      'service',
-      'environment',
-      mode as keyof typeof expected
-    )
+    await api.setImageAutoUpdates('environment', 'service', 'nightly')
 
     expect(calls).toEqual([{
-      query: AUTO_UPDATE_MUTATION,
-      variables: { serviceId: 'service', environmentId: 'environment', schedule }
+      query: ENVIRONMENT_PATCH_COMMIT_MUTATION,
+      variables: {
+        environmentId: 'environment',
+        patch: {
+          services: {
+            service: {
+              source: {
+                autoUpdates: {
+                  type: 'patch',
+                  schedule: Array.from(
+                    { length: 7 },
+                    (_, day) => ({ day, startHour: 2, endHour: 6 })
+                  )
+                }
+              }
+            }
+          }
+        },
+        commitMessage: 'Configure AgentField image auto-updates (nightly)'
+      }
     }])
-    expect(calls[0].variables).toEqual({
-      serviceId: 'service',
-      environmentId: 'environment',
-      schedule
+    expect(JSON.stringify(calls[0].variables.patch)).not.toContain('image')
+    expect(calls[0].query).not.toContain('serviceInstanceAutoUpdateScheduleUpdate')
+  })
+
+  it('C4 / F10 — setting off bypasses the non-empty schedule builder', async () => {
+    const { api, calls } = graphqlHarness()
+    await api.setImageAutoUpdates('environment', 'service', 'off')
+
+    expect(calls[0].variables.patch).toEqual({
+      services: {
+        service: {
+          source: { autoUpdates: { type: 'disabled' } }
+        }
+      }
     })
-    expect(calls[0].variables.schedule).toEqual(schedule)
+    expect(JSON.stringify(calls[0].variables.patch)).not.toContain('schedule')
+  })
+
+  it('C1 — an existing service without autoUpdates reads as not set', async () => {
+    const { api } = graphqlHarness({
+      environment: {
+        config: {
+          services: {
+            service: { source: { image: 'agentfield/control-plane-cloud:v0.1.135' } }
+          }
+        }
+      }
+    })
+
+    const autoUpdates = await api.getEnvironmentConfigAutoUpdates('environment', 'service')
+    expect(autoUpdates).toBeNull()
+    expect(classifyAutoUpdates(autoUpdates)).toEqual({ mode: null, policy: null })
+  })
+
+  it('F8 — a missing environment configuration is a read failure', async () => {
+    const { api } = graphqlHarness({ environment: null })
+
+    await expect(api.getEnvironmentConfigAutoUpdates('environment', 'service'))
+      .rejects.toThrow('Railway returned no configuration for this service')
+
+    const missingService = graphqlHarness({
+      environment: { config: { services: {} } }
+    }).api
+    await expect(missingService.getEnvironmentConfigAutoUpdates('environment', 'service'))
+      .rejects.toThrow('Railway returned no configuration for this service')
+  })
+
+  it('C8 — environment config reads drop extra policy and window keys', async () => {
+    const railwayAutoUpdates = {
+      type: 'patch',
+      schedule: [{ day: 0, startHour: 2, endHour: 6, bar: 'drop-me' }],
+      foo: 'drop-me'
+    }
+    const { api, calls } = graphqlHarness({
+      environment: {
+        config: {
+          services: {
+            service: {
+              source: { image: 'private/image:v1.2.3', autoUpdates: railwayAutoUpdates },
+              variables: { SECRET: 'do-not-forward' }
+            }
+          }
+        }
+      }
+    })
+
+    await expect(api.getEnvironmentConfigAutoUpdates('environment', 'service'))
+      .resolves.toEqual({
+        type: 'patch',
+        schedule: [{ day: 0, startHour: 2, endHour: 6 }]
+      })
+    expect(calls).toEqual([{
+      query: ENVIRONMENT_CONFIG_QUERY,
+      variables: { environmentId: 'environment' }
+    }])
+  })
+
+  it('F9 — an existing minor policy is preserved in the patch', async () => {
+    const { api, calls } = graphqlHarness()
+    await api.setImageAutoUpdates('environment', 'service', 'weekends', 'minor')
+
+    expect(calls[0].variables.patch).toEqual({
+      services: {
+        service: {
+          source: {
+            autoUpdates: {
+              type: 'minor',
+              schedule: [
+                { day: 6, startHour: 0, endHour: 24 },
+                { day: 0, startHour: 0, endHour: 24 }
+              ]
+            }
+          }
+        }
+      }
+    })
+  })
+
+  it('C10 — removes the old schedule mutation while retaining the window table', () => {
+    expect(railwayApiModule).not.toHaveProperty('AUTO_UPDATE_MUTATION')
+    expect(railwayApiModule).not.toHaveProperty('setAutoUpdateSchedule')
+    expect(autoUpdateSchedule('weekends')).toEqual([
+      { day: 6, startHour: 0, endHour: 24 },
+      { day: 0, startHour: 0, endHour: 24 }
+    ])
   })
 })

--- a/desktop/src/main/railwayApi.ts
+++ b/desktop/src/main/railwayApi.ts
@@ -11,7 +11,22 @@ export interface RailwayScheduleWindow {
   endHour: number
 }
 
+export type RailwayAutoUpdatePolicy = 'disabled' | 'patch' | 'minor'
+export type RailwayEnabledAutoUpdatePolicy = Exclude<RailwayAutoUpdatePolicy, 'disabled'>
+
+/** Sanitized subset of Railway's untyped environment config. No other source
+ * or service config fields are allowed to leave this module. */
+export interface RailwayImageAutoUpdates {
+  type: unknown
+  schedule?: Array<{
+    day: unknown
+    startHour: unknown
+    endHour: unknown
+  }>
+}
+
 const RAILWAY_GRAPHQL = 'https://backboard.railway.com/graphql/v2'
+const RAILWAY_REQUEST_TIMEOUT_MS = 20_000
 
 export const SERVICE_IMAGE_MUTATION = `mutation ServiceInstanceUpdate($serviceId: String!, $environmentId: String!, $image: String!) {
   serviceInstanceUpdate(serviceId: $serviceId, environmentId: $environmentId, input: {source: {image: $image}})
@@ -21,12 +36,17 @@ export const REDEPLOY_MUTATION = `mutation ServiceInstanceRedeploy($serviceId: S
   serviceInstanceRedeploy(serviceId: $serviceId, environmentId: $environmentId)
 }`
 
-export const AUTO_UPDATE_MUTATION = `mutation ServiceInstanceAutoUpdateScheduleUpdate($serviceId: String!, $environmentId: String!, $schedule: [AutoUpdateScheduleWindowInput!]!) {
-  serviceInstanceAutoUpdateScheduleUpdate(serviceId: $serviceId, environmentId: $environmentId, schedule: $schedule)
+export const ENVIRONMENT_CONFIG_QUERY = `query EnvironmentConfig($environmentId: String!) {
+  environment(id: $environmentId) { config }
 }`
 
-export function autoUpdateSchedule(mode: CloudAutoUpdateMode): RailwayScheduleWindow[] {
-  if (mode === 'off') return []
+export const ENVIRONMENT_PATCH_COMMIT_MUTATION = `mutation EnvironmentPatchCommit($environmentId: String!, $patch: EnvironmentConfig!, $commitMessage: String) {
+  environmentPatchCommit(environmentId: $environmentId, patch: $patch, commitMessage: $commitMessage)
+}`
+
+export function autoUpdateSchedule(
+  mode: Exclude<CloudAutoUpdateMode, 'off'>
+): RailwayScheduleWindow[] {
   if (mode === 'weekends') {
     // Railway uses the conventional 0=Sunday … 6=Saturday numbering.
     return [
@@ -40,6 +60,23 @@ export function autoUpdateSchedule(mode: CloudAutoUpdateMode): RailwayScheduleWi
   return Array.from({ length: 7 }, (_, day) => ({ day, ...hours }))
 }
 
+export function imageAutoUpdatesPatch(
+  serviceId: string,
+  mode: CloudAutoUpdateMode,
+  policy: RailwayEnabledAutoUpdatePolicy = 'patch'
+): Record<string, unknown> {
+  const autoUpdates = mode === 'off'
+    ? { type: 'disabled' }
+    : { type: policy, schedule: autoUpdateSchedule(mode) }
+  return {
+    services: {
+      [serviceId]: {
+        source: { autoUpdates }
+      }
+    }
+  }
+}
+
 export interface RailwayApi {
   listWorkspaces(): Promise<RailwayWorkspace[]>
   listVolumes(projectId: string): Promise<unknown[]>
@@ -51,10 +88,15 @@ export interface RailwayApi {
   ): Promise<void>
   setServiceImage(serviceId: string, environmentId: string, image: string): Promise<void>
   redeploy(serviceId: string, environmentId: string): Promise<void>
-  setAutoUpdateSchedule(
-    serviceId: string,
+  getEnvironmentConfigAutoUpdates(
     environmentId: string,
-    mode: CloudAutoUpdateMode
+    serviceId: string
+  ): Promise<RailwayImageAutoUpdates | null>
+  setImageAutoUpdates(
+    environmentId: string,
+    serviceId: string,
+    mode: CloudAutoUpdateMode,
+    policy?: RailwayEnabledAutoUpdatePolicy
   ): Promise<void>
 }
 
@@ -66,18 +108,32 @@ export function createRailwayApi(
     query: string,
     variables: Record<string, unknown> = {}
   ): Promise<Record<string, unknown>> {
-    const response = await fetchImpl(RAILWAY_GRAPHQL, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': 'application/json',
-        'User-Agent': 'agentfield-desktop'
-      },
-      body: JSON.stringify({ query, variables })
-    })
-    const payload = await response.json().catch(() => ({})) as {
+    const signal = AbortSignal.timeout(RAILWAY_REQUEST_TIMEOUT_MS)
+    let response: Response
+    let payload: {
       data?: Record<string, unknown>
       errors?: Array<{ message?: string }>
+    }
+    try {
+      response = await fetchImpl(RAILWAY_GRAPHQL, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+          'User-Agent': 'agentfield-desktop'
+        },
+        body: JSON.stringify({ query, variables }),
+        signal
+      })
+      payload = await response.json().catch((error) => {
+        if (signal.aborted) throw error
+        return {}
+      }) as typeof payload
+    } catch (error) {
+      if (signal.aborted) {
+        throw new Error(`Railway GraphQL request timed out after ${RAILWAY_REQUEST_TIMEOUT_MS / 1000} seconds`)
+      }
+      throw error
     }
     if (!response.ok || payload.errors?.length) {
       const detail = payload.errors
@@ -114,11 +170,53 @@ export function createRailwayApi(
     async redeploy(serviceId, environmentId) {
       await request(REDEPLOY_MUTATION, { serviceId, environmentId })
     },
-    async setAutoUpdateSchedule(serviceId, environmentId, mode) {
-      await request(AUTO_UPDATE_MUTATION, {
-        serviceId,
+    async getEnvironmentConfigAutoUpdates(environmentId, serviceId) {
+      const data = await request(ENVIRONMENT_CONFIG_QUERY, { environmentId })
+      const environment = data.environment
+      if (typeof environment !== 'object' || environment === null) {
+        throw new Error('Railway returned no configuration for this service')
+      }
+      const config = (environment as { config?: unknown }).config
+      if (typeof config !== 'object' || config === null) {
+        throw new Error('Railway returned no configuration for this service')
+      }
+      const services = (config as { services?: unknown }).services
+      if (typeof services !== 'object' || services === null) {
+        throw new Error('Railway returned no configuration for this service')
+      }
+      const service = (services as Record<string, unknown>)[serviceId]
+      if (typeof service !== 'object' || service === null) {
+        throw new Error('Railway returned no configuration for this service')
+      }
+      const source = (service as { source?: unknown }).source
+      if (typeof source !== 'object' || source === null) return null
+      const value = (source as { autoUpdates?: unknown }).autoUpdates
+      if (value === undefined || value === null) return null
+      if (typeof value !== 'object') {
+        throw new Error('Railway returned an invalid auto-update configuration')
+      }
+
+      const raw = value as { type?: unknown; schedule?: unknown }
+      const autoUpdates: RailwayImageAutoUpdates = { type: raw.type }
+      if (Array.isArray(raw.schedule)) {
+        autoUpdates.schedule = raw.schedule.map((window) => {
+          const item = typeof window === 'object' && window !== null
+            ? window as Record<string, unknown>
+            : {}
+          return {
+            day: item.day,
+            startHour: item.startHour,
+            endHour: item.endHour
+          }
+        })
+      }
+      return autoUpdates
+    },
+    async setImageAutoUpdates(environmentId, serviceId, mode, policy = 'patch') {
+      await request(ENVIRONMENT_PATCH_COMMIT_MUTATION, {
         environmentId,
-        schedule: autoUpdateSchedule(mode)
+        patch: imageAutoUpdatesPatch(serviceId, mode, policy),
+        commitMessage: `Configure AgentField image auto-updates (${mode})`
       })
     }
   }

--- a/desktop/src/main/railwayStatus.test.ts
+++ b/desktop/src/main/railwayStatus.test.ts
@@ -8,12 +8,14 @@ describe('loadRailwayStatus', () => {
       engineAvailable: true,
       hasDeployment: true,
       deploymentWorkspaceId: 'workspace-from-state',
+      deploymentServiceId: 'service-from-state',
       listWorkspaces: vi.fn(async () => { throw new Error('Railway unavailable') })
     })).resolves.toEqual({
       loggedIn: true,
       engineAvailable: true,
       hasDeployment: true,
       deploymentWorkspaceId: 'workspace-from-state',
+      deploymentServiceId: 'service-from-state',
       workspaces: [],
       message: 'Signed in, but Railway workspaces could not be loaded: Railway unavailable. Check Railway and try again.'
     })

--- a/desktop/src/main/railwayStatus.ts
+++ b/desktop/src/main/railwayStatus.ts
@@ -6,6 +6,7 @@ export interface RailwayStatusInput {
   engineAvailable: boolean
   hasDeployment: boolean
   deploymentWorkspaceId: string | null
+  deploymentServiceId?: string | null
   listWorkspaces: (token: string) => Promise<RailwayWorkspace[]>
 }
 
@@ -22,6 +23,9 @@ export async function loadRailwayStatus(input: RailwayStatusInput): Promise<Rail
     hasDeployment: input.hasDeployment,
     ...(input.deploymentWorkspaceId
       ? { deploymentWorkspaceId: input.deploymentWorkspaceId }
+      : {}),
+    ...(input.deploymentServiceId
+      ? { deploymentServiceId: input.deploymentServiceId }
       : {}),
     workspaces: []
   }

--- a/desktop/src/main/settings.test.ts
+++ b/desktop/src/main/settings.test.ts
@@ -256,6 +256,23 @@ describe('mergeSettings', () => {
     })
   })
 
+  it('C6 — persists the chosen mode together with its Railway service identity', async () => {
+    const previous = normalizeSettings({
+      cloud: { autoUpdate: null, autoUpdateServiceId: null }
+    })
+    let persisted: typeof previous | null = null
+    const next = await persistCloudAutoUpdatePreference(
+      previous,
+      'weekends',
+      'service-a',
+      async (value) => { persisted = value }
+    )
+
+    expect(next.cloud.autoUpdate).toBe('weekends')
+    expect(next.cloud.autoUpdateServiceId).toBe('service-a')
+    expect(persisted).toBe(next)
+  })
+
   it('does not publish a Railway schedule preference when persistence fails', async () => {
     const previous = normalizeSettings({
       cloud: {

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -36,6 +36,7 @@ const api: AgentFieldApi = {
   checkCloudUpdate: () => ipcRenderer.invoke('agentfield:cloud-update-check'),
   applyCloudUpdate: () => ipcRenderer.invoke('agentfield:cloud-update-apply'),
   dismissCloudUpdate: (version) => ipcRenderer.invoke('agentfield:cloud-update-dismiss', version),
+  getCloudAutoUpdate: () => ipcRenderer.invoke('agentfield:cloud-auto-update-get'),
   setCloudAutoUpdate: (mode) => ipcRenderer.invoke('agentfield:cloud-auto-update-set', mode),
   onCloudUpdateStatus: (listener) => {
     const wrapped = (

--- a/desktop/src/renderer/src/components/CloudPanel.tsx
+++ b/desktop/src/renderer/src/components/CloudPanel.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import type {
+    CloudAutoUpdateLiveMode,
     CloudAutoUpdateMode,
+    CloudAutoUpdateStateResult,
     CloudDeployResult,
     CloudTestResult,
     CloudUpdateStatus,
@@ -49,7 +51,175 @@ export function cloudUpdateActionLabel(status: CloudUpdateStatus): string {
     return status.status === "legacy" ? "Update control plane" : "Update now";
 }
 
-type CloudUpdateFeedback = { ok: boolean; text: string };
+type CloudUpdateFeedback = { ok: boolean; text: string; settingsUrl?: string };
+
+export interface CloudUpdateFeedbackSnapshot {
+    target: string;
+    feedback: CloudUpdateFeedback;
+}
+
+export interface CloudAutoUpdateSnapshot {
+    target: string;
+    state: CloudAutoUpdateStateResult | null;
+}
+
+export const CLOUD_AUTO_UPDATE_FALLBACK_HINT =
+    "Railway could not be reached.";
+export const CLOUD_AUTO_UPDATE_NOT_SET_LABEL = "Not set — choose a window";
+export const CLOUD_AUTO_UPDATE_UNKNOWN_LABEL =
+    "Current window unknown — choose one to set it";
+export const CLOUD_AUTO_UPDATE_LOADING_HINT = "Checking Railway…";
+export const CLOUD_AUTO_UPDATE_SAVING_HINT = "Saving to Railway…";
+export const CLOUD_AUTO_UPDATE_MINOR_HINT =
+    "Railway applies minor updates and patches.";
+export const CLOUD_AUTO_UPDATE_CUSTOM_HINT =
+    "Choosing a Desktop window replaces the custom Railway window; an existing minor policy is preserved unless you choose Off.";
+
+const CLOUD_AUTO_UPDATE_MODE_LABELS: Record<CloudAutoUpdateMode, string> = {
+    off: "Off",
+    nightly: "Nightly",
+    weekends: "Weekends",
+    anytime: "Anytime",
+};
+
+export function cloudAutoUpdateTargetKey(
+    railwayLoggedIn: boolean | undefined,
+    cloud: Pick<DesktopSettings["cloud"], "enabled" | "serverUrl"> | null | undefined,
+): string {
+    return [
+        railwayLoggedIn === true ? "logged-in" : "logged-out",
+        cloud?.enabled === true ? "enabled" : "disabled",
+        cloud?.serverUrl ?? "",
+    ].join("|");
+}
+
+export function cloudAutoUpdateReadEnabled(
+    railwayLoggedIn: boolean | undefined,
+    cloudEnabled: boolean | undefined,
+): boolean {
+    return railwayLoggedIn === true && cloudEnabled === true;
+}
+
+export function cloudAutoUpdateForTarget(
+    snapshot: CloudAutoUpdateSnapshot | null,
+    target: string,
+): CloudAutoUpdateStateResult | null {
+    return snapshot?.target === target ? snapshot.state : null;
+}
+
+export function cloudAutoUpdateSnapshotAfterRead(
+    snapshot: CloudAutoUpdateSnapshot | null,
+    target: string,
+    state: CloudAutoUpdateStateResult,
+): CloudAutoUpdateSnapshot | null {
+    return snapshot?.target === target ? { target, state } : snapshot;
+}
+
+export function cloudUpdateFeedbackForTarget(
+    snapshot: CloudUpdateFeedbackSnapshot | null,
+    target: string,
+): CloudUpdateFeedback | null {
+    return snapshot?.target === target ? snapshot.feedback : null;
+}
+
+export function cloudUpdateFeedbackAfterTargetChange(
+    snapshot: CloudUpdateFeedbackSnapshot | null,
+    target: string,
+): CloudUpdateFeedbackSnapshot | null {
+    return snapshot?.target === target ? snapshot : null;
+}
+
+export function cloudUpdateFeedbackAfterSave(
+    snapshot: CloudUpdateFeedbackSnapshot | null,
+    saved: boolean,
+): CloudUpdateFeedbackSnapshot | null {
+    return saved ? null : snapshot;
+}
+
+export function cloudAutoUpdateStoredMode(
+    live: CloudAutoUpdateStateResult | null,
+    storedMode: CloudAutoUpdateMode | null,
+    storedServiceId: string | null,
+    tfstateServiceId: string | null,
+): CloudAutoUpdateMode | null {
+    const serviceId = live?.serviceId ?? tfstateServiceId;
+    return serviceId && storedServiceId === serviceId ? storedMode : null;
+}
+
+export function cloudAutoUpdateSelectState(
+    live: CloudAutoUpdateStateResult | null,
+    stored: CloudAutoUpdateMode | null,
+    busy = false,
+    pending: CloudAutoUpdateMode | null = null,
+): {
+    value: Exclude<CloudAutoUpdateLiveMode, null> | "";
+    placeholder: string;
+    hint: string | null;
+    disabled: boolean;
+} {
+    if (pending) {
+        return {
+            value: pending,
+            placeholder: CLOUD_AUTO_UPDATE_NOT_SET_LABEL,
+            hint: CLOUD_AUTO_UPDATE_SAVING_HINT,
+            disabled: true,
+        };
+    }
+    if (live?.ok) {
+        return {
+            value: live.mode ?? "",
+            placeholder: CLOUD_AUTO_UPDATE_NOT_SET_LABEL,
+            hint: live.policy === "minor" ? CLOUD_AUTO_UPDATE_MINOR_HINT : null,
+            disabled: busy,
+        };
+    }
+    if (live) {
+        const messageDetail = live.message
+            ? cloudAutoUpdateFeedbackText({
+                ok: false,
+                text: live.message,
+                settingsUrl: live.settingsUrl,
+            })
+            : "";
+        const detail = messageDetail || CLOUD_AUTO_UPDATE_FALLBACK_HINT;
+        const cached = stored
+            ? `Last known window: ${CLOUD_AUTO_UPDATE_MODE_LABELS[stored]}. `
+            : "";
+        return {
+            value: "",
+            placeholder: CLOUD_AUTO_UPDATE_UNKNOWN_LABEL,
+            hint: `${cached}${detail}`,
+            disabled: busy,
+        };
+    }
+    return {
+        value: stored ?? "",
+        placeholder: CLOUD_AUTO_UPDATE_LOADING_HINT,
+        hint: stored
+            ? `Last known window: ${CLOUD_AUTO_UPDATE_MODE_LABELS[stored]}`
+            : null,
+        disabled: true,
+    };
+}
+
+export function cloudAutoUpdateFeedbackText(feedback: CloudUpdateFeedback): string {
+    if (!feedback.settingsUrl) return feedback.text;
+    return feedback.text.replace(feedback.settingsUrl, "").trim();
+}
+
+export function cloudDeployAutoUpdateFeedback(
+    result: CloudDeployResult,
+): CloudUpdateFeedback | null {
+    if (
+        typeof result.autoUpdateOk !== "boolean" ||
+        !result.autoUpdateMessage
+    ) return null;
+    return {
+        ok: result.autoUpdateOk,
+        text: result.autoUpdateMessage,
+        settingsUrl: result.autoUpdateSettingsUrl,
+    };
+}
 
 export function cloudUpdateFeedbackClass(feedback: CloudUpdateFeedback): string {
     return feedback.ok ? "row-sub" : "row-sub error-text";
@@ -79,9 +249,13 @@ export function CloudPanel() {
     const [confirmation, setConfirmation] = useState<Confirmation | null>(null);
     const [railway, setRailway] = useState<RailwayStatus | null>(null);
     const [cloudUpdate, setCloudUpdate] = useState<CloudUpdateStatus | null>(null);
+    const [cloudAutoUpdateSnapshot, setCloudAutoUpdateSnapshot] =
+        useState<CloudAutoUpdateSnapshot | null>(null);
     const [cloudUpdateBusy, setCloudUpdateBusy] = useState<"apply" | "schedule" | null>(null);
-    const [cloudUpdateMessage, setCloudUpdateMessage] =
-        useState<CloudUpdateFeedback | null>(null);
+    const [pendingAutoUpdateMode, setPendingAutoUpdateMode] =
+        useState<CloudAutoUpdateMode | null>(null);
+    const [cloudUpdateMessageSnapshot, setCloudUpdateMessageSnapshot] =
+        useState<CloudUpdateFeedbackSnapshot | null>(null);
     const [railwayBusy, setRailwayBusy] = useState<
         "login" | "deploy" | "destroy" | null
     >(null);
@@ -94,6 +268,49 @@ export function CloudPanel() {
     const [showDestroy, setShowDestroy] = useState(false);
     const [destroyed, setDestroyed] = useState(false);
     const [activeTab, setActiveTab] = useState<CloudTab>("railway");
+
+    const cloudAutoUpdateTarget = cloudAutoUpdateTargetKey(
+        railway?.loggedIn,
+        settings?.cloud,
+    );
+    const cloudAutoUpdate = cloudAutoUpdateForTarget(
+        cloudAutoUpdateSnapshot,
+        cloudAutoUpdateTarget,
+    );
+    const cloudUpdateMessage = cloudUpdateFeedbackForTarget(
+        cloudUpdateMessageSnapshot,
+        cloudAutoUpdateTarget,
+    );
+    const setCloudUpdateMessage = (
+        feedback: CloudUpdateFeedback | null,
+        target = cloudAutoUpdateTarget,
+    ) => {
+        setCloudUpdateMessageSnapshot(feedback
+            ? { target, feedback }
+            : null);
+    };
+
+    const refreshCloudAutoUpdate = async () => {
+        const target = cloudAutoUpdateTarget;
+        setCloudAutoUpdateSnapshot({ target, state: null });
+        if (!cloudAutoUpdateReadEnabled(
+            railway?.loggedIn,
+            settings?.cloud.enabled,
+        )) return;
+        try {
+            const state = await window.agentfield.getCloudAutoUpdate();
+            setCloudAutoUpdateSnapshot((snapshot) =>
+                cloudAutoUpdateSnapshotAfterRead(snapshot, target, state));
+        } catch (err) {
+            setCloudAutoUpdateSnapshot((snapshot) =>
+                cloudAutoUpdateSnapshotAfterRead(snapshot, target, {
+                    ok: false,
+                    mode: null,
+                    policy: null,
+                    message: err instanceof Error ? err.message : String(err),
+                }));
+        }
+    };
 
     useEffect(() => {
         void window.agentfield.getSettings().then((next) => {
@@ -114,6 +331,12 @@ export function CloudPanel() {
             setDeployLines((lines) => [...lines.slice(-199), line]);
         });
     }, []);
+
+    useEffect(() => {
+        setCloudUpdateMessageSnapshot((snapshot) =>
+            cloudUpdateFeedbackAfterTargetChange(snapshot, cloudAutoUpdateTarget));
+        void refreshCloudAutoUpdate();
+    }, [cloudAutoUpdateTarget]);
 
     useEffect(() => {
         if (!settings?.cloud.enabled) return;
@@ -178,12 +401,13 @@ export function CloudPanel() {
     };
 
     const saveCloud = async () => {
+        let proceed = true;
         if (!result?.ok) {
-            const proceed = window.confirm(
+            proceed = window.confirm(
                 "The connection has not passed its test. Switch to this remote control plane anyway?",
             );
-            if (!proceed) return;
         }
+        if (!proceed) return;
         setSaving(true);
         setError(null);
         setConfirmation(null);
@@ -194,6 +418,8 @@ export function CloudPanel() {
                 apiKey: apiKey.trim(),
             });
             setSettings(next);
+            setCloudUpdateMessageSnapshot((snapshot) =>
+                cloudUpdateFeedbackAfterSave(snapshot, true));
             setServerUrl(next.cloud?.serverUrl ?? serverUrl.trim());
             setApiKey(next.cloud?.apiKey ?? apiKey.trim());
             setConfirmation({
@@ -208,6 +434,7 @@ export function CloudPanel() {
     };
 
     const disconnect = async () => {
+        setCloudUpdateMessage(null);
         setSaving(true);
         setError(null);
         setConfirmation(null);
@@ -260,19 +487,32 @@ export function CloudPanel() {
         setDeployResult(null);
         setDestroyed(false);
         setError(null);
+        setCloudUpdateMessage(null);
         try {
             const nextResult =
                 await window.agentfield.cloudDeploy(actionWorkspaceId);
             setDeployResult(nextResult);
+            const feedback = cloudDeployAutoUpdateFeedback(nextResult);
+            let feedbackTarget = cloudAutoUpdateTarget;
+            let targetChanged = false;
             if (nextResult.ok) {
                 const next = await window.agentfield.getSettings();
+                feedbackTarget = cloudAutoUpdateTargetKey(
+                    railway?.loggedIn,
+                    next.cloud,
+                );
+                targetChanged =
+                    next.cloud.enabled !== settings?.cloud.enabled ||
+                    next.cloud.serverUrl !== settings?.cloud.serverUrl;
                 setSettings(next);
                 setServerUrl(next.cloud.serverUrl);
                 setApiKey(next.cloud.apiKey);
             }
+            setCloudUpdateMessage(feedback, feedbackTarget);
             await refreshRailway();
             if (nextResult.ok) {
                 setCloudUpdate(await window.agentfield.checkCloudUpdate());
+                if (!targetChanged) await refreshCloudAutoUpdate();
             }
         } catch (err) {
             setError(err instanceof Error ? err.message : String(err));
@@ -285,6 +525,7 @@ export function CloudPanel() {
         if (deleteText !== "delete") return;
         setRailwayBusy("destroy");
         setError(null);
+        setCloudUpdateMessage(null);
         try {
             const result = await window.agentfield.cloudDestroy();
             if (!result.ok) {
@@ -313,6 +554,7 @@ export function CloudPanel() {
             const applied = await window.agentfield.applyCloudUpdate();
             setCloudUpdateMessage({ ok: applied.ok, text: applied.message });
             setCloudUpdate(await window.agentfield.checkCloudUpdate());
+            if (applied.ok) await refreshCloudAutoUpdate();
         } catch (err) {
             setCloudUpdateMessage({
                 ok: false,
@@ -324,12 +566,17 @@ export function CloudPanel() {
     };
 
     const setAutoUpdate = async (mode: CloudAutoUpdateMode) => {
+        setPendingAutoUpdateMode(mode);
         setCloudUpdateBusy("schedule");
         setCloudUpdateMessage(null);
         try {
             const changed = await window.agentfield.setCloudAutoUpdate(mode);
             if (!changed.ok) {
-                setCloudUpdateMessage({ ok: false, text: changed.message });
+                setCloudUpdateMessage({
+                    ok: false,
+                    text: changed.message,
+                    settingsUrl: changed.settingsUrl,
+                });
                 return;
             }
             const next = await window.agentfield.getSettings();
@@ -341,6 +588,8 @@ export function CloudPanel() {
                 text: `${err instanceof Error ? err.message : String(err)} Try again.`,
             });
         } finally {
+            await refreshCloudAutoUpdate();
+            setPendingAutoUpdateMode(null);
             setCloudUpdateBusy(null);
         }
     };
@@ -352,6 +601,19 @@ export function CloudPanel() {
             </div>
         );
     }
+
+    const storedAutoUpdateMode = cloudAutoUpdateStoredMode(
+        cloudAutoUpdate,
+        settings.cloud.autoUpdate,
+        settings.cloud.autoUpdateServiceId,
+        railway?.deploymentServiceId ?? null,
+    );
+    const autoUpdateSelect = cloudAutoUpdateSelectState(
+        cloudAutoUpdate,
+        storedAutoUpdateMode,
+        cloudUpdateBusy !== null,
+        pendingAutoUpdateMode,
+    );
 
     return (
         <>
@@ -412,7 +674,20 @@ export function CloudPanel() {
                         <span className="row-sub">{cloudUpdate.message}</span>
                         {cloudUpdateMessage && (
                             <span className={cloudUpdateFeedbackClass(cloudUpdateMessage)}>
-                                {cloudUpdateMessage.text}
+                                {cloudAutoUpdateFeedbackText(cloudUpdateMessage)}
+                                {cloudUpdateMessage.settingsUrl && (
+                                    <>
+                                        {" "}
+                                        <a
+                                            className="link-button"
+                                            href={cloudUpdateMessage.settingsUrl}
+                                            target="_blank"
+                                            rel="noreferrer"
+                                        >
+                                            Open Railway settings
+                                        </a>
+                                    </>
+                                )}
                             </span>
                         )}
                     </div>
@@ -433,23 +708,58 @@ export function CloudPanel() {
                             railwayImageUpdatesVisible(cloudUpdate) && (
                                 <label className="cloud-workspace-field">
                                     <span className="row-sub">Railway image updates</span>
-                                    <select
-                                        className="env-input"
-                                        aria-label="Railway image auto-update schedule"
-                                        value={settings.cloud.autoUpdate ?? ""}
-                                        disabled={cloudUpdateBusy !== null}
-                                        onChange={(event) =>
-                                            void setAutoUpdate(event.target.value as CloudAutoUpdateMode)
+                                        <select
+                                            className="env-input"
+                                            aria-label="Railway image auto-update schedule"
+                                            value={autoUpdateSelect.value}
+                                            disabled={autoUpdateSelect.disabled}
+                                            title={autoUpdateSelect.value === "custom"
+                                                ? CLOUD_AUTO_UPDATE_CUSTOM_HINT
+                                                : undefined}
+                                            onChange={(event) =>
+                                                void setAutoUpdate(event.target.value as CloudAutoUpdateMode)
                                         }
                                     >
                                         <option value="" disabled>
-                                            Not set — choose a window
+                                            {autoUpdateSelect.placeholder}
                                         </option>
+                                        {autoUpdateSelect.value === "custom" && (
+                                            <option
+                                                value="custom"
+                                                disabled
+                                                title={CLOUD_AUTO_UPDATE_CUSTOM_HINT}
+                                            >
+                                                Custom — set in Railway
+                                            </option>
+                                        )}
                                         <option value="off">Off — never update automatically</option>
                                         <option value="nightly">Nightly — every day, 02:00–06:00 UTC</option>
                                         <option value="weekends">Weekends — Saturday and Sunday, all day UTC</option>
                                         <option value="anytime">Anytime — apply after Railway detects a release</option>
                                     </select>
+                                    {autoUpdateSelect.hint && (
+                                        <span className="row-sub">
+                                            {autoUpdateSelect.hint}
+                                            {cloudAutoUpdate?.settingsUrl && (
+                                                <>
+                                                    {" "}
+                                                    <a
+                                                        className="link-button"
+                                                        href={cloudAutoUpdate.settingsUrl}
+                                                        target="_blank"
+                                                        rel="noreferrer"
+                                                    >
+                                                        Open Railway settings
+                                                    </a>
+                                                </>
+                                            )}
+                                        </span>
+                                    )}
+                                    {autoUpdateSelect.value === "custom" && (
+                                        <span className="row-sub">
+                                            {CLOUD_AUTO_UPDATE_CUSTOM_HINT}
+                                        </span>
+                                    )}
                                 </label>
                             )}
                     </div>

--- a/desktop/src/renderer/src/components/autoUpdateUi.test.ts
+++ b/desktop/src/renderer/src/components/autoUpdateUi.test.ts
@@ -11,8 +11,25 @@ import {
   cloudUpdateBannerVisible
 } from './CloudUpdateBanner'
 import {
+  CLOUD_AUTO_UPDATE_FALLBACK_HINT,
+  CLOUD_AUTO_UPDATE_CUSTOM_HINT,
+  CLOUD_AUTO_UPDATE_LOADING_HINT,
+  CLOUD_AUTO_UPDATE_MINOR_HINT,
+  CLOUD_AUTO_UPDATE_NOT_SET_LABEL,
+  CLOUD_AUTO_UPDATE_SAVING_HINT,
+  CLOUD_AUTO_UPDATE_UNKNOWN_LABEL,
+  cloudAutoUpdateForTarget,
+  cloudAutoUpdateReadEnabled,
+  cloudAutoUpdateSelectState,
+  cloudAutoUpdateSnapshotAfterRead,
+  cloudAutoUpdateStoredMode,
+  cloudAutoUpdateTargetKey,
+  cloudDeployAutoUpdateFeedback,
   cloudUpdateActionLabel,
   cloudUpdateActionVisible,
+  cloudUpdateFeedbackForTarget,
+  cloudUpdateFeedbackAfterSave,
+  cloudUpdateFeedbackAfterTargetChange,
   cloudUpdateFeedbackClass,
   deployedWorkspacePickerDisabled,
   deployedWorkspacePickerVisible,
@@ -121,6 +138,251 @@ describe('deployed Railway workspace picker', () => {
       deploymentWorkspaceId: 'recorded',
       workspaces: [{ id: 'recorded', name: 'Recorded' }, { id: 'other', name: 'Other' }]
     }, 'other')).toBe('recorded')
+  })
+})
+
+describe('Railway live auto-update control', () => {
+  it('C1 — shows the not-set choice when Railway has no policy', () => {
+    expect(cloudAutoUpdateSelectState({
+      ok: true,
+      mode: null,
+      policy: null
+    }, 'nightly')).toEqual({
+      value: '',
+      placeholder: CLOUD_AUTO_UPDATE_NOT_SET_LABEL,
+      hint: null,
+      disabled: false
+    })
+    expect(CLOUD_AUTO_UPDATE_NOT_SET_LABEL).toBe('Not set — choose a window')
+  })
+
+  it('C6 — selects the re-read live value instead of the stored preference', () => {
+    expect(cloudAutoUpdateSelectState({
+      ok: true,
+      mode: 'nightly',
+      policy: 'patch'
+    }, 'weekends')).toEqual({
+      value: 'nightly',
+      placeholder: CLOUD_AUTO_UPDATE_NOT_SET_LABEL,
+      hint: null,
+      disabled: false
+    })
+  })
+
+  it('C7 / H3 — failed reads leave the placeholder selected and disclose the cached mode', () => {
+    expect(cloudAutoUpdateSelectState({
+      ok: false,
+      mode: null,
+      policy: null,
+      settingsUrl: 'https://railway.com/dashboard'
+    }, 'weekends')).toEqual({
+      value: '',
+      placeholder: CLOUD_AUTO_UPDATE_UNKNOWN_LABEL,
+      hint: `Last known window: Weekends. ${CLOUD_AUTO_UPDATE_FALLBACK_HINT}`,
+      disabled: false
+    })
+  })
+
+  it('F2 — a target change hides stale state and reads only an eligible target', () => {
+    const live = { ok: true, mode: 'nightly', policy: 'patch' } as const
+    expect(cloudAutoUpdateForTarget({ target: 'old', state: live }, 'new')).toBeNull()
+    expect(cloudAutoUpdateForTarget({ target: 'new', state: live }, 'new')).toBe(live)
+    expect(cloudAutoUpdateReadEnabled(true, true)).toBe(true)
+    expect(cloudAutoUpdateReadEnabled(false, true)).toBe(false)
+    expect(cloudAutoUpdateReadEnabled(true, false)).toBe(false)
+  })
+
+  it('F4 / H5 — loading shows one checking label and only hints at a cached mode', () => {
+    expect(cloudAutoUpdateSelectState(null, 'weekends')).toEqual({
+      value: 'weekends',
+      placeholder: CLOUD_AUTO_UPDATE_LOADING_HINT,
+      hint: 'Last known window: Weekends',
+      disabled: true
+    })
+    expect(cloudAutoUpdateSelectState(null, null)).toEqual({
+      value: '',
+      placeholder: CLOUD_AUTO_UPDATE_LOADING_HINT,
+      hint: null,
+      disabled: true
+    })
+  })
+
+  it('F6 / H3 — failed reads combine cached disclosure and cause without the raw URL', () => {
+    expect(cloudAutoUpdateSelectState({
+      ok: false,
+      mode: null,
+      policy: null,
+      message: 'Railway could not read image auto-updates: network down. https://railway.com/dashboard',
+      settingsUrl: 'https://railway.com/dashboard'
+    }, 'nightly')).toEqual({
+      value: '',
+      placeholder: CLOUD_AUTO_UPDATE_UNKNOWN_LABEL,
+      hint: 'Last known window: Nightly. Railway could not read image auto-updates: network down.',
+      disabled: false
+    })
+  })
+
+  it('F9 — a live minor policy is explained in the hint', () => {
+    expect(cloudAutoUpdateSelectState({
+      ok: true,
+      mode: 'nightly',
+      policy: 'minor'
+    }, null)).toEqual({
+      value: 'nightly',
+      placeholder: CLOUD_AUTO_UPDATE_NOT_SET_LABEL,
+      hint: CLOUD_AUTO_UPDATE_MINOR_HINT,
+      disabled: false
+    })
+  })
+
+  it('F11 — select state owns the actual busy disabled expression', () => {
+    const live = { ok: true, mode: 'nightly', policy: 'patch' } as const
+    expect(cloudAutoUpdateSelectState(live, null, false).disabled).toBe(false)
+    expect(cloudAutoUpdateSelectState(live, null, true).disabled).toBe(true)
+  })
+
+  it('F1 — deploy auto-update fields become the shared feedback row model', () => {
+    expect(cloudDeployAutoUpdateFeedback({
+      ok: true,
+      message: 'deployed',
+      autoUpdateOk: false,
+      autoUpdateMessage: 'patch commit rejected',
+      autoUpdateSettingsUrl: 'https://railway.com/project/project/service/service/settings'
+    })).toEqual({
+      ok: false,
+      text: 'patch commit rejected',
+      settingsUrl: 'https://railway.com/project/project/service/service/settings'
+    })
+  })
+
+  it('G3 — placeholder distinguishes loading, failed unknown, and successful not-set state', () => {
+    expect(cloudAutoUpdateSelectState(null, null).placeholder)
+      .toBe('Checking Railway…')
+    expect(cloudAutoUpdateSelectState({
+      ok: false,
+      mode: null,
+      policy: null
+    }, null).placeholder).toBe('Current window unknown — choose one to set it')
+    expect(cloudAutoUpdateSelectState({
+      ok: true,
+      mode: null,
+      policy: null
+    }, null).placeholder).toBe('Not set — choose a window')
+  })
+
+  it('G4 — target-keyed feedback never exposes a rejected write link on another service', () => {
+    const snapshot = {
+      target: 'logged-in|enabled|https://service-a.example',
+      feedback: {
+        ok: false,
+        text: 'write rejected',
+        settingsUrl: 'https://railway.com/project/p/service/a/settings'
+      }
+    }
+    expect(cloudUpdateFeedbackForTarget(snapshot, snapshot.target))
+      .toEqual(snapshot.feedback)
+    expect(cloudUpdateFeedbackForTarget(
+      snapshot,
+      'logged-in|enabled|https://service-b.example'
+    )).toBeNull()
+  })
+
+  it('H1 — first-deploy feedback keeps its post-deploy target', () => {
+    const preDeployTarget = cloudAutoUpdateTargetKey(true, {
+      enabled: false,
+      serverUrl: ''
+    })
+    const postDeployTarget = cloudAutoUpdateTargetKey(true, {
+      enabled: true,
+      serverUrl: 'https://deployed.example'
+    })
+    const snapshot = {
+      target: postDeployTarget,
+      feedback: { ok: true, text: 'Railway image auto-updates set to Nightly.' }
+    }
+
+    expect(preDeployTarget).toBe('logged-in|disabled|')
+    expect(postDeployTarget).toBe('logged-in|enabled|https://deployed.example')
+    expect(cloudUpdateFeedbackAfterTargetChange(snapshot, postDeployTarget))
+      .toBe(snapshot)
+    expect(cloudUpdateFeedbackAfterTargetChange(snapshot, preDeployTarget))
+      .toBeNull()
+  })
+
+  it('I6 / H6 — feedback clears only after the cloud profile save succeeds', () => {
+    const snapshot = {
+      target: 'logged-in|enabled|https://service.example',
+      feedback: { ok: false, text: 'write rejected' }
+    }
+
+    expect(cloudUpdateFeedbackAfterSave(snapshot, false)).toBe(snapshot)
+    expect(cloudUpdateFeedbackAfterSave(snapshot, true)).toBeNull()
+  })
+
+  it('I2 — a pending selection is shown while Railway saves it', () => {
+    expect(cloudAutoUpdateSelectState({
+      ok: true,
+      mode: 'nightly',
+      policy: 'patch',
+      serviceId: 'service'
+    }, null, true, 'weekends')).toEqual({
+      value: 'weekends',
+      placeholder: CLOUD_AUTO_UPDATE_NOT_SET_LABEL,
+      hint: CLOUD_AUTO_UPDATE_SAVING_HINT,
+      disabled: true
+    })
+  })
+
+  it('I3 — a service B read failure cannot show service A cached state', () => {
+    const serviceBFailure = {
+      ok: false,
+      mode: null,
+      policy: null,
+      serviceId: 'service-b',
+      message: 'read failed'
+    } as const
+    const scoped = cloudAutoUpdateStoredMode(
+      serviceBFailure,
+      'nightly',
+      'service-a',
+      'service-a'
+    )
+
+    expect(scoped).toBeNull()
+    expect(cloudAutoUpdateSelectState(serviceBFailure, scoped).hint)
+      .toBe('read failed')
+    expect(cloudAutoUpdateStoredMode(null, 'nightly', 'service-a', 'service-a'))
+      .toBe('nightly')
+  })
+
+  it('I4 — cached copy describes a neutral last-known window', () => {
+    expect(cloudAutoUpdateSelectState({
+      ok: false,
+      mode: null,
+      policy: null
+    }, 'nightly')).toMatchObject({
+      value: '',
+      placeholder: CLOUD_AUTO_UPDATE_UNKNOWN_LABEL,
+      hint: `Last known window: Nightly. ${CLOUD_AUTO_UPDATE_FALLBACK_HINT}`
+    })
+    expect(CLOUD_AUTO_UPDATE_CUSTOM_HINT).toContain(
+      'minor policy is preserved unless you choose Off'
+    )
+  })
+
+  it('G8 — a stale read cannot replace the snapshot for a newly rendered target', () => {
+    const current = {
+      target: 'service-b',
+      state: null
+    }
+    const staleState = { ok: true, mode: 'nightly', policy: 'patch' } as const
+    expect(cloudAutoUpdateSnapshotAfterRead(current, 'service-a', staleState))
+      .toBe(current)
+    expect(cloudAutoUpdateSnapshotAfterRead(
+      { target: 'service-a', state: null },
+      'service-a',
+      staleState
+    )).toEqual({ target: 'service-a', state: staleState })
   })
 })
 

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -213,6 +213,23 @@ export interface CliStatus {
  * moment Claude/Codex/anything asks.
  */
 export type CloudAutoUpdateMode = 'off' | 'nightly' | 'weekends' | 'anytime'
+export type CloudAutoUpdateLiveMode = CloudAutoUpdateMode | 'custom' | null
+export type CloudAutoUpdatePolicy = 'disabled' | 'patch' | 'minor' | null
+
+export interface CloudAutoUpdateStateResult {
+  ok: boolean
+  mode: CloudAutoUpdateLiveMode
+  policy: CloudAutoUpdatePolicy
+  serviceId?: string
+  message?: string
+  settingsUrl?: string
+}
+
+export interface CloudAutoUpdateSetResult {
+  ok: boolean
+  message: string
+  settingsUrl?: string
+}
 
 export interface DesktopSettings {
   /** Remote control-plane profile. The API key remains in main-process settings. */
@@ -360,6 +377,8 @@ export interface RailwayStatus {
   workspaces: Array<{ id: string; name: string }>
   /** Workspace recorded in the desktop deployment's tfstate, when present. */
   deploymentWorkspaceId?: string
+  /** Service recorded in the desktop deployment's tfstate, when present. */
+  deploymentServiceId?: string
   /** Non-fatal Railway lookup problem; login remains valid. */
   message?: string
 }
@@ -369,6 +388,10 @@ export interface CloudDeployResult {
   url?: string
   furrowAddress?: string
   message: string
+  /** Post-deploy Railway Image Auto Updates reconciliation feedback. */
+  autoUpdateOk?: boolean
+  autoUpdateMessage?: string
+  autoUpdateSettingsUrl?: string
 }
 
 export interface PackageUpdateCheckResponse {
@@ -544,8 +567,10 @@ export interface AgentFieldApi {
   applyCloudUpdate(): Promise<CloudUpdateApplyResult>
   /** Dismiss exactly one cloud control-plane version in the main process. */
   dismissCloudUpdate(version: string): Promise<void>
+  /** Read Railway's live Image Auto Updates policy and maintenance window. */
+  getCloudAutoUpdate(): Promise<CloudAutoUpdateStateResult>
   /** Configure Railway Image Auto Updates for the connected control plane. */
-  setCloudAutoUpdate(mode: CloudAutoUpdateMode): Promise<{ ok: boolean; message: string }>
+  setCloudAutoUpdate(mode: CloudAutoUpdateMode): Promise<CloudAutoUpdateSetResult>
   onCloudUpdateStatus(listener: (status: CloudUpdateStatus) => void): () => void
   railwayLogin(): Promise<{ ok: boolean; message: string; workspaces?: RailwayStatus['workspaces'] }>
   railwayLogout(): Promise<void>


### PR DESCRIPTION
## Summary

After a cloud deploy, Desktop showed **"Railway could not save that schedule: Auto updates are not enabled for this service"**, and the "Railway image updates" dropdown could never reflect what Railway actually had. Root cause: Desktop called `serviceInstanceAutoUpdateScheduleUpdate`, whose own API description says *"Only the schedule changes — the update policy is untouched"* — it cannot enable auto-updates on a service where the policy was never set, and it rejects the empty schedule our "Off" sent. Nothing in the public schema's typed fields sets the policy, and the community Terraform provider (v0.6.2) has no attribute for it either.

The policy *is* settable through the public API — via the environment config document, which is how Railway's dashboard and `railway config apply` do it. Verified live against a real service (2026-08-26): committing `services.<serviceId>.source.autoUpdates = { type: "patch", schedule: [...] }` with `environmentPatchCommit` reads back exactly as written and **does not trigger a redeploy**; `environment(id).config` returns the current policy.

## What changes

- **One write path.** `setImageAutoUpdates` commits a patch containing only `source.autoUpdates`: Off → `{ type: "disabled" }` (no schedule), Nightly/Weekends/Anytime → `{ type: "patch", schedule }` with the existing window tables. The service is pinned to `vX.Y.Z`, so `patch` follows patch releases and never jumps a minor. `serviceInstanceAutoUpdateScheduleUpdate` is gone.
- **Live state.** New IPC `cloud-auto-update-get` reads Railway's real policy and classifies it (Not set / Off / Nightly / Weekends / Anytime / Custom). The dropdown shows that on mount, after a change and after a deploy; the stored preference is only a fallback when Railway can't be read (with a visible hint).
- **Honest failures.** Every Railway failure message carries a deep link to the service's Railway settings (`/project/<id>/service/<id>/settings` when the project is known, the dashboard otherwise), opened in the system browser through the existing window-open handler.
- **Config document hygiene.** The environment config contains service variables; main extracts `source.autoUpdates` only, and the IPC reply carries nothing else (tested).
- **Deploys read before they write.** First deploy → Nightly (also when the read fails: a brand-new service has nothing to preserve). Re-run deploy → writes the stored mode only when Railway has no policy; a policy set in Railway (custom window, `minor`) is left alone, reported, and cached as the offline fallback.
- Railway GraphQL requests time out after 20 s, so a stalled read is an ordinary failure rather than a stuck control.
- `deployments/railway/README.md` describes the real behaviour.

## Validation

Tests are named after the contract items C1–C10 in the spec (classification table, exact patch shape, no empty schedule, failure link, persistence only on success, fallback hint, no config leakage, first-deploy path, mutation removal). Gates on Node 22: `npm ci`, `npm run typecheck`, `npm test`, `npm run dist:dir`. Three independent verification passes (15, 12 and 9 agents: contract skeptics plus deploy-flow / secrets-handling / UX lenses) ran against the tree; each round's confirmed findings were fixed before the next. Round 1 caught the post-deploy failure never being rendered, live state not re-read on a control-plane switch, reconcile deploys overwriting a policy set in Railway, and "Not set" shown while loading; round 2 caught the read-before-write rule being too strict (a failed Railway read must not block an explicit Off, and a first deploy must still get Nightly), placeholder text per state, feedback leaking across control planes, and a missing request timeout on Railway calls.

Not exercised here: the Electron UI against a signed-in Railway account — the API calls themselves were exercised live during the investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
