### PR TITLE
fix(python-sdk): scope LiteLLM cap to Python 3.10

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "pydantic>=2.0",
     # LiteLLM 1.97.0 crashes on Python 3.10 building ModelResponse, and
     # 1.98.0 imports typing.NotRequired (only available in Python 3.11+).
-    "litellm!=1.97.0,<1.98.0",
+    "litellm!=1.97.0,<1.98.0; python_version < '3.11'",
+    "litellm; python_version >= '3.11'",
     "psutil",
     "PyYAML>=6.0",
     "aiohttp>=3.8",


### PR DESCRIPTION
## Summary

Apply the LiteLLM `<1.98.0` compatibility cap only on Python 3.10, where the documented `ModelResponse` and `typing.NotRequired` failures occur. Python 3.11–3.13 now receive an unconstrained LiteLLM requirement and can install current releases.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] Tests only
- [ ] CI / tooling
- [ ] Breaking change

## Test plan

- [x] Built the SDK wheel before the change and confirmed the `<1.98.0` cap had no Python marker.
- [x] Rebuilt the wheel and verified its METADATA contains separate Python `<3.11` and `>=3.11` requirements.
- [x] Evaluated both markers with `packaging`: Python 3.10 selects `!=1.97.0,<1.98.0`; Python 3.11 selects the unconstrained requirement.
- [x] Ran pre-commit for `sdk/python/pyproject.toml` and `git diff --check`.

## Test coverage

- [x] I ran the packaging checks for the Python SDK surface changed locally.
- [x] No runtime code path was added; the built-wheel METADATA assertion directly covers this change.
- [x] I did not modify `coverage-baseline.json`.
- [ ] The coverage gate check is green in CI before requesting review.

## Checklist

- [x] I have read the contributing guidance.
- [x] The commit is signed off and follows conventional-commits style.
- [x] I have linked the related issue.

## Related issues / PRs

Fixes #982