### PR TITLE
fix: end SSE streams on shutdown so af server exits promptly; restore Go SDK notify-then-drain order

### DIFF
--- a/control-plane/cmd/af/main.go
+++ b/control-plane/cmd/af/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -258,6 +259,10 @@ func drainOnShutdown(ctx context.Context, stopSignals func(), stop func() error)
 	}
 	fmt.Println("\nShutdown signal received, draining connections...")
 	if err := stop(); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			log.Printf("Warning: shutdown drain timed out; forced close completed: %v", err)
+			return nil
+		}
 		return err
 	}
 	fmt.Println("Server stopped gracefully.")

--- a/control-plane/cmd/af/main_test.go
+++ b/control-plane/cmd/af/main_test.go
@@ -156,3 +156,11 @@ func TestDrainOnShutdownPropagatesStopError(t *testing.T) {
 		t.Fatalf("got %v, want %v", err, want)
 	}
 }
+
+func TestDrainOnShutdownTreatsTimeoutAsSuccessfulExit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.NoError(t, drainOnShutdown(ctx, nil, func() error {
+		return context.DeadlineExceeded
+	}))
+}

--- a/control-plane/cmd/agentfield-server/main.go
+++ b/control-plane/cmd/agentfield-server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -260,11 +261,20 @@ func runServer(cmd *cobra.Command, args []string) {
 
 	// Graceful shutdown
 	fmt.Println("\nShutdown signal received, draining connections...")
-	if err := agentfieldServer.Stop(); err != nil {
+	if err := finishShutdown(agentfieldServer.Stop); err != nil {
 		log.Printf("Error during shutdown: %v", err)
 		os.Exit(1)
 	}
 	fmt.Println("Server stopped gracefully.")
+}
+
+func finishShutdown(stop func() error) error {
+	err := stop()
+	if errors.Is(err, context.DeadlineExceeded) {
+		log.Printf("Warning: shutdown drain timed out; forced close completed: %v", err)
+		return nil
+	}
+	return err
 }
 
 // loadConfig loads configuration from file and environment variables.

--- a/control-plane/cmd/agentfield-server/main_test.go
+++ b/control-plane/cmd/agentfield-server/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -17,6 +18,19 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
+
+func TestFinishShutdownTreatsTimeoutAsSuccessfulExit(t *testing.T) {
+	if err := finishShutdown(func() error { return context.DeadlineExceeded }); err != nil {
+		t.Fatalf("timeout should be a successful shutdown exit: %v", err)
+	}
+}
+
+func TestFinishShutdownPropagatesGenuineFailure(t *testing.T) {
+	want := errors.New("close failed")
+	if err := finishShutdown(func() error { return want }); !errors.Is(err, want) {
+		t.Fatalf("got %v, want %v", err, want)
+	}
+}
 
 func TestLoadConfig_DefaultsApplied(t *testing.T) {
 	t.Setenv("AGENTFIELD_PORT", "")

--- a/control-plane/internal/config/config.go
+++ b/control-plane/internal/config/config.go
@@ -727,10 +727,14 @@ func ApplyEnvOverrides(cfg *Config) {
 		}
 	}
 
-	// Shutdown timeout override
+	// Shutdown timeout override. The SDKs accept bare seconds ("30") as well
+	// as Go durations ("30s", "5m") for the same variable name, so accept both
+	// here too instead of silently keeping the default.
 	if val := os.Getenv("AGENTFIELD_SHUTDOWN_TIMEOUT"); val != "" {
-		if d, err := time.ParseDuration(val); err == nil {
+		if d, ok := parseShutdownTimeout(val); ok {
 			cfg.AgentField.ShutdownTimeout = d
+		} else {
+			fmt.Fprintf(os.Stderr, "Warning: invalid AGENTFIELD_SHUTDOWN_TIMEOUT=%q; keeping %s\n", val, cfg.AgentField.ShutdownTimeout)
 		}
 	}
 
@@ -1062,4 +1066,18 @@ func splitEnvCSV(value string) []string {
 		}
 	}
 	return out
+}
+
+// parseShutdownTimeout parses a shutdown budget given as a Go duration or as
+// bare seconds; non-positive values are rejected.
+func parseShutdownTimeout(val string) (time.Duration, bool) {
+	val = strings.TrimSpace(val)
+	if d, err := time.ParseDuration(val); err == nil {
+		return d, d > 0
+	}
+	if secs, err := strconv.ParseFloat(val, 64); err == nil {
+		d := time.Duration(secs * float64(time.Second))
+		return d, d > 0
+	}
+	return 0, false
 }

