### PR TITLE
feat(sdk/go): add OrcaRouter as a first-class named provider

### DIFF
--- a/sdk/go/ai/README.md
+++ b/sdk/go/ai/README.md
@@ -1,10 +1,10 @@
 # Go SDK AI Package
 
-This package provides AI/LLM capabilities for the AgentField Go SDK, supporting both OpenAI and OpenRouter APIs with structured output support.
+This package provides AI/LLM capabilities for the AgentField Go SDK, supporting OpenAI, OpenRouter, Infron, and OrcaRouter APIs with structured output support.
 
 ## Features
 
-- ✅ **OpenAI & OpenRouter Support**: Works with both OpenAI API and OpenRouter for multi-model routing
+- ✅ **OpenAI, OpenRouter, Infron & OrcaRouter Support**: Works with OpenAI API, OpenRouter, Infron, and OrcaRouter for multi-model routing
 - ✅ **Structured Outputs**: JSON schema validation with Go struct support
 - ✅ **Streaming**: Support for streaming responses
 - ✅ **Type-Safe**: Automatic conversion from Go structs to JSON schemas
@@ -86,6 +86,10 @@ export AI_MODEL="gpt-4o"  # Optional, defaults to gpt-4o
 export OPENROUTER_API_KEY="sk-..."
 export AI_MODEL="openai/gpt-4o"  # Use OpenRouter model format
 
