### PR TITLE
fix(control-plane): mirror workflow execution events

### DIFF
--- a/control-plane/internal/handlers/coverage_handlers_92_target_test.go
+++ b/control-plane/internal/handlers/coverage_handlers_92_target_test.go
@@ -163,14 +163,16 @@ func (s *cancelHandlerErrorStorage) StoreWorkflowExecutionEvent(_ context.Contex
 
 type workflowEventStoreStub struct {
 	storage.StorageProvider
-	exec             *types.Execution
-	getErr           error
-	createErr        error
-	updateErr        error
-	storeWorkflowErr error
-	createdExec      *types.Execution
-	storedWorkflow   *types.WorkflowExecution
-	updatedExecution *types.Execution
+	exec              *types.Execution
+	getErr            error
+	createErr         error
+	updateErr         error
+	storeWorkflowErr  error
+	updateWorkflowErr error
+	workflow          *types.WorkflowExecution
+	createdExec       *types.Execution
+	storedWorkflow    *types.WorkflowExecution
+	updatedExecution  *types.Execution
 }
 
 func (s *workflowEventStoreStub) GetExecutionRecord(_ context.Context, _ string) (*types.Execution, error) {
@@ -206,7 +208,23 @@ func (s *workflowEventStoreStub) CreateExecutionRecord(_ context.Context, execut
 
 func (s *workflowEventStoreStub) StoreWorkflowExecution(_ context.Context, execution *types.WorkflowExecution) error {
 	s.storedWorkflow = execution
+	s.workflow = execution
 	return s.storeWorkflowErr
+}
+
+func (s *workflowEventStoreStub) UpdateWorkflowExecution(_ context.Context, _ string, update func(*types.WorkflowExecution) (*types.WorkflowExecution, error)) error {
+	if s.updateWorkflowErr != nil {
+		return s.updateWorkflowErr
+	}
+	if s.workflow == nil {
+		return errors.New("workflow execution not found")
+	}
+	updated, err := update(s.workflow)
+	if err != nil {
+		return err
+	}
+	s.workflow = updated
+	return nil
 }
 
 func (s *workflowEventStoreStub) UpdateExecutionRecord(_ context.Context, _ string, update func(*types.Execution) (*types.Execution, error)) (*types.Execution, error) {
@@ -683,6 +701,31 @@ func TestWorkflowExecutionEventHandlerAdditionalBranches(t *testing.T) {
 
 		require.Equal(t, http.StatusInternalServerError, resp.Code)
 		assert.Contains(t, resp.Body.String(), "failed to update execution")
+	})
+
+	t.Run("workflow projection update failure returns 500", func(t *testing.T) {
+		router := gin.New()
+		store := &workflowEventStoreStub{exec: &types.Execution{ExecutionID: "exec-5", Status: types.ExecutionStatusRunning}, updateWorkflowErr: errors.New("workflow update failed")}
+		router.POST("/events", WorkflowExecutionEventHandler(store))
+		req := httptest.NewRequest(http.MethodPost, "/events", strings.NewReader(`{"execution_id":"exec-5","status":"succeeded"}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusInternalServerError, resp.Code)
+		assert.Contains(t, resp.Body.String(), "failed to update workflow execution")
+	})
+
+	t.Run("missing workflow projection is recreated", func(t *testing.T) {
+		router := gin.New()
+		store := &workflowEventStoreStub{exec: &types.Execution{ExecutionID: "exec-6", Status: types.ExecutionStatusRunning}}
+		router.POST("/events", WorkflowExecutionEventHandler(store))
+		req := httptest.NewRequest(http.MethodPost, "/events", strings.NewReader(`{"execution_id":"exec-6","status":"succeeded"}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusOK, resp.Code)
+		require.NotNil(t, store.storedWorkflow)
+		assert.Equal(t, string(types.ExecutionStatusSucceeded), store.storedWorkflow.Status)
 	})
 }
 

--- a/control-plane/internal/handlers/workflow_execution_events.go
+++ b/control-plane/internal/handlers/workflow_execution_events.go
@@ -100,11 +100,64 @@ func WorkflowExecutionEventHandler(store ExecutionStore) gin.HandlerFunc {
 				continue
 			}
 
+			// Keep the workflow projection in sync for events received after the
+			// execution row was created. The normal execution path creates the
+			// workflow row before the agent can emit events, but event delivery is
+			// asynchronous and the status callback is not a reliable replacement
+			// for this projection update.
+			if err := store.UpdateWorkflowExecution(ctx, req.ExecutionID, func(current *types.WorkflowExecution) (*types.WorkflowExecution, error) {
+				if current == nil {
+					return nil, fmt.Errorf("workflow execution %s not found", req.ExecutionID)
+				}
+				applyEventToWorkflowExecution(current, &req, now)
+				return current, nil
+			}); err != nil {
+				if strings.Contains(strings.ToLower(err.Error()), "not found") {
+					if storeErr := store.StoreWorkflowExecution(ctx, buildWorkflowExecutionFromEvent(&req, now)); storeErr != nil {
+						lastErr = storeErr
+						continue
+					}
+				} else {
+					c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to update workflow execution: %v", err)})
+					return
+				}
+			}
+
 			c.JSON(http.StatusOK, gin.H{"success": true, "updated": true})
 			return
 		}
 
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to persist execution event after retries: %v", lastErr)})
+	}
+}
+
+func applyEventToWorkflowExecution(current *types.WorkflowExecution, req *WorkflowExecutionEventRequest, now time.Time) {
+	if types.IsTerminalExecutionStatus(current.Status) {
+		current.UpdatedAt = now
+		return
+	}
+
+	current.Status = types.NormalizeExecutionStatus(req.Status)
+	current.UpdatedAt = now
+	if current.StartedAt.IsZero() {
+		current.StartedAt = now
+	}
+	if req.DurationMS != nil {
+		current.DurationMS = req.DurationMS
+	}
+	if result := marshalJSON(req.Result); len(result) > 0 {
+		current.OutputData = result
+		current.OutputSize = len(result)
+	}
+	if req.Error != "" {
+		errCopy := req.Error
+		current.ErrorMessage = &errCopy
+	} else if types.IsTerminalExecutionStatus(current.Status) {
+		current.ErrorMessage = nil
+	}
+	if types.IsTerminalExecutionStatus(current.Status) {
+		completed := now
+		current.CompletedAt = &completed
 	}
 }
 

