### PR TITLE
test(events): cover node/exec/reasoner publish + dedupe helpers

### DIFF
--- a/control-plane/internal/events/execution_events_publish_test.go
+++ b/control-plane/internal/events/execution_events_publish_test.go
@@ -1,0 +1,73 @@
+package events
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExecutionPublishersSetCanonicalStatus asserts each execution publish
+// helper emits the expected event Type *and* the canonical Status string. The
+// existing TestExecutionPublishers checks Type only; this covers the status
+// contract (e.g. completed -> succeeded) the handlers depend on.
+func TestExecutionPublishersSetCanonicalStatus(t *testing.T) {
+	subID := "test-execution-status-sub"
+	ch := GlobalExecutionEventBus.Subscribe(subID)
+	defer GlobalExecutionEventBus.Unsubscribe(subID)
+
+	tests := []struct {
+		name       string
+		publish    func()
+		wantType   ExecutionEventType
+		wantStatus string
+	}{
+		{"created", func() { PublishExecutionCreated("e", "w", "n", nil) }, ExecutionCreated, "created"},
+		{"started", func() { PublishExecutionStarted("e", "w", "n", nil) }, ExecutionStarted, "running"},
+		{"updated preserves caller status", func() { PublishExecutionUpdated("e", "w", "n", "custom", nil) }, ExecutionUpdated, "custom"},
+		{"completed uses succeeded", func() { PublishExecutionCompleted("e", "w", "n", nil) }, ExecutionCompleted, string(types.ExecutionStatusSucceeded)},
+		{"failed", func() { PublishExecutionFailed("e", "w", "n", nil) }, ExecutionFailed, "failed"},
+		{"waiting", func() { PublishExecutionWaiting("e", "w", "n", nil) }, ExecutionWaiting, string(types.ExecutionStatusWaiting)},
+		{"paused", func() { PublishExecutionPaused("e", "w", "n", nil) }, ExecutionPaused, string(types.ExecutionStatusPaused)},
+		{"resumed uses running", func() { PublishExecutionResumed("e", "w", "n", nil) }, ExecutionResumed, string(types.ExecutionStatusRunning)},
+		{"cancelled", func() { PublishExecutionCancelled("e", "w", "n", nil) }, ExecutionCancelledEvent, string(types.ExecutionStatusCancelled)},
+		{"approval resolved forwards new status", func() { PublishExecutionApprovalResolved("e", "w", "n", "approved", nil) }, ExecutionApprovalResolved, "approved"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.publish()
+			select {
+			case ev := <-ch:
+				assert.Equal(t, tt.wantType, ev.Type)
+				assert.Equal(t, tt.wantStatus, ev.Status)
+			case <-time.After(5 * time.Second):
+				t.Fatalf("timed out waiting for %s", tt.wantType)
+			}
+		})
+	}
+}
+
+// TestExecutionPublisherForwardsDataPayload confirms the arbitrary data payload
+// is forwarded to subscribers unchanged.
+func TestExecutionPublisherForwardsDataPayload(t *testing.T) {
+	subID := "test-execution-data-sub"
+	ch := GlobalExecutionEventBus.Subscribe(subID)
+	defer GlobalExecutionEventBus.Unsubscribe(subID)
+
+	payload := map[string]interface{}{"tokens": 42, "note": "hello"}
+	PublishExecutionUpdated("e", "w", "n", "running", payload)
+
+	select {
+	case ev := <-ch:
+		require.Equal(t, ExecutionUpdated, ev.Type)
+		data, ok := ev.Data.(map[string]interface{})
+		require.True(t, ok, "data payload should be forwarded unchanged")
+		assert.Equal(t, 42, data["tokens"])
+		assert.Equal(t, "hello", data["note"])
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for ExecutionUpdated")
+	}
+}

