### PR TITLE
fix(control-plane): complete a synchronous execute from the stored record when no terminal event arrives

### DIFF
--- a/control-plane/internal/handlers/execute.go
+++ b/control-plane/internal/handlers/execute.go
@@ -1357,9 +1357,24 @@ func (c *executionController) publishExecutionStartedEvent(plan *preparedExecuti
 	)
 }
 
+// completionPollInterval is how often waitForExecutionCompletion re-reads the
+// execution record while it waits on the event bus. Var, not const, so tests
+// can shrink it.
+var completionPollInterval = 500 * time.Millisecond
+
 // waitForExecutionCompletion waits for an execution to complete by subscribing to the event bus.
 // It returns the completed execution record or an error if the execution fails or times out.
 // This is used when agents return HTTP 202 (async acknowledgment) but the sync endpoint needs to wait for completion.
+//
+// The event bus is the fast path, but not every writer of a terminal status
+// publishes a lifecycle event: the SDK's reasoner.completed workflow event
+// persists the terminal state through WorkflowExecutionEventHandler without
+// one, and when the authoritative /status callback lands afterwards it is an
+// idempotent terminal->terminal update. If that ordering wins the race, the
+// only signal a synchronous caller would ever get was the timeout, ninety
+// seconds after its result had been stored. The store is therefore polled as
+// a fallback, so the wait is bounded by completionPollInterval rather than by
+// whichever callback happened to arrive first.
 func (c *executionController) waitForExecutionCompletion(ctx context.Context, executionID string, timeout time.Duration) (*types.Execution, error) {
 	if c.eventBus == nil {
 		return nil, fmt.Errorf("event bus not available")
@@ -1375,6 +1390,10 @@ func (c *executionController) waitForExecutionCompletion(ctx context.Context, ex
 	// Create timeout timer
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
+
+	// Fallback for terminal states that reach the store without an event.
+	poll := time.NewTicker(completionPollInterval)
+	defer poll.Stop()
 
 	logger.Logger.Debug().
 		Str("execution_id", executionID).
@@ -1404,6 +1423,17 @@ func (c *executionController) waitForExecutionCompletion(ctx context.Context, ex
 				Dur("timeout", timeout).
 				Msg("execution completion timeout")
 			return nil, fmt.Errorf("execution timeout after %v", timeout)
+
+		case <-poll.C:
+			existing, err := c.store.GetExecutionRecord(ctx, executionID)
+			if err != nil || existing == nil || !types.IsTerminalExecutionStatus(existing.Status) {
+				continue
+			}
+			logger.Logger.Debug().
+				Str("execution_id", executionID).
+				Str("status", existing.Status).
+				Msg("execution reached a terminal state without a terminal event; completing from the stored record")
+			return existing, nil
 
 		case event := <-eventChan:
 			// Only process events for this specific execution

--- a/control-plane/internal/handlers/execute_status_update_test.go
+++ b/control-plane/internal/handlers/execute_status_update_test.go
@@ -768,3 +768,59 @@ func TestUpdateExecutionStatusHandler_WebhookTriggeredFromStore(t *testing.T) {
 	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &statusResp))
 	require.True(t, statusResp.WebhookRegistered, "GET status must report webhook_registered=true from the webhooks table")
 }
+
+// A terminal status can reach the store without a lifecycle event on the bus
+// (the SDK's reasoner.completed workflow event takes that path, and the
+// /status callback that follows is then an idempotent no-op). The waiter must
+// still return promptly rather than sit out the full timeout.
+func TestWaitForExecutionCompletion_TerminalStatusWithoutEvent(t *testing.T) {
+	store := newTestExecutionStorage(nil)
+	controller := newExecutionController(store, nil, nil, 90*time.Second, "")
+
+	previousInterval := completionPollInterval
+	completionPollInterval = 50 * time.Millisecond
+	defer func() { completionPollInterval = previousInterval }()
+
+	execution := &types.Execution{
+		ExecutionID: "exec-1",
+		RunID:       "run-1",
+		Status:      types.ExecutionStatusRunning,
+		StartedAt:   time.Now().UTC(),
+		CreatedAt:   time.Now().UTC(),
+		UpdatedAt:   time.Now().UTC(),
+	}
+	require.NoError(t, store.CreateExecutionRecord(context.Background(), execution))
+
+	done := make(chan struct{})
+	var result *types.Execution
+	var err error
+	started := time.Now()
+	go func() {
+		result, err = controller.waitForExecutionCompletion(context.Background(), "exec-1", 5*time.Second)
+		close(done)
+	}()
+
+	// Let the waiter subscribe and run its pre-subscribe check while the
+	// record is still running, then store the terminal state with NO event.
+	time.Sleep(100 * time.Millisecond)
+	_, updateErr := store.UpdateExecutionRecord(context.Background(), "exec-1", func(current *types.Execution) (*types.Execution, error) {
+		if current == nil {
+			return nil, nil
+		}
+		now := time.Now().UTC()
+		current.Status = types.ExecutionStatusSucceeded
+		current.CompletedAt = &now
+		return current, nil
+	})
+	require.NoError(t, updateErr)
+
+	select {
+	case <-done:
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, types.ExecutionStatusSucceeded, result.Status)
+		require.Less(t, time.Since(started), 2*time.Second, "waiter should complete from the poll, not the timeout")
+	case <-time.After(3 * time.Second):
+		t.Fatal("waitForExecutionCompletion never noticed the stored terminal status")
+	}
+}


### PR DESCRIPTION
## Summary

`POST /api/v1/execute/<node>.<reasoner>` — the README's own "call your agent" curl — can hang for the full 90 s and then return `{"error":"execution timeout after 1m30s"}` even though the execution succeeded and its result is already stored. This makes the synchronous waiter poll the execution record as a fallback so the wait is bounded by the poll interval (500 ms), not by which callback happens to arrive first.

**Pre-existing, not a regression.** `waitForExecutionCompletion` is byte-identical back to v0.1.134 and the hang reproduces with the v0.1.134 SDK against today's control plane; it was found during the post-merge regression sweep of #963–#973 and is unrelated to those changes.

## Mechanism

When an agent answers 202 (async acknowledgment) the sync handler subscribes to the execution event bus and waits for `execution_completed` / `execution_failed`. Two callbacks then race in from the SDK:

1. the `reasoner.completed` **workflow event** (`POST /api/v1/workflow/executions/events`), which `WorkflowExecutionEventHandler` persists as the terminal status — without publishing a lifecycle event;
2. the authoritative **status callback** (`POST /api/v1/executions/<id>/status`), which normally publishes the event the waiter is listening for.

If (1) lands first, (2) is an idempotent terminal→terminal update and the lifecycle event the waiter needs is never published. The existing pre-subscribe store check does not help because the record is still `running` at that instant. Nothing wakes the waiter; it times out 90 s after the result was stored. Any slowdown of the agent's callback ordering (a loaded box, `python -X dev`, a slow agent) exposes it.

## Change

- `waitForExecutionCompletion` now also ticks a store poll (`completionPollInterval`, 500 ms, a package var so tests can shrink it) and returns the stored record as soon as it is terminal. The event bus stays the fast path; nothing else changes — no new events, no double webhooks.
- Test `TestWaitForExecutionCompletion_TerminalStatusWithoutEvent` stores a terminal status and publishes **no** event; the waiter must return within the poll interval. Red with the poll disabled (times out at the test deadline), green with it.

## Validation

- Unit: the five `TestWaitForExecutionCompletion_*` tests pass; the new one fails when the poll is neutralised.
- Live: a real Python agent (`python -X dev`, explicit callback URL) against an isolated control plane built from this branch — sync executes return in ~20 ms, and the control-plane log shows the fallback firing (`completing from the stored record`) on an execution whose event never arrived. The hang was observed against the unfixed rc.6 binary in the same harness (1 of ~70 calls on an idle box; the regression sweep's agent hit it 3/3 under load, and 1/1 on the pre-merge commit).
- Gates: `go build`, `go vet`, `go test ./...`, `golangci-lint` (no new findings vs `main`).

## Type of change

- [x] Bug fix
- [ ] Breaking change

Refs the post-merge regression sweep of #963–#973.