+# For OrcaRouter
+export ORCAROUTER_API_KEY="sk-orca-..."
+export AI_MODEL="orcarouter/auto"  # Use OrcaRouter model format
+
 # Custom base URL
 export AI_BASE_URL="https://api.openai.com/v1"
 ```
@@ -143,6 +147,33 @@ Model: "infron/moonshotai/kimi-k2.6"  // sent as moonshotai/kimi-k2.6
 Note that Infron reports native cost at the top level of the body (and of the
 final stream chunk) rather than nested under `usage.cost`. The SDK normalizes
 both shapes into `Usage.Cost`, so cost tracking reads the same either way.
+
+### OrcaRouter Configuration
+
+OrcaRouter is an OpenAI-compatible AI gateway. Like OpenRouter, it exposes a
+provider/model namespace across many models (`orcarouter/auto`,
+`orcarouter/fusion`, ...), and it combines adaptive routing, automatic
+failover, observability, and guardrails behind the same endpoint. The
+`orcarouter/` prefix is part of the published model id, so it stays on the
+wire:
+
+```go
+aiConfig := &ai.Config{
+    APIKey:   os.Getenv("ORCAROUTER_API_KEY"),
+    BaseURL:  "https://api.orcarouter.ai/v1",
+    Model:    "orcarouter/auto", // OrcaRouter format: orcarouter/<model>
+    SiteURL:  "https://myapp.com", // app attribution
+    SiteName: "My AI App",
+}
+```
+
+`ai.DefaultConfig()` picks this up from `ORCAROUTER_API_KEY` automatically. A
+gateway key already present in the environment keeps precedence, so adding an
+OrcaRouter key to a configured environment never silently reroutes it.
+
+OrcaRouter reports native cost inside `usage.cost` when the request opts in
+with `usage: {"include": true}`, which the SDK sends for OrcaRouter requests
+automatically.
 
 ## API Reference
 

--- a/sdk/go/ai/client.go
+++ b/sdk/go/ai/client.go
@@ -146,6 +146,8 @@ func (c *Client) doRequest(ctx context.Context, req *Request) (*Response, error)
 		applyOpenRouterAttributionHeaders(httpReq.Header, c.config.SiteURL, c.config.SiteName)
 	case c.config.IsInfron():
 		applyInfronAttributionHeaders(httpReq.Header, c.config.SiteURL, c.config.SiteName)
+	case c.config.IsOrcaRouter():
+		applyOrcaRouterAttributionHeaders(httpReq.Header, c.config.SiteURL, c.config.SiteName)
 	}
 
 	// Execute request
@@ -243,6 +245,8 @@ func (c *Client) StreamComplete(ctx context.Context, prompt string, opts ...Opti
 			applyOpenRouterAttributionHeaders(httpReq.Header, c.config.SiteURL, c.config.SiteName)
 		case c.config.IsInfron():
 			applyInfronAttributionHeaders(httpReq.Header, c.config.SiteURL, c.config.SiteName)
+		case c.config.IsOrcaRouter():
+			applyOrcaRouterAttributionHeaders(httpReq.Header, c.config.SiteURL, c.config.SiteName)
 		}
 
 		// Execute request

--- a/sdk/go/ai/client_additional_test.go
+++ b/sdk/go/ai/client_additional_test.go
@@ -247,6 +247,7 @@ func TestSimpleAIAndStructuredAI_ErrorPaths(t *testing.T) {
 	t.Run("simple ai config validation error", func(t *testing.T) {
 		t.Setenv("OPENAI_API_KEY", "")
 		t.Setenv("OPENROUTER_API_KEY", "")
+		t.Setenv("ORCAROUTER_API_KEY", "")
 		t.Setenv("AI_BASE_URL", "")
 		t.Setenv("AI_MODEL", "")
 

--- a/sdk/go/ai/config.go
+++ b/sdk/go/ai/config.go
@@ -12,6 +12,12 @@ import (
 // refer to the same service, so grepping for either one should land here.
 const defaultInfronBaseURL = "https://llm.onerouter.pro/v1"
 
+// defaultOrcaRouterBaseURL is OrcaRouter's OpenAI-compatible endpoint. The
+// gateway is model-agnostic: like OpenRouter it exposes a `<provider>/<model>`
+// namespace, and the `orcarouter/` prefix is part of the published model id
+// (e.g. "orcarouter/auto"), so it must stay on the wire.
+const defaultOrcaRouterBaseURL = "https://api.orcarouter.ai/v1"
+
 // Config holds AI/LLM configuration for making API calls.
 type Config struct {
 	// API Key for OpenAI or OpenRouter
@@ -21,6 +27,7 @@ type Config struct {
 	// Default: https://api.openai.com/v1
 	// OpenRouter: https://openrouter.ai/api/v1
 	// Infron: https://llm.onerouter.pro/v1
+	// OrcaRouter: https://api.orcarouter.ai/v1
 	BaseURL string
 
 	// Default model to use (e.g., "gpt-4o", "openai/gpt-4o" for OpenRouter)
@@ -46,6 +53,7 @@ type Config struct {
 // It reads from environment variables:
 // - OPENAI_API_KEY or OPENROUTER_API_KEY
 // - INFRON_API_KEY
+// - ORCAROUTER_API_KEY
 // - AI_BASE_URL (defaults to OpenAI)
 // - AI_MODEL (defaults to gpt-4o)
 //
@@ -69,6 +77,15 @@ func DefaultConfig() *Config {
 	if routerKey := os.Getenv("OPENROUTER_API_KEY"); routerKey != "" {
 		apiKey = routerKey
 		baseURL = "https://openrouter.ai/api/v1"
+	}
+
+	// Check for OrcaRouter configuration. Like Infron, it only applies when no
+	// other gateway key already resolved — an existing key keeps precedence so
+	// that adding ORCAROUTER_API_KEY to a configured environment cannot
+	// silently move traffic (and the credential) to a different gateway.
+	if orcaKey := os.Getenv("ORCAROUTER_API_KEY"); orcaKey != "" && apiKey == "" {
+		apiKey = orcaKey
+		baseURL = defaultOrcaRouterBaseURL
 	}
 
 	// Allow override via AI_BASE_URL
@@ -97,6 +114,8 @@ func DefaultConfig() *Config {
 		}
 	case cfg.IsInfron():
 		cfg.SiteURL, cfg.SiteName, _ = resolveInfronAttribution("", "")
+	case cfg.IsOrcaRouter():
+		cfg.SiteURL, cfg.SiteName, _ = resolveOrcaRouterAttribution("", "")
 	}
 	return cfg
 }
@@ -130,4 +149,10 @@ func (c *Config) IsOpenRouter() bool {
 func (c *Config) IsInfron() bool {
 	return strings.Contains(strings.ToLower(c.BaseURL), "onerouter.pro") ||
 		strings.HasPrefix(strings.ToLower(c.Model), infronModelPrefix)
+}
+
+// IsOrcaRouter returns true if the base URL is for the OrcaRouter gateway.
+func (c *Config) IsOrcaRouter() bool {
+	return strings.Contains(strings.ToLower(c.BaseURL), "orcarouter.ai") ||
+		strings.HasPrefix(strings.ToLower(c.Model), "orcarouter/")
 }

--- a/sdk/go/ai/model_params.go
+++ b/sdk/go/ai/model_params.go
@@ -53,6 +53,7 @@ var vouchedRewriteDomains = []string{
 	"openai.com",       // api.openai.com
 	"openai.azure.com", // <resource>.openai.azure.com
 	"openrouter.ai",
+	"orcarouter.ai", // api.orcarouter.ai (accepts max_completion_tokens)
 }
 
 // isVouchedRewriteEndpoint reports whether baseURL points at an endpoint we
@@ -94,8 +95,9 @@ func (c *Client) marshalRequest(req *Request) ([]byte, error) {
 	//
 	// Infron returns that cost at the top level of the body rather than nested
 	// under usage, which Response and StreamChunk normalize on parse (see
-	// normalizeNativeCost).
-	if req.Usage == nil && (c.config.IsOpenRouter() || c.config.IsInfron()) {
+	// normalizeNativeCost). OrcaRouter returns it nested under usage.cost, like
+	// OpenRouter, so no normalization is needed on its path.
+	if req.Usage == nil && (c.config.IsOpenRouter() || c.config.IsInfron() || c.config.IsOrcaRouter()) {
 		req.Usage = &RequestUsage{Include: true}
 	}
 

--- a/sdk/go/ai/model_params_test.go
+++ b/sdk/go/ai/model_params_test.go
@@ -320,6 +320,9 @@ func TestIsVouchedRewriteEndpoint(t *testing.T) {
 		{"https://my-resource.openai.azure.com/openai/deployments/gpt-4o", true},
 		// OpenRouter
 		{"https://openrouter.ai/api/v1", true},
+		// OrcaRouter
+		{"https://api.orcarouter.ai/v1", true},
+		{"https://api.orcarouter.ai/v1/", true},
 		// Known non-OpenAI providers — should NOT rewrite
 		{"https://api.anthropic.com/v1", false},
 		{"https://api.cohere.ai/v1", false},
@@ -333,6 +336,7 @@ func TestIsVouchedRewriteEndpoint(t *testing.T) {
 		// Lookalike hosts must not match by substring
 		{"https://notopenai.com/v1", false},
 		{"https://api.openai.com.evil.example/v1", false},
+		{"https://orcarouter.ai.evil.example/v1", false},
 		// Edge cases: no scheme means no host, and requests can't be sent
 		// there anyway
 		{"api.openai.com/v1", false},

--- a/sdk/go/ai/orcarouter_attribution.go
+++ b/sdk/go/ai/orcarouter_attribution.go
@@ -1,0 +1,81 @@
+package ai
+
+import (
+	"net/http"
+	"os"
+	"strings"
+)
+
+const (
+	defaultOrcaRouterSiteURL = "https://agentfield.ai"
+	defaultOrcaRouterAppName = "AgentField AI"
+)
+
+func orcaRouterAttributionEnabled() bool {
+	value := strings.TrimSpace(os.Getenv("AGENTFIELD_ORCAROUTER_ATTRIBUTION"))
+	if value == "" {
+		return true
+	}
+	switch strings.ToLower(value) {
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
+}
+
+func resolveOrcaRouterAttribution(siteURL, siteName string) (string, string, bool) {
+	if !orcaRouterAttributionEnabled() {
+		return "", "", false
+	}
+
+	// OrcaRouter is OpenAI-compatible, so the HTTP-Referer / X-Title pair this
+	// package already sends keeps working. The OpenRouter-scoped values are
+	// honored as fallbacks so a deployment keeps its declared identity when it
+	// moves gateways — but the opt-out travels with them: values a deployment
+	// suppressed for one vendor (often because they name internal hosts or
+	// products) must not be sent to another.
+	inheritedURL, inheritedName := "", ""
+	if openRouterAttributionEnabled() {
+		inheritedURL = firstNonEmpty(
+			os.Getenv("AGENTFIELD_OPENROUTER_SITE_URL"),
+			os.Getenv("OR_SITE_URL"),
+		)
+		inheritedName = firstNonEmpty(
+			os.Getenv("AGENTFIELD_OPENROUTER_APP_NAME"),
+			os.Getenv("OR_APP_NAME"),
+		)
+	}
+
+	resolvedURL := firstNonEmpty(
+		siteURL,
+		os.Getenv("AGENTFIELD_ORCAROUTER_SITE_URL"),
+		inheritedURL,
+		defaultOrcaRouterSiteURL,
+	)
+	resolvedName := firstNonEmpty(
+		siteName,
+		os.Getenv("AGENTFIELD_ORCAROUTER_APP_NAME"),
+		inheritedName,
+		defaultOrcaRouterAppName,
+	)
+	return resolvedURL, resolvedName, true
+}
+
+// applyOrcaRouterAttributionHeaders sets the app-attribution headers on an
+// OrcaRouter request. OrcaRouter is OpenAI-compatible and accepts the
+// HTTP-Referer / X-Title pair this package already sends, so a deployment that
+// already identifies itself as "AgentField AI" keeps doing so after switching
+// gateways.
+func applyOrcaRouterAttributionHeaders(header http.Header, siteURL, siteName string) {
+	resolvedURL, resolvedName, ok := resolveOrcaRouterAttribution(siteURL, siteName)
+	if !ok {
+		return
+	}
+	if resolvedURL != "" {
+		header.Set("HTTP-Referer", resolvedURL)
+	}
+	if resolvedName != "" {
+		header.Set("X-Title", resolvedName)
+	}
+}

--- a/sdk/go/ai/orcarouter_attribution_test.go
+++ b/sdk/go/ai/orcarouter_attribution_test.go
@@ -1,0 +1,243 @@
+package ai
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsOrcaRouter(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseURL  string
+		model    string
+		expected bool
+	}{
+		{
+			name:     "OrcaRouter URL without trailing slash",
+			baseURL:  "https://api.orcarouter.ai/v1",
+			expected: true,
+		},
+		{
+			name:     "OrcaRouter URL with trailing slash",
+			baseURL:  "https://api.orcarouter.ai/v1/",
+			expected: true,
+		},
+		{
+			name:     "OpenAI URL",
+			baseURL:  "https://api.openai.com/v1",
+			expected: false,
+		},
+		{
+			name:     "another gateway URL",
+			baseURL:  "https://openrouter.ai/api/v1",
+			expected: false,
+		},
+		{
+			name:     "empty URL",
+			baseURL:  "",
+			expected: false,
+		},
+		{
+			name:     "OrcaRouter model prefix",
+			baseURL:  "https://api.openai.com/v1",
+			model:    "orcarouter/auto",
+			expected: true,
+		},
+		{
+			name:     "bare shared model id is not OrcaRouter",
+			baseURL:  "https://api.openai.com/v1",
+			model:    "auto",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{BaseURL: tt.baseURL, Model: tt.model}
+			assert.Equal(t, tt.expected, cfg.IsOrcaRouter())
+		})
+	}
+}
+
+func TestDefaultConfigOrcaRouterKey(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENROUTER_API_KEY", "")
+	t.Setenv("ORCAROUTER_API_KEY", "orcarouter-key")
+	t.Setenv("AI_BASE_URL", "")
+	t.Setenv("AI_MODEL", "")
+
+	cfg := DefaultConfig()
+
+	assert.Equal(t, "orcarouter-key", cfg.APIKey)
+	assert.Equal(t, defaultOrcaRouterBaseURL, cfg.BaseURL)
+	assert.True(t, cfg.IsOrcaRouter())
+	assert.Equal(t, defaultOrcaRouterSiteURL, cfg.SiteURL)
+	assert.Equal(t, defaultOrcaRouterAppName, cfg.SiteName)
+}
+
+// An OrcaRouter key must never move an existing deployment off the gateway it
+// already resolves to — the same backwards-compatibility guarantee the Infron
+// integration established.
+func TestDefaultConfigExistingGatewayWinsOverOrcaRouter(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENROUTER_API_KEY", "existing-gateway-key")
+	t.Setenv("ORCAROUTER_API_KEY", "orcarouter-key")
+	t.Setenv("AI_BASE_URL", "")
+	t.Setenv("AI_MODEL", "")
+
+	cfg := DefaultConfig()
+
+	assert.Equal(t, "existing-gateway-key", cfg.APIKey)
+	assert.Equal(t, "https://openrouter.ai/api/v1", cfg.BaseURL)
+	assert.True(t, cfg.IsOpenRouter())
+	assert.False(t, cfg.IsOrcaRouter())
+}
+
+func TestDefaultConfigExistingOpenAIKeyWinsOverOrcaRouter(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "existing-openai-key")
+	t.Setenv("OPENROUTER_API_KEY", "")
+	t.Setenv("ORCAROUTER_API_KEY", "orcarouter-key")
+	t.Setenv("AI_BASE_URL", "")
+	t.Setenv("AI_MODEL", "")
+
+	cfg := DefaultConfig()
+
+	assert.Equal(t, "existing-openai-key", cfg.APIKey)
+	assert.Equal(t, "https://api.openai.com/v1", cfg.BaseURL)
+	assert.False(t, cfg.IsOrcaRouter())
+}
+
+func TestDefaultConfigOrcaRouterAppliesWhenNoDirectKey(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENROUTER_API_KEY", "")
+	t.Setenv("INFRON_API_KEY", "")
+	t.Setenv("ORCAROUTER_API_KEY", "orcarouter-key")
+	t.Setenv("AI_BASE_URL", "")
+	t.Setenv("AI_MODEL", "")
+
+	cfg := DefaultConfig()
+
+	assert.Equal(t, "orcarouter-key", cfg.APIKey)
+	assert.Equal(t, defaultOrcaRouterBaseURL, cfg.BaseURL)
+	assert.True(t, cfg.IsOrcaRouter())
+}
+
+func TestDefaultConfigOrcaRouterAttributionEnvOverrides(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENROUTER_API_KEY", "")
+	t.Setenv("ORCAROUTER_API_KEY", "orcarouter-key")
+	t.Setenv("AI_BASE_URL", "")
+	t.Setenv("AI_MODEL", "")
+	t.Setenv("AGENTFIELD_ORCAROUTER_SITE_URL", "https://custom.example")
+	t.Setenv("AGENTFIELD_ORCAROUTER_APP_NAME", "Custom App")
+
+	cfg := DefaultConfig()
+
+	assert.Equal(t, "https://custom.example", cfg.SiteURL)
+	assert.Equal(t, "Custom App", cfg.SiteName)
+}
+
+// A deployment that already declared its identity keeps it after switching
+// gateways, so nobody has to re-declare to move.
+func TestOrcaRouterAttributionFallsBackToExistingVars(t *testing.T) {
+	t.Setenv("AGENTFIELD_ORCAROUTER_ATTRIBUTION", "")
+	t.Setenv("AGENTFIELD_ORCAROUTER_SITE_URL", "")
+	t.Setenv("AGENTFIELD_ORCAROUTER_APP_NAME", "")
+	t.Setenv("AGENTFIELD_OPENROUTER_ATTRIBUTION", "")
+	t.Setenv("AGENTFIELD_OPENROUTER_SITE_URL", "https://legacy.example")
+	t.Setenv("AGENTFIELD_OPENROUTER_APP_NAME", "Legacy App")
+
+	header := http.Header{}
+	applyOrcaRouterAttributionHeaders(header, "", "")
+
+	assert.Equal(t, "https://legacy.example", header.Get("HTTP-Referer"))
+	assert.Equal(t, "Legacy App", header.Get("X-Title"))
+}
+
+// The opt-out travels with the inherited values: attribution a deployment
+// suppressed for OpenRouter — often because the site URL names an internal
+// host — must not be sent to a different vendor either.
+func TestOrcaRouterAttributionDoesNotInheritOptedOutValues(t *testing.T) {
+	t.Setenv("AGENTFIELD_ORCAROUTER_ATTRIBUTION", "")
+	t.Setenv("AGENTFIELD_ORCAROUTER_SITE_URL", "")
+	t.Setenv("AGENTFIELD_ORCAROUTER_APP_NAME", "")
+	t.Setenv("AGENTFIELD_OPENROUTER_ATTRIBUTION", "false")
+	t.Setenv("AGENTFIELD_OPENROUTER_SITE_URL", "https://internal-tools.corp.example")
+	t.Setenv("AGENTFIELD_OPENROUTER_APP_NAME", "Internal Risk Engine")
+	t.Setenv("OR_SITE_URL", "")
+	t.Setenv("OR_APP_NAME", "")
+
+	header := http.Header{}
+	applyOrcaRouterAttributionHeaders(header, "", "")
+
+	assert.Equal(t, defaultOrcaRouterSiteURL, header.Get("HTTP-Referer"))
+	assert.Equal(t, defaultOrcaRouterAppName, header.Get("X-Title"))
+}
+
+func TestApplyOrcaRouterAttributionHeadersDisabled(t *testing.T) {
+	t.Setenv("AGENTFIELD_ORCAROUTER_ATTRIBUTION", "false")
+
+	header := http.Header{}
+	applyOrcaRouterAttributionHeaders(header, "https://example.com", "Example")
+
+	assert.Empty(t, header.Get("HTTP-Referer"))
+	assert.Empty(t, header.Get("X-Title"))
+}
+
+func TestApplyOrcaRouterAttributionHeadersDefaults(t *testing.T) {
+	t.Setenv("AGENTFIELD_ORCAROUTER_ATTRIBUTION", "")
+	t.Setenv("AGENTFIELD_ORCAROUTER_SITE_URL", "")
+	t.Setenv("AGENTFIELD_ORCAROUTER_APP_NAME", "")
+	t.Setenv("AGENTFIELD_OPENROUTER_SITE_URL", "")
+	t.Setenv("AGENTFIELD_OPENROUTER_APP_NAME", "")
+	t.Setenv("OR_SITE_URL", "")
+	t.Setenv("OR_APP_NAME", "")
+
+	header := http.Header{}
+	applyOrcaRouterAttributionHeaders(header, "", "")
+
+	assert.Equal(t, defaultOrcaRouterSiteURL, header.Get("HTTP-Referer"))
+	assert.Equal(t, defaultOrcaRouterAppName, header.Get("X-Title"))
+}
+
+// OrcaRouter requests must carry the usage opt-in so responses report cost,
+// mirroring the OpenRouter and Infron behavior.
+func TestMarshalRequestAddsUsageIncludeForOrcaRouter(t *testing.T) {
+	client, err := NewClient(&Config{
+		APIKey:  "k",
+		BaseURL: defaultOrcaRouterBaseURL,
+		Model:   "orcarouter/auto",
+	})
+	require.NoError(t, err)
+
+	body, err := client.marshalRequest(&Request{Model: "orcarouter/auto"})
+	require.NoError(t, err)
+
+	var wire map[string]any
+	require.NoError(t, json.Unmarshal(body, &wire))
+	usage, ok := wire["usage"].(map[string]any)
+	require.True(t, ok, "usage opt-in missing: %s", body)
+	assert.Equal(t, true, usage["include"])
+}
+
+// The "orcarouter/" prefix is part of the published model id on OrcaRouter (the
+// gateway rejects the bare id), so unlike Infron it must stay on the wire.
+func TestMarshalRequestKeepsOrcaRouterPrefix(t *testing.T) {
+	client, err := NewClient(&Config{
+		APIKey:  "k",
+		BaseURL: defaultOrcaRouterBaseURL,
+		Model:   "orcarouter/auto",
+	})
+	require.NoError(t, err)
+
+	body, err := client.marshalRequest(&Request{Model: "orcarouter/auto"})
+	require.NoError(t, err)
+
+	var wire map[string]any
+	require.NoError(t, json.Unmarshal(body, &wire))
+	assert.Equal(t, "orcarouter/auto", wire["model"])
+}


### PR DESCRIPTION
This adds OrcaRouter as a first-class named provider in the Go SDK's AI package, so AgentField agents can route through it the same way they already route through OpenRouter or Infron — `ORCAROUTER_API_KEY` in the environment, and you're off to the races with `ai.DefaultConfig()`.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means AgentField users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The change mirrors the existing Infron integration (an OpenAI-compatible gateway that was wired in the same way): `Config.IsOrcaRouter()` detection by base URL and `orcarouter/` model prefix, `DefaultConfig()` resolution from `ORCAROUTER_API_KEY`, attribution headers on both the sync and streaming paths, and the `usage: {"include": true}` opt-in so responses carry native `usage.cost`. One deliberate difference: the `orcarouter/` prefix is part of the published model id on OrcaRouter (the gateway rejects the bare id), so it stays on the wire rather than being stripped like Infron's routing-only prefix.

**Files changed:** `sdk/go/ai/config.go`, `sdk/go/ai/client.go`, `sdk/go/ai/model_params.go`, new `sdk/go/ai/orcarouter_attribution.go` (plus a matching attribution test file and README section).

**Verification:** `go build ./...`, `go vet`, and `go test ./...` all pass in `sdk/go` (new tests cover config detection, precedence, attribution fallback/opt-out, the usage opt-in, and prefix preservation). I also ran a live check against `https://api.orcarouter.ai/v1` through the new code path — both the sync and streaming completions returned 200 with populated usage, and native cost came back inside `usage.cost`.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