--- a/control-plane/internal/config/config_additional_test.go
+++ b/control-plane/internal/config/config_additional_test.go
@@ -661,3 +661,20 @@ func TestAgentDrainGraceFromEnvironment(t *testing.T) {
 		t.Fatalf("expected 75s drain grace, got %s", cfg.AgentField.NodeHealth.AgentDrainGrace)
 	}
 }
+
+func TestShutdownTimeoutEnvAcceptsBareSecondsLikeTheSDKs(t *testing.T) {
+	t.Setenv("AGENTFIELD_SHUTDOWN_TIMEOUT", "20")
+	cfg := &Config{}
+	ApplyDefaults(cfg)
+	ApplyEnvOverrides(cfg)
+	if cfg.AgentField.ShutdownTimeout != 20*time.Second {
+		t.Fatalf("expected 20s from bare seconds, got %v", cfg.AgentField.ShutdownTimeout)
+	}
+	t.Setenv("AGENTFIELD_SHUTDOWN_TIMEOUT", "nonsense")
+	cfg = &Config{}
+	ApplyDefaults(cfg)
+	ApplyEnvOverrides(cfg)
+	if cfg.AgentField.ShutdownTimeout != 30*time.Second {
+		t.Fatalf("expected the 30s default to survive an invalid value, got %v", cfg.AgentField.ShutdownTimeout)
+	}
+}

--- a/control-plane/internal/handlers/stream_context.go
+++ b/control-plane/internal/handlers/stream_context.go
@@ -1,0 +1,25 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/gin-gonic/gin"
+)
+
+// WithStreamContext makes a streaming handler stop when either its client
+// disconnects or the server begins shutting down.
+func WithStreamContext(streamCtx context.Context, handler gin.HandlerFunc) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, cancel := context.WithCancel(c.Request.Context())
+		defer cancel()
+		go func() {
+			select {
+			case <-streamCtx.Done():
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
+		c.Request = c.Request.WithContext(ctx)
+		handler(c)
+	}
+}

--- a/control-plane/internal/handlers/stream_context_test.go
+++ b/control-plane/internal/handlers/stream_context_test.go
@@ -1,0 +1,37 @@
+package handlers
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithStreamContextEndsHandlerWhenServerContextIsCancelled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	streamCtx, cancelStream := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	done := make(chan struct{})
+	router := gin.New()
+	router.GET("/events", WithStreamContext(streamCtx, func(c *gin.Context) {
+		close(started)
+		<-c.Request.Context().Done()
+		close(done)
+	}))
+
+	go router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/events", nil))
+	<-started
+	cancelStream()
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+}

--- a/control-plane/internal/server/graceful_shutdown_test.go
+++ b/control-plane/internal/server/graceful_shutdown_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bufio"
 	"context"
 	"net"
 	"net/http"
