### PR TITLE
chore(pre-commit): repair the ruff hooks, pin them to CI's version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,9 +7,28 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
+  # Pinned in lockstep with .github/workflows/sdk-python.yml, and scoped to the
+  # same tree that workflow lints (it runs with working-directory: sdk/python).
+  #
+  # v0.6.9 predates the ASYNC rules that sdk/python/pyproject.toml selects, so
+  # the hook aborted with "Unknown rule selector: ASYNC240" on every Python
+  # commit and had been silently dead. 0.16.x is a separate bump: it flags
+  # ~2700 pre-existing violations repo-wide.
+  #
+  # The `files:` scope is deliberate. Unscoped, the hook runs from the repo
+  # root and turns up 53 pre-existing errors in examples/ and scripts/ that CI
+  # has never checked — a backlog worth its own PR, not something a version
+  # bump should start enforcing by surprise.
+  #
+  # ruff-format still has a backlog of ~2200 lines across 99 files in
+  # sdk/python (CI's format step is continue-on-error, so it never landed).
+  # The hook only touches staged files, so that burns down as files are
+  # edited; expect a reformat alongside your first change to one of them.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.15.22
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: ["--fix"]
+        files: ^sdk/python/
       - id: ruff-format
+        files: ^sdk/python/


### PR DESCRIPTION
## The bug

Both ruff pre-commit hooks have been dead. `sdk/python/pyproject.toml` selects the ASYNC ruleset, which the pinned `v0.6.9` does not know, so ruff aborted before linting anything:

```
ruff failed
  Cause: Failed to parse sdk/python/pyproject.toml
  Cause: TOML parse error at line 136, column 1
    |
136 | [tool.ruff.lint]
    | ^^^^^^^^^^^^^^^^
Unknown rule selector: `ASYNC240`
```

Every Python commit hit this. It is how #1018 ended up needing `--no-verify` — the escape hatch that a permanently-red hook trains everyone to reach for.

## Fix

**Pin to `v0.15.22`** — the version `.github/workflows/sdk-python.yml` already installs — so local and CI enforce one contract. `0.16.x` stays out of scope; per that workflow's own comment it flags ~2700 pre-existing violations repo-wide.

**Scope both hooks to `^sdk/python/`**, matching that workflow's `working-directory`. Unscoped, the hook runs from the repo root and turns up **53 pre-existing errors** (30 F401, 9 F541, 6 E402, 5 E701, 3 F841) in `examples/` and `scripts/` that CI has never checked. That backlog is real and worth a PR — but it should not arrive as a side effect of a version bump, and a hook that is red on arrival is a hook people bypass.

**`ruff` → `ruff-check`**, since the old id is now a legacy alias.

## Verification

- `pre-commit run --all-files ruff-check`: **Passed**, no files modified
- `pre-commit run --files sdk/python/tests/test_execution_logger.py`: all six hooks pass — this is the exact file that forced `--no-verify` on #1018
- `ruff 0.15.22 check .` in `sdk/python`: `All checks passed!`

## Known follow-ups, not in this PR

1. **`ruff-format` backlog**: ~2200 lines across 99 files in `sdk/python`. CI's format step is `continue-on-error: true`, so it has never been enforced and the result is discarded. The hook only touches staged files, so this burns down as files are edited — but expect a reformat alongside your first change to one of those files. Flagged in a config comment. A one-shot `ruff format .` would zero it if you would rather take it in one diff.
2. **The 53 `examples/` + `scripts/` errors** described above. 38 are auto-fixable; the other 15 are mostly `F841`/`E402` in demo code where the current shape may well be deliberate, so they want a human read rather than a blanket `--fix`.