### PR TITLE
refactor(desktop): share one linear trailing-slash trim

### DIFF
--- a/desktop/src/main/cloudUpdate.ts
+++ b/desktop/src/main/cloudUpdate.ts
@@ -16,6 +16,7 @@ import type {
   RailwayImageAutoUpdates
 } from './railwayApi'
 import { compareAppVersions } from './updates'
+import { stripTrailingSlashes } from '../shared/trimSlashes'
 
 const APPLY_TIMEOUT_MS = 6 * 60_000
 const POLL_INTERVAL_MS = 5_000
@@ -48,9 +49,9 @@ function normalizedUrl(value: string | null | undefined): string | null {
   if (!value) return null
   try {
     const url = new URL(value)
-    return `${url.origin}${url.pathname.replace(/\/+$/, '')}`
+    return `${url.origin}${stripTrailingSlashes(url.pathname)}`
   } catch {
-    return value.trim().replace(/\/+$/, '') || null
+    return stripTrailingSlashes(value.trim()) || null
   }
 }
 

--- a/desktop/src/main/cpClient.ts
+++ b/desktop/src/main/cpClient.ts
@@ -1,4 +1,5 @@
 import { getApiKey, getBaseUrl } from './connection'
+import { stripTrailingSlashes } from '../shared/trimSlashes'
 import type {
   ControlPlaneVersion,
   PackageMaintenanceStatus,
@@ -338,7 +339,7 @@ export function createCpClient(options: CpClientOptions = {}): CpClient {
     if (key !== null) headers.set('X-API-Key', key)
     if (init.body !== undefined) headers.set('Content-Type', 'application/json')
 
-    const response = await fetchImpl(`${baseUrl().replace(/\/+$/, '')}${path}`, {
+    const response = await fetchImpl(`${stripTrailingSlashes(baseUrl())}${path}`, {
       ...init,
       headers,
       signal: AbortSignal.timeout(

--- a/desktop/src/shared/catalog.ts
+++ b/desktop/src/shared/catalog.ts
@@ -1,4 +1,5 @@
 import { BUNDLED_NODES } from './bundled'
+import { stripTrailingSlashes } from './trimSlashes'
 import type { CatalogEntry } from './types'
 
 // Curated list of installable agent nodes, shown in the app's Install view.
@@ -70,7 +71,7 @@ export function sourceRepo(source: string): string {
   if (subdir >= 0) repo = repo.slice(0, subdir)
   const ref = repo.lastIndexOf('@')
   if (ref > repo.lastIndexOf('/')) repo = repo.slice(0, ref)
-  return repo.replace(/\/+$/, '').replace(/\.git$/i, '').toLowerCase()
+  return stripTrailingSlashes(repo).replace(/\.git$/i, '').toLowerCase()
 }
 
 /** True when two source strings name the same repository (see sourceRepo). */

--- a/desktop/src/shared/trimSlashes.test.ts
+++ b/desktop/src/shared/trimSlashes.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { stripTrailingSlashes } from './trimSlashes'
+
+describe('stripTrailingSlashes', () => {
+  it('strips a single trailing slash', () => {
+    expect(stripTrailingSlashes('http://localhost:8080/')).toBe('http://localhost:8080')
+  })
+
+  it('strips repeated trailing slashes', () => {
+    expect(stripTrailingSlashes('http://localhost:8080///')).toBe('http://localhost:8080')
+  })
+
+  it('leaves interior slashes and slash-free input alone', () => {
+    expect(stripTrailingSlashes('owner/repo//go')).toBe('owner/repo//go')
+    expect(stripTrailingSlashes('owner/repo')).toBe('owner/repo')
+  })
+
+  it('handles the empty string and an all-slash string', () => {
+    expect(stripTrailingSlashes('')).toBe('')
+    expect(stripTrailingSlashes('////')).toBe('')
+  })
+
+  it('stays linear on a long slash run', () => {
+    const long = `${'/'.repeat(200000)}x`
+    const start = Date.now()
+    expect(stripTrailingSlashes(long)).toBe(long)
+    expect(Date.now() - start).toBeLessThan(1000)
+  })
+})

--- a/desktop/src/shared/trimSlashes.ts
+++ b/desktop/src/shared/trimSlashes.ts
@@ -1,0 +1,16 @@
+/**
+ * Trailing-slash trimming without a regex.
+ *
+ * `value.replace(/\/+$/, '')` reads well but backtracks quadratically on
+ * inputs shaped like '///…x' (CodeQL js/polynomial-redos). Only the SDK's
+ * LocalVerifier was ever flagged — the desktop call sites take operator
+ * config, not attacker input — but there is no reason to keep four copies of
+ * a pattern the scanner objects to when one linear helper does the job.
+ */
+export function stripTrailingSlashes(value: string): string {
+  let end = value.length
+  while (end > 0 && value.charCodeAt(end - 1) === 47 /* '/' */) {
+    end--
+  }
+  return value.slice(0, end)
+}


### PR DESCRIPTION
Follow-up to #1019.

## What

#1019 replaced `agentFieldUrl.replace(/\/+$/, '')` in the TypeScript SDK's `LocalVerifier` after CodeQL flagged it as `js/polynomial-redos`. Four copies of the same pattern remained in `desktop/`:

| File | Call site |
|---|---|
| `desktop/src/shared/catalog.ts:73` | `sourceRepo` |
| `desktop/src/main/cloudUpdate.ts:51` | `normalizedUrl`, URL path |
| `desktop/src/main/cloudUpdate.ts:53` | `normalizedUrl`, non-URL fallback |
| `desktop/src/main/cpClient.ts:341` | `request`, base URL |

CodeQL does not flag any of them — they take operator config, not attacker input, so there is no taint path. This is consistency work, not a security fix. But there is no reason to keep four copies of a pattern the scanner objects to when one linear helper does the job.

## Fix

New `desktop/src/shared/trimSlashes.ts` exporting `stripTrailingSlashes`, using the same backward index scan `LocalVerifier` now uses: linear, one allocation, no regex. All four call sites route through it.

Behavior is unchanged for every input. Worth noting for `catalog.sourceRepo`, which relies on an interior `//` (the `superseded_by:` redirect form `owner/repo//go`): only *trailing* slashes are stripped, so that path is untouched — covered by a test.

## Tests

`desktop/src/shared/trimSlashes.test.ts`: single, repeated, absent, interior-`//`, empty-string and all-slash inputs, plus a 200k-slash run that fails if this regresses to quadratic behavior.

## Verification

- `npm run typecheck` (desktop): clean
- `npm test` (desktop): 34 files, 668 tests passed — 5 of them new
- `grep` confirms no `/\/+$/` remains in `desktop/src` outside the helper's own doc comment