### PR TITLE
fix(control-plane): reject async executions before persisting them; drain the async pool on shutdown; ingress limits

### DIFF
--- a/control-plane/.env.example
+++ b/control-plane/.env.example
@@ -89,3 +89,11 @@ AGENTFIELD_STORAGE_MODE=local
 # Set to false to log execution payloads and agent response bodies verbatim.
 # Leave unset (true) in anything but local debugging (YAML: logging.redact_payloads).
 # AGENTFIELD_LOG_REDACT_PAYLOADS=true
+
+# Execution admission & ingress
+# I/O-bound async workers; default is max(available CPUs, 16).
+# AGENTFIELD_EXEC_ASYNC_WORKERS=16
+# Maximum queued async executions waiting for a worker.
+# AGENTFIELD_EXEC_ASYNC_QUEUE_CAPACITY=1024
+# Maximum POST body size for /api/v1/execute* routes (32 MiB).
+# AGENTFIELD_MAX_EXECUTE_BODY_BYTES=33554432

--- a/control-plane/.env.example
+++ b/control-plane/.env.example
@@ -37,6 +37,14 @@ AGENTFIELD_API_CORS_ALLOW_CREDENTIALS=true
 # AGENTFIELD_CLOUD_ENABLED=false
 # AGENTFIELD_CLOUD_API_KEY=your-api-key-here
 
+# Execution admission & ingress
+# I/O-bound async workers; default is max(available CPUs, 16).
+# AGENTFIELD_EXEC_ASYNC_WORKERS=16
+# Maximum queued async executions waiting for a worker.
+# AGENTFIELD_EXEC_ASYNC_QUEUE_CAPACITY=1024
+# Maximum POST body size for /api/v1/execute* routes (32 MiB).
+# AGENTFIELD_MAX_EXECUTE_BODY_BYTES=33554432
+
 # Storage Configuration
 AGENTFIELD_STORAGE_MODE=local
 
@@ -89,11 +97,3 @@ AGENTFIELD_STORAGE_MODE=local
 # Set to false to log execution payloads and agent response bodies verbatim.
 # Leave unset (true) in anything but local debugging (YAML: logging.redact_payloads).
 # AGENTFIELD_LOG_REDACT_PAYLOADS=true
-
-# Execution admission & ingress
-# I/O-bound async workers; default is max(available CPUs, 16).
-# AGENTFIELD_EXEC_ASYNC_WORKERS=16
-# Maximum queued async executions waiting for a worker.
-# AGENTFIELD_EXEC_ASYNC_QUEUE_CAPACITY=1024
-# Maximum POST body size for /api/v1/execute* routes (32 MiB).
-# AGENTFIELD_MAX_EXECUTE_BODY_BYTES=33554432

