### PR TITLE
fix(control-plane): skip disk payload writes in postgres storage mode

### DIFF
--- a/control-plane/internal/handlers/coverage_handlers_90_additional_test.go
+++ b/control-plane/internal/handlers/coverage_handlers_90_additional_test.go
@@ -501,6 +501,11 @@ func TestExecuteHelpers_AdditionalCoverage(t *testing.T) {
 		require.NotNil(t, uri)
 		assert.True(t, strings.HasPrefix(*uri, "payload://"))
 
+		// NopPayloadStore returns nil record - savePayload must handle gracefully
+		controller.payloads = services.NopPayloadStore{}
+		nopURI := controller.savePayload(context.Background(), []byte(`{"data":true}`))
+		assert.Nil(t, nopURI)
+
 		controller.triggerWebhook("")
 		controller.webhooks = &mockWebhookDispatcher{
 			notifyFunc: func(ctx context.Context, executionID string) error {

--- a/control-plane/internal/handlers/execute_helpers.go
+++ b/control-plane/internal/handlers/execute_helpers.go
@@ -816,6 +816,9 @@ func (c *executionController) savePayload(ctx context.Context, data []byte) *str
 		logger.Logger.Warn().Err(err).Int("bytes", len(data)).Msg("failed to persist payload; proceeding without URI")
 		return nil
 	}
+	if record == nil {
+		return nil
+	}
 	uri := record.URI
 	return &uri
 }

--- a/control-plane/internal/server/server.go
+++ b/control-plane/internal/server/server.go
@@ -429,7 +429,12 @@ func NewAgentFieldServer(cfg *config.Config) (*AgentFieldServer, error) {
 		})
 	}
 
-	payloadStore := services.NewFilePayloadStore(dirs.PayloadsDir)
+	var payloadStore services.PayloadStore
+	if cfg.Storage.Mode == "postgres" {
+		payloadStore = services.NopPayloadStore{}
+	} else {
+		payloadStore = services.NewFilePayloadStore(dirs.PayloadsDir)
+	}
 
 	// Configure SSRF-safe webhook client allowlist. Hosts/CIDRs listed here
 	// bypass the private-IP check (e.g. for internal Docker/K8s service names).

--- a/control-plane/internal/services/payload_store.go
+++ b/control-plane/internal/services/payload_store.go
@@ -31,6 +31,19 @@ type PayloadStore interface {
 	Remove(ctx context.Context, uri string) error
 }
 
+// NopPayloadStore is a no-op implementation of PayloadStore used when payloads
+// are persisted inline (e.g. in Postgres) and disk storage is unnecessary.
+type NopPayloadStore struct{}
+
+func (NopPayloadStore) SaveFromReader(context.Context, io.Reader) (*PayloadRecord, error) {
+	return nil, nil
+}
+func (NopPayloadStore) SaveBytes(context.Context, []byte) (*PayloadRecord, error) { return nil, nil }
+func (NopPayloadStore) Open(context.Context, string) (io.ReadCloser, error) {
+	return nil, errors.New("nop payload store does not support Open")
+}
+func (NopPayloadStore) Remove(context.Context, string) error { return nil }
+
 // FilePayloadStore persists payloads on the local filesystem under a base directory.
 type FilePayloadStore struct {
 	baseDir string

--- a/control-plane/internal/services/payload_store_test.go
+++ b/control-plane/internal/services/payload_store_test.go
@@ -90,3 +90,28 @@ func TestCopyWithContextCancels(t *testing.T) {
 	err := copyWithContext(ctx, io.Discard, pr)
 	require.ErrorIs(t, err, context.Canceled)
 }
+
+func TestNopPayloadStoreReturnsNilOnSave(t *testing.T) {
+	store := NopPayloadStore{}
+	ctx := context.Background()
+
+	rec, err := store.SaveBytes(ctx, []byte(`{"hello":"world"}`))
+	require.NoError(t, err)
+	require.Nil(t, rec)
+
+	rec, err = store.SaveFromReader(ctx, strings.NewReader("data"))
+	require.NoError(t, err)
+	require.Nil(t, rec)
+}
+
+func TestNopPayloadStoreOpenReturnsError(t *testing.T) {
+	store := NopPayloadStore{}
+	_, err := store.Open(context.Background(), "payload://abc")
+	require.Error(t, err)
+}
+
+func TestNopPayloadStoreRemoveIsNoop(t *testing.T) {
+	store := NopPayloadStore{}
+	err := store.Remove(context.Background(), "payload://abc")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

Fixes #983. When `storage.mode` is `postgres`, the control plane was unconditionally writing execution payloads to the local filesystem via `FilePayloadStore`, even though the same data is already persisted inline in the `input_payload` / `result_payload` BYTEA columns of the execution record. This caused unbounded disk growth (~2GB over 30 days) leading to pod evictions on Kubernetes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Root cause

`server.go` always instantiated a `FilePayloadStore` regardless of the configured storage mode. Every execution wrote payloads to both the database (inline columns) and the filesystem (via URI), but only the database path was used on read in postgres mode.

## Fix

- Added `NopPayloadStore` - a no-op implementation of `PayloadStore` that returns nil on save
- When `cfg.Storage.Mode == "postgres"`, the server uses `NopPayloadStore` instead of `FilePayloadStore`
- `savePayload` now handles nil records gracefully (prevents panic)
- All read paths (`resolveExecutionData`, `previewPayload`, etc.) already check inline data first and only fall back to URI when inline is empty - since URIs are now nil in postgres mode, the file path is never reached

## Files changed

| File | Change |
|------|--------|
| `services/payload_store.go` | Added `NopPayloadStore` (no-op implementation) |
| `server/server.go` | Use `NopPayloadStore` when mode is postgres |
| `handlers/execute_helpers.go` | Handle nil record from `SaveBytes` |
| `services/payload_store_test.go` | Tests for `NopPayloadStore` |
| `handlers/coverage_handlers_90_additional_test.go` | Test `savePayload` with nop store |

## Test plan

- [x] `go build ./...` - clean
- [x] `go vet ./internal/services/ ./internal/server/ ./internal/handlers/` - clean
- [x] `go test ./internal/services/` - pass (59s)
- [x] `go test ./internal/handlers/` - pass (73s)
- [x] Verified read paths (`resolveExecutionData`, `previewPayload`) short-circuit on nil URI without calling `Open`

## Test coverage

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR.
- [x] If I removed code, I updated `coverage-baseline.json` in this PR *only if* the removal caused a legitimate regression.
- [ ] The coverage gate check is green in CI before requesting review.

## Checklist

- [x] Commits follow conventional-commits style.
- [x] I have linked any related issues (Fixes #983).

## Related issues / PRs

Fixes #983