@@ -8,8 +9,88 @@ import (
 	"time"
 
 	"github.com/Agent-Field/agentfield/control-plane/internal/config"
+	"github.com/Agent-Field/agentfield/control-plane/internal/handlers"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
+
+func TestStopCancelsSSEBeforeHTTPDrain(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	streamCtx, cancelStreams := context.WithCancel(context.Background())
+	router := gin.New()
+	router.GET("/events", handlers.WithStreamContext(streamCtx, func(c *gin.Context) {
+		c.Header("Content-Type", "text/event-stream")
+		_, _ = c.Writer.Write([]byte("event: connected\ndata: {}\n\n"))
+		c.Writer.Flush()
+		<-c.Request.Context().Done()
+	}))
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	httpServer := &http.Server{Handler: router}
+	srv := &AgentFieldServer{
+		config:        &config.Config{},
+		httpServer:    httpServer,
+		streamCtx:     streamCtx,
+		cancelStreams: cancelStreams,
+	}
+	go func() { _ = httpServer.Serve(ln) }()
+
+	resp, err := http.Get("http://" + ln.Addr().String() + "/events")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	line, err := bufio.NewReader(resp.Body).ReadString('\n')
+	require.NoError(t, err)
+	require.Equal(t, "event: connected\n", line)
+
+	started := time.Now()
+	require.NoError(t, srv.Stop())
+	require.Less(t, time.Since(started), time.Second)
+}
+
+func TestStopAllowsNonStreamingRequestToCompleteWithinBudget(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	httpServer := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(requestStarted)
+		<-releaseRequest
+		w.WriteHeader(http.StatusNoContent)
+	})}
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := &AgentFieldServer{
+		config:     &config.Config{AgentField: config.AgentFieldConfig{ShutdownTimeout: time.Second}},
+		httpServer: httpServer,
+	}
+	go func() { _ = httpServer.Serve(ln) }()
+	requestDone := make(chan error, 1)
+	go func() {
+		resp, requestErr := http.Get("http://" + ln.Addr().String())
+		if requestErr == nil {
+			_ = resp.Body.Close()
+		}
+		requestDone <- requestErr
+	}()
+	<-requestStarted
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		close(releaseRequest)
+	}()
+
+	require.NoError(t, srv.Stop())
+	require.NoError(t, <-requestDone)
+}
+
+func TestAsyncDrainContextGetsFreshMinimumBudget(t *testing.T) {
+	expired, cancelExpired := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancelExpired()
+
+	ctx, cancel := asyncDrainContext(expired)
+	defer cancel()
+	deadline, ok := ctx.Deadline()
+	require.True(t, ok)
+	require.GreaterOrEqual(t, time.Until(deadline), 4900*time.Millisecond)
+	require.NoError(t, ctx.Err())
+}
 
 func TestStopGracefulShutdownOnEmptyServer(t *testing.T) {
 	// Stop() should not panic on a zero-value server (all fields nil)

--- a/control-plane/internal/server/routes_core.go
+++ b/control-plane/internal/server/routes_core.go
@@ -132,7 +132,7 @@ func (s *AgentFieldServer) registerCoreRoutes(agentAPI *gin.RouterGroup) {
 	// pattern as POST /executions/batch-status); gin matches static first.
 	agentAPI.GET("/executions/active", handlers.ActiveExecutionsHandler(s.storage))
 	agentAPI.GET("/executions/:execution_id", handlers.GetExecutionStatusHandler(s.storage))
-	agentAPI.GET("/executions/:execution_id/events", handlers.StreamExecutionEventsHandler(s.storage))
+	agentAPI.GET("/executions/:execution_id/events", s.streamHandler(handlers.StreamExecutionEventsHandler(s.storage)))
 	agentAPI.POST("/executions/batch-status", handlers.BatchExecutionStatusHandler(s.storage))
 	agentAPI.POST("/executions/:execution_id/status", handlers.UpdateExecutionStatusHandler(s.storage, s.payloadStore, s.webhookDispatcher, s.config.AgentField.ExecutionQueue.AgentCallTimeout))
 	agentAPI.POST("/executions/:execution_id/logs", handlers.StructuredExecutionLogsHandler(s.storage, func() config.ExecutionLogsConfig {

--- a/control-plane/internal/server/routes_memory.go
+++ b/control-plane/internal/server/routes_memory.go
@@ -48,7 +48,7 @@ func (s *AgentFieldServer) registerMemoryRoutes(agentAPI *gin.RouterGroup) {
 		// Memory events endpoints
 		memoryEventsHandler := handlers.NewMemoryEventsHandler(s.storage)
 		memoryGroup.GET("/events/ws", memoryEventsHandler.WebSocketHandler)
-		memoryGroup.GET("/events/sse", memoryEventsHandler.SSEHandler)
+		memoryGroup.GET("/events/sse", s.streamHandler(memoryEventsHandler.SSEHandler))
 		memoryGroup.GET("/events/history", handlers.GetEventHistoryHandler(s.storage))
 	}
 }

--- a/control-plane/internal/server/routes_triggers.go
+++ b/control-plane/internal/server/routes_triggers.go
@@ -39,7 +39,7 @@ func (s *AgentFieldServer) registerTriggerRoutes(agentAPI *gin.RouterGroup) {
 	triggers.GET("/:trigger_id/secret-status", s.triggerHandlers.GetSecretStatus())
 	triggers.POST("/:trigger_id/test", s.triggerHandlers.TestTrigger())
 	// SSE: live inbound-event stream for one trigger.
-	triggers.GET("/:trigger_id/events/stream", s.triggerHandlers.StreamTriggerEvents())
+	triggers.GET("/:trigger_id/events/stream", s.streamHandler(s.triggerHandlers.StreamTriggerEvents()))
 
 	// Plugin catalog — UI uses this to render the "new trigger" form.
 	agentAPI.GET("/sources", handlers.ListSourcesHandler())

--- a/control-plane/internal/server/routes_ui.go
+++ b/control-plane/internal/server/routes_ui.go
@@ -136,7 +136,7 @@ func (s *AgentFieldServer) registerUIAPI() {
 		{
 			uiNodesHandler := ui.NewNodesHandler(s.uiService)
 			nodes.GET("/summary", uiNodesHandler.GetNodesSummaryHandler)
-			nodes.GET("/events", uiNodesHandler.StreamNodeEventsHandler)
+			nodes.GET("/events", s.streamHandler(uiNodesHandler.StreamNodeEventsHandler))
 
 			// Unified status endpoints
 			nodes.GET("/:nodeId/status", uiNodesHandler.GetNodeStatusHandler)
@@ -190,7 +190,7 @@ func (s *AgentFieldServer) registerUIAPI() {
 			executions.GET("/summary", uiExecutionsHandler.GetExecutionsSummaryHandler)
 			executions.GET("/stats", uiExecutionsHandler.GetExecutionStatsHandler)
 			executions.GET("/enhanced", uiExecutionsHandler.GetEnhancedExecutionsHandler)
-			executions.GET("/events", uiExecutionsHandler.StreamExecutionEventsHandler)
+			executions.GET("/events", s.streamHandler(uiExecutionsHandler.StreamExecutionEventsHandler))
 
 			// Timeline endpoint for hourly aggregated data
 			timelineHandler := ui.NewExecutionTimelineHandler(s.storage)
@@ -217,7 +217,7 @@ func (s *AgentFieldServer) registerUIAPI() {
 				return s.config.AgentField.ExecutionLogs
 			})
 			executions.GET("/:execution_id/logs", execLogsHandler.GetExecutionLogsHandler)
-			executions.GET("/:execution_id/logs/stream", execLogsHandler.StreamExecutionLogsHandler)
+			executions.GET("/:execution_id/logs/stream", s.streamHandler(execLogsHandler.StreamExecutionLogsHandler))
 
 			// DID and VC management endpoints for executions
 			didHandler := ui.NewDIDHandler(s.storage, s.didService, s.vcService, s.didWebService)
@@ -267,7 +267,7 @@ func (s *AgentFieldServer) registerUIAPI() {
 
 			// Workflow notes SSE streaming
 			workflowNotesHandler := ui.NewExecutionHandler(s.storage, s.payloadStore, s.webhookDispatcher)
-			workflows.GET("/:workflowId/notes/events", workflowNotesHandler.StreamWorkflowNodeNotesHandler)
+			workflows.GET("/:workflowId/notes/events", s.streamHandler(workflowNotesHandler.StreamWorkflowNodeNotesHandler))
 		}
 
 		// Reasoners management group
@@ -275,7 +275,7 @@ func (s *AgentFieldServer) registerUIAPI() {
 		{
 			reasonersHandler := ui.NewReasonersHandler(s.storage)
 			reasoners.GET("/all", reasonersHandler.GetAllReasonersHandler)
-			reasoners.GET("/events", reasonersHandler.StreamReasonerEventsHandler)
+			reasoners.GET("/events", s.streamHandler(reasonersHandler.StreamReasonerEventsHandler))
 			reasoners.GET("/:reasonerId/details", reasonersHandler.GetReasonerDetailsHandler)
 			reasoners.GET("/:reasonerId/metrics", reasonersHandler.GetPerformanceMetricsHandler)
 			reasoners.GET("/:reasonerId/executions", reasonersHandler.GetExecutionHistoryHandler)

--- a/control-plane/internal/server/server.go
+++ b/control-plane/internal/server/server.go
@@ -113,9 +113,12 @@ type AgentFieldServer struct {
 	// Native scope-aware RAG knowledge store (embed-on-write/search).
 	knowledgeService *knowledge.Service
 	// HTTP server for graceful shutdown support
-	httpServerMu sync.RWMutex
-	httpServer   *http.Server
-	stopping     bool
+	httpServerMu      sync.RWMutex
+	httpServer        *http.Server
+	stopping          bool
+	streamCtx         context.Context
+	cancelStreams     context.CancelFunc
+	cancelStreamsOnce sync.Once
 }
 
 // newRouter builds the gin engine the control plane serves from, with the
@@ -557,6 +560,7 @@ func NewAgentFieldServer(cfg *config.Config) (*AgentFieldServer, error) {
 		Msg("knowledge store embedding provider initialized")
 	knowledgeService := knowledge.NewService(storageProvider, embedder)
 
+	streamCtx, cancelStreams := context.WithCancel(context.Background())
 	return &AgentFieldServer{
 		storage:                storageProvider,
 		cache:                  cacheProvider,
@@ -588,6 +592,8 @@ func NewAgentFieldServer(cfg *config.Config) (*AgentFieldServer, error) {
 		observabilityForwarder: observabilityForwarder,
 		executionTracer:        executionTracer,
 		tracerShutdown:         tracerShutdown,
+		streamCtx:              streamCtx,
+		cancelStreams:          cancelStreams,
 		telemetryService:       telemetryService,
 		registryWatcherCancel:  nil,
 		adminGRPCPort:          adminPort,
@@ -908,6 +914,11 @@ func (s *AgentFieldServer) Stop() error {
 	s.httpServerMu.Lock()
 	s.stopping = true
 	s.httpServerMu.Unlock()
+	s.cancelStreamsOnce.Do(func() {
+		if s.cancelStreams != nil {
+			s.cancelStreams()
+		}
+	})
 
 	shutdownTimeout := 30 * time.Second
 	if s.config != nil && s.config.AgentField.ShutdownTimeout > 0 {
@@ -916,7 +927,9 @@ func (s *AgentFieldServer) Stop() error {
 	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancelShutdown()
 	httpShutdownErr := s.shutdownHTTPServerWithContext(shutdownCtx)
-	handlers.StopAsyncWorkerPool(shutdownCtx)
+	asyncCtx, cancelAsync := asyncDrainContext(shutdownCtx)
+	handlers.StopAsyncWorkerPool(asyncCtx)
+	cancelAsync()
 
 	if s.adminGRPCServer != nil {
 		s.adminGRPCServer.GracefulStop()
@@ -1018,6 +1031,25 @@ func (s *AgentFieldServer) Stop() error {
 
 	// TODO: Implement graceful shutdown for WebSocket
 	return httpShutdownErr
+}
+
+func (s *AgentFieldServer) streamHandler(handler gin.HandlerFunc) gin.HandlerFunc {
+	if s.streamCtx == nil {
+		s.streamCtx, s.cancelStreams = context.WithCancel(context.Background())
+	}
+	return handlers.WithStreamContext(s.streamCtx, handler)
+}
+
+func asyncDrainContext(shutdownCtx context.Context) (context.Context, context.CancelFunc) {
+	budget := 5 * time.Second
+	if deadline, ok := shutdownCtx.Deadline(); ok {
+		if remaining := time.Until(deadline); remaining > budget {
+			budget = remaining
+		}
+	}
+	// The async pool always gets a useful drain window, so total shutdown may
+	// exceed AGENTFIELD_SHUTDOWN_TIMEOUT by up to five seconds.
+	return context.WithTimeout(context.Background(), budget)
 }
 
 // setupRoutes composes the full HTTP surface by delegating to focused

--- a/deployments/helm/agentfield/templates/control-plane-deployment.yaml
+++ b/deployments/helm/agentfield/templates/control-plane-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: {{ .Values.controlPlane.terminationGracePeriodSeconds }}
       {{- with .Values.controlPlane.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/deployments/helm/agentfield/templates/demo-agent-deployment.yaml
+++ b/deployments/helm/agentfield/templates/demo-agent-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         {{- include "agentfield.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: demo-agent
     spec:
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: {{ .Values.demoAgent.terminationGracePeriodSeconds }}
       initContainers:
         - name: wait-control-plane
           image: curlimages/curl:8.12.1

--- a/deployments/helm/agentfield/templates/demo-python-agent-deployment.yaml
+++ b/deployments/helm/agentfield/templates/demo-python-agent-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         {{- include "agentfield.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: demo-python-agent
     spec:
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: {{ .Values.demoPythonAgent.terminationGracePeriodSeconds }}
       initContainers:
         - name: wait-control-plane
           image: curlimages/curl:8.12.1

--- a/deployments/helm/agentfield/values.yaml
+++ b/deployments/helm/agentfield/values.yaml
@@ -1,5 +1,6 @@
 controlPlane:
   replicaCount: 1
+  terminationGracePeriodSeconds: 45
 
   image:
     repository: agentfield/control-plane
@@ -91,6 +92,7 @@ postgres:
 
 demoAgent:
   enabled: false
+  terminationGracePeriodSeconds: 45
   image:
     # Build locally from deployments/docker/Dockerfile.demo-go-agent and push/load into your cluster.
     repository: agentfield-demo-go-agent
@@ -108,6 +110,7 @@ demoPythonAgent:
   # Demo agent that installs the Python SDK from PyPI at startup (no custom image required).
   # Intended for evaluation only.
   enabled: false
+  terminationGracePeriodSeconds: 45
   image:
     repository: python
     tag: "3.11-slim"

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -195,7 +195,7 @@ AGENTFIELD_CONNECTOR_CAP_DID_MANAGEMENT=false
 - `AGENTFIELD_LOGS_ENABLED` (default: `true`): Enables Python, Go, and TypeScript agent-node stdout/stderr capture and the `/agentfield/v1/logs` endpoint. This controls capture, not control-plane execution-log dispatch.
 - `AGENTFIELD_LOG_TRUNCATE` (Python default: `200` characters): Truncates human-readable plain log messages and visible plain-log payloads. It does not truncate structured records.
 - `AGENTFIELD_LOG_PAYLOADS` (Python default: `false`): Shows payloads in human-readable plain logs when `true`. Structured execution attributes are unaffected.
-- `AGENTFIELD_LOG_MAX_LINE_BYTES` (default: `16384`, minimum: `256`): Maximum emitted process-log line size in bytes. Values below 256 bytes are raised to the minimum. The Python structured stdout mirror elides attributes, then the message or entire record as needed, so every emitted line—including the complete JSON envelope—is valid JSON and fits this cap.
+- `AGENTFIELD_LOG_MAX_LINE_BYTES` (default: `16384`, minimum: `256`): Maximum emitted process-log line size in bytes. The Go and TypeScript SDKs treat invalid values or values below 256 as unset and use the 16384-byte default. The Python structured stdout mirror elides attributes, then the message or entire record as needed, so every emitted line—including the complete JSON envelope—is valid JSON and fits this cap.
 - `AGENTFIELD_LOG_BUFFER_BYTES` (default: `4194304`): Approximate total byte capacity of the in-memory process-log capture ring; oldest entries are discarded when full.
 
 Agent nodes run as separate processes/pods and register with the control plane. The most important Kubernetes-specific concept is:

--- a/sdk/go/agent/agent_lifecycle.go
+++ b/sdk/go/agent/agent_lifecycle.go
@@ -388,9 +388,6 @@ func (a *Agent) shutdownWithOptions(ctx context.Context, graceful bool, timeout 
 		"node_id": a.cfg.NodeID,
 	})
 	a.stopLeaseOnce.Do(func() { close(a.stopLease) })
-	a.shutdownMu.Lock()
-	a.shuttingDown = true
-	a.shutdownMu.Unlock()
 
 	if a.client != nil {
 		if _, err := a.client.Shutdown(ctx, a.cfg.NodeID, types.ShutdownRequest{Reason: "shutdown", Version: a.cfg.Version}); err != nil {
@@ -401,6 +398,9 @@ func (a *Agent) shutdownWithOptions(ctx context.Context, graceful bool, timeout 
 			})
 		}
 	}
+	a.shutdownMu.Lock()
+	a.shuttingDown = true
+	a.shutdownMu.Unlock()
 	a.serverMu.RLock()
 	server := a.server
 	a.serverMu.RUnlock()

--- a/sdk/go/agent/agent_lifecycle_test.go
+++ b/sdk/go/agent/agent_lifecycle_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -268,32 +269,33 @@ func TestAcceptedReasonerRequestAfterShutdownBeginsReturnsUnavailable(t *testing
 	assert.Contains(t, recorder.Body.String(), "agent is shutting down")
 }
 
-func TestAsyncReasonerDispatchDuringShutdownNotifyReturnsUnavailable(t *testing.T) {
-	testDispatchDuringShutdownNotifyReturnsUnavailable(t, "/reasoners/echo", true, false)
+func TestAsyncReasonerDispatchDuringShutdownNotifyIsAccepted(t *testing.T) {
+	testDispatchDuringShutdownNotifyIsAccepted(t, "/reasoners/echo", true, false)
 }
 
-func TestSyncReasonerDispatchDuringShutdownNotifyReturnsUnavailable(t *testing.T) {
-	testDispatchDuringShutdownNotifyReturnsUnavailable(t, "/reasoners/echo", false, false)
+func TestSyncReasonerDispatchDuringShutdownNotifyIsAccepted(t *testing.T) {
+	testDispatchDuringShutdownNotifyIsAccepted(t, "/reasoners/echo", false, false)
 }
 
-func TestSkillDispatchDuringShutdownNotifyReturnsUnavailable(t *testing.T) {
-	testDispatchDuringShutdownNotifyReturnsUnavailable(t, "/skills/echo", false, true)
+func TestSkillDispatchDuringShutdownNotifyIsAccepted(t *testing.T) {
+	testDispatchDuringShutdownNotifyIsAccepted(t, "/skills/echo", false, true)
 }
 
-func TestExecuteDispatchDuringShutdownNotifyReturnsUnavailable(t *testing.T) {
-	testDispatchDuringShutdownNotifyReturnsUnavailable(t, "/execute/echo", false, false)
+func TestExecuteDispatchDuringShutdownNotifyIsAccepted(t *testing.T) {
+	testDispatchDuringShutdownNotifyIsAccepted(t, "/execute/echo", false, false)
 }
 
-func testDispatchDuringShutdownNotifyReturnsUnavailable(t *testing.T, path string, async, skill bool) {
+func testDispatchDuringShutdownNotifyIsAccepted(t *testing.T, path string, async, skill bool) {
 	t.Helper()
 	notifyStarted := make(chan struct{})
 	releaseNotify := make(chan struct{})
 	cp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/v1/nodes/node-1/shutdown", r.URL.Path)
-		close(notifyStarted)
-		select {
-		case <-releaseNotify:
-		case <-time.After(time.Second):
+		if r.URL.Path == "/api/v1/nodes/node-1/shutdown" {
+			close(notifyStarted)
+			select {
+			case <-releaseNotify:
+			case <-time.After(time.Second):
+			}
 		}
 		_, _ = io.WriteString(w, `{}`)
 	}))
@@ -304,9 +306,9 @@ func testDispatchDuringShutdownNotifyReturnsUnavailable(t *testing.T, path strin
 		Logger: log.New(io.Discard, "", 0),
 	})
 	require.NoError(t, err)
-	handlerCalled := false
+	var handlerCalled atomic.Bool
 	handler := func(context.Context, map[string]any) (any, error) {
-		handlerCalled = true
+		handlerCalled.Store(true)
 		return map[string]any{"ok": true}, nil
 	}
 	if skill {
@@ -330,11 +332,19 @@ func testDispatchDuringShutdownNotifyReturnsUnavailable(t *testing.T, path strin
 	recorder := httptest.NewRecorder()
 	a.Handler().ServeHTTP(recorder, req)
 
-	assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
-	assert.Equal(t, "agent is shutting down\n", recorder.Body.String())
-	assert.False(t, handlerCalled)
+	wantStatus := http.StatusOK
+	if async {
+		wantStatus = http.StatusAccepted
+	}
+	assert.Equal(t, wantStatus, recorder.Code)
+	require.Eventually(t, handlerCalled.Load, time.Second, time.Millisecond)
 	close(releaseNotify)
 	require.NoError(t, <-shutdownDone)
+
+	after := httptest.NewRecorder()
+	a.Handler().ServeHTTP(after, httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{}`)))
+	assert.Equal(t, http.StatusServiceUnavailable, after.Code)
+	assert.Equal(t, "agent is shutting down\n", after.Body.String())
 }
 
 func TestServeReturnsAfterRemoteImmediateShutdown(t *testing.T) {


### PR DESCRIPTION
Two regressions introduced by #1010 (found by an adversarial review of the merged diff), plus two small related corrections.

## Regressions fixed
- **`af server` waited up to 30s and exited 1 on Ctrl+C whenever the UI was open.** The graceful HTTP drain waited for the dashboard's SSE streams, which only end when the browser disconnects — and `af server` opens the browser by default. rc.12 exited instantly. Streaming handlers now end when shutdown starts (a server-level stream context cancelled before `http.Server.Shutdown`), normal in-flight requests keep the full drain budget, and a drain that merely runs out of time exits 0 with a warning instead of 1 (the macOS tray relaunches on non-zero exit).
- **Go SDK: `shuttingDown` was set before the control-plane notify**, so dispatches arriving during that notify (up to the client's 10s timeout) got a 503 the control plane records as a non-retryable failure; rc.12 accepted and drained that work. Restored notify-then-flag order; the 503 gate on all entry points stays for after the notify.

## Related
- The async-pool drain gets its own budget (max of the remaining shutdown budget and 5s) instead of inheriting an already-expired context after a slow HTTP drain.
- `terminationGracePeriodSeconds` is a Helm value (default 45) instead of a hardcoded template constant; `AGENTFIELD_LOG_MAX_LINE_BYTES` floor wording corrected per SDK.

## Validation contract
- With one SSE client attached and nothing else in flight, `Stop()` returns in well under a second; the stream ends cleanly.
- A non-streaming in-flight request still completes within `AGENTFIELD_SHUTDOWN_TIMEOUT`.
- Drain timeout → exit 0 + warning; real `Stop()` failure → exit 1.
- HTTP budget exhausted → queued async jobs still get ≥5s before being failed.
- Go agent: dispatch during the CP notify is accepted and drained; after the notify, 503.

## Tests
CI-literal gates run locally on the branch (base `cd483045` = rc.13):
  - control-plane: `go build ./...` ✓ · `golangci-lint run` 0 findings ✓ · `go test -tags sqlite_fts5` on server/handlers/config/cmd packages (12) ✓
  - sdk/go: `go build` · `go vet ./agent/...` · `go test ./...` · `go test -race ./agent/...` ✓
  - `helm template deployments/helm/agentfield` renders identically by default ✓

Manual (one isolated control plane): 
  - SSE regression: one client on `/api/ui/v1/executions/events`, then SIGTERM — **main: exited after 30.1s with "Error during shutdown: context deadline exceeded"; this branch: 0.1s, "Server stopped gracefully."**
  - `AGENTFIELD_SHUTDOWN_TIMEOUT=20` (bare seconds) is now honoured by the control plane (was silently ignored).
  - Re-ran the #1010 behavioural checks on this binary: `AGENTFIELD_AGENT_CALL_TIMEOUT=0s` → sync 2s reasoner returns 200 in 2.5s; 9 MiB registration → 413 (Content-Length and chunked), normal execute unaffected; stopped node → 503 `node_unavailable` with `Retry-After: 1` after the hold; SIGTERM to `af server` → full shutdown sequence, exit 0; no leftover listeners.


Refs #987 #989

🤖 Generated with [Claude Code](https://claude.com/claude-code)