--- a/control-plane/internal/events/node_events_dedupe_test.go
+++ b/control-plane/internal/events/node_events_dedupe_test.go
@@ -1,0 +1,211 @@
+package events
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetEventCache clears the package-level dedup cache so each subtest starts
+// from a known state. lastEventCache and its mutex are shared across the bus,
+// so isolation must be explicit.
+func resetEventCache(t *testing.T) {
+	t.Helper()
+	lastEventCacheMutex.Lock()
+	lastEventCache = make(map[string]NodeEvent)
+	lastEventCacheMutex.Unlock()
+}
+
+func TestNodeEventBusShouldFilterEvent(t *testing.T) {
+	t.Run("heartbeat filtered when there are no subscribers", func(t *testing.T) {
+		resetEventCache(t)
+		bus := NewNodeEventBus()
+		assert.True(t, bus.shouldFilterEvent(NodeEvent{Type: NodeHeartbeat, NodeID: "n1"}))
+	})
+
+	t.Run("heartbeat not filtered when a subscriber exists", func(t *testing.T) {
+		resetEventCache(t)
+		bus := NewNodeEventBus()
+		_ = bus.Subscribe("sub-hb")
+		defer bus.Unsubscribe("sub-hb")
+		assert.False(t, bus.shouldFilterEvent(NodeEvent{Type: NodeHeartbeat, NodeID: "n1"}))
+	})
+
+	t.Run("non-status event is never treated as a duplicate", func(t *testing.T) {
+		resetEventCache(t)
+		bus := NewNodeEventBus()
+		ev := NodeEvent{Type: NodeRegistered, NodeID: "n1", Timestamp: time.Now()}
+		assert.False(t, bus.shouldFilterEvent(ev))
+		assert.False(t, bus.shouldFilterEvent(ev))
+	})
+}
+
+func TestNodeEventBusIsDuplicateStatusEvent(t *testing.T) {
+	t.Run("first status event is not a duplicate and is cached", func(t *testing.T) {
+		resetEventCache(t)
+		bus := NewNodeEventBus()
+		ev := NodeEvent{Type: NodeStatusUpdated, NodeID: "n1", Status: "active", Timestamp: time.Now()}
+		assert.False(t, bus.isDuplicateStatusEvent(ev))
+	})
+
+	t.Run("identical status event within 1s is a duplicate", func(t *testing.T) {
+		resetEventCache(t)
+		bus := NewNodeEventBus()
+		now := time.Now()
+		first := NodeEvent{Type: NodeStatusUpdated, NodeID: "n1", Status: "active", Timestamp: now}
+		require.False(t, bus.isDuplicateStatusEvent(first))
+		// Same status, still within the 1s window.
+		second := NodeEvent{Type: NodeStatusUpdated, NodeID: "n1", Status: "active", Timestamp: now}
+		assert.True(t, bus.isDuplicateStatusEvent(second))
+	})
+
+	t.Run("changed status within 1s is not a duplicate", func(t *testing.T) {
+		resetEventCache(t)
+		bus := NewNodeEventBus()
+		now := time.Now()
+		require.False(t, bus.isDuplicateStatusEvent(NodeEvent{Type: NodeStatusUpdated, NodeID: "n1", Status: "active", Timestamp: now}))
+		// Different Status value: not a duplicate even inside the window.
+		assert.False(t, bus.isDuplicateStatusEvent(NodeEvent{Type: NodeStatusUpdated, NodeID: "n1", Status: "inactive", Timestamp: now}))
+	})
+
+	t.Run("changed new/old status on unified event is not a duplicate", func(t *testing.T) {
+		resetEventCache(t)
+		bus := NewNodeEventBus()
+		now := time.Now()
+		first := NodeEvent{Type: NodeUnifiedStatusChanged, NodeID: "n1", Status: "s", OldStatus: "a", NewStatus: "b", Timestamp: now}
+		require.False(t, bus.isDuplicateStatusEvent(first))
+		// Same Status but different NewStatus transition.
+		second := NodeEvent{Type: NodeUnifiedStatusChanged, NodeID: "n1", Status: "s", OldStatus: "a", NewStatus: "c", Timestamp: now}
+		assert.False(t, bus.isDuplicateStatusEvent(second))
+	})
+
+	t.Run("non-comparable status event within 1s is a duplicate", func(t *testing.T) {
+		resetEventCache(t)
+		bus := NewNodeEventBus()
+		now := time.Now()
+		// NodeOnline is a status event type but not one of the compared kinds,
+		// so a second one within the window is a flat duplicate.
+		first := NodeEvent{Type: NodeOnline, NodeID: "n1", Timestamp: now}
+		require.False(t, bus.isDuplicateStatusEvent(first))
+		assert.True(t, bus.isDuplicateStatusEvent(NodeEvent{Type: NodeOnline, NodeID: "n1", Timestamp: now}))
+	})
+
+	t.Run("stale cached event outside 1s window is not a duplicate", func(t *testing.T) {
+		resetEventCache(t)
+		bus := NewNodeEventBus()
+		old := NodeEvent{Type: NodeStatusUpdated, NodeID: "n1", Status: "active", Timestamp: time.Now().Add(-2 * time.Second)}
+		lastEventCacheMutex.Lock()
+		lastEventCache["node_status_updated:n1"] = old
+		lastEventCacheMutex.Unlock()
+
+		fresh := NodeEvent{Type: NodeStatusUpdated, NodeID: "n1", Status: "active", Timestamp: time.Now()}
+		assert.False(t, bus.isDuplicateStatusEvent(fresh))
+	})
+}
+
+func TestNodeEventBusCompareStatusEventData(t *testing.T) {
+	bus := NewNodeEventBus()
+
+	t.Run("different status is not equal", func(t *testing.T) {
+		assert.False(t, bus.compareStatusEventData(
+			NodeEvent{Status: "a"},
+			NodeEvent{Status: "b"},
+		))
+	})
+
+	t.Run("same status non-unified is equal", func(t *testing.T) {
+		assert.True(t, bus.compareStatusEventData(
+			NodeEvent{Type: NodeStatusUpdated, Status: "a"},
+			NodeEvent{Type: NodeStatusUpdated, Status: "a"},
+		))
+	})
+
+	t.Run("unified event compares old/new status", func(t *testing.T) {
+		last := NodeEvent{Type: NodeUnifiedStatusChanged, Status: "a", OldStatus: "x", NewStatus: "y"}
+		assert.True(t, bus.compareStatusEventData(last, NodeEvent{Type: NodeUnifiedStatusChanged, Status: "a", OldStatus: "x", NewStatus: "y"}))
+		assert.False(t, bus.compareStatusEventData(last, NodeEvent{Type: NodeUnifiedStatusChanged, Status: "a", OldStatus: "x", NewStatus: "z"}))
+	})
+}
+
+func TestNodeEventBusCleanupEventCache(t *testing.T) {
+	resetEventCache(t)
+	bus := NewNodeEventBus()
+
+	lastEventCacheMutex.Lock()
+	lastEventCache["stale:n1"] = NodeEvent{Type: NodeStatusUpdated, NodeID: "n1", Timestamp: time.Now().Add(-10 * time.Minute)}
+	lastEventCache["fresh:n2"] = NodeEvent{Type: NodeStatusUpdated, NodeID: "n2", Timestamp: time.Now()}
+	lastEventCacheMutex.Unlock()
+
+	bus.cleanupEventCache()
+
+	lastEventCacheMutex.RLock()
+	_, staleExists := lastEventCache["stale:n1"]
+	_, freshExists := lastEventCache["fresh:n2"]
+	lastEventCacheMutex.RUnlock()
+
+	assert.False(t, staleExists, "entries older than 5 minutes should be dropped")
+	assert.True(t, freshExists, "recent entries should be retained")
+}
+
+func TestPublishNodeStatusUpdatedEnhancedExtractsState(t *testing.T) {
+	resetEventCache(t)
+	subID := "test-enhanced-state"
+	ch := GlobalNodeEventBus.Subscribe(subID)
+	defer GlobalNodeEventBus.Unsubscribe(subID)
+
+	// newStatus is a map carrying a "state" field: the legacy NodeStatusUpdated
+	// event should carry that extracted state string. Both the unified and the
+	// legacy event are published, so drain until the legacy one arrives.
+	PublishNodeStatusUpdatedEnhanced("node-state", nil, map[string]interface{}{"state": "ready"}, "src", "reason")
+
+	var legacy *NodeEvent
+	deadline := time.After(5 * time.Second)
+	for legacy == nil {
+		select {
+		case ev := <-ch:
+			if ev.Type == NodeStatusUpdated {
+				e := ev
+				legacy = &e
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for legacy NodeStatusUpdated event")
+		}
+	}
+	assert.Equal(t, "ready", legacy.Status)
+}
+
+func TestStartNodeHeartbeatEmitsOnlyWithSubscribers(t *testing.T) {
+	resetEventCache(t)
+	// No subscribers: PublishNodeHeartbeat filtered out by shouldFilterEvent,
+	// so nothing is delivered. With a subscriber, the ticker delivers one.
+	StartNodeHeartbeat(10 * time.Millisecond)
+
+	subID := "test-node-hb-start"
+	ch := GlobalNodeEventBus.Subscribe(subID)
+	defer GlobalNodeEventBus.Unsubscribe(subID)
+
+	select {
+	case ev := <-ch:
+		assert.Equal(t, NodeHeartbeat, ev.Type)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a heartbeat once a subscriber was present")
+	}
+}
+
+// Guard against a data race on the shared cache when helpers run concurrently.
+func TestIsDuplicateStatusEventConcurrent(t *testing.T) {
+	resetEventCache(t)
+	bus := NewNodeEventBus()
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			_ = bus.isDuplicateStatusEvent(NodeEvent{Type: NodeStatusUpdated, NodeID: "race", Status: "active", Timestamp: time.Now()})
+		}(i)
+	}
+	wg.Wait()
+}