--- a/control-plane/internal/handlers/workflow_execution_events_test.go
+++ b/control-plane/internal/handlers/workflow_execution_events_test.go
@@ -90,6 +90,15 @@ func TestWorkflowExecutionEventHandler_CreateAndUpdate(t *testing.T) {
 	assert.Contains(t, string(exec.ResultPayload), "result")
 	require.NotNil(t, exec.DurationMS)
 	assert.Equal(t, duration, *exec.DurationMS)
+
+	wfExec, err := storage.GetWorkflowExecution(context.Background(), "exec_child")
+	require.NoError(t, err)
+	require.NotNil(t, wfExec)
+	assert.Equal(t, string(types.ExecutionStatusSucceeded), wfExec.Status)
+	assert.Contains(t, string(wfExec.OutputData), `"result":"ok"`)
+	require.NotNil(t, wfExec.CompletedAt)
+	require.NotNil(t, wfExec.DurationMS)
+	assert.Equal(t, duration, *wfExec.DurationMS)
 }
 
 // TestWorkflowExecutionEventHandler_TerminalRegression covers the case where


### PR DESCRIPTION
## Summary

Fixes #978.

Workflow execution events updated the primary execution record but did not mirror later events to the `workflow_executions` projection when that row already existed. As a result, executions whose reasoners yielded could remain displayed as `running`.

This change applies the event status, result, duration, completion time, and error to the workflow projection as well, creating the projection when an event-based execution has no row. Existing terminal-state protection is preserved.

## Validation

- Added coverage to `TestWorkflowExecutionEventHandler_CreateAndUpdate` for the terminal workflow projection.
- `gofmt` completed successfully.
- `git diff --check` completed successfully.
- The focused Go test could not build in this environment because the required C compiler (`gcc`) is not installed for the SQLite cgo dependency.
