### PR TITLE
fix(sdk/typescript): replace trailing-slash regex to resolve CodeQL polynomial-redos alert

### DIFF
--- a/sdk/typescript/src/verification/LocalVerifier.ts
+++ b/sdk/typescript/src/verification/LocalVerifier.ts
@@ -45,7 +45,13 @@ export class LocalVerifier {
     timestampWindow = 300,
     apiKey?: string,
   ) {
-    this.agentFieldUrl = agentFieldUrl.replace(/\/+$/, '');
+    // Trim trailing slashes without a regex: /\/+$/.test-style patterns are
+    // flagged by CodeQL as polynomial-time on uncontrolled input.
+    let url = agentFieldUrl;
+    while (url.endsWith('/')) {
+      url = url.slice(0, -1);
+    }
+    this.agentFieldUrl = url;
     this.refreshInterval = refreshInterval;
     this.timestampWindow = timestampWindow;
     this.apiKey = apiKey;

--- a/sdk/typescript/src/verification/LocalVerifier.ts
+++ b/sdk/typescript/src/verification/LocalVerifier.ts
@@ -45,13 +45,15 @@ export class LocalVerifier {
     timestampWindow = 300,
     apiKey?: string,
   ) {
-    // Trim trailing slashes without a regex: /\/+$/.test-style patterns are
-    // flagged by CodeQL as polynomial-time on uncontrolled input.
-    let url = agentFieldUrl;
-    while (url.endsWith('/')) {
-      url = url.slice(0, -1);
+    // Strip trailing slashes with a single backward scan. A `/\/+$/` replace
+    // backtracks quadratically on inputs like '///...x' (CodeQL
+    // js/polynomial-redos), and repeated `slice(0, -1)` reallocates per
+    // character; walking an index and slicing once is linear.
+    let end = agentFieldUrl.length;
+    while (end > 0 && agentFieldUrl.charCodeAt(end - 1) === 47 /* '/' */) {
+      end--;
     }
-    this.agentFieldUrl = url;
+    this.agentFieldUrl = agentFieldUrl.slice(0, end);
     this.refreshInterval = refreshInterval;
     this.timestampWindow = timestampWindow;
     this.apiKey = apiKey;

--- a/sdk/typescript/tests/local_verifier.test.ts
+++ b/sdk/typescript/tests/local_verifier.test.ts
@@ -2,6 +2,34 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { LocalVerifier, type PolicyEntry } from '../src/verification/LocalVerifier.js';
 
 describe('LocalVerifier', () => {
+
+  describe('constructor url normalization', () => {
+    const url = (v: LocalVerifier) => (v as any).agentFieldUrl as string;
+
+    it('strips a single trailing slash', () => {
+      expect(url(new LocalVerifier('http://localhost:8080/'))).toBe('http://localhost:8080');
+    });
+
+    it('strips repeated trailing slashes', () => {
+      expect(url(new LocalVerifier('http://localhost:8080///'))).toBe('http://localhost:8080');
+    });
+
+    it('leaves a url without a trailing slash untouched', () => {
+      expect(url(new LocalVerifier('http://localhost:8080/api'))).toBe('http://localhost:8080/api');
+    });
+
+    it('handles the empty string and an all-slash string', () => {
+      expect(url(new LocalVerifier(''))).toBe('');
+      expect(url(new LocalVerifier('////'))).toBe('');
+    });
+
+    it('stays linear on a long slash run', () => {
+      const long = `${'/'.repeat(200000)}x`;
+      const start = Date.now();
+      expect(url(new LocalVerifier(long))).toBe(long);
+      expect(Date.now() - start).toBeLessThan(1000);
+    });
+  });
   describe('checkRevocation', () => {
     it('returns false when DID is not revoked', () => {
       const verifier = new LocalVerifier('http://localhost:8080');


### PR DESCRIPTION
## What

CodeQL alert **#54** (`js/polynomial-redos`) flagged line 48 of `sdk/typescript/src/verification/LocalVerifier.ts`:

```ts
this.agentFieldUrl = agentFieldUrl.replace(/\/+$/, '');
```

`/\/+$/` backtracks quadratically on inputs shaped like `'///…x'`.

## Fix

Strip trailing slashes with a single backward index scan, then one `slice`. No regex, linear time, one allocation.

```ts
let end = agentFieldUrl.length;
while (end > 0 && agentFieldUrl.charCodeAt(end - 1) === 47 /* '/' */) {
  end--;
}
this.agentFieldUrl = agentFieldUrl.slice(0, end);
```

Behavior is identical to the regex for every input, including the empty string and all-slash strings.

## Tests

`sdk/typescript/tests/local_verifier.test.ts` gains a `constructor url normalization` block covering single, repeated, absent, empty-string and all-slash inputs, plus a 200k-slash run that fails if this ever regresses to quadratic behavior.

## Verification

- `npx tsc --noEmit`: clean
- `npx vitest run`: 87 files, 951 tests passed (946 before, +5 new)
- `npm run build` (tsup): ESM + DTS build success

## Note on severity

`agentFieldUrl` is a constructor config value, not request-borne data, so the practical DoS surface here is nil. The change is worth making on its own merits (it is simpler and faster than the regex), but this alert was not a live vulnerability.

Fixes CodeQL alert #54.