--- a/control-plane/internal/events/reasoner_events_publish_test.go
+++ b/control-plane/internal/events/reasoner_events_publish_test.go
@@ -1,0 +1,70 @@
+package events
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStartHeartbeatEmitsOnlyWithSubscribers(t *testing.T) {
+	// StartHeartbeat only publishes while at least one subscriber is attached.
+	// Start the ticker first, then subscribe, and confirm a heartbeat arrives.
+	StartHeartbeat(10 * time.Millisecond)
+
+	subID := "test-reasoner-hb-start"
+	ch := GlobalReasonerEventBus.Subscribe(subID)
+	defer GlobalReasonerEventBus.Unsubscribe(subID)
+
+	select {
+	case ev := <-ch:
+		assert.Equal(t, Heartbeat, ev.Type)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a heartbeat once a subscriber was present")
+	}
+}
+
+func TestReasonerPublishHelpersSetTypeAndStatus(t *testing.T) {
+	subID := "test-reasoner-helpers"
+	ch := GlobalReasonerEventBus.Subscribe(subID)
+	defer GlobalReasonerEventBus.Unsubscribe(subID)
+
+	tests := []struct {
+		name       string
+		publish    func()
+		wantType   ReasonerEventType
+		wantStatus string
+	}{
+		{"online sets online status", func() { PublishReasonerOnline("r1", "n1", nil) }, ReasonerOnline, "online"},
+		{"offline sets offline status", func() { PublishReasonerOffline("r1", "n1", nil) }, ReasonerOffline, "offline"},
+		{"updated preserves caller status", func() { PublishReasonerUpdated("r1", "n1", "degraded", nil) }, ReasonerUpdated, "degraded"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.publish()
+			select {
+			case ev := <-ch:
+				assert.Equal(t, tt.wantType, ev.Type)
+				assert.Equal(t, tt.wantStatus, ev.Status)
+			case <-time.After(5 * time.Second):
+				t.Fatalf("timed out waiting for %s", tt.wantType)
+			}
+		})
+	}
+}
+
+func TestPublishReasonersRefreshEmitsEmptyID(t *testing.T) {
+	subID := "test-reasoners-refresh"
+	ch := GlobalReasonerEventBus.Subscribe(subID)
+	defer GlobalReasonerEventBus.Unsubscribe(subID)
+
+	PublishReasonersRefresh(map[string]interface{}{"count": 3})
+	select {
+	case ev := <-ch:
+		assert.Equal(t, ReasonersRefresh, ev.Type)
+		assert.Empty(t, ev.ReasonerID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for ReasonersRefresh")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #394. Adds tests for the `internal/events` publish + dedupe helpers. Test-only change - no source files modified.

## Type of change

- [x] Tests / coverage

## New files

The three files named in the issue:

| File | Covers |
|------|--------|
| `node_events_dedupe_test.go` | `shouldFilterEvent`, `isDuplicateStatusEvent`, `compareStatusEventData`, `cleanupEventCache`, `PublishNodeStatusUpdatedEnhanced` state extraction, `StartNodeHeartbeat`, plus a concurrency race test |
| `reasoner_events_publish_test.go` | `StartHeartbeat`, `PublishReasonerOnline/Offline/Updated` status contracts, `PublishReasonersRefresh` empty-id |
| `execution_events_publish_test.go` | canonical `Status` for all 10 execution publishers + data-payload forwarding |

## Test cases

Dedupe:
- heartbeat filtered when no subscribers; not filtered when a subscriber exists
- duplicate status event within 1s is filtered
- changed `Status` (or `NewStatus` on unified) within 1s is not a duplicate
- non-comparable status event within 1s is a flat duplicate
- stale cached event outside the 1s window is not a duplicate
- `cleanupEventCache` drops stale entries only (older than 5 minutes)
- `PublishNodeStatusUpdatedEnhanced` extracts `state` into the legacy event
- `StartNodeHeartbeat` / `StartHeartbeat` emit only once a subscriber exists

Execution helpers:
- `created` -> `created`, `started` -> `running`, `completed` -> `succeeded`, `resumed` -> `running`, `waiting`/`paused`/`cancelled` use canonical statuses
- `updated` preserves caller-provided status; `approval resolved` forwards new status
- data payload forwarded unchanged

## Coverage impact

Gaps left after prior events tests, now closed:

| Function | Before | After |
|----------|-------:|------:|
| `cleanupEventCache` | 0% | 100% |
| `StartHeartbeat` | 0% | 100% |
| `StartNodeHeartbeat` | 0% | 100% |
| `PublishNodeStatusUpdatedEnhanced` | 57% | 100% |
| `shouldFilterEvent` | 83% | 100% |
| `compareStatusEventData` | 83% | 100% |

Package total: 87.0% -> 97.2%.

## Test plan

- [x] `cd control-plane && go test ./internal/events/ -count=1 -race` - all pass
- [x] `go vet ./internal/events/` - clean
- [x] `gofmt -l` on the new files - clean
- [x] `golangci-lint run ./internal/events/` - no issues in the new files

## Test coverage

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR.
- [x] If I removed code, I updated `coverage-baseline.json` in this PR *only if* the removal caused a legitimate regression.
- [ ] The coverage gate check is green in CI before requesting review.

## Checklist

- [x] Commits follow conventional-commits style.
- [x] I have linked any related issues (Closes #394).

## Related issues / PRs

Closes #394
Part of epic #387 (push test coverage to >= 95%)
