### PR TITLE
ci(sdk/python): lock drift check, Python 3.13 leg, weekly latest-litellm canary

### DIFF
--- a/.github/workflows/litellm-canary.yml
+++ b/.github/workflows/litellm-canary.yml
@@ -1,0 +1,96 @@
+name: LiteLLM Canary
+
+on:
+  schedule:
+    - cron: '17 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  test-latest-litellm:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+      matrix:
+        python-version: ['3.11', '3.12']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install SDK with latest LiteLLM
+        working-directory: sdk/python
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[dev]" --upgrade litellm
+
+      - name: Show LiteLLM version
+        id: litellm
+        working-directory: sdk/python
+        run: |
+          pip show litellm
+          echo "version=$(python -c 'from importlib.metadata import version; print(version("litellm"))')" >> "$GITHUB_OUTPUT"
+
+      - name: Run tests
+        id: tests
+        continue-on-error: true
+        working-directory: sdk/python
+        run: ./scripts/run_pytest.sh
+
+      - name: Open or update tracking issue
+        if: steps.tests.outcome == 'failure'
+        uses: actions/github-script@v7
+        env:
+          LITELLM_VERSION: ${{ steps.litellm.outputs.version }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        with:
+          script: |
+            const title = `litellm canary failed: ${process.env.LITELLM_VERSION}`;
+            const body = [
+              `The weekly LiteLLM canary failed on Python ${process.env.PYTHON_VERSION}.`,
+              '',
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            ].join('\n');
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'all',
+              per_page: 100,
+            });
+            const existing = issues.find(
+              issue => !issue.pull_request && issue.title === title,
+            );
+            if (existing) {
+              if (existing.state === 'closed') {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: existing.number,
+                  state: 'open',
+                });
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+              });
+            }
+
+      - name: Fail canary
+        if: steps.tests.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,6 +29,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Check dependency lock
+        working-directory: sdk/python
+        run: uv lock --check
 
       - name: Install dependencies
         working-directory: sdk/python

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -31,6 +31,10 @@ dependencies = [
     "pydantic>=2.0",
     # LiteLLM 1.97.0 crashes on Python 3.10 building ModelResponse, and
     # 1.98.0 imports typing.NotRequired (only available in Python 3.11+).
+    # The 3.10 cap can be lifted once upstream guards that import the way
+    # litellm/types/compression.py does. The 3.11+ branch floats on purpose;
+    # .github/workflows/litellm-canary.yml tests it weekly against the
+    # latest release so a break is caught before users hit it.
     "litellm!=1.97.0,<1.98.0; python_version < '3.11'",
     "litellm; python_version >= '3.11'",
     "psutil",

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -1,10 +1,10 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.14"
 
 [[package]]
 name = "agentfield"
-version = "0.1.121rc3"
+version = "0.1.137rc2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -67,7 +67,7 @@ requires-dist = [
     { name = "freezegun", marker = "extra == 'dev'", specifier = ">=1.2,<2" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.88,<7" },
     { name = "joserfc", specifier = ">=1.0" },
-    { name = "litellm" },
+    { name = "litellm", specifier = "!=1.97.0,<1.98.0" },
     { name = "openai-codex", marker = "extra == 'harness-all'", specifier = ">=0.1.0b3" },
     { name = "openai-codex", marker = "extra == 'harness-codex'", specifier = ">=0.1.0b3" },
     { name = "openai-codex-cli-bin", marker = "extra == 'harness-all'", specifier = "==0.137.0a4" },

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -1,10 +1,14 @@
 version = 1
 revision = 2
 requires-python = ">=3.10, <3.14"
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version < '3.11'",
+]
 
 [[package]]
 name = "agentfield"
-version = "0.1.137rc2"
+version = "0.1.137rc3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -67,7 +71,8 @@ requires-dist = [
     { name = "freezegun", marker = "extra == 'dev'", specifier = ">=1.2,<2" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.88,<7" },
     { name = "joserfc", specifier = ">=1.0" },
-    { name = "litellm", specifier = "!=1.97.0,<1.98.0" },
+    { name = "litellm", marker = "python_full_version < '3.11'", specifier = "!=1.97.0,<1.98.0" },
+    { name = "litellm", marker = "python_full_version >= '3.11'" },
     { name = "openai-codex", marker = "extra == 'harness-all'", specifier = ">=0.1.0b3" },
     { name = "openai-codex", marker = "extra == 'harness-codex'", specifier = ">=0.1.0b3" },
     { name = "openai-codex-cli-bin", marker = "extra == 'harness-all'", specifier = "==0.137.0a4" },
@@ -596,7 +601,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Follow-ups from #982 (the litellm `<1.98.0` cap that reached every Python):

- **`sdk/python/uv.lock` regenerated.** It was stale on `main` (`uv lock --check` failed; `version = "0.1.121rc3"`, litellm `requires-dist` with no specifier, resolved pin 1.87.0), so the `uv run --frozen` recipe from #950 did not work for contributors.
- **`uv lock --check` step in `sdk-python.yml`** so the lock cannot drift silently again (fast, no install).
- **Python 3.13 added to the `lint-and-test` matrix.** `pyproject.toml` declares `requires-python = ">=3.10, <3.14"` and a 3.13 classifier, but nothing tested it — and after #993 lands, 3.11+ gets an unconstrained litellm with 3.13 exercising nothing.
- **Weekly `litellm-canary.yml`** (schedule + `workflow_dispatch`, never on PRs, not a required check): installs the SDK with `--upgrade litellm` on 3.11/3.12, prints the resolved version, runs `./scripts/run_pytest.sh`, and on failure opens or updates a single issue titled `litellm canary failed: <version>` (deduped by exact title, `max-parallel: 1`). litellm ships weekly and broke this SDK twice in ten days (#925, #950); the canary is what makes keeping it floating safe.

## Ordering — do not merge before #993

The lock currently encodes today's global cap (`litellm!=1.97.0,<1.98.0`). Once #993 (marker-scoped cap) merges, this branch will be rebased and the lock regenerated so it records both marker branches; merging this first would make the new `uv lock --check` step fail on `main` the moment #993 lands. Kept as a draft until then.

## Validation contract

- `cd sdk/python && uv lock --check` passes on this branch and the lock's litellm `requires-dist` matches `pyproject.toml` exactly.
- The full SDK suite passes on 3.13 (the new leg is not a latent red).
- Workflow files pass `actionlint`; every new bash snippet runs under `bash --noprofile --norc -e -o pipefail`.
- The canary never runs on pull requests and is not in the required-checks set.

## Test plan

- [x] `uv lock --check` (uv 0.7.8): no drift
- [x] `./scripts/run_pytest.sh` on Python 3.13.3 in a clean venv: 2213 passed, 4 skipped
- [x] `./scripts/run_pytest.sh` on Python 3.10 in a clean venv: 2213 passed, 4 skipped
- [x] `ruff check .` clean
- [x] `actionlint` on both workflow files: 0 findings

Refs #982

🤖 Generated with [Claude Code](https://claude.com/claude-code)