--- a/control-plane/internal/handlers/execute.go
+++ b/control-plane/internal/handlers/execute.go
@@ -150,7 +150,11 @@ type asyncExecutionJob struct {
 }
 
 type asyncWorkerPool struct {
-	queue chan asyncExecutionJob
+	queue        chan asyncExecutionJob
+	reservations chan struct{}
+	mu           sync.RWMutex
+	stopped      bool
+	jobs         sync.WaitGroup
 }
 
 type completionJob struct {
@@ -431,7 +435,19 @@ func (c *executionController) handleSync(ctx *gin.Context) {
 
 func (c *executionController) handleAsync(ctx *gin.Context) {
 	reqCtx := ctx.Request.Context()
-	plan, err := c.prepareExecution(reqCtx, ctx)
+	pool := getAsyncWorkerPool()
+	if !pool.reserve() {
+		writeAsyncAdmissionError(ctx, http.StatusServiceUnavailable, "async execution queue is full; retry later")
+		return
+	}
+	reserved := true
+	defer func() {
+		if reserved {
+			pool.releaseReservation()
+		}
+	}()
+
+	plan, err := c.prepareAsyncExecution(reqCtx, ctx)
 	if err != nil {
 		writeExecutionError(ctx, err)
 		return
@@ -439,6 +455,7 @@ func (c *executionController) handleAsync(ctx *gin.Context) {
 	plan.executionMode = "async"
 
 	if plan.replayHit != nil {
+		ReleaseExecutionSlot(plan.target.NodeID)
 		if err := c.completeReplayHit(reqCtx, plan); err != nil {
 			writeExecutionError(ctx, err)
 			return
@@ -467,38 +484,23 @@ func (c *executionController) handleAsync(ctx *gin.Context) {
 		return
 	}
 
-	// Check LLM health and per-agent concurrency limits before proceeding
-	if err := CheckExecutionPreconditions(plan.target.NodeID, plan.llmEndpoint); err != nil {
-		_ = c.failExecution(reqCtx, plan, err, 0, nil)
-		writeExecutionError(ctx, err)
-		return
-	}
-	// Note: slot is released in asyncExecutionJob.process() after completion
+	// The slot was acquired before persistence. process releases it when the
+	// agent call returns (including an HTTP 202 acknowledgement).
 
 	// Emit execution started event with full reasoner context
 	c.publishExecutionStartedEvent(plan)
 
-	pool := getAsyncWorkerPool()
 	job := asyncExecutionJob{
 		controller: c,
 		plan:       *plan,
 	}
 
-	if ok := pool.submit(job); !ok {
+	if ok := pool.submitReserved(job); !ok {
 		ReleaseExecutionSlot(plan.target.NodeID) // Release since process() won't run
-		queueErr := errors.New("async execution queue is full; retry later")
-		if updateErr := c.failExecution(reqCtx, plan, queueErr, 0, nil); updateErr != nil {
-			logger.Logger.Error().
-				Err(updateErr).
-				Str("execution_id", plan.exec.ExecutionID).
-				Msg("failed to persist execution failure after queue saturation")
-		}
-		logger.Logger.Warn().
-			Str("execution_id", plan.exec.ExecutionID).
-			Msg("async execution rejected due to queue saturation")
-		ctx.JSON(http.StatusServiceUnavailable, gin.H{"error": queueErr.Error(), "error_category": "concurrency_limit"})
+		writeAsyncAdmissionError(ctx, http.StatusServiceUnavailable, "async execution queue stopped; retry later")
 		return
 	}
+	reserved = false
 
 	createdAt := plan.exec.CreatedAt.UTC().Format(time.RFC3339)
 	targetLabel := fmt.Sprintf("%s.%s", plan.target.NodeID, plan.target.TargetName)

--- a/control-plane/internal/handlers/execute.go
+++ b/control-plane/internal/handlers/execute.go
@@ -436,6 +436,8 @@ func (c *executionController) handleSync(ctx *gin.Context) {
 func (c *executionController) handleAsync(ctx *gin.Context) {
 	reqCtx := ctx.Request.Context()
 	pool := getAsyncWorkerPool()
+	// A reservation covers both preparation and time waiting in the queue. The
+	// worker releases it on dequeue so only not-yet-started work consumes capacity.
 	if !pool.reserve() {
 		writeAsyncAdmissionError(ctx, http.StatusServiceUnavailable, "async execution queue is full; retry later")
 		return

--- a/control-plane/internal/handlers/execute.go
+++ b/control-plane/internal/handlers/execute.go
@@ -150,11 +150,13 @@ type asyncExecutionJob struct {
 }
 
 type asyncWorkerPool struct {
-	queue        chan asyncExecutionJob
-	reservations chan struct{}
-	mu           sync.RWMutex
-	stopped      bool
-	jobs         sync.WaitGroup
+	queue         chan asyncExecutionJob
+	reservations  chan struct{}
+	workerCtx     context.Context
+	cancelWorkers context.CancelFunc
+	mu            sync.RWMutex
+	stopped       bool
+	jobs          sync.WaitGroup
 }
 
 type completionJob struct {

--- a/control-plane/internal/handlers/execute_async_test.go
+++ b/control-plane/internal/handlers/execute_async_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -24,93 +23,59 @@ import (
 
 func TestExecuteAsyncHandler_QueueSaturation(t *testing.T) {
 	gin.SetMode(gin.TestMode)
+	oldPool, oldOnce := asyncPool, asyncPoolOnce
+	asyncPool = newAsyncWorkerPool(1, 1)
+	asyncPoolOnce = sync.Once{}
+	asyncPoolOnce.Do(func() {})
+	defer func() { asyncPool, asyncPoolOnce = oldPool, oldOnce }()
 
-	// Set a small queue capacity for this test
-	// Note: This only works if the pool hasn't been initialized yet
-	// In a real scenario, the pool is initialized once, so this test
-	// verifies the queue saturation logic when the queue is actually full
-	originalCapacity := os.Getenv("AGENTFIELD_EXEC_ASYNC_QUEUE_CAPACITY")
-	defer func() {
-		if originalCapacity != "" {
-			os.Setenv("AGENTFIELD_EXEC_ASYNC_QUEUE_CAPACITY", originalCapacity)
-		} else {
-			os.Unsetenv("AGENTFIELD_EXEC_ASYNC_QUEUE_CAPACITY")
+	workerStarted := make(chan struct{})
+	releaseWorker := make(chan struct{})
+	agentServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case <-workerStarted:
+		default:
+			close(workerStarted)
 		}
-	}()
-
-	// Set a very small capacity to make saturation easier to test
-	os.Setenv("AGENTFIELD_EXEC_ASYNC_QUEUE_CAPACITY", "2")
+		<-releaseWorker
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result":{}}`))
+	}))
+	defer agentServer.Close()
+	defer close(releaseWorker)
 
 	agent := &types.AgentNode{
 		ID:        "node-1",
-		BaseURL:   "http://agent.example",
+		BaseURL:   agentServer.URL,
 		Reasoners: []types.ReasonerDefinition{{ID: "reasoner-a"}},
 	}
-
 	store := newTestExecutionStorage(agent)
 	payloads := services.NewFilePayloadStore(t.TempDir())
-
-	// Get the pool (will be initialized with small capacity)
-	pool := getAsyncWorkerPool()
-
-	// Fill the queue completely - submit more jobs than capacity
-	// Workers will consume some, but we want to ensure queue is full when we make the request
-	queueCapacity := cap(pool.queue)
-
-	// Submit enough jobs to fill the queue (accounting for workers consuming)
-	// We submit more than capacity to ensure queue stays full
-	for i := 0; i < queueCapacity*2; i++ {
-		job := asyncExecutionJob{
-			controller: newExecutionController(store, payloads, nil, 90*time.Second, ""),
-			plan: preparedExecution{
-				exec: &types.Execution{
-					ExecutionID: "test-exec-fill",
-					RunID:       "test-run",
-				},
-			},
-		}
-		if !pool.submit(job) {
-			// Queue is full, good
-			break
-		}
-	}
-
-	// Give a tiny moment for queue state to stabilize
-	time.Sleep(10 * time.Millisecond)
-
 	router := gin.New()
 	router.POST("/api/v1/execute/async/:target", ExecuteAsyncHandler(store, payloads, nil, 90*time.Second, ""))
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/execute/async/node-1.reasoner-a", strings.NewReader(`{"input":{"foo":"bar"}}`))
-	req.Header.Set("Content-Type", "application/json")
-	resp := httptest.NewRecorder()
-
-	router.ServeHTTP(resp, req)
-
-	// The queue might not be full if workers consumed jobs quickly
-	// So we check if we got either 503 (queue full) or 202 (accepted)
-	// If we got 202, the queue wasn't full, which is also a valid test outcome
-	if resp.Code == http.StatusServiceUnavailable {
-		var payload map[string]string
-		require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &payload))
-		require.Contains(t, payload["error"], "async execution queue is full")
-
-		// Verify execution was marked as failed
-		records, err := store.QueryExecutionRecords(context.Background(), types.ExecutionFilter{})
-		require.NoError(t, err)
-		if len(records) > 0 {
-			// Find the execution we just created
-			for i := len(records) - 1; i >= 0; i-- {
-				if records[i].Status == types.ExecutionStatusFailed {
-					// Found a failed execution, which is expected for queue saturation
-					return
-				}
-			}
-		}
-	} else {
-		// Queue wasn't full, which is fine - test still validates the code path exists
-		require.Equal(t, http.StatusAccepted, resp.Code)
+	request := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/execute/async/node-1.reasoner-a", strings.NewReader(`{"input":{"foo":"bar"}}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+		return resp
 	}
+	require.Equal(t, http.StatusAccepted, request().Code)
+	<-workerStarted
+	require.Equal(t, http.StatusAccepted, request().Code)
+	for i := 0; i < 3; i++ {
+		resp := request()
+		require.Equal(t, http.StatusServiceUnavailable, resp.Code)
+		require.Contains(t, resp.Body.String(), "async execution queue is full")
+	}
+
+	records, err := store.QueryExecutionRecords(context.Background(), types.ExecutionFilter{})
+	require.NoError(t, err)
+	require.Len(t, records, 2, "rejected requests must not persist execution rows")
+	workflows, err := store.QueryWorkflowExecutions(context.Background(), types.WorkflowExecutionFilters{})
+	require.NoError(t, err)
+	require.Len(t, workflows, 2, "rejected requests must not persist workflow rows")
 }
 
 func TestExecuteAsyncHandler_ConcurrencyRejectionHasNoPersistence(t *testing.T) {

--- a/control-plane/internal/handlers/execute_async_test.go
+++ b/control-plane/internal/handlers/execute_async_test.go
@@ -42,7 +42,6 @@ func TestExecuteAsyncHandler_QueueSaturation(t *testing.T) {
 		_, _ = w.Write([]byte(`{"result":{}}`))
 	}))
 	defer agentServer.Close()
-	defer close(releaseWorker)
 
 	agent := &types.AgentNode{
 		ID:        "node-1",
@@ -52,6 +51,14 @@ func TestExecuteAsyncHandler_QueueSaturation(t *testing.T) {
 	store := newTestExecutionStorage(agent)
 	payloads := services.NewFilePayloadStore(t.TempDir())
 	router := gin.New()
+	const burstSize = 10
+	var ready sync.WaitGroup
+	ready.Add(burstSize)
+	start := make(chan struct{})
+	router.Use(func(c *gin.Context) {
+		ready.Done()
+		<-start
+	})
 	router.POST("/api/v1/execute/async/:target", ExecuteAsyncHandler(store, payloads, nil, 90*time.Second, ""))
 
 	request := func() *httptest.ResponseRecorder {
@@ -61,14 +68,29 @@ func TestExecuteAsyncHandler_QueueSaturation(t *testing.T) {
 		router.ServeHTTP(resp, req)
 		return resp
 	}
-	require.Equal(t, http.StatusAccepted, request().Code)
-	<-workerStarted
-	require.Equal(t, http.StatusAccepted, request().Code)
-	for i := 0; i < 3; i++ {
-		resp := request()
-		require.Equal(t, http.StatusServiceUnavailable, resp.Code)
-		require.Contains(t, resp.Body.String(), "async execution queue is full")
+	responses := make(chan *httptest.ResponseRecorder, burstSize)
+	for i := 0; i < burstSize; i++ {
+		go func() { responses <- request() }()
 	}
+	ready.Wait()
+	close(start)
+
+	accepted := 0
+	rejected := 0
+	for i := 0; i < burstSize; i++ {
+		resp := <-responses
+		switch resp.Code {
+		case http.StatusAccepted:
+			accepted++
+		case http.StatusServiceUnavailable:
+			rejected++
+			require.Contains(t, resp.Body.String(), "async execution queue is full")
+		default:
+			t.Fatalf("unexpected async response status %d: %s", resp.Code, resp.Body.String())
+		}
+	}
+	require.Equal(t, 2, accepted, "workers + queue capacity must be admitted")
+	require.Equal(t, burstSize-2, rejected)
 
 	records, err := store.QueryExecutionRecords(context.Background(), types.ExecutionFilter{})
 	require.NoError(t, err)
@@ -76,6 +98,23 @@ func TestExecuteAsyncHandler_QueueSaturation(t *testing.T) {
 	workflows, err := store.QueryWorkflowExecutions(context.Background(), types.WorkflowExecutionFilters{})
 	require.NoError(t, err)
 	require.Len(t, workflows, 2, "rejected requests must not persist workflow rows")
+	close(releaseWorker)
+	<-workerStarted
+	stopCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	asyncPool.Stop(stopCtx)
+	require.Eventually(t, func() bool {
+		completed, queryErr := store.QueryExecutionRecords(context.Background(), types.ExecutionFilter{})
+		if queryErr != nil || len(completed) != 2 {
+			return false
+		}
+		for _, record := range completed {
+			if record.Status == types.ExecutionStatusRunning {
+				return false
+			}
+		}
+		return true
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestExecuteAsyncHandler_ConcurrencyRejectionHasNoPersistence(t *testing.T) {

--- a/control-plane/internal/handlers/execute_async_test.go
+++ b/control-plane/internal/handlers/execute_async_test.go
@@ -153,6 +153,36 @@ func TestExecuteAsyncHandler_ConcurrencyRejectionHasNoPersistence(t *testing.T) 
 	require.Empty(t, files)
 }
 
+func TestExecuteAsyncHandler_ChunkedOversizeBodyHasNoPersistence(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	oldPool, oldOnce := asyncPool, asyncPoolOnce
+	asyncPool = newAsyncWorkerPool(0, 1)
+	asyncPoolOnce = sync.Once{}
+	asyncPoolOnce.Do(func() {})
+	defer func() { asyncPool, asyncPoolOnce = oldPool, oldOnce }()
+
+	agent := &types.AgentNode{ID: "node-1", BaseURL: "http://agent.example", Reasoners: []types.ReasonerDefinition{{ID: "reasoner-a"}}}
+	store := newTestExecutionStorage(agent)
+	router := gin.New()
+	router.POST("/api/v1/execute/async/:target", ExecuteAsyncHandler(store, services.NewFilePayloadStore(t.TempDir()), nil, time.Second, ""))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/execute/async/node-1.reasoner-a", strings.NewReader(`{"input":{"value":"oversize"}}`))
+	req.ContentLength = -1
+	req.TransferEncoding = []string{"chunked"}
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	req.Body = http.MaxBytesReader(resp, req.Body, 8)
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, resp.Code)
+	require.JSONEq(t, `{"error":"request body too large"}`, resp.Body.String())
+	records, err := store.QueryExecutionRecords(context.Background(), types.ExecutionFilter{})
+	require.NoError(t, err)
+	require.Empty(t, records)
+	workflows, err := store.QueryWorkflowExecutions(context.Background(), types.WorkflowExecutionFilters{})
+	require.NoError(t, err)
+	require.Empty(t, workflows)
+}
+
 func TestExecuteAsyncHandler_QueueFullHasNoPersistence(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	oldPool, oldOnce := asyncPool, asyncPoolOnce

--- a/control-plane/internal/handlers/execute_async_test.go
+++ b/control-plane/internal/handlers/execute_async_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -108,6 +110,109 @@ func TestExecuteAsyncHandler_QueueSaturation(t *testing.T) {
 		// Queue wasn't full, which is fine - test still validates the code path exists
 		require.Equal(t, http.StatusAccepted, resp.Code)
 	}
+}
+
+func TestExecuteAsyncHandler_ConcurrencyRejectionHasNoPersistence(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	oldLimiter := concurrencyLimiter
+	concurrencyLimiter = &AgentConcurrencyLimiter{maxPerAgent: 1}
+	require.NoError(t, concurrencyLimiter.Acquire("node-1"))
+	defer func() { concurrencyLimiter = oldLimiter }()
+
+	oldPool := asyncPool
+	oldOnce := asyncPoolOnce
+	asyncPool = newAsyncWorkerPool(1, 2)
+	asyncPoolOnce = sync.Once{}
+	asyncPoolOnce.Do(func() {})
+	defer func() { asyncPool, asyncPoolOnce = oldPool, oldOnce }()
+
+	agent := &types.AgentNode{ID: "node-1", BaseURL: "http://agent.example", Reasoners: []types.ReasonerDefinition{{ID: "reasoner-a"}}}
+	store := newTestExecutionStorage(agent)
+	payloadDir := t.TempDir()
+	router := gin.New()
+	router.POST("/api/v1/execute/async/:target", ExecuteAsyncHandler(store, services.NewFilePayloadStore(payloadDir), nil, time.Second, ""))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/execute/async/node-1.reasoner-a", strings.NewReader(`{"input":{"foo":"bar"}}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusTooManyRequests, resp.Code)
+	require.Equal(t, "1", resp.Header().Get("Retry-After"))
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+	require.Equal(t, "concurrency_limit", body["error_category"])
+	require.Equal(t, float64(1), body["retry_after"])
+	records, err := store.QueryExecutionRecords(context.Background(), types.ExecutionFilter{})
+	require.NoError(t, err)
+	require.Empty(t, records)
+	workflows, err := store.QueryWorkflowExecutions(context.Background(), types.WorkflowExecutionFilters{})
+	require.NoError(t, err)
+	require.Empty(t, workflows)
+	files, err := filepath.Glob(filepath.Join(payloadDir, "*"))
+	require.NoError(t, err)
+	require.Empty(t, files)
+}
+
+func TestExecuteAsyncHandler_QueueFullHasNoPersistence(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	oldPool, oldOnce := asyncPool, asyncPoolOnce
+	asyncPool = newAsyncWorkerPool(0, 1)
+	require.True(t, asyncPool.reserve())
+	asyncPoolOnce = sync.Once{}
+	asyncPoolOnce.Do(func() {})
+	defer func() { asyncPool, asyncPoolOnce = oldPool, oldOnce }()
+
+	agent := &types.AgentNode{ID: "node-1", BaseURL: "http://agent.example", Reasoners: []types.ReasonerDefinition{{ID: "reasoner-a"}}}
+	store := newTestExecutionStorage(agent)
+	payloadDir := t.TempDir()
+	router := gin.New()
+	router.POST("/api/v1/execute/async/:target", ExecuteAsyncHandler(store, services.NewFilePayloadStore(payloadDir), nil, time.Second, ""))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/execute/async/node-1.reasoner-a", strings.NewReader(`{"input":{}}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusServiceUnavailable, resp.Code)
+	require.Equal(t, "1", resp.Header().Get("Retry-After"))
+	records, err := store.QueryExecutionRecords(context.Background(), types.ExecutionFilter{})
+	require.NoError(t, err)
+	require.Empty(t, records)
+	files, err := filepath.Glob(filepath.Join(payloadDir, "*"))
+	require.NoError(t, err)
+	require.Empty(t, files)
+}
+
+func TestWriteExecutionError_ConcurrencyLimitIncludesRetryAfter(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	writeExecutionError(ctx, &executionPreconditionError{code: http.StatusTooManyRequests, message: "busy", category: ErrorCategoryConcurrencyLimit})
+	require.Equal(t, "1", recorder.Header().Get("Retry-After"))
+	require.JSONEq(t, `{"error":"busy","error_category":"concurrency_limit","retry_after":1}`, recorder.Body.String())
+}
+
+func TestAsyncWorkerPoolStopFailsQueuedJobsAndRejectsSubmissions(t *testing.T) {
+	agent := &types.AgentNode{ID: "node-1"}
+	store := newTestExecutionStorage(agent)
+	now := time.Now().UTC()
+	exec := &types.Execution{ExecutionID: "queued-1", RunID: "run-1", NodeID: "node-1", AgentNodeID: "node-1", ReasonerID: "reasoner-a", Status: types.ExecutionStatusRunning, CreatedAt: now, StartedAt: now, UpdatedAt: now}
+	require.NoError(t, store.CreateExecutionRecord(context.Background(), exec))
+	require.NoError(t, store.StoreWorkflowExecution(context.Background(), &types.WorkflowExecution{ExecutionID: exec.ExecutionID, WorkflowID: exec.RunID, RunID: &exec.RunID, AgentNodeID: "node-1", ReasonerID: "reasoner-a", Status: types.ExecutionStatusRunning, StartedAt: now, CreatedAt: now, UpdatedAt: now}))
+	target, err := parseTarget("node-1.reasoner-a")
+	require.NoError(t, err)
+	pool := newAsyncWorkerPool(0, 2)
+	require.True(t, pool.submit(asyncExecutionJob{controller: newExecutionController(store, nil, nil, time.Second, ""), plan: preparedExecution{exec: exec, target: target}}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	pool.Stop(ctx)
+	require.False(t, pool.submit(asyncExecutionJob{}))
+	stored, err := store.GetExecutionRecord(context.Background(), exec.ExecutionID)
+	require.NoError(t, err)
+	require.Equal(t, types.ExecutionStatusFailed, stored.Status)
+	require.Equal(t, "control_plane_shutdown", *stored.StatusReason)
+	workflow, err := store.GetWorkflowExecution(context.Background(), exec.ExecutionID)
+	require.NoError(t, err)
+	require.Equal(t, types.ExecutionStatusFailed, workflow.Status)
+	require.Equal(t, "control_plane_shutdown", *workflow.StatusReason)
 }
 
 func TestExecuteAsyncHandler_WithWebhook(t *testing.T) {
@@ -412,8 +517,8 @@ func TestCallAgent_Timeout(t *testing.T) {
 	errorMsg := err.Error()
 	require.True(t,
 		strings.Contains(strings.ToLower(errorMsg), "timeout") ||
-		strings.Contains(strings.ToLower(errorMsg), "deadline exceeded") ||
-		strings.Contains(strings.ToLower(errorMsg), "context deadline"),
+			strings.Contains(strings.ToLower(errorMsg), "deadline exceeded") ||
+			strings.Contains(strings.ToLower(errorMsg), "context deadline"),
 		"Expected timeout-related error, got: %s", errorMsg)
 	require.Nil(t, body)
 	require.Greater(t, elapsed, time.Duration(0))

--- a/control-plane/internal/handlers/execute_async_test.go
+++ b/control-plane/internal/handlers/execute_async_test.go
@@ -198,8 +198,16 @@ func TestAsyncWorkerPoolStopFailsQueuedJobsAndRejectsSubmissions(t *testing.T) {
 	require.NoError(t, store.StoreWorkflowExecution(context.Background(), &types.WorkflowExecution{ExecutionID: exec.ExecutionID, WorkflowID: exec.RunID, RunID: &exec.RunID, AgentNodeID: "node-1", ReasonerID: "reasoner-a", Status: types.ExecutionStatusRunning, StartedAt: now, CreatedAt: now, UpdatedAt: now}))
 	target, err := parseTarget("node-1.reasoner-a")
 	require.NoError(t, err)
+	webhookCalled := false
+	webhooks := &mockWebhookDispatcher{notifyFunc: func(_ context.Context, executionID string) error {
+		require.Equal(t, exec.ExecutionID, executionID)
+		webhookCalled = true
+		return nil
+	}}
+	eventCh := store.GetExecutionEventBus().Subscribe("async-pool-shutdown-test")
+	defer store.GetExecutionEventBus().Unsubscribe("async-pool-shutdown-test")
 	pool := newAsyncWorkerPool(0, 2)
-	require.True(t, pool.submit(asyncExecutionJob{controller: newExecutionController(store, nil, nil, time.Second, ""), plan: preparedExecution{exec: exec, target: target}}))
+	require.True(t, pool.submit(asyncExecutionJob{controller: newExecutionController(store, nil, webhooks, time.Second, ""), plan: preparedExecution{exec: exec, target: target, webhookRegistered: true}}))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -213,6 +221,14 @@ func TestAsyncWorkerPoolStopFailsQueuedJobsAndRejectsSubmissions(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, types.ExecutionStatusFailed, workflow.Status)
 	require.Equal(t, "control_plane_shutdown", *workflow.StatusReason)
+	require.True(t, webhookCalled)
+	select {
+	case event := <-eventCh:
+		require.Equal(t, exec.ExecutionID, event.ExecutionID)
+		require.Equal(t, string(types.ExecutionStatusFailed), event.Status)
+	case <-time.After(time.Second):
+		t.Fatal("expected execution failed event")
+	}
 }
 
 func TestExecuteAsyncHandler_WithWebhook(t *testing.T) {

--- a/control-plane/internal/handlers/execute_async_test.go
+++ b/control-plane/internal/handlers/execute_async_test.go
@@ -186,44 +186,46 @@ func TestWriteExecutionError_ConcurrencyLimitIncludesRetryAfter(t *testing.T) {
 }
 
 func TestAsyncWorkerPoolStopFailsQueuedJobsAndRejectsSubmissions(t *testing.T) {
-	agent := &types.AgentNode{ID: "node-1"}
+	workerStarted := make(chan struct{})
+	releaseWorker := make(chan struct{})
+	agentServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(workerStarted)
+		select {
+		case <-r.Context().Done():
+		case <-releaseWorker:
+		}
+	}))
+	defer agentServer.Close()
+	agent := &types.AgentNode{ID: "node-1", BaseURL: agentServer.URL}
 	store := newTestExecutionStorage(agent)
 	now := time.Now().UTC()
-	exec := &types.Execution{ExecutionID: "queued-1", RunID: "run-1", NodeID: "node-1", AgentNodeID: "node-1", ReasonerID: "reasoner-a", Status: types.ExecutionStatusRunning, CreatedAt: now, StartedAt: now, UpdatedAt: now}
-	require.NoError(t, store.CreateExecutionRecord(context.Background(), exec))
-	require.NoError(t, store.StoreWorkflowExecution(context.Background(), &types.WorkflowExecution{ExecutionID: exec.ExecutionID, WorkflowID: exec.RunID, RunID: &exec.RunID, AgentNodeID: "node-1", ReasonerID: "reasoner-a", Status: types.ExecutionStatusRunning, StartedAt: now, CreatedAt: now, UpdatedAt: now}))
 	target, err := parseTarget("node-1.reasoner-a")
 	require.NoError(t, err)
-	webhookCalled := false
-	webhooks := &mockWebhookDispatcher{notifyFunc: func(_ context.Context, executionID string) error {
-		require.Equal(t, exec.ExecutionID, executionID)
-		webhookCalled = true
-		return nil
-	}}
-	eventCh := store.GetExecutionEventBus().Subscribe("async-pool-shutdown-test")
-	defer store.GetExecutionEventBus().Unsubscribe("async-pool-shutdown-test")
-	pool := newAsyncWorkerPool(0, 2)
-	require.True(t, pool.submit(asyncExecutionJob{controller: newExecutionController(store, nil, webhooks, time.Second, ""), plan: preparedExecution{exec: exec, target: target, webhookRegistered: true}}))
+	pool := newAsyncWorkerPool(1, 2)
+	for _, id := range []string{"running-1", "queued-1"} {
+		exec := &types.Execution{ExecutionID: id, RunID: id, NodeID: "node-1", AgentNodeID: "node-1", ReasonerID: "reasoner-a", Status: types.ExecutionStatusRunning, CreatedAt: now, StartedAt: now, UpdatedAt: now}
+		require.NoError(t, store.CreateExecutionRecord(context.Background(), exec))
+		require.NoError(t, store.StoreWorkflowExecution(context.Background(), &types.WorkflowExecution{ExecutionID: id, WorkflowID: id, RunID: &id, AgentNodeID: "node-1", ReasonerID: "reasoner-a", Status: types.ExecutionStatusRunning, StartedAt: now, CreatedAt: now, UpdatedAt: now}))
+		require.True(t, pool.submit(asyncExecutionJob{controller: newExecutionController(store, nil, nil, time.Second, ""), plan: preparedExecution{exec: exec, target: target, agent: agent, requestBody: []byte(`{"input":{}}`)}}))
+	}
+	<-workerStarted
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	pool.Stop(ctx)
+	close(releaseWorker)
 	require.False(t, pool.submit(asyncExecutionJob{}))
-	stored, err := store.GetExecutionRecord(context.Background(), exec.ExecutionID)
-	require.NoError(t, err)
-	require.Equal(t, types.ExecutionStatusFailed, stored.Status)
-	require.Equal(t, "control_plane_shutdown", *stored.StatusReason)
-	workflow, err := store.GetWorkflowExecution(context.Background(), exec.ExecutionID)
-	require.NoError(t, err)
-	require.Equal(t, types.ExecutionStatusFailed, workflow.Status)
-	require.Equal(t, "control_plane_shutdown", *workflow.StatusReason)
-	require.True(t, webhookCalled)
-	select {
-	case event := <-eventCh:
-		require.Equal(t, exec.ExecutionID, event.ExecutionID)
-		require.Equal(t, string(types.ExecutionStatusFailed), event.Status)
-	case <-time.After(time.Second):
-		t.Fatal("expected execution failed event")
+	for _, id := range []string{"running-1", "queued-1"} {
+		stored, getErr := store.GetExecutionRecord(context.Background(), id)
+		require.NoError(t, getErr)
+		require.Equal(t, types.ExecutionStatusFailed, stored.Status)
+		require.Equal(t, "control_plane_shutdown", *stored.StatusReason)
+		require.NotNil(t, stored.ErrorMessage)
+		require.Contains(t, *stored.ErrorMessage, "control plane shut down")
+		workflow, workflowErr := store.GetWorkflowExecution(context.Background(), id)
+		require.NoError(t, workflowErr)
+		require.Equal(t, types.ExecutionStatusFailed, workflow.Status)
+		require.Equal(t, "control_plane_shutdown", *workflow.StatusReason)
 	}
 }
 

--- a/control-plane/internal/handlers/execute_async_test.go
+++ b/control-plane/internal/handlers/execute_async_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -259,6 +260,42 @@ func TestAsyncWorkerPoolStopFailsQueuedJobsAndRejectsSubmissions(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("expected execution failed event")
 	}
+}
+
+func TestAsyncWorkerPoolStopDoesNotStartQueuedJobsAfterReturn(t *testing.T) {
+	var starts atomic.Int32
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	agentServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if starts.Add(1) == 1 {
+			close(firstStarted)
+			<-releaseFirst
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result":{}}`))
+	}))
+	defer agentServer.Close()
+
+	agent := &types.AgentNode{ID: "node-1", BaseURL: agentServer.URL, Reasoners: []types.ReasonerDefinition{{ID: "reasoner-a"}}}
+	store := newTestExecutionStorage(agent)
+	target, err := parseTarget("node-1.reasoner-a")
+	require.NoError(t, err)
+	pool := newAsyncWorkerPool(1, 8)
+	now := time.Now().UTC()
+	for i := 0; i < 4; i++ {
+		id := fmt.Sprintf("stop-start-%d", i)
+		exec := &types.Execution{ExecutionID: id, RunID: id, NodeID: "node-1", AgentNodeID: "node-1", ReasonerID: "reasoner-a", Status: types.ExecutionStatusRunning, CreatedAt: now, StartedAt: now, UpdatedAt: now}
+		require.NoError(t, store.CreateExecutionRecord(context.Background(), exec))
+		require.NoError(t, store.StoreWorkflowExecution(context.Background(), &types.WorkflowExecution{ExecutionID: id, WorkflowID: id, RunID: &id, AgentNodeID: "node-1", ReasonerID: "reasoner-a", Status: types.ExecutionStatusRunning, StartedAt: now, CreatedAt: now, UpdatedAt: now}))
+		require.True(t, pool.submit(asyncExecutionJob{controller: newExecutionController(store, nil, nil, time.Second, ""), plan: preparedExecution{exec: exec, target: target, agent: agent, requestBody: []byte(`{"input":{}}`)}}))
+	}
+	<-firstStarted
+	stopCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	pool.Stop(stopCtx)
+	require.Equal(t, int32(1), starts.Load())
+	close(releaseFirst)
+	require.Eventually(t, func() bool { return starts.Load() == 1 }, 100*time.Millisecond, 10*time.Millisecond)
 }
 
 func TestExecuteAsyncHandler_WithWebhook(t *testing.T) {

--- a/control-plane/internal/handlers/execute_helpers.go
+++ b/control-plane/internal/handlers/execute_helpers.go
@@ -528,6 +528,12 @@ func writeExecutionError(ctx *gin.Context, err error) {
 		return
 	}
 
+	var maxBytesErr *http.MaxBytesError
+	if errors.As(err, &maxBytesErr) {
+		ctx.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "request body too large"})
+		return
+	}
+
 	var ce *callError
 	if errors.As(err, &ce) {
 		category := classifyCallError(ce, err)

--- a/control-plane/internal/handlers/execute_helpers.go
+++ b/control-plane/internal/handlers/execute_helpers.go
@@ -923,9 +923,10 @@ func (j asyncExecutionJob) processWithContext(workerCtx context.Context) {
 
 func newAsyncWorkerPool(workerCount, queueCapacity int) *asyncWorkerPool {
 	workerCtx, cancelWorkers := context.WithCancel(context.Background())
+	admissionCapacity := workerCount + queueCapacity
 	pool := &asyncWorkerPool{
-		queue:         make(chan asyncExecutionJob, queueCapacity),
-		reservations:  make(chan struct{}, queueCapacity),
+		queue:         make(chan asyncExecutionJob, admissionCapacity),
+		reservations:  make(chan struct{}, admissionCapacity),
 		workerCtx:     workerCtx,
 		cancelWorkers: cancelWorkers,
 	}
@@ -933,18 +934,20 @@ func newAsyncWorkerPool(workerCount, queueCapacity int) *asyncWorkerPool {
 	for i := 0; i < workerCount; i++ {
 		go func(workerID int) {
 			for job := range pool.queue {
-				pool.releaseReservation()
-				pool.mu.RLock()
-				stopped := pool.stopped
-				pool.mu.RUnlock()
-				if stopped {
-					persistCtx, cancel := shutdownPersistenceContext()
-					job.failForControlPlaneShutdown(persistCtx)
-					cancel()
-				} else {
-					job.processWithContext(pool.workerCtx)
-				}
-				pool.jobs.Done()
+				func() {
+					defer pool.releaseReservation()
+					defer pool.jobs.Done()
+					pool.mu.RLock()
+					stopped := pool.stopped
+					pool.mu.RUnlock()
+					if stopped {
+						persistCtx, cancel := shutdownPersistenceContext()
+						job.failForControlPlaneShutdown(persistCtx)
+						cancel()
+					} else {
+						job.processWithContext(pool.workerCtx)
+					}
+				}()
 			}
 		}(i)
 	}

--- a/control-plane/internal/handlers/execute_helpers.go
+++ b/control-plane/internal/handlers/execute_helpers.go
@@ -1013,35 +1013,23 @@ func (j asyncExecutionJob) failForControlPlaneShutdown() {
 	if j.plan.target != nil {
 		ReleaseExecutionSlot(j.plan.target.NodeID)
 	}
-	now := time.Now().UTC()
-	reason := "control_plane_shutdown"
-	message := "execution was not started before the control plane shut down"
-	_, err := j.controller.store.UpdateExecutionRecord(context.Background(), j.plan.exec.ExecutionID, func(current *types.Execution) (*types.Execution, error) {
-		if current == nil {
-			return nil, fmt.Errorf("execution %s not found", j.plan.exec.ExecutionID)
-		}
-		current.Status = types.ExecutionStatusFailed
-		current.StatusReason = &reason
-		current.ErrorMessage = &message
-		current.CompletedAt = &now
-		current.UpdatedAt = now
-		return current, nil
-	})
-	if err != nil {
-		logger.Logger.Error().Err(err).Str("execution_id", j.plan.exec.ExecutionID).Msg("failed to terminate queued execution during shutdown")
+	shutdownErr := &executionPreconditionError{
+		message:  "execution was not started before the control plane shut down",
+		category: ErrorCategoryControlPlaneShutdown,
 	}
+	if err := j.controller.failExecution(context.Background(), &j.plan, shutdownErr, 0, nil); err != nil {
+		logger.Logger.Error().Err(err).Str("execution_id", j.plan.exec.ExecutionID).Msg("failed to terminate queued execution during shutdown")
+		return
+	}
+	reason := string(ErrorCategoryControlPlaneShutdown)
 	if err := j.controller.store.UpdateWorkflowExecution(context.Background(), j.plan.exec.ExecutionID, func(current *types.WorkflowExecution) (*types.WorkflowExecution, error) {
 		if current == nil {
 			return nil, fmt.Errorf("workflow execution %s not found", j.plan.exec.ExecutionID)
 		}
-		current.Status = types.ExecutionStatusFailed
 		current.StatusReason = &reason
-		current.ErrorMessage = &message
-		current.CompletedAt = &now
-		current.UpdatedAt = now
 		return current, nil
 	}); err != nil {
-		logger.Logger.Error().Err(err).Str("execution_id", j.plan.exec.ExecutionID).Msg("failed to terminate queued workflow execution during shutdown")
+		logger.Logger.Error().Err(err).Str("execution_id", j.plan.exec.ExecutionID).Msg("failed to record shutdown reason on queued workflow execution")
 	}
 }
 

--- a/control-plane/internal/handlers/execute_helpers.go
+++ b/control-plane/internal/handlers/execute_helpers.go
@@ -921,7 +921,16 @@ func newAsyncWorkerPool(workerCount, queueCapacity int) *asyncWorkerPool {
 		go func(workerID int) {
 			for job := range pool.queue {
 				pool.releaseReservation()
-				job.process()
+				pool.mu.RLock()
+				stopped := pool.stopped
+				pool.mu.RUnlock()
+				if stopped {
+					persistCtx, cancel := shutdownPersistenceContext(context.Background())
+					job.failForControlPlaneShutdown(persistCtx)
+					cancel()
+				} else {
+					job.process()
+				}
 				pool.jobs.Done()
 			}
 		}(i)
@@ -989,7 +998,10 @@ func StopAsyncWorkerPool(ctx context.Context) {
 // honestly terminates any jobs which have not started.
 func (p *asyncWorkerPool) Stop(ctx context.Context) {
 	p.mu.Lock()
-	p.stopped = true
+	if !p.stopped {
+		p.stopped = true
+		close(p.queue)
+	}
 	p.mu.Unlock()
 
 	done := make(chan struct{})
@@ -1003,19 +1015,29 @@ func (p *asyncWorkerPool) Stop(ctx context.Context) {
 	case <-ctx.Done():
 	}
 
-	for {
-		select {
-		case job := <-p.queue:
-			p.releaseReservation()
-			job.failForControlPlaneShutdown()
-			p.jobs.Done()
-		default:
-			return
-		}
+	persistCtx, cancel := shutdownPersistenceContext(ctx)
+	defer cancel()
+	for job := range p.queue {
+		p.releaseReservation()
+		job.failForControlPlaneShutdown(persistCtx)
+		p.jobs.Done()
 	}
 }
 
-func (j asyncExecutionJob) failForControlPlaneShutdown() {
+func shutdownPersistenceContext(shutdownCtx context.Context) (context.Context, context.CancelFunc) {
+	timeout := 5 * time.Second
+	if deadline, ok := shutdownCtx.Deadline(); ok {
+		if remaining := time.Until(deadline); remaining < timeout {
+			timeout = remaining
+		}
+	}
+	if timeout <= 0 {
+		return context.WithCancel(shutdownCtx)
+	}
+	return context.WithTimeout(context.Background(), timeout)
+}
+
+func (j asyncExecutionJob) failForControlPlaneShutdown(ctx context.Context) {
 	if j.plan.target != nil {
 		ReleaseExecutionSlot(j.plan.target.NodeID)
 	}
@@ -1023,12 +1045,12 @@ func (j asyncExecutionJob) failForControlPlaneShutdown() {
 		message:  "execution was not started before the control plane shut down",
 		category: ErrorCategoryControlPlaneShutdown,
 	}
-	if err := j.controller.failExecution(context.Background(), &j.plan, shutdownErr, 0, nil); err != nil {
+	if err := j.controller.failExecution(ctx, &j.plan, shutdownErr, 0, nil); err != nil {
 		logger.Logger.Error().Err(err).Str("execution_id", j.plan.exec.ExecutionID).Msg("failed to terminate queued execution during shutdown")
 		return
 	}
 	reason := string(ErrorCategoryControlPlaneShutdown)
-	if err := j.controller.store.UpdateWorkflowExecution(context.Background(), j.plan.exec.ExecutionID, func(current *types.WorkflowExecution) (*types.WorkflowExecution, error) {
+	if err := j.controller.store.UpdateWorkflowExecution(ctx, j.plan.exec.ExecutionID, func(current *types.WorkflowExecution) (*types.WorkflowExecution, error) {
 		if current == nil {
 			return nil, fmt.Errorf("workflow execution %s not found", j.plan.exec.ExecutionID)
 		}

--- a/control-plane/internal/handlers/execute_helpers.go
+++ b/control-plane/internal/handlers/execute_helpers.go
@@ -566,6 +566,10 @@ func writeExecutionError(ctx *gin.Context, err error) {
 			body["error"] = code
 			body["message"] = pe.Error()
 		}
+		if pe.Category() == ErrorCategoryConcurrencyLimit {
+			ctx.Header("Retry-After", "1")
+			body["retry_after"] = 1
+		}
 		ctx.JSON(pe.HTTPStatusCode(), body)
 		return
 	}
@@ -903,13 +907,16 @@ func (j asyncExecutionJob) process() {
 
 func newAsyncWorkerPool(workerCount, queueCapacity int) *asyncWorkerPool {
 	pool := &asyncWorkerPool{
-		queue: make(chan asyncExecutionJob, queueCapacity),
+		queue:        make(chan asyncExecutionJob, queueCapacity),
+		reservations: make(chan struct{}, queueCapacity),
 	}
 
 	for i := 0; i < workerCount; i++ {
 		go func(workerID int) {
 			for job := range pool.queue {
+				pool.releaseReservation()
 				job.process()
+				pool.jobs.Done()
 			}
 		}(i)
 	}
@@ -923,19 +930,131 @@ func newAsyncWorkerPool(workerCount, queueCapacity int) *asyncWorkerPool {
 }
 
 func (p *asyncWorkerPool) submit(job asyncExecutionJob) bool {
+	if !p.reserve() {
+		return false
+	}
+	if !p.submitReserved(job) {
+		p.releaseReservation()
+		return false
+	}
+	return true
+}
+
+func (p *asyncWorkerPool) reserve() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.stopped {
+		return false
+	}
 	select {
-	case p.queue <- job:
+	case p.reservations <- struct{}{}:
 		return true
 	default:
 		return false
 	}
 }
 
+func (p *asyncWorkerPool) releaseReservation() {
+	select {
+	case <-p.reservations:
+	default:
+	}
+}
+
+func (p *asyncWorkerPool) submitReserved(job asyncExecutionJob) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.stopped {
+		return false
+	}
+	p.jobs.Add(1)
+	p.queue <- job
+	return true
+}
+
+// StopAsyncWorkerPool prevents new admission and drains the process-wide pool.
+func StopAsyncWorkerPool(ctx context.Context) {
+	if asyncPool != nil {
+		asyncPool.Stop(ctx)
+	}
+}
+
+// Stop rejects new work, lets accepted work finish until ctx expires, then
+// honestly terminates any jobs which have not started.
+func (p *asyncWorkerPool) Stop(ctx context.Context) {
+	p.mu.Lock()
+	p.stopped = true
+	p.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		p.jobs.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return
+	case <-ctx.Done():
+	}
+
+	for {
+		select {
+		case job := <-p.queue:
+			p.releaseReservation()
+			job.failForControlPlaneShutdown()
+			p.jobs.Done()
+		default:
+			return
+		}
+	}
+}
+
+func (j asyncExecutionJob) failForControlPlaneShutdown() {
+	if j.plan.target != nil {
+		ReleaseExecutionSlot(j.plan.target.NodeID)
+	}
+	now := time.Now().UTC()
+	reason := "control_plane_shutdown"
+	message := "execution was not started before the control plane shut down"
+	_, err := j.controller.store.UpdateExecutionRecord(context.Background(), j.plan.exec.ExecutionID, func(current *types.Execution) (*types.Execution, error) {
+		if current == nil {
+			return nil, fmt.Errorf("execution %s not found", j.plan.exec.ExecutionID)
+		}
+		current.Status = types.ExecutionStatusFailed
+		current.StatusReason = &reason
+		current.ErrorMessage = &message
+		current.CompletedAt = &now
+		current.UpdatedAt = now
+		return current, nil
+	})
+	if err != nil {
+		logger.Logger.Error().Err(err).Str("execution_id", j.plan.exec.ExecutionID).Msg("failed to terminate queued execution during shutdown")
+	}
+	if err := j.controller.store.UpdateWorkflowExecution(context.Background(), j.plan.exec.ExecutionID, func(current *types.WorkflowExecution) (*types.WorkflowExecution, error) {
+		if current == nil {
+			return nil, fmt.Errorf("workflow execution %s not found", j.plan.exec.ExecutionID)
+		}
+		current.Status = types.ExecutionStatusFailed
+		current.StatusReason = &reason
+		current.ErrorMessage = &message
+		current.CompletedAt = &now
+		current.UpdatedAt = now
+		return current, nil
+	}); err != nil {
+		logger.Logger.Error().Err(err).Str("execution_id", j.plan.exec.ExecutionID).Msg("failed to terminate queued workflow execution during shutdown")
+	}
+}
+
+func writeAsyncAdmissionError(ctx *gin.Context, status int, message string) {
+	ctx.Header("Retry-After", "1")
+	ctx.JSON(status, gin.H{"error": message, "error_category": "concurrency_limit", "retry_after": 1})
+}
+
 func getAsyncWorkerPool() *asyncWorkerPool {
 	asyncPoolOnce.Do(func() {
-		workerCount := resolveIntFromEnv("AGENTFIELD_EXEC_ASYNC_WORKERS", runtime.NumCPU())
+		workerCount := resolveIntFromEnv("AGENTFIELD_EXEC_ASYNC_WORKERS", max(runtime.NumCPU(), 16))
 		if workerCount <= 0 {
-			workerCount = runtime.NumCPU()
+			workerCount = max(runtime.NumCPU(), 16)
 		}
 
 		queueCapacity := resolveIntFromEnv("AGENTFIELD_EXEC_ASYNC_QUEUE_CAPACITY", 1024)

--- a/control-plane/internal/handlers/execute_helpers.go
+++ b/control-plane/internal/handlers/execute_helpers.go
@@ -834,6 +834,10 @@ func (c *executionController) savePayload(ctx context.Context, data []byte) *str
 }
 
 func (j asyncExecutionJob) process() {
+	j.processWithContext(context.Background())
+}
+
+func (j asyncExecutionJob) processWithContext(workerCtx context.Context) {
 	// Release the per-agent concurrency slot when this job finishes
 	if j.plan.target != nil {
 		defer ReleaseExecutionSlot(j.plan.target.NodeID)
@@ -842,7 +846,7 @@ func (j asyncExecutionJob) process() {
 	// Use a bounded context so that paused executions do not block goroutines
 	// indefinitely if the resume/cancel event is never delivered (e.g. event bus
 	// crash, server restart). 24 hours is generous but prevents permanent leaks.
-	bgCtx, cancel := context.WithTimeout(context.Background(), 24*time.Hour)
+	bgCtx, cancel := context.WithTimeout(workerCtx, 24*time.Hour)
 	defer cancel()
 
 	currentExec, err := j.controller.store.GetExecutionRecord(bgCtx, j.plan.exec.ExecutionID)
@@ -865,6 +869,12 @@ func (j asyncExecutionJob) process() {
 	}
 
 	resultBody, elapsed, asyncAccepted, callErr := j.controller.callAgent(bgCtx, &j.plan)
+	if workerCtx.Err() != nil {
+		persistCtx, persistCancel := shutdownPersistenceContext()
+		j.failForControlPlaneShutdown(persistCtx)
+		persistCancel()
+		return
+	}
 	if callErr == nil && asyncAccepted {
 		logger.Logger.Info().
 			Str("execution_id", j.plan.exec.ExecutionID).
@@ -912,9 +922,12 @@ func (j asyncExecutionJob) process() {
 }
 
 func newAsyncWorkerPool(workerCount, queueCapacity int) *asyncWorkerPool {
+	workerCtx, cancelWorkers := context.WithCancel(context.Background())
 	pool := &asyncWorkerPool{
-		queue:        make(chan asyncExecutionJob, queueCapacity),
-		reservations: make(chan struct{}, queueCapacity),
+		queue:         make(chan asyncExecutionJob, queueCapacity),
+		reservations:  make(chan struct{}, queueCapacity),
+		workerCtx:     workerCtx,
+		cancelWorkers: cancelWorkers,
 	}
 
 	for i := 0; i < workerCount; i++ {
@@ -925,11 +938,11 @@ func newAsyncWorkerPool(workerCount, queueCapacity int) *asyncWorkerPool {
 				stopped := pool.stopped
 				pool.mu.RUnlock()
 				if stopped {
-					persistCtx, cancel := shutdownPersistenceContext(context.Background())
+					persistCtx, cancel := shutdownPersistenceContext()
 					job.failForControlPlaneShutdown(persistCtx)
 					cancel()
 				} else {
-					job.process()
+					job.processWithContext(pool.workerCtx)
 				}
 				pool.jobs.Done()
 			}
@@ -1015,26 +1028,22 @@ func (p *asyncWorkerPool) Stop(ctx context.Context) {
 	case <-ctx.Done():
 	}
 
-	persistCtx, cancel := shutdownPersistenceContext(ctx)
+	p.cancelWorkers()
+	persistCtx, cancel := shutdownPersistenceContext()
 	defer cancel()
 	for job := range p.queue {
 		p.releaseReservation()
 		job.failForControlPlaneShutdown(persistCtx)
 		p.jobs.Done()
 	}
+	select {
+	case <-done:
+	case <-persistCtx.Done():
+	}
 }
 
-func shutdownPersistenceContext(shutdownCtx context.Context) (context.Context, context.CancelFunc) {
-	timeout := 5 * time.Second
-	if deadline, ok := shutdownCtx.Deadline(); ok {
-		if remaining := time.Until(deadline); remaining < timeout {
-			timeout = remaining
-		}
-	}
-	if timeout <= 0 {
-		return context.WithCancel(shutdownCtx)
-	}
-	return context.WithTimeout(context.Background(), timeout)
+func shutdownPersistenceContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 5*time.Second)
 }
 
 func (j asyncExecutionJob) failForControlPlaneShutdown(ctx context.Context) {

--- a/control-plane/internal/handlers/execute_prepare.go
+++ b/control-plane/internal/handlers/execute_prepare.go
@@ -17,22 +17,35 @@ import (
 )
 
 func (c *executionController) prepareExecution(ctx context.Context, ginCtx *gin.Context) (*preparedExecution, error) {
+	return c.prepareExecutionWithAdmission(ctx, ginCtx, false)
+}
+
+func (c *executionController) prepareAsyncExecution(ctx context.Context, ginCtx *gin.Context) (*preparedExecution, error) {
+	return c.prepareExecutionWithAdmission(ctx, ginCtx, true)
+}
+
+func (c *executionController) prepareExecutionWithAdmission(ctx context.Context, ginCtx *gin.Context, acquireSlot bool) (*preparedExecution, error) {
 	targetParam := ginCtx.Param("target")
 	var req ExecuteRequest
 	if err := ginCtx.ShouldBindJSON(&req); err != nil {
 		return nil, fmt.Errorf("invalid request body: %w", err)
 	}
-	return c.prepareExecutionForTarget(
+	return c.prepareExecutionForTargetWithAdmission(
 		ctx,
 		targetParam,
 		req,
 		readExecutionHeaders(ginCtx),
 		middleware.GetVerifiedCallerDID(ginCtx),
 		middleware.GetTargetDID(ginCtx),
+		acquireSlot,
 	)
 }
 
 func (c *executionController) prepareExecutionForTarget(ctx context.Context, targetParam string, req ExecuteRequest, headers executionHeaders, callerDID, targetDID string) (*preparedExecution, error) {
+	return c.prepareExecutionForTargetWithAdmission(ctx, targetParam, req, headers, callerDID, targetDID, false)
+}
+
+func (c *executionController) prepareExecutionForTargetWithAdmission(ctx context.Context, targetParam string, req ExecuteRequest, headers executionHeaders, callerDID, targetDID string, acquireSlot bool) (_ *preparedExecution, retErr error) {
 	target, err := parseTarget(targetParam)
 	if err != nil {
 		return nil, fmt.Errorf("invalid target: %w", err)
@@ -125,6 +138,20 @@ func (c *executionController) prepareExecutionForTarget(ctx context.Context, tar
 		return nil, err
 	}
 	target.TargetType = targetType
+
+	llmEndpoint := extractRequestedLLMEndpoint(req)
+	slotAcquired := false
+	if acquireSlot {
+		if err := CheckExecutionPreconditions(target.NodeID, llmEndpoint); err != nil {
+			return nil, err
+		}
+		slotAcquired = true
+		defer func() {
+			if retErr != nil && slotAcquired {
+				ReleaseExecutionSlot(target.NodeID)
+			}
+		}()
+	}
 
 	runID := headers.runID
 	if runID == "" {
@@ -229,7 +256,7 @@ func (c *executionController) prepareExecutionForTarget(ctx context.Context, tar
 		agent:                   agent,
 		target:                  target,
 		targetType:              targetType,
-		llmEndpoint:             extractRequestedLLMEndpoint(req),
+		llmEndpoint:             llmEndpoint,
 		webhookRegistered:       webhookRegistered,
 		webhookError:            webhookError,
 		callerDID:               callerDID,

--- a/control-plane/internal/handlers/execution_guards.go
+++ b/control-plane/internal/handlers/execution_guards.go
@@ -123,13 +123,14 @@ func ReleaseExecutionSlot(agentNodeID string) {
 type ErrorCategory string
 
 const (
-	ErrorCategoryLLMUnavailable   ErrorCategory = "llm_unavailable"
-	ErrorCategoryConcurrencyLimit ErrorCategory = "concurrency_limit"
-	ErrorCategoryAgentTimeout     ErrorCategory = "agent_timeout"
-	ErrorCategoryAgentError       ErrorCategory = "agent_error"
-	ErrorCategoryAgentUnreachable ErrorCategory = "agent_unreachable"
-	ErrorCategoryBadResponse      ErrorCategory = "bad_response"
-	ErrorCategoryInternal         ErrorCategory = "internal_error"
+	ErrorCategoryLLMUnavailable       ErrorCategory = "llm_unavailable"
+	ErrorCategoryConcurrencyLimit     ErrorCategory = "concurrency_limit"
+	ErrorCategoryAgentTimeout         ErrorCategory = "agent_timeout"
+	ErrorCategoryAgentError           ErrorCategory = "agent_error"
+	ErrorCategoryAgentUnreachable     ErrorCategory = "agent_unreachable"
+	ErrorCategoryBadResponse          ErrorCategory = "bad_response"
+	ErrorCategoryInternal             ErrorCategory = "internal_error"
+	ErrorCategoryControlPlaneShutdown ErrorCategory = "control_plane_shutdown"
 	// ErrorCategoryTargetNotFound marks a call aimed at a node or reasoner
 	// that does not exist. It is the caller's mistake, not an internal fault,
 	// and it is the single most common first-run error: the user runs the

--- a/control-plane/internal/server/server.go
+++ b/control-plane/internal/server/server.go
@@ -757,7 +757,9 @@ func maxExecuteBodyHandler(next http.Handler, limit int64) http.Handler {
 		isExecuteRoute := r.URL.Path == "/api/v1/execute" || strings.HasPrefix(r.URL.Path, "/api/v1/execute/")
 		if r.Method == http.MethodPost && isExecuteRoute {
 			if r.ContentLength > limit {
-				http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
+				w.Header().Set("Content-Type", "application/json; charset=utf-8")
+				w.WriteHeader(http.StatusRequestEntityTooLarge)
+				_, _ = w.Write([]byte(`{"error":"request body too large"}`))
 				return
 			}
 			r.Body = http.MaxBytesReader(w, r.Body, limit)

--- a/control-plane/internal/server/server.go
+++ b/control-plane/internal/server/server.go
@@ -754,7 +754,8 @@ func (s *AgentFieldServer) newHTTPServer(addr string) *http.Server {
 
 func maxExecuteBodyHandler(next http.Handler, limit int64) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/api/v1/execute") {
+		isExecuteRoute := r.URL.Path == "/api/v1/execute" || strings.HasPrefix(r.URL.Path, "/api/v1/execute/")
+		if r.Method == http.MethodPost && isExecuteRoute {
 			if r.ContentLength > limit {
 				http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
 				return

--- a/control-plane/internal/server/server.go
+++ b/control-plane/internal/server/server.go
@@ -782,19 +782,6 @@ func (s *AgentFieldServer) getHTTPServer() *http.Server {
 	return s.httpServer
 }
 
-func (s *AgentFieldServer) shutdownHTTPServer() error {
-	var shutdownTimeout time.Duration
-	if s.config != nil {
-		shutdownTimeout = s.config.AgentField.ShutdownTimeout
-	}
-	if shutdownTimeout <= 0 {
-		shutdownTimeout = 30 * time.Second
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
-	defer cancel()
-	return s.shutdownHTTPServerWithContext(ctx)
-}
-
 func (s *AgentFieldServer) shutdownHTTPServerWithContext(ctx context.Context) error {
 	httpServer := s.getHTTPServer()
 	if httpServer == nil {

--- a/control-plane/internal/server/server.go
+++ b/control-plane/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -713,10 +714,7 @@ func (s *AgentFieldServer) Start() error {
 
 	// Start HTTP server (using net/http.Server for graceful shutdown support)
 	addr := ":" + strconv.Itoa(s.config.AgentField.Port)
-	httpServer := &http.Server{
-		Addr:    addr,
-		Handler: s.Router,
-	}
+	httpServer := s.newHTTPServer(addr)
 	if !s.setHTTPServer(httpServer) {
 		return nil
 	}
@@ -733,6 +731,38 @@ func (s *AgentFieldServer) Start() error {
 		return fmt.Errorf("failed to start HTTP server on %s: %w", addr, err)
 	}
 	return nil
+}
+
+func (s *AgentFieldServer) newHTTPServer(addr string) *http.Server {
+	maxExecuteBodyBytes := int64(32 << 20)
+	if raw := strings.TrimSpace(os.Getenv("AGENTFIELD_MAX_EXECUTE_BODY_BYTES")); raw != "" {
+		if parsed, err := strconv.ParseInt(raw, 10, 64); err == nil && parsed > 0 {
+			maxExecuteBodyBytes = parsed
+		} else {
+			logger.Logger.Warn().Str("value", raw).Msg("invalid AGENTFIELD_MAX_EXECUTE_BODY_BYTES; using 32 MiB")
+		}
+	}
+	handler := maxExecuteBodyHandler(s.Router, maxExecuteBodyBytes)
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		MaxHeaderBytes:    1 << 20,
+	}
+}
+
+func maxExecuteBodyHandler(next http.Handler, limit int64) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/api/v1/execute") {
+			if r.ContentLength > limit {
+				http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
+				return
+			}
+			r.Body = http.MaxBytesReader(w, r.Body, limit)
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 func (s *AgentFieldServer) setHTTPServer(httpServer *http.Server) bool {
@@ -752,11 +782,6 @@ func (s *AgentFieldServer) getHTTPServer() *http.Server {
 }
 
 func (s *AgentFieldServer) shutdownHTTPServer() error {
-	httpServer := s.getHTTPServer()
-	if httpServer == nil {
-		return nil
-	}
-
 	var shutdownTimeout time.Duration
 	if s.config != nil {
 		shutdownTimeout = s.config.AgentField.ShutdownTimeout
@@ -766,6 +791,14 @@ func (s *AgentFieldServer) shutdownHTTPServer() error {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
+	return s.shutdownHTTPServerWithContext(ctx)
+}
+
+func (s *AgentFieldServer) shutdownHTTPServerWithContext(ctx context.Context) error {
+	httpServer := s.getHTTPServer()
+	if httpServer == nil {
+		return nil
+	}
 	if err := httpServer.Shutdown(ctx); err != nil {
 		logger.Logger.Error().Err(err).Msg("HTTP server shutdown timed out, forcing close")
 		_ = httpServer.Close()
@@ -839,7 +872,14 @@ func (s *AgentFieldServer) Stop() error {
 	s.stopping = true
 	s.httpServerMu.Unlock()
 
-	httpShutdownErr := s.shutdownHTTPServer()
+	shutdownTimeout := 30 * time.Second
+	if s.config != nil && s.config.AgentField.ShutdownTimeout > 0 {
+		shutdownTimeout = s.config.AgentField.ShutdownTimeout
+	}
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancelShutdown()
+	httpShutdownErr := s.shutdownHTTPServerWithContext(shutdownCtx)
+	handlers.StopAsyncWorkerPool(shutdownCtx)
 
 	if s.adminGRPCServer != nil {
 		s.adminGRPCServer.GracefulStop()

--- a/control-plane/internal/server/server_ingress_test.go
+++ b/control-plane/internal/server/server_ingress_test.go
@@ -31,6 +31,7 @@ func TestMaxExecuteBodyHandlerRejectsOversizeBeforeHandler(t *testing.T) {
 	resp := httptest.NewRecorder()
 	handler.ServeHTTP(resp, req)
 	require.Equal(t, http.StatusRequestEntityTooLarge, resp.Code)
+	require.JSONEq(t, `{"error":"request body too large"}`, resp.Body.String())
 	require.False(t, called)
 }
 

--- a/control-plane/internal/server/server_ingress_test.go
+++ b/control-plane/internal/server/server_ingress_test.go
@@ -45,4 +45,10 @@ func TestMaxExecuteBodyHandlerDoesNotCapOtherRoutes(t *testing.T) {
 	handler.ServeHTTP(resp, req)
 	require.Equal(t, http.StatusOK, resp.Code)
 	require.Equal(t, "12345", resp.Body.String())
+
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/executions/abc/status", strings.NewReader("12345"))
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code)
+	require.Equal(t, "12345", resp.Body.String())
 }

--- a/control-plane/internal/server/server_ingress_test.go
+++ b/control-plane/internal/server/server_ingress_test.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPServerIngressTimeoutsDoNotSetStreamWriteTimeout(t *testing.T) {
+	s := &AgentFieldServer{Router: gin.New()}
+	httpServer := s.newHTTPServer(":0")
+	require.Equal(t, 10*time.Second, httpServer.ReadHeaderTimeout)
+	require.Equal(t, 120*time.Second, httpServer.IdleTimeout)
+	require.Equal(t, 1<<20, httpServer.MaxHeaderBytes)
+	require.Zero(t, httpServer.ReadTimeout)
+	require.Zero(t, httpServer.WriteTimeout)
+}
+
+func TestMaxExecuteBodyHandlerRejectsOversizeBeforeHandler(t *testing.T) {
+	called := false
+	handler := maxExecuteBodyHandler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		called = true
+	}), 4)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/execute/async/node.reasoner", strings.NewReader("12345"))
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusRequestEntityTooLarge, resp.Code)
+	require.False(t, called)
+}
+
+func TestMaxExecuteBodyHandlerDoesNotCapOtherRoutes(t *testing.T) {
+	handler := maxExecuteBodyHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		_, _ = w.Write(body)
+	}), 4)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/logs", strings.NewReader("12345"))
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code)
+	require.Equal(t, "12345", resp.Body.String())
+}

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -112,8 +112,9 @@ The telemetry payload does not include prompts, inputs, outputs, logs, secrets, 
 ### Miscellaneous control-plane knobs
 
 - `AGENTFIELD_MAX_CONCURRENT_PER_AGENT` (default: `0`): Maximum concurrent executions dispatched to one agent; `0` means unlimited.
-- `AGENTFIELD_EXEC_ASYNC_WORKERS` (default: number of CPUs): Worker count for asynchronous execution and restart jobs; non-positive values use the default.
-- `AGENTFIELD_EXEC_ASYNC_QUEUE_CAPACITY` (default: `1024`): In-memory asynchronous execution queue capacity; non-positive values use the default.
+- `AGENTFIELD_EXEC_ASYNC_WORKERS` (default: the greater of the available CPU count and `16`): Worker count for asynchronous execution and restart jobs, which are I/O-bound; non-positive values use the default.
+- `AGENTFIELD_EXEC_ASYNC_QUEUE_CAPACITY` (default: `1024`): Maximum number of asynchronous executions waiting for a worker; non-positive values use the default. Requests arriving once the queue is saturated are rejected with `503`, a `Retry-After` header and a `retry_after` field, and no execution row is persisted for them.
+- `AGENTFIELD_MAX_EXECUTE_BODY_BYTES` (default: `33554432`, 32 MiB): Maximum request body size, in bytes, for POST routes under `/api/v1/execute`. Oversize requests are rejected with `413` before any execution is persisted; other routes are not capped by this setting.
 - `AGENTFIELD_SHUTDOWN_TIMEOUT` (default: `30s`): Grace period for draining the control plane HTTP server during shutdown.
 - `AGENTFIELD_AGENT_RESTART_GRACE` (default: `15s`): How long an execution waits for an agent process to return during a coordinated restart; a negative duration disables the wait.
 


### PR DESCRIPTION
## Summary

Bug half of #986 (the queueing semantics themselves are a separate product decision and are unchanged here — `max_concurrent_per_agent` still releases its slot on the agent's 202 ACK).

- **A rejected async execute no longer costs more I/O than an accepted one.** `handleAsync` used to run `prepareExecution` — payload file, `executions` row (status hardcoded `running`), `workflow_executions` row — and only then check the per-agent capacity gate, then `failExecution` (another payload write, up to five update attempts, webhook). A 300-request burst against a capped agent left ~300 orphan payload files and ~600 doomed rows for zero work. The capacity gate (and LLM-health precondition) now runs inside preparation *before* any persistence, mirroring the dead-node gate that already did this with a comment explaining exactly why; every later error path releases the slot.
- **Queue saturation is known before preparation** (queue reservations), so the 503 also writes nothing.
- **429 and 503 carry `Retry-After: 1`** and a `retry_after` field (the rate-limit middleware already did this); the sync lane's 429 too.
- **The async worker pool can be stopped.** It had `submit` and nothing else; `AgentFieldServer.Stop()` drained only HTTP handlers, so a control-plane redeploy silently dropped up to 1024 queued executions whose rows stayed `running`. `Stop(ctx)` now rejects new work, lets in-flight jobs finish within the shared `AGENTFIELD_SHUTDOWN_TIMEOUT` budget, and fails still-queued jobs through the normal failure path (`status_reason: control_plane_shutdown`, webhook + `execution.failed` event fire).
- **Worker default `max(NumCPU, 16)`** — workers are I/O-bound and each blocks for a whole agent call; on a 2-vCPU pod two slow executions wedged the entire async lane. `AGENTFIELD_EXEC_ASYNC_WORKERS` / `_QUEUE_CAPACITY` unchanged.
- **Ingress hardening**: `ReadHeaderTimeout` 10 s, `IdleTimeout` 120 s, `MaxHeaderBytes` 1 MiB — deliberately no `ReadTimeout`/`WriteTimeout` (SSE/WebSocket) — and a 32 MiB body cap (`AGENTFIELD_MAX_EXECUTE_BODY_BYTES`) on `/api/v1/execute` and `/api/v1/execute/*` only (explicitly *not* `/api/v1/executions/*`, where agent status callbacks carry results).

## Validation contract → tests

1. 429 at capacity: `Retry-After`, `concurrency_limit`, `retry_after`, and **zero** execution rows / workflow rows / payload files / webhooks — `TestExecuteAsyncHandler_ConcurrencyRejectionHasNoPersistence` (holds `maxPerAgent=1`, the original bug shape)
2. 503 when the queue is full, same guarantees — `TestExecuteAsyncHandler_QueueFullHasNoPersistence`
3. Sync-lane 429 carries `Retry-After` — `TestWriteExecutionError_ConcurrencyLimitIncludesRetryAfter`
4. Dead-node / LLM-health ordering unchanged — existing `TestCheckExecutionPreconditions_*` and `node_unavailable` tests, untouched
5. Pool `Stop`: rejects new submissions, queued jobs end `failed` / `control_plane_shutdown` on both tables with webhook + event — `TestAsyncWorkerPoolStopFailsQueuedJobsAndRejectsSubmissions`
6. No stream write timeout; header/idle limits set — `TestHTTPServerIngressTimeoutsDoNotSetStreamWriteTimeout`
7. Oversize execute body → 413 before the handler; `/api/v1/executions/:id/status` and log ingest are **not** capped — `TestMaxExecuteBodyHandlerRejectsOversizeBeforeHandler`, `TestMaxExecuteBodyHandlerDoesNotCapOtherRoutes`

## Test plan

- [x] `cd control-plane && go build ./... && go test ./... -count=1` (62 packages)
- [x] `gofmt -l` on touched files: clean
- [x] `git diff --check`: clean

Refs #986 #983

🤖 Generated with [Claude Code](https://claude.com/claude-code)