### PR TITLE
fix(sdk/python): parse URL in logger test to resolve CodeQL substring-sanitization alert

### DIFF
--- a/sdk/python/tests/test_execution_logger.py
+++ b/sdk/python/tests/test_execution_logger.py
@@ -2,6 +2,7 @@ import json
 import io
 import sys
 from unittest.mock import AsyncMock, Mock
+from urllib.parse import urlparse
 
 import pytest
 
@@ -236,7 +237,9 @@ def test_logger_security_output(base_logger, caplog):
 @pytest.mark.unit
 def test_logger_network_output(base_logger, caplog):
     base_logger.network("GET https://api.openai.com", method="GET")
-    assert "api.openai.com" in caplog.text
+    assert "GET https://api.openai.com" in caplog.text
+    parsed = urlparse("https://api.openai.com")
+    assert parsed.hostname == "api.openai.com"
 
 
 @pytest.mark.unit

--- a/sdk/python/tests/test_execution_logger.py
+++ b/sdk/python/tests/test_execution_logger.py
@@ -237,9 +237,11 @@ def test_logger_security_output(base_logger, caplog):
 @pytest.mark.unit
 def test_logger_network_output(base_logger, caplog):
     base_logger.network("GET https://api.openai.com", method="GET")
-    assert "GET https://api.openai.com" in caplog.text
-    parsed = urlparse("https://api.openai.com")
-    assert parsed.hostname == "api.openai.com"
+    # Pull the URL back out of the captured log line and compare the parsed
+    # hostname for equality, rather than substring-matching the host against
+    # caplog.text (CodeQL py/incomplete-url-substring-sanitization).
+    logged_urls = [tok for tok in caplog.text.split() if tok.startswith("https://")]
+    assert any(urlparse(url).hostname == "api.openai.com" for url in logged_urls)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What

CodeQL alert **#56** (`py/incomplete-url-substring-sanitization`) flagged the bare hostname substring check in `test_logger_network_output`:

```python
assert "api.openai.com" in caplog.text
```

## Fix

Pull the URL back out of the captured log line and compare parsed hostnames for equality:

```python
logged_urls = [tok for tok in caplog.text.split() if tok.startswith("https://")]
assert any(urlparse(url).hostname == "api.openai.com" for url in logged_urls)
```

A log line mentioning `api.openai.com.evil.test` no longer satisfies the assertion.

Note the shape: an earlier revision used `assert "api.openai.com" in {urlparse(t).hostname for t in ...}`. That is set membership, not a substring test, but the query still flags any `in` against a bare hostname literal, so the comparison is written as `any(... == ...)` instead.

## Verification

- `pytest tests/test_execution_logger.py`: 17 passed
- Negative check: changing the logged URL to `https://evil.example` makes the assertion fail, confirming it tests the logger rather than restating a constant
- CodeQL: alert cleared on this branch

## Note on severity

This is a test asserting a log line was emitted. There is no authorization decision and no trust boundary, so the alert is a false positive in substance. The rewrite is still an improvement — the previous assertion would have passed on a spoofed-subdomain host — but it is a test-quality fix, not a security fix.

Fixes CodeQL alert #56.