### PR TITLE
fix(control-plane): keep postgres payloads off local disk

### DIFF
--- a/control-plane/internal/server/server.go
+++ b/control-plane/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -429,7 +430,7 @@ func NewAgentFieldServer(cfg *config.Config) (*AgentFieldServer, error) {
 		})
 	}
 
-	payloadStore := services.NewFilePayloadStore(dirs.PayloadsDir)
+	payloadStore := newPayloadStore(cfg.Storage.Mode, dirs.PayloadsDir)
 
 	// Configure SSRF-safe webhook client allowlist. Hosts/CIDRs listed here
 	// bypass the private-IP check (e.g. for internal Docker/K8s service names).
@@ -582,6 +583,13 @@ func NewAgentFieldServer(cfg *config.Config) (*AgentFieldServer, error) {
 		kb:                     initKnowledgeBase(),
 		knowledgeService:       knowledgeService,
 	}, nil
+}
+
+func newPayloadStore(storageMode, payloadsDir string) services.PayloadStore {
+	if strings.EqualFold(strings.TrimSpace(storageMode), "postgres") {
+		return nil
+	}
+	return services.NewFilePayloadStore(payloadsDir)
 }
 
 // configReloadFn returns a function that reloads config from the database,

--- a/control-plane/internal/server/server_additional_test.go
+++ b/control-plane/internal/server/server_additional_test.go
@@ -37,6 +37,18 @@ func TestInitCatalogAndKnowledgeBase(t *testing.T) {
 	require.NotNil(t, kb.Get("observability/metrics"))
 }
 
+func TestNewPayloadStore(t *testing.T) {
+	t.Run("postgres keeps payloads in the database", func(t *testing.T) {
+		require.Nil(t, newPayloadStore("postgres", t.TempDir()))
+		require.Nil(t, newPayloadStore(" POSTGRES ", t.TempDir()))
+	})
+
+	t.Run("local storage retains file payloads", func(t *testing.T) {
+		store := newPayloadStore("local", t.TempDir())
+		require.IsType(t, &services.FilePayloadStore{}, store)
+	})
+}
+
 func TestConfigReloadFn(t *testing.T) {
 	t.Run("disabled when config source is not db", func(t *testing.T) {
 		t.Setenv("AGENTFIELD_CONFIG_SOURCE", "")


### PR DESCRIPTION
## Summary

In Postgres storage mode, execution input and result payloads are already persisted in the database. This change stops wiring the local `FilePayloadStore` in that mode, preventing every run from also accumulating duplicate payload files under the control-plane data directory. Local storage mode keeps its existing file-backed behavior.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] Tests only
- [ ] CI / tooling
- [ ] Breaking change

## Test plan

- [x] `cd control-plane && go test -v ./internal/server -run "^TestNewPayloadStore$" -count=1`
- [x] `gofmt -w control-plane/internal/server/server.go control-plane/internal/server/server_additional_test.go`
- [x] `git diff --check`

## Test coverage

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR (no bare additions).
- [ ] If I removed code, I updated `coverage-baseline.json` in this PR only if the removal caused a legitimate regression and I called it out in the summary above.
- [ ] The coverage gate check is green in CI before requesting review.

## Checklist

- [x] I have read `docs/DEVELOPMENT.md`.
- [ ] Commits are signed and follow conventional-commits style.
- [x] I have linked any related issues.

## Related issues / PRs

Fixes #983