### PR TITLE
feat(ts-sdk): support multimodal AI request content

### DIFF
--- a/sdk/typescript/src/ai/AIClient.ts
+++ b/sdk/typescript/src/ai/AIClient.ts
@@ -22,6 +22,7 @@ import {
 } from './openrouterAttribution.js';
 import { withOpenRouterUsageInclude } from './openrouterUsage.js';
 import { recordAiSdkUsage } from '../usage/aiUsage.js';
+import type { MultimodalContent } from './multimodal.js';
 
 export type ZodSchema<T> = z.Schema<T, z.ZodTypeDef, any>;
 
@@ -70,6 +71,8 @@ export interface AIRequestOptions {
    * - 'tool': Force tool calling mode
    */
   mode?: 'auto' | 'json' | 'tool';
+  /** Additional image, audio, video, or file parts for the user message. */
+  content?: MultimodalContent[];
 }
 
 export type AIStream = AsyncIterable<string>;
@@ -101,13 +104,14 @@ export class AIClient {
   async generate<T = any>(prompt: string, options: AIRequestOptions = {}): Promise<T | string> {
     const { provider, modelName } = this.resolveModelChoice(options);
     const model = this.buildModel(options);
+    const requestPrompt = this.buildPrompt(prompt, options.content);
 
     if (options.schema) {
       const schema = options.schema;
       const call = async () =>
         generateObject({
           model: model,
-          prompt,
+          prompt: requestPrompt,
           output: 'object',
           system: options.system,
           temperature: options.temperature ?? this.config.temperature,
@@ -124,7 +128,7 @@ export class AIClient {
     const call = async () =>
       generateText({
         model: model,
-        prompt,
+        prompt: requestPrompt,
         system: options.system,
         temperature: options.temperature ?? this.config.temperature,
         maxOutputTokens: options.maxTokens ?? this.config.maxTokens
@@ -143,7 +147,7 @@ export class AIClient {
     const model = this.buildModel(options);
     const streamResult = streamText({
       model: model,
-      prompt,
+      prompt: this.buildPrompt(prompt, options.content),
       system: options.system,
       temperature: options.temperature ?? this.config.temperature,
       maxOutputTokens: options.maxTokens ?? this.config.maxTokens
@@ -295,6 +299,24 @@ export class AIClient {
         return openai(modelName);
       }
     }
+  }
+
+  private buildPrompt(prompt: string, content?: MultimodalContent[]) {
+    if (!content?.length) return prompt;
+
+    return [{
+      role: 'user' as const,
+      content: [
+        { type: 'text' as const, text: prompt },
+        ...content.map((part) => {
+          if (part.type === 'text') return { type: 'text' as const, text: part.text };
+          if (part.type === 'image_url') return { type: 'image' as const, image: part.imageUrl.url };
+          if (part.type === 'video_url') return { type: 'file' as const, data: part.videoUrl.url, mimeType: 'video/*' };
+          if (part.type === 'input_audio') return { type: 'file' as const, data: part.audio.data, mimeType: `audio/${part.audio.format}` };
+          return { type: 'file' as const, data: part.file.url, mimeType: part.file.mimeType };
+        })
+      ]
+    }] as any;
   }
 
   private buildEmbeddingModel(options: AIEmbeddingOptions) {

--- a/sdk/typescript/src/ai/AIClient.ts
+++ b/sdk/typescript/src/ai/AIClient.ts
@@ -5,6 +5,7 @@ import {
   generateText,
   streamText
 } from 'ai';
+import type { ModelMessage, UserContent } from 'ai';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
@@ -22,7 +23,11 @@ import {
 } from './openrouterAttribution.js';
 import { withOpenRouterUsageInclude } from './openrouterUsage.js';
 import { recordAiSdkUsage } from '../usage/aiUsage.js';
-import type { MultimodalContent } from './multimodal.js';
+import {
+  audioMediaType,
+  guessUrlMimeType,
+  type MultimodalContent,
+} from './multimodal.js';
 
 export type ZodSchema<T> = z.Schema<T, z.ZodTypeDef, any>;
 
@@ -301,22 +306,40 @@ export class AIClient {
     }
   }
 
-  private buildPrompt(prompt: string, content?: MultimodalContent[]) {
+  private buildPrompt(prompt: string, content?: MultimodalContent[]): string | ModelMessage[] {
     if (!content?.length) return prompt;
 
-    return [{
+    const messageContent: Exclude<UserContent, string> = [
+      { type: 'text', text: prompt },
+      ...content.map((part) => {
+        if (part.type === 'text') return { type: 'text' as const, text: part.text };
+        if (part.type === 'image_url') return { type: 'image' as const, image: part.imageUrl.url };
+        if (part.type === 'video_url') {
+          return {
+            type: 'file' as const,
+            data: part.videoUrl.url,
+            mediaType: guessUrlMimeType(part.videoUrl.url) ?? 'video/mp4',
+          };
+        }
+        if (part.type === 'input_audio') {
+          return {
+            type: 'file' as const,
+            data: part.audio.data,
+            mediaType: audioMediaType(part.audio.format),
+          };
+        }
+        return {
+          type: 'file' as const,
+          data: part.file.url,
+          mediaType: part.file.mimeType ?? guessUrlMimeType(part.file.url) ?? 'application/octet-stream',
+        };
+      })
+    ];
+    const messages: ModelMessage[] = [{
       role: 'user' as const,
-      content: [
-        { type: 'text' as const, text: prompt },
-        ...content.map((part) => {
-          if (part.type === 'text') return { type: 'text' as const, text: part.text };
-          if (part.type === 'image_url') return { type: 'image' as const, image: part.imageUrl.url };
-          if (part.type === 'video_url') return { type: 'file' as const, data: part.videoUrl.url, mimeType: 'video/*' };
-          if (part.type === 'input_audio') return { type: 'file' as const, data: part.audio.data, mimeType: `audio/${part.audio.format}` };
-          return { type: 'file' as const, data: part.file.url, mimeType: part.file.mimeType };
-        })
-      ]
-    }] as any;
+      content: messageContent
+    }];
+    return messages;
   }
 
   private buildEmbeddingModel(options: AIEmbeddingOptions) {

--- a/sdk/typescript/src/ai/multimodal.ts
+++ b/sdk/typescript/src/ai/multimodal.ts
@@ -348,6 +348,22 @@ function guessMimeType(filePath: string): string | null {
   return documentMimeTypes[ext] || null;
 }
 
+/** Get the declared MIME type from a base64 data URL. */
+function getDataUrlMimeType(url: string): string | null {
+  const match = /^data:([^;,]+)(?:;[^,]*)?,/i.exec(url);
+  return match?.[1] || null;
+}
+
+/** Infer a MIME type from a URL's data prefix or pathname extension. */
+export function guessUrlMimeType(url: string): string | null {
+  return getDataUrlMimeType(url) ?? guessMimeType(url.split(/[?#]/, 1)[0]);
+}
+
+/** Canonical IANA media type for an audio format (e.g. 'mp3' -> 'audio/mpeg'). */
+export function audioMediaType(format: string): string {
+  return AUDIO_MIME_TYPES[`.${format.toLowerCase()}`] ?? `audio/${format}`;
+}
+
 // Convenience factory functions
 
 /**

--- a/sdk/typescript/tests/ai_client_extra.test.ts
+++ b/sdk/typescript/tests/ai_client_extra.test.ts
@@ -105,7 +105,7 @@ vi.mock('@ai-sdk/cohere', () => ({
 }));
 
 import { AIClient } from '../src/ai/AIClient.js';
-import { Audio, Image } from '../src/ai/multimodal.js';
+import { Audio, File, Image, Video } from '../src/ai/multimodal.js';
 
 describe('AIClient extra coverage', () => {
   beforeEach(() => {
@@ -166,10 +166,17 @@ describe('AIClient extra coverage', () => {
   it('passes multimodal content through generate and stream requests', async () => {
     const client = new AIClient({ apiKey: 'test-key' });
     const image = Image.fromUrl('https://example.com/image.png');
-    const audio = await Audio.fromBase64('YQ==', 'wav');
+    const dataImage = await Image.fromBase64('aW1hZ2U=', 'image/webp');
+    const audio = await Audio.fromBase64('YQ==', 'mp3');
+    const video = Video.fromUrl('https://example.com/clip.webm');
+    const dataVideo = await Video.fromBase64('dmlkZW8=', 'video/quicktime');
+    const file = File.fromUrl('https://example.com/report.pdf?download=1');
+    const dataFile = await File.fromBase64('ZmlsZQ==', 'text/plain');
 
-    await client.generate('describe these inputs', { content: [image, audio] });
-    await client.stream('summarize these inputs', { content: [image] });
+    await client.generate('describe these inputs', {
+      content: [image, dataImage, audio, video, dataVideo, file, dataFile]
+    });
+    await client.stream('summarize these inputs', { content: [image, video, file] });
 
     expect(generateTextMock).toHaveBeenCalledWith(expect.objectContaining({
       prompt: [{
@@ -177,7 +184,12 @@ describe('AIClient extra coverage', () => {
         content: [
           { type: 'text', text: 'describe these inputs' },
           { type: 'image', image: 'https://example.com/image.png' },
-          { type: 'file', data: 'YQ==', mimeType: 'audio/wav' }
+          { type: 'image', image: 'data:image/webp;base64,aW1hZ2U=' },
+          { type: 'file', data: 'YQ==', mediaType: 'audio/mpeg' },
+          { type: 'file', data: 'https://example.com/clip.webm', mediaType: 'video/webm' },
+          { type: 'file', data: 'data:video/quicktime;base64,dmlkZW8=', mediaType: 'video/quicktime' },
+          { type: 'file', data: 'https://example.com/report.pdf?download=1', mediaType: 'application/pdf' },
+          { type: 'file', data: 'data:text/plain;base64,ZmlsZQ==', mediaType: 'text/plain' }
         ]
       }]
     }));
@@ -186,7 +198,9 @@ describe('AIClient extra coverage', () => {
         role: 'user',
         content: [
           { type: 'text', text: 'summarize these inputs' },
-          { type: 'image', image: 'https://example.com/image.png' }
+          { type: 'image', image: 'https://example.com/image.png' },
+          { type: 'file', data: 'https://example.com/clip.webm', mediaType: 'video/webm' },
+          { type: 'file', data: 'https://example.com/report.pdf?download=1', mediaType: 'application/pdf' }
         ]
       }]
     }));
@@ -196,7 +210,21 @@ describe('AIClient extra coverage', () => {
     const client = new AIClient({ apiKey: 'test-key' });
     const schema = z.object({ value: z.number() });
 
-    await expect(client.generate('json please', { schema, system: 'sys' })).resolves.toEqual({ ok: true });
+    await expect(client.generate('json please', {
+      schema,
+      system: 'sys',
+      content: [File.fromUrl('https://example.com/data.json')]
+    })).resolves.toEqual({ ok: true });
+
+    expect(generateObjectMock).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: [{
+        role: 'user',
+        content: [
+          { type: 'text', text: 'json please' },
+          { type: 'file', data: 'https://example.com/data.json', mediaType: 'application/json' }
+        ]
+      }]
+    }));
 
     const repair = generateObjectMock.mock.calls[0]?.[0]?.experimental_repairText as
       | ((input: { text: string }) => Promise<string | null>)

--- a/sdk/typescript/tests/ai_client_extra.test.ts
+++ b/sdk/typescript/tests/ai_client_extra.test.ts
@@ -105,6 +105,7 @@ vi.mock('@ai-sdk/cohere', () => ({
 }));
 
 import { AIClient } from '../src/ai/AIClient.js';
+import { Audio, Image } from '../src/ai/multimodal.js';
 
 describe('AIClient extra coverage', () => {
   beforeEach(() => {
@@ -160,6 +161,35 @@ describe('AIClient extra coverage', () => {
       maxOutputTokens: 22
     }));
     expect(chunks).toEqual(['one', 'two']);
+  });
+
+  it('passes multimodal content through generate and stream requests', async () => {
+    const client = new AIClient({ apiKey: 'test-key' });
+    const image = Image.fromUrl('https://example.com/image.png');
+    const audio = await Audio.fromBase64('YQ==', 'wav');
+
+    await client.generate('describe these inputs', { content: [image, audio] });
+    await client.stream('summarize these inputs', { content: [image] });
+
+    expect(generateTextMock).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: [{
+        role: 'user',
+        content: [
+          { type: 'text', text: 'describe these inputs' },
+          { type: 'image', image: 'https://example.com/image.png' },
+          { type: 'file', data: 'YQ==', mimeType: 'audio/wav' }
+        ]
+      }]
+    }));
+    expect(streamTextMock).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: [{
+        role: 'user',
+        content: [
+          { type: 'text', text: 'summarize these inputs' },
+          { type: 'image', image: 'https://example.com/image.png' }
+        ]
+      }]
+    }));
   });
 
   it('uses generateObject with JSON repair for structured output', async () => {


### PR DESCRIPTION
## Summary

Closes #91.

The TypeScript SDK already exposed `Image`, `Audio`, `Video`, and `File` helpers, but `AIClient.generate` and `AIClient.stream` only accepted a plain string prompt. This change adds an optional `content` request field and translates those helpers into AI SDK user message parts.

## Changes

- Add `content?: MultimodalContent[]` to `AIRequestOptions`.
- Preserve the existing string prompt behavior when content is omitted.
- Pass image, audio, video, and file content through both generation entry points.
- Add deterministic provider-mocked coverage for image and audio requests.

## Validation

- `npm test -- --run tests/ai_client_extra.test.ts` — 7 passed.
- `npm run lint` — passed.
- `npm run build` — passed.
- Full test suite: 892 passed, 1 unrelated Windows path-separator assertion failed in `tests/harness_runner.test.ts`.
