### PR TITLE
docs: correct storage modes, document execute/restart contracts and live control-plane knobs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ go run ./cmd/af dev
 # Or: go run ./cmd/agentfield-server
 ```
 
-**Cloud mode** (requires PostgreSQL):
+**PostgreSQL storage mode**:
 ```bash
 # Run migrations first
 cd control-plane
@@ -48,7 +48,7 @@ export AGENTFIELD_DATABASE_URL="postgres://agentfield:agentfield@localhost:5432/
 goose -dir ./migrations postgres "$AGENTFIELD_DATABASE_URL" up
 
 # Start server
-AGENTFIELD_STORAGE_MODE=postgresql \
+AGENTFIELD_STORAGE_MODE=postgres \
 AGENTFIELD_DATABASE_URL="postgres://agentfield:agentfield@localhost:5432/agentfield?sslmode=disable" \
 go run ./cmd/agentfield-server
 ```
@@ -158,7 +158,7 @@ The UI dev server proxies API requests to the control plane. In production, the 
 **Configuration:**
 - Environment variables take precedence over `config/agentfield.yaml`
 - See `control-plane/.env.example` for all options
-- Key modes: `AGENTFIELD_MODE=local` (SQLite/BoltDB) vs `AGENTFIELD_STORAGE_MODE=postgresql` (cloud)
+- Storage modes: `AGENTFIELD_STORAGE_MODE=local` (SQLite/BoltDB) or `AGENTFIELD_STORAGE_MODE=postgres` (PostgreSQL)
 
 **Database Schema:**
 - `migrations/` - SQL migrations managed by Goose
@@ -317,7 +317,7 @@ Releases are automated via `.github/workflows/release.yml` and `.goreleaser.yml`
 See `control-plane/.env.example` for comprehensive list. Key vars:
 - `AGENTFIELD_PORT` - HTTP server port (default: 8080)
 - `AGENTFIELD_MODE` - `local` or `cloud`
-- `AGENTFIELD_STORAGE_MODE` - `local`, `postgresql`, or `cloud`
+- `AGENTFIELD_STORAGE_MODE` - `local` or `postgres`
 - `AGENTFIELD_DATABASE_URL` - PostgreSQL connection string
 - `AGENTFIELD_UI_ENABLED` - Enable/disable web UI
 - `AGENTFIELD_UI_MODE` - `embedded` (production) or `development` (Vite proxy)

--- a/README.md
+++ b/README.md
@@ -307,12 +307,13 @@ Two examples already run at this load. The [deep-research engine](https://agentf
 
 | Feature | How |
 |---|---|
-| Sync execution (REST) | `POST /api/v1/execute/{agent}.{func}` |
-| Async (fire-and-forget) | `POST /api/v1/execute/async/{agent}.{func}` |
+| Sync execution (REST) | [`POST /api/v1/execute/{agent}.{func}`](docs/api/EXECUTE.md) |
+| Async (fire-and-forget) | [`POST /api/v1/execute/async/{agent}.{func}`](docs/api/EXECUTE.md) |
 | Webhooks + HMAC-SHA256 signing | `AsyncConfig(webhook_url="...", secret="...")` |
 | SSE streaming (real-time) | `/api/v1/execute/stream/{id}` |
 | No timeout limits (hours/days) | Control plane allows unlimited duration |
 | Execution polling | `GET /api/v1/executions/{id}` |
+| Restart/replay | [`POST /api/v1/executions/{id}/restart`](docs/api/EXECUTION_RESTART.md) |
 | Batch status checks | `POST /api/v1/executions/batch-status` |
 | Progress updates mid-execution | Intermediate payloads during long tasks |
 | Auto retries + exponential backoff | Transparent - control plane handles |

--- a/control-plane/.env.example
+++ b/control-plane/.env.example
@@ -33,14 +33,14 @@ AGENTFIELD_API_CORS_ALLOWED_HEADERS=Origin,Content-Type,Accept,Authorization,X-R
 AGENTFIELD_API_CORS_EXPOSED_HEADERS=Content-Length,X-Total-Count
 AGENTFIELD_API_CORS_ALLOW_CREDENTIALS=true
 
-# Cloud Configuration (if using cloud mode)
+# Hosted-service configuration (independent of the storage mode)
 # AGENTFIELD_CLOUD_ENABLED=false
 # AGENTFIELD_CLOUD_API_KEY=your-api-key-here
 
 # Storage Configuration
 AGENTFIELD_STORAGE_MODE=local
 
-# PostgreSQL Storage Configuration (when AGENTFIELD_STORAGE_MODE=postgresql)
+# PostgreSQL Storage Configuration (when AGENTFIELD_STORAGE_MODE=postgres)
 # AGENTFIELD_STORAGE_POSTGRES_URL=postgresql://user:password@localhost:5432/agentfield?sslmode=disable
 # AGENTFIELD_STORAGE_POSTGRES_MAX_CONNECTIONS=25
 # AGENTFIELD_STORAGE_POSTGRES_MAX_IDLE_CONNECTIONS=5
@@ -50,12 +50,6 @@ AGENTFIELD_STORAGE_MODE=local
 # AGENTFIELD_STORAGE_POSTGRES_ENABLE_DID_FALLBACK=true
 # AGENTFIELD_STORAGE_POSTGRES_ENABLE_VC_FALLBACK=true
 # AGENTFIELD_STORAGE_POSTGRES_ENABLE_AUTO_MIGRATION=true
-
-# Cloud Storage Configuration (when AGENTFIELD_STORAGE_MODE=cloud)
-# AGENTFIELD_STORAGE_CLOUD_POSTGRES_URL=postgresql://user:password@localhost:5432/agentfield
-# AGENTFIELD_STORAGE_CLOUD_MAX_CONNECTIONS=50
-# AGENTFIELD_STORAGE_CLOUD_CONNECTION_POOL=true
-# AGENTFIELD_STORAGE_CLOUD_REPLICATION_MODE=async
 
 # VC Authorization
 # Admin token for admin API endpoints (tag approval, policy management) and

--- a/control-plane/config/agentfield.yaml
+++ b/control-plane/config/agentfield.yaml
@@ -10,6 +10,9 @@ agentfield:
     batch_size: 200
     preserve_recent_duration: 1h
     stale_execution_timeout: 10m
+    # max_retries only rewinds stale workflow rows to pending; no dispatcher
+    # re-enqueues them, so do not rely on it for execution retries.
+    max_retries: 0
   execution_queue:
     agent_call_timeout: 1800s  # Timeout for agent HTTP calls (0s or -1s to disable)
     webhook_timeout: 10s          # Per-attempt timeout for webhook deliveries

--- a/deployments/helm/agentfield/README.md
+++ b/deployments/helm/agentfield/README.md
@@ -91,5 +91,5 @@ curl -H "X-API-Key: change-me" http://localhost:8080/api/v1/nodes
 
 ## Notes
 
-- The chart defaults `AGENTFIELD_CONFIG_FILE=/dev/null` so the control plane uses built-in defaults + environment variables.
+- The chart defaults `AGENTFIELD_CONFIG_FILE=/dev/null` so the control plane uses built-in defaults + environment variables. YAML-only settings therefore do not apply unless you mount a config file and change this variable. This includes the `agentfield.rate_limit` block (enabled and per-route/global RPS and burst limits) and `agentfield.execution_cleanup.max_retries` / `retry_backoff`.
 - Admin gRPC listens on `(AGENTFIELD_PORT + 100)` and is exposed via the Service port named `grpc`.

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -109,6 +109,18 @@ The telemetry payload does not include prompts, inputs, outputs, logs, secrets, 
 - `AGENTFIELD_LOG_LEVEL` (default: `info`): Minimum severity written to stderr — `debug`, `info`, `warn` or `error`. Equivalent YAML: `logging.level`. The `--verbose` flag on `af` overrides both. A value that is not one of those four is reported once at `warn` on startup (`unrecognized log level, falling back to info`) and the server runs at `info`. Successful HTTP requests are logged at `debug`; a `404` at `info` (a request for a route that does not exist is routine noise, not an operator signal); the other 4xx responses at `warn` and 5xx at `error`, so failures stay visible at the default level and alerting keyed on `warn` is not tripped by scanners. Every request is logged, including the ones rejected before they reach a route: a disallowed `Origin` is answered with `403` by the CORS middleware and still produces one `warn` line.
 - `AGENTFIELD_LOG_REDACT_PAYLOADS` (default: `true`): When `true`, execution inputs/outputs and agent response bodies are kept out of log events and internal event-bus payloads; log lines carry the media type, byte length and a short keyed digest (an HMAC under a key minted at process start, so the digest correlates repeats within a run without committing to the plaintext) instead. Set to `false` only for local debugging. Equivalent YAML: `logging.redact_payloads`.
 
+### Miscellaneous control-plane knobs
+
+- `AGENTFIELD_MAX_CONCURRENT_PER_AGENT` (default: `0`): Maximum concurrent executions dispatched to one agent; `0` means unlimited.
+- `AGENTFIELD_EXEC_ASYNC_WORKERS` (default: number of CPUs): Worker count for asynchronous execution and restart jobs; non-positive values use the default.
+- `AGENTFIELD_EXEC_ASYNC_QUEUE_CAPACITY` (default: `1024`): In-memory asynchronous execution queue capacity; non-positive values use the default.
+- `AGENTFIELD_SHUTDOWN_TIMEOUT` (default: `30s`): Grace period for draining the control plane HTTP server during shutdown.
+- `AGENTFIELD_AGENT_RESTART_GRACE` (default: `15s`): How long an execution waits for an agent process to return during a coordinated restart; a negative duration disables the wait.
+
+Rate limiting is off by default and has no dedicated environment-variable overrides. Configure the YAML-only `agentfield.rate_limit` block with `enabled`, `execute_rps`, `execute_burst`, `discovery_rps`, `discovery_burst`, `bulk_status_rps`, `bulk_status_burst`, `global_rps`, and `global_burst`.
+
+Execution cleanup also has YAML keys `agentfield.execution_cleanup.max_retries` (default `0`) and `retry_backoff` (default `30s`), with environment overrides `AGENTFIELD_EXECUTION_MAX_RETRIES` and `AGENTFIELD_EXECUTION_RETRY_BACKOFF`. Despite its name, `max_retries` only rewinds stale workflow rows to `pending`; nothing re-dispatches those rows, so do not rely on it for execution retries.
+
 ### CORS (HTTP API)
 
 These map to `api.cors.*` in config. When set via env, use comma-separated values.

--- a/docs/api/EXECUTE.md
+++ b/docs/api/EXECUTE.md
@@ -1,0 +1,70 @@
+# Execute API
+
+The control plane exposes synchronous and asynchronous execution endpoints:
+
+- `POST /api/v1/execute/{agent}.{reasoner}`
+- `POST /api/v1/execute/async/{agent}.{reasoner}`
+
+## Request
+
+```json
+{
+  "input": {"question": "What changed?"},
+  "context": {"provider": "openai"},
+  "webhook": {
+    "url": "https://example.com/execution-events",
+    "secret": "shared-secret",
+    "headers": {"X-Tenant": "example"}
+  }
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `input` | Object delivered to the local agent reasoner as its arguments. |
+| `context` | Optional control-plane context. This is a reserved, control-plane-interpreted field, not a general user metadata bag. |
+| `webhook` | Optional completion webhook registration (`url`, optional `secret`, and optional string `headers`). |
+
+The control plane stores `input` and `context` together in `executions.input_payload` and includes `context` in replay matching. It inspects the reserved context keys `llm_endpoint`, `llm_backend`, `backend`, `provider`, and `model_provider` for LLM-endpoint gating. For external ARD targets it also interprets `operation` for policy enforcement and forwards the complete context object verbatim to the external endpoint.
+
+`context` is never delivered to a local agent node: local dispatch sends only `input`. The Python, Go, and TypeScript execute helpers currently serialize only `input`, so callers that need these control-plane fields must use the REST endpoint directly. The restart helper is the exception and can send restart context.
+
+## Responses
+
+A successful synchronous request returns the terminal execution:
+
+```json
+{
+  "execution_id": "exec_...",
+  "run_id": "run_...",
+  "status": "succeeded",
+  "result": {},
+  "duration_ms": 42,
+  "finished_at": "2026-08-27T12:00:00Z",
+  "webhook_registered": true
+}
+```
+
+Failures may add `error_message` and `error_details`.
+
+An accepted asynchronous request returns HTTP `202`:
+
+```json
+{
+  "execution_id": "exec_...",
+  "run_id": "run_...",
+  "workflow_id": "run_...",
+  "status": "queued",
+  "target": "agent.reasoner",
+  "type": "reasoner",
+  "created_at": "2026-08-27T12:00:00Z",
+  "enqueued_at": "2026-08-27T12:00:00Z",
+  "webhook_registered": false
+}
+```
+
+If webhook registration failed, the response may include `webhook_error`.
+
+Poll `GET /api/v1/executions/{execution_id}`. Its response contains `execution_id`, `run_id`, `status`, `started_at`, and `webhook_registered`, plus applicable `status_reason`, `result`, `error`, `error_details`, `completed_at`, `duration_ms`, `webhook_events`, and approval fields.
+
+The execute routes do not accept an idempotency key. Retrying a request can create another execution; use the [restart/replay API](EXECUTION_RESTART.md) when replaying an existing run.

--- a/docs/api/EXECUTION_RESTART.md
+++ b/docs/api/EXECUTION_RESTART.md
@@ -1,0 +1,50 @@
+# Execution restart and replay API
+
+`POST /api/v1/executions/{execution_id}/restart` starts a new execution from an existing run. It always mints a new `execution_id` and `run_id`; it never reuses or mutates the source execution ID. The new workflow run records backward lineage in `workflow_runs.metadata.lineage`.
+
+The same operation is available through the UI API and the `af execution restart` command. The Python SDK exposes `client.restart_execution(...)`.
+
+## Request
+
+```json
+{
+  "scope": "workflow",
+  "reuse": "succeeded-before",
+  "fork": false,
+  "input": {"question": "Try again"},
+  "context": {"provider": "openai"},
+  "webhook": {"url": "https://example.com/execution-events"}
+}
+```
+
+| Field | Values and behavior |
+|-------|---------------------|
+| `scope` | `workflow` (default) restarts the source run's root; `execution` restarts the selected execution. |
+| `reuse` | `succeeded-before` (default), `all-succeeded`, or `none`. |
+| `fork` | Marks the lineage as a fork. Supplying replacement `input` or `context` also makes it a fork. |
+| `input` | Optional replacement input; otherwise the restarted execution's stored input is used. |
+| `context` | Optional replacement control-plane context; otherwise its stored context is used. See [Execute API](EXECUTE.md). |
+| `webhook` | Optional webhook registration (`url`, optional `secret`, optional string `headers`). |
+
+With workflow scope, `succeeded-before` replays matching successful children from the source run only before the selected source execution. `all-succeeded` allows any matching successful child in that run; `none` executes every child again. Execution scope converts `succeeded-before` to `all-succeeded`. Replay matching includes target, input, and context. The control plane propagates replay state internally with `X-AgentField-Replay-Source-Run-ID`, `X-AgentField-Replay-Before-Execution-ID`, and `X-AgentField-Replay-Mode` headers.
+
+## Response
+
+An accepted restart returns HTTP `202` with the new execution fields (`execution_id`, `run_id`, `workflow_id`, `status`, `target`, `type`, timestamps), source identifiers (`source_execution_id`, `source_run_id`, `restarted_execution_id`), and replay metadata (`replay_before_execution_id` when applicable, `replay_mode`, `scope`, `kind`). It also reports `webhook_registered` and an optional `webhook_error`.
+
+## Status reasons
+
+Operators polling execution state should branch on the stable category before any `:` suffix:
+
+| `status_reason` | Meaning |
+|-----------------|---------|
+| `awaiting_agent_restart` | Dispatch is deliberately waiting for a restarting agent to return. |
+| `agent_restart_orphaned[: ...]` | The old agent process is gone and its in-flight execution cannot be revived. |
+| `replayed_from_execution:<id>` | The result was reused from the named source execution. |
+| `waiting_for_approval` | Human/external approval is pending. |
+| `approval_rejected[: ...]` | Approval was rejected; an optional suffix contains feedback. |
+| `awaiting_child` | The parent is waiting for a child execution. |
+| `agent_client_error:<status>` | The agent reported a client-facing HTTP 4xx failure. |
+| `llm_unavailable`, `concurrency_limit`, `agent_timeout`, `agent_error`, `agent_unreachable`, `bad_response`, `internal_error`, `validation`, `permission_denied`, `node_unavailable`, `target_not_found` | Canonical failure categories used for operator routing and HTTP mapping. |
+
+Do not emulate restart by re-submitting `/execute`: execute has no idempotency key, creates unrelated executions, and cannot establish restart lineage or replay boundaries.

--- a/docs/deploying-on-kubernetes.md
+++ b/docs/deploying-on-kubernetes.md
@@ -1,0 +1,10 @@
+# Deploying agent nodes on Kubernetes
+
+For agent nodes running on Kubernetes:
+
+- Set `terminationGracePeriodSeconds` higher than the agent's drain budget, and leave extra time for the process to exit. Check the SDK release notes for the drain setting your SDK version honours (`AGENTFIELD_SHUTDOWN_TIMEOUT` where supported); older SDK releases cut in-flight Python reasoners at a fixed 30 seconds and Go skills at 5 seconds regardless of the pod's grace period.
+- Keep the agent manifest's `version` string stable across ordinary pod rollouts. Changing it represents a new agent version, not a new replica.
+- To recover or replay work, call [`POST /api/v1/executions/{execution_id}/restart`](api/EXECUTION_RESTART.md) with `reuse=succeeded-before` instead of submitting the original execute request again.
+- Mount `AGENTFIELD_HOME` on a persistent volume claim. Size it for continuing SQLite/BoltDB and execution-payload growth until retention is enabled and configured for your deployment.
+
+The control plane must be able to reach the callback URL registered by each agent; normally this is a Kubernetes Service DNS name.


### PR DESCRIPTION
## Summary

Documentation that was actively misleading operators, found while triaging the Kubernetes issues from pocesar (#983, #986, #987, #989, #988):

- `AGENTFIELD_STORAGE_MODE` docs (CLAUDE.md, `.env.example`) cited `postgresql` and `cloud`, neither of which the server accepts (`storage.go` accepts only `local`/`postgres` and hard-fails otherwise). The nonexistent `AGENTFIELD_STORAGE_CLOUD_*` example block is removed.
- `POST /api/v1/executions/{id}/restart` (scope/reuse/fork semantics, replay headers, lineage, `status_reason` vocabulary) was documented nowhere — pocesar was hand-rolling re-submission against a shipped feature. New `docs/api/EXECUTION_RESTART.md`, linked from the README API table.
- The `/execute` `context` field is documented as what it is: a control-plane-interpreted, reserved-key field (LLM-endpoint gating, external-ARD `operation` policy, part of the replay key, forwarded verbatim to external ARD endpoints) that is **never delivered to local agent nodes** and cannot be sent by any SDK's execute helper. New `docs/api/EXECUTE.md` with the request/response shapes.
- Live knobs that were undocumented: `AGENTFIELD_MAX_CONCURRENT_PER_AGENT`, `AGENTFIELD_EXEC_ASYNC_WORKERS`, `AGENTFIELD_EXEC_ASYNC_QUEUE_CAPACITY`, `AGENTFIELD_SHUTDOWN_TIMEOUT`, `AGENTFIELD_AGENT_RESTART_GRACE`, the YAML-only rate-limit block, and the fact that `execution_cleanup.max_retries` only rewinds rows and nothing re-dispatches them.
- Helm README: `AGENTFIELD_CONFIG_FILE=/dev/null` means YAML-only settings do not apply in the chart.
- A short Kubernetes deployment note for agent nodes (grace period vs drain budget, stable `version` across rollouts, restart/replay instead of re-submitting, PVC for `AGENTFIELD_HOME`).

Docs only; no code changes.

## Validation contract

- Every route, env var and YAML key documented here exists on `main` at the cited source (spot-checked with `rg` against `routes_core.go`, `config.go`, `execute_helpers.go`, `storage.go`, `execute_agent_restart.go`).
- No remaining reference to `AGENTFIELD_STORAGE_MODE=postgresql` or `=cloud` anywhere in `CLAUDE.md`, `.env.example`, `docs/`, `README.md`.
- No broken local markdown links in the changed files.

## Test plan

- [x] Link check over changed markdown: 0 broken local targets
- [x] `git diff --check`: clean
- [x] `cd control-plane && go build ./... && go test ./... -count=1` (config example only; 62 packages green)

Refs #983 #986 #987 #989 #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)