### PR TITLE
ci(sdk/python): make the uv lock drift check advisory until releases relock

### DIFF
--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -33,8 +33,13 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
 
-      - name: Check dependency lock
+      # Advisory until the release workflow regenerates uv.lock when it bumps
+      # pyproject.toml: every "chore(release)" commit changes the project
+      # version without touching the lock, so a blocking check fails on every
+      # open PR after each release candidate.
+      - name: Check dependency lock (advisory)
         working-directory: sdk/python
+        continue-on-error: true
         run: uv lock --check
 
       - name: Install dependencies


### PR DESCRIPTION
## Why

The lock-drift gate added in #999 (`uv lock --check` in `sdk-python.yml`) blocks every open Python PR as soon as the release workflow cuts the next rc: the release commit bumps `sdk/python/pyproject.toml` (main is at `0.1.137-rc.7`) but never regenerates `uv.lock` (still `0.1.137rc3`), and PR checks run on the merge ref. #1002 and #1006 are red for exactly this reason right now.

## What

Mark the step `continue-on-error: true` so drift stays visible in the job log without blocking.

## Follow-up (the real fix)

Make the release workflow's version-bump step run `uv lock` in `sdk/python` and include `uv.lock` in the `chore(release)` commit, then drop `continue-on-error` here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)