### PR TITLE
feat(sdk-python): opt-in litellm observability callbacks and execution metadata

### DIFF
--- a/.github/workflows/litellm-canary.yml
+++ b/.github/workflows/litellm-canary.yml
@@ -34,7 +34,9 @@ jobs:
         working-directory: sdk/python
         run: |
           python -m pip install --upgrade pip
-          pip install ".[dev]" --upgrade litellm
+          # The langfuse extra makes the local ingestion test exercise the real
+          # LiteLLM callback instead of accepting a missing-package no-op.
+          pip install ".[dev,langfuse]" --upgrade litellm
 
       - name: Show LiteLLM version
         id: litellm

--- a/.github/workflows/litellm-canary.yml
+++ b/.github/workflows/litellm-canary.yml
@@ -1,5 +1,10 @@
 name: LiteLLM Canary
 
+# agentfield/litellm_observability.py reads LiteLLM's private
+# logging_callback_manager and _known_custom_logger_compatible_callbacks.
+# tests/test_litellm_observability.py catches upstream renames here instead of
+# allowing them to surface first in a user's process.
+
 on:
   schedule:
     - cron: '17 9 * * 1'

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -293,9 +293,12 @@ When the `AGENTFIELD_INFRON_*` vars are unset, these OpenRouter attribution valu
 ### LLM observability (Python SDK)
 
 - `AGENTFIELD_LITELLM_CALLBACKS`: Comma-separated LiteLLM callback names. When
-  unset or empty, AgentField registers nothing.
-- `AGENTFIELD_LITELLM_METADATA=false`: Opt out of the execution-correlation
-  metadata stamp added to `app.ai` text completions.
+  unset or empty, AgentField registers nothing. Setting it also opts into the
+  execution-correlation metadata stamp for `app.ai` text completions.
+- `AGENTFIELD_LITELLM_METADATA=true`: Opt into the execution-correlation stamp
+  without configuring an AgentField-managed callback. Set it to `false` to
+  disable the stamp while retaining callback registration. When neither
+  observability variable is configured, stamping is off.
 
 See [LLM observability](llm-observability.md) for metadata fields, scope, and
 callback behavior.

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -290,6 +290,16 @@ When the `AGENTFIELD_INFRON_*` vars are unset, these OpenRouter attribution valu
   an inherited numeric value for nested sessions. An explicit per-call `env`
   value wins over the derived depth.
 
+### LLM observability (Python SDK)
+
+- `AGENTFIELD_LITELLM_CALLBACKS`: Comma-separated LiteLLM callback names. When
+  unset or empty, AgentField registers nothing.
+- `AGENTFIELD_LITELLM_METADATA=false`: Opt out of the execution-correlation
+  metadata stamp added to `app.ai` text completions.
+
+See [LLM observability](llm-observability.md) for metadata fields, scope, and
+callback behavior.
+
 ### Tracing (control plane)
 
 - `AGENTFIELD_TRACING_ENABLED`: Set to `true` or `1` to enable tracing. Setting any of the endpoint variables below also enables it.

--- a/docs/llm-observability.md
+++ b/docs/llm-observability.md
@@ -10,6 +10,21 @@ export AGENTFIELD_LITELLM_CALLBACKS=langfuse,logfire
 
 Names are trimmed, lowercased, deduplicated, and passed to LiteLLM. When the variable is unset or empty, AgentField does not import LiteLLM or change its callback state. Callback registration failures are logged and do not prevent the Agent or its LLM calls from running.
 
+### LangFuse setup
+
+Install AgentField's compatible LangFuse extra before enabling LiteLLM's standard `langfuse` callback:
+
+```bash
+pip install "agentfield[langfuse]"
+export LANGFUSE_PUBLIC_KEY=pk-lf-...
+export LANGFUSE_SECRET_KEY=sk-lf-...
+# Optional for self-hosted LangFuse; defaults to LangFuse Cloud.
+export LANGFUSE_HOST=https://cloud.langfuse.com
+export AGENTFIELD_LITELLM_CALLBACKS=langfuse
+```
+
+The extra deliberately installs LangFuse 2.x, the client API supported by LiteLLM's standard `langfuse` callback. Installing an unbounded LangFuse 3.x or 4.x package with that callback can degrade to a logged no-op, so AgentField refuses the standard callback at registration time when the compatible client is missing or outside its tested range. Use the extra rather than installing `langfuse` separately. Other callback integrations remain separate packages; for example, install and configure `logfire` before selecting the `logfire` callback.
+
 ## Execution metadata
 
 Inside a reasoner, each `app.ai` text completion receives a LiteLLM `metadata` dictionary containing the available values below. Empty or missing values are omitted.
@@ -27,20 +42,20 @@ Inside a reasoner, each `app.ai` text completion receives a LiteLLM `metadata` d
 
 The execution ID, run ID, agent node ID, and reasoner name appear when they are available from the current execution context. Session and parent execution IDs appear only when present. Caller-provided metadata keys take precedence. `user_id` and `requester_metadata` are never added.
 
-When AgentField itself successfully registers a LangFuse-family callback (`langfuse` or `langfuse_otel`), it also supplies that vendor's native aliases: `trace_id` is the run ID, `session_id` is the session ID, `trace_name` is the node ID, `generation_name` is the node and reasoner name, and `tags` identifies AgentField plus the available node and reasoner. These aliases are never added merely because application code registered a process-global LiteLLM callback itself, nor because AgentField registered some other vendor's callback — either would silently re-key, rename and re-tag an existing LangFuse setup's generations.
+When AgentField itself successfully registers a LangFuse-family callback (`langfuse` or `langfuse_otel`), it also supplies that vendor's native aliases: `trace_id` is a stable W3C-compatible 32-hex ID derived from the run ID, `trace_metadata` carries the original AgentField correlation fields, `session_id` is the session ID, `trace_name` is the node ID, `generation_name` is the node and reasoner name, and `tags` identifies AgentField plus the available node and reasoner. The original run ID therefore remains available as `agentfield_run_id` in LangFuse trace metadata for joins with AgentField. These aliases are never added merely because application code registered a process-global LiteLLM callback itself, nor because AgentField registered some other vendor's callback — either would silently re-key, rename and re-tag an existing LangFuse setup's generations. If an AgentField-owned callback is later removed from LiteLLM's process-global callback list, AgentField drops its ownership record and stops adding the native aliases.
 
-`metadata` is a LiteLLM-only parameter and is not included in the provider request body. To disable all AgentField execution metadata stamping while retaining callback registration, set:
+`metadata` is a LiteLLM-only parameter and is not included in the provider request body. Stamping is off when neither observability variable is configured. Setting `AGENTFIELD_LITELLM_CALLBACKS` opts into both the selected callbacks and the correlation stamp. To enable the stamp for an integration registered elsewhere, set:
 
 ```bash
-export AGENTFIELD_LITELLM_METADATA=false
+export AGENTFIELD_LITELLM_METADATA=true
 ```
 
-The values `0`, `false`, `no`, and `off` are treated as false, case-insensitively and with surrounding whitespace ignored. The stamp is enabled for every other value, including when the variable is unset.
+Set `AGENTFIELD_LITELLM_METADATA=false` to retain callback registration without AgentField's stamp. Only `1`, `true`, `yes`, and `on` enable the standalone flag, case-insensitively and with surrounding whitespace ignored; unset or unrecognized values do not opt in unless AgentField has a configured/active callback.
 
 ## Scope and pitfalls
 
 The stamp covers text completions made by `app.ai`, including its tool-calling turns. Image generation and harness schema-repair completions call LiteLLM directly and are out of scope. Text-to-speech is also out of scope: to trace TTS, pass `metadata=` explicitly into the `aspeech` call.
 
 - LiteLLM callback state is process-global. A process hosting several Agents applies the union of their configured callbacks.
-- `langfuse` and `logfire` are not AgentField SDK dependencies. When the corresponding package is missing, LiteLLM degrades the callback to a logged no-op.
+- LangFuse is optional; install `agentfield[langfuse]` for the tested standard-callback path. Other callback packages such as `logfire` are not AgentField SDK dependencies. When a corresponding package is missing or incompatible, LiteLLM degrades the callback to a logged no-op.
 - Enabling an OpenTelemetry-family callback yields a second trace tree disconnected from the control plane's own OTLP spans, because AgentField does not propagate W3C `traceparent` to agent nodes.

--- a/docs/llm-observability.md
+++ b/docs/llm-observability.md
@@ -1,0 +1,46 @@
+# LLM observability in the Python SDK
+
+The Python SDK can register LiteLLM observability callbacks and attach AgentField execution correlation data to text completions made through `app.ai`.
+
+Set `AGENTFIELD_LITELLM_CALLBACKS` to a comma-separated list of LiteLLM callback names, for example:
+
+```bash
+export AGENTFIELD_LITELLM_CALLBACKS=langfuse,logfire
+```
+
+Names are trimmed, lowercased, deduplicated, and passed to LiteLLM. When the variable is unset or empty, AgentField does not import LiteLLM or change its callback state. Callback registration failures are logged and do not prevent the Agent or its LLM calls from running.
+
+## Execution metadata
+
+Inside a reasoner, each `app.ai` text completion receives a LiteLLM `metadata` dictionary containing the available values below. Empty or missing values are omitted.
+
+```json
+{
+  "agentfield_execution_id": "exec_123",
+  "agentfield_run_id": "run_123",
+  "agentfield_agent_node_id": "support-agent",
+  "agentfield_reasoner": "answer",
+  "agentfield_session_id": "session_123",
+  "agentfield_parent_execution_id": "exec_parent"
+}
+```
+
+The execution ID, run ID, agent node ID, and reasoner name appear when they are available from the current execution context. Session and parent execution IDs appear only when present. Caller-provided metadata keys take precedence. `user_id` and `requester_metadata` are never added.
+
+When AgentField itself successfully registers at least one callback, it also supplies callback-native aliases: `trace_id` is the run ID, `session_id` is the session ID, `trace_name` is the node ID, `generation_name` is the node and reasoner name, and `tags` identifies AgentField plus the available node and reasoner. These aliases are not added merely because application code registered a process-global LiteLLM callback, avoiding changes to an existing callback setup.
+
+`metadata` is a LiteLLM-only parameter and is not included in the provider request body. To disable all AgentField execution metadata stamping while retaining callback registration, set:
+
+```bash
+export AGENTFIELD_LITELLM_METADATA=false
+```
+
+The values `0`, `false`, `no`, and `off` are treated as false, case-insensitively and with surrounding whitespace ignored. The stamp is enabled for every other value, including when the variable is unset.
+
+## Scope and pitfalls
+
+The stamp covers text completions made by `app.ai`, including its tool-calling turns. Image generation and harness schema-repair completions call LiteLLM directly and are out of scope. Text-to-speech is also out of scope: to trace TTS, pass `metadata=` explicitly into the `aspeech` call.
+
+- LiteLLM callback state is process-global. A process hosting several Agents applies the union of their configured callbacks.
+- `langfuse` and `logfire` are not AgentField SDK dependencies. When the corresponding package is missing, LiteLLM degrades the callback to a logged no-op.
+- Enabling an OpenTelemetry-family callback yields a second trace tree disconnected from the control plane's own OTLP spans, because AgentField does not propagate W3C `traceparent` to agent nodes.

--- a/docs/llm-observability.md
+++ b/docs/llm-observability.md
@@ -27,7 +27,7 @@ Inside a reasoner, each `app.ai` text completion receives a LiteLLM `metadata` d
 
 The execution ID, run ID, agent node ID, and reasoner name appear when they are available from the current execution context. Session and parent execution IDs appear only when present. Caller-provided metadata keys take precedence. `user_id` and `requester_metadata` are never added.
 
-When AgentField itself successfully registers at least one callback, it also supplies callback-native aliases: `trace_id` is the run ID, `session_id` is the session ID, `trace_name` is the node ID, `generation_name` is the node and reasoner name, and `tags` identifies AgentField plus the available node and reasoner. These aliases are not added merely because application code registered a process-global LiteLLM callback, avoiding changes to an existing callback setup.
+When AgentField itself successfully registers a LangFuse-family callback (`langfuse` or `langfuse_otel`), it also supplies that vendor's native aliases: `trace_id` is the run ID, `session_id` is the session ID, `trace_name` is the node ID, `generation_name` is the node and reasoner name, and `tags` identifies AgentField plus the available node and reasoner. These aliases are never added merely because application code registered a process-global LiteLLM callback itself, nor because AgentField registered some other vendor's callback — either would silently re-key, rename and re-tag an existing LangFuse setup's generations.
 
 `metadata` is a LiteLLM-only parameter and is not included in the provider request body. To disable all AgentField execution metadata stamping while retaining callback registration, set:
 

--- a/sdk/python/agentfield/agent.py
+++ b/sdk/python/agentfield/agent.py
@@ -47,6 +47,7 @@ from agentfield.vc_generator import VCGenerator
 from agentfield.memory import MemoryClient, MemoryInterface
 from agentfield.memory_events import MemoryEventClient
 from agentfield.logger import log_debug, log_error, log_info, log_warn, set_cp_client
+from agentfield.litellm_observability import register_callbacks
 from agentfield.router import AgentRouter
 from agentfield.connection_manager import ConnectionManager
 from agentfield.cost_tracker import (
@@ -898,6 +899,11 @@ class Agent(FastAPI):
 
         # Initialize AI and Memory configurations
         self.ai_config = ai_config if ai_config else AIConfig.from_env()
+        # LiteLLM callback registration is opt-in and process-global.
+        try:
+            register_callbacks()
+        except Exception as exc:
+            log_debug(f"Could not configure LiteLLM observability callbacks: {exc}")
         self.harness_config = harness_config
         self.cost_tracker = CostTracker()
         self.memory_config = (

--- a/sdk/python/agentfield/agent_ai.py
+++ b/sdk/python/agentfield/agent_ai.py
@@ -796,6 +796,10 @@ class AgentAI:
         # Ensure messages are always included in the final params
         litellm_params["messages"] = messages
 
+        from agentfield.litellm_observability import apply_execution_metadata
+
+        apply_execution_metadata(litellm_params)
+
         # CRITICAL: Pass an HTTP-level timeout to litellm so httpx itself
         # aborts the underlying socket, not just the asyncio coroutine wrapper.
         # Without this, asyncio.wait_for cancels the coroutine but leaves the
@@ -856,6 +860,7 @@ class AgentAI:
 
             async def _tool_loop_completion(params):
                 """Make an LLM call with rate limiting and model fallbacks."""
+                apply_execution_metadata(params)
                 if litellm_module is None:
                     raise ImportError(
                         "litellm is not installed. Please install it with `pip install litellm`."

--- a/sdk/python/agentfield/litellm_observability.py
+++ b/sdk/python/agentfield/litellm_observability.py
@@ -1,0 +1,170 @@
+"""Opt-in LiteLLM callbacks and AgentField execution metadata."""
+
+import os
+from collections.abc import Mapping, MutableMapping, Sequence
+from typing import Any, FrozenSet, List, Optional
+
+from agentfield.logger import log_debug, log_warn
+
+CALLBACKS_ENV = "AGENTFIELD_LITELLM_CALLBACKS"
+METADATA_ENV = "AGENTFIELD_LITELLM_METADATA"
+
+_FALSE_VALUES = {"0", "false", "no", "off"}
+_AGENTFIELD_REGISTERED: set[str] = set()
+
+
+def resolve_callbacks(
+    explicit: Optional[Sequence[str]] = None,
+    env: Optional[Mapping[str, str]] = None,
+) -> List[str]:
+    """Resolve callback names from explicit values and the environment."""
+    source = os.environ if env is None else env
+    values = list(explicit or [])
+    configured = source.get(CALLBACKS_ENV)
+    if configured:
+        values.extend(configured.split(","))
+
+    resolved: List[str] = []
+    for value in values:
+        name = str(value).strip().lower()
+        if name and name not in resolved:
+            resolved.append(name)
+    return resolved
+
+
+def register_callbacks(
+    explicit: Optional[Sequence[str]] = None,
+    env: Optional[Mapping[str, str]] = None,
+    litellm_module: Any = None,
+) -> List[str]:
+    """Register configured LiteLLM callbacks without allowing failures to escape."""
+    names = resolve_callbacks(explicit, env)
+    if not names:
+        return []
+
+    registered: List[str] = []
+    try:
+        if litellm_module is None:
+            import litellm as litellm_module
+
+        known = (
+            getattr(
+                litellm_module,
+                "_known_custom_logger_compatible_callbacks",
+                [],
+            )
+            or []
+        )
+        manager = getattr(litellm_module, "logging_callback_manager", None)
+        for name in names:
+            if name not in known:
+                log_debug(
+                    f"LiteLLM callback '{name}' is not in LiteLLM's known callback list; registering it anyway"
+                )
+            add_callback = getattr(manager, "add_litellm_callback", None)
+            if callable(add_callback):
+                add_callback(name)
+            else:
+                callbacks = getattr(litellm_module, "callbacks", None)
+                if isinstance(callbacks, list) and name not in callbacks:
+                    callbacks.append(name)
+            _AGENTFIELD_REGISTERED.add(name)
+            registered.append(name)
+    except Exception as exc:
+        log_warn(f"Could not register LiteLLM observability callback: {exc}")
+    return registered
+
+
+def agentfield_registered_callbacks() -> FrozenSet[str]:
+    """Return callbacks successfully registered by AgentField in this process."""
+    return frozenset(_AGENTFIELD_REGISTERED)
+
+
+def metadata_enabled(env: Optional[Mapping[str, str]] = None) -> bool:
+    """Return whether AgentField execution metadata injection is enabled."""
+    source = os.environ if env is None else env
+    return source.get(METADATA_ENV, "").strip().lower() not in _FALSE_VALUES
+
+
+def build_execution_metadata(
+    context: Any = None,
+    *,
+    env: Optional[Mapping[str, str]] = None,
+) -> dict[str, Any]:
+    """Build LiteLLM-only correlation metadata for an execution context."""
+    if not metadata_enabled(env):
+        return {}
+    if context is None:
+        from agentfield.execution_context import get_current_context
+
+        context = get_current_context()
+    if context is None:
+        return {}
+
+    node_id = getattr(context, "agent_node_id", None) or getattr(
+        getattr(context, "agent_instance", None), "node_id", None
+    )
+    reasoner = getattr(context, "reasoner_name", None)
+    run_id = getattr(context, "run_id", None)
+    values = {
+        "agentfield_execution_id": getattr(context, "execution_id", None),
+        "agentfield_run_id": run_id,
+        "agentfield_agent_node_id": node_id,
+        "agentfield_reasoner": reasoner,
+        "agentfield_session_id": getattr(context, "session_id", None),
+        "agentfield_parent_execution_id": getattr(context, "parent_execution_id", None),
+    }
+    metadata: dict[str, Any] = {
+        key: str(value) for key, value in values.items() if value not in (None, "")
+    }
+
+    if agentfield_registered_callbacks():
+        aliases = {
+            "trace_id": run_id,
+            "session_id": getattr(context, "session_id", None),
+            "trace_name": node_id,
+            "generation_name": (
+                f"{node_id}.{reasoner}" if node_id and reasoner else reasoner
+            ),
+        }
+        metadata.update(
+            {
+                key: str(value)
+                for key, value in aliases.items()
+                if value not in (None, "")
+            }
+        )
+        tags = ["agentfield"]
+        if node_id not in (None, ""):
+            tags.append(f"agentfield-node:{node_id}")
+        if reasoner not in (None, ""):
+            tags.append(f"agentfield-reasoner:{reasoner}")
+        metadata["tags"] = tags
+
+    metadata.pop("user_id", None)
+    metadata.pop("requester_metadata", None)
+    return metadata
+
+
+def apply_execution_metadata(
+    params: MutableMapping[str, Any],
+    *,
+    context: Any = None,
+    env: Optional[Mapping[str, str]] = None,
+) -> None:
+    """Merge execution metadata into completion parameters without overriding callers."""
+    try:
+        if not metadata_enabled(env):
+            return
+        stamp = build_execution_metadata(context, env=env)
+        if not stamp:
+            return
+        existing = params.get("metadata")
+        if existing is not None and not isinstance(existing, dict):
+            return
+        merged = dict(existing or {})
+        for key, value in stamp.items():
+            merged.setdefault(key, value)
+        params["metadata"] = merged
+    except Exception as exc:
+        log_debug(f"Could not apply AgentField LiteLLM metadata: {exc}")

--- a/sdk/python/agentfield/litellm_observability.py
+++ b/sdk/python/agentfield/litellm_observability.py
@@ -1,6 +1,10 @@
 """Opt-in LiteLLM callbacks and AgentField execution metadata."""
 
+import hashlib
+import importlib.metadata
 import os
+import re
+import threading
 from collections.abc import Mapping, MutableMapping, Sequence
 from typing import Any, FrozenSet, List, Optional
 
@@ -9,10 +13,13 @@ from agentfield.logger import log_debug, log_warn
 CALLBACKS_ENV = "AGENTFIELD_LITELLM_CALLBACKS"
 METADATA_ENV = "AGENTFIELD_LITELLM_METADATA"
 
-_FALSE_VALUES = {"0", "false", "no", "off"}
+_TRUE_VALUES = {"1", "true", "yes", "on"}
 _AGENTFIELD_REGISTERED: set[str] = set()
+_AGENTFIELD_REGISTRATION_MODULES: dict[str, Any] = {}
+_REGISTRATION_LOCK = threading.RLock()
 # LiteLLM callback names whose logger reads the LangFuse-native metadata
-# aliases (trace_id, session_id, trace_name, generation_name, tags).
+# aliases (trace_id, trace_metadata, session_id, trace_name, generation_name,
+# tags).
 _LANGFUSE_CALLBACKS = frozenset({"langfuse", "langfuse_otel"})
 
 
@@ -45,57 +52,144 @@ def register_callbacks(
     if not names:
         return []
 
-    registered: List[str] = []
     try:
         if litellm_module is None:
             import litellm as litellm_module
+    except Exception as exc:
+        log_warn(f"Could not register LiteLLM observability callback: {exc}")
+        return []
 
-        known = (
-            getattr(
-                litellm_module,
-                "_known_custom_logger_compatible_callbacks",
-                [],
-            )
-            or []
+    known = (
+        getattr(
+            litellm_module,
+            "_known_custom_logger_compatible_callbacks",
+            [],
         )
-        manager = getattr(litellm_module, "logging_callback_manager", None)
+        or []
+    )
+    manager = getattr(litellm_module, "logging_callback_manager", None)
+    registered: List[str] = []
+    with _REGISTRATION_LOCK:
+        _reconcile_registered_callbacks()
         for name in names:
+            if (
+                name == "langfuse"
+                and getattr(litellm_module, "__name__", None) == "litellm"
+                and not _standard_langfuse_runtime_compatible()
+            ):
+                continue
             if name not in known:
                 log_debug(
                     f"LiteLLM callback '{name}' is not in LiteLLM's known callback list; registering it anyway"
                 )
-            # Only record a name that one of the branches below actually
-            # installed: reporting success for a callback that was never
-            # registered would also flip the vendor-alias gate in
-            # build_execution_metadata() on for it.
-            added = False
-            add_callback = getattr(manager, "add_litellm_callback", None)
-            if callable(add_callback):
-                add_callback(name)
-                added = True
-            else:
-                callbacks = getattr(litellm_module, "callbacks", None)
-                if isinstance(callbacks, list):
-                    if name not in callbacks:
+
+            # A callback already installed by application code is deliberately
+            # not claimed by AgentField. This ownership distinction is what
+            # prevents the native LangFuse aliases from re-keying an existing
+            # application-managed integration.
+            if _callback_is_active(litellm_module, name):
+                if (
+                    name in _AGENTFIELD_REGISTERED
+                    and _AGENTFIELD_REGISTRATION_MODULES.get(name) is litellm_module
+                ):
+                    registered.append(name)
+                continue
+
+            try:
+                add_callback = getattr(manager, "add_litellm_callback", None)
+                if callable(add_callback):
+                    add_callback(name)
+                else:
+                    callbacks = getattr(litellm_module, "callbacks", None)
+                    if isinstance(callbacks, list) and name not in callbacks:
                         callbacks.append(name)
-                    added = True
-            if added:
+            except Exception as exc:
+                log_warn(
+                    f"Could not register LiteLLM observability callback '{name}': {exc}"
+                )
+                continue
+
+            # LiteLLM's manager returns None even when it refuses a callback
+            # (for example, at MAX_CALLBACKS). Only claim ownership after the
+            # public callback list proves that the name is actually active.
+            if _callback_is_active(litellm_module, name):
                 _AGENTFIELD_REGISTERED.add(name)
+                _AGENTFIELD_REGISTRATION_MODULES[name] = litellm_module
                 registered.append(name)
-    except Exception as exc:
-        log_warn(f"Could not register LiteLLM observability callback: {exc}")
+            else:
+                log_debug(f"LiteLLM did not install observability callback '{name}'")
     return registered
+
+
+def _standard_langfuse_runtime_compatible() -> bool:
+    """Validate the v2 client required by LiteLLM's standard callback path."""
+    try:
+        installed = importlib.metadata.version("langfuse")
+    except importlib.metadata.PackageNotFoundError:
+        log_warn(
+            "LiteLLM callback 'langfuse' was not registered: install "
+            "agentfield[langfuse] first"
+        )
+        return False
+
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)", installed)
+    release = tuple(int(part) for part in match.groups()) if match else None
+    if release is None or not ((2, 59, 7) <= release < (3, 0, 0)):
+        log_warn(
+            "LiteLLM callback 'langfuse' was not registered: installed "
+            f"langfuse {installed} is incompatible; install "
+            "agentfield[langfuse] for the supported v2 client"
+        )
+        return False
+    return True
+
+
+def _callback_is_active(litellm_module: Any, name: str) -> bool:
+    """Return whether ``name`` is present in LiteLLM's process-global callbacks."""
+    callbacks = getattr(litellm_module, "callbacks", None)
+    if not isinstance(callbacks, Sequence) or isinstance(callbacks, (str, bytes)):
+        return False
+    try:
+        return any(callback == name for callback in callbacks)
+    except Exception:
+        return False
+
+
+def _reconcile_registered_callbacks() -> None:
+    """Drop AgentField ownership records whose LiteLLM callback was removed."""
+    for name in tuple(_AGENTFIELD_REGISTERED):
+        module = _AGENTFIELD_REGISTRATION_MODULES.get(name)
+        if module is None or not _callback_is_active(module, name):
+            _AGENTFIELD_REGISTERED.discard(name)
+            _AGENTFIELD_REGISTRATION_MODULES.pop(name, None)
 
 
 def agentfield_registered_callbacks() -> FrozenSet[str]:
     """Return callbacks successfully registered by AgentField in this process."""
-    return frozenset(_AGENTFIELD_REGISTERED)
+    with _REGISTRATION_LOCK:
+        _reconcile_registered_callbacks()
+        return frozenset(_AGENTFIELD_REGISTERED)
 
 
 def metadata_enabled(env: Optional[Mapping[str, str]] = None) -> bool:
     """Return whether AgentField execution metadata injection is enabled."""
     source = os.environ if env is None else env
-    return source.get(METADATA_ENV, "").strip().lower() not in _FALSE_VALUES
+    configured = source.get(METADATA_ENV)
+    if configured is not None:
+        return configured.strip().lower() in _TRUE_VALUES
+
+    # Callback configuration is itself an explicit observability opt-in. The
+    # active-registration fallback covers programmatic register_callbacks()
+    # calls and keeps metadata enabled for the lifetime of a callback that
+    # AgentField owns, even if the environment is later cleared.
+    return bool(resolve_callbacks(env=source)) or bool(
+        agentfield_registered_callbacks()
+    )
+
+
+def _langfuse_trace_id(run_id: Any) -> str:
+    """Derive LangFuse's stable 32-hex W3C trace ID from an AgentField run ID."""
+    return hashlib.sha256(str(run_id).encode("utf-8")).hexdigest()[:32]
 
 
 def build_execution_metadata(
@@ -136,8 +230,18 @@ def build_execution_metadata(
     # generations of an application that registered `langfuse` itself while the
     # operator set AGENTFIELD_LITELLM_CALLBACKS to some other vendor.
     if agentfield_registered_callbacks() & _LANGFUSE_CALLBACKS:
+        trace_metadata = {
+            key: value
+            for key, value in metadata.items()
+            if key.startswith("agentfield_")
+        }
         aliases = {
-            "trace_id": run_id,
+            "trace_id": _langfuse_trace_id(run_id) if run_id else None,
+            # LiteLLM intentionally filters arbitrary completion metadata from
+            # LangFuse. Its trace_* steering convention promotes this mapping
+            # to trace.metadata so the original AgentField IDs remain usable
+            # for joins instead of being lost behind the derived trace ID.
+            "trace_metadata": trace_metadata or None,
             "session_id": getattr(context, "session_id", None),
             "trace_name": node_id,
             "generation_name": (
@@ -146,7 +250,7 @@ def build_execution_metadata(
         }
         metadata.update(
             {
-                key: str(value)
+                key: value if key == "trace_metadata" else str(value)
                 for key, value in aliases.items()
                 if value not in (None, "")
             }

--- a/sdk/python/agentfield/litellm_observability.py
+++ b/sdk/python/agentfield/litellm_observability.py
@@ -11,6 +11,9 @@ METADATA_ENV = "AGENTFIELD_LITELLM_METADATA"
 
 _FALSE_VALUES = {"0", "false", "no", "off"}
 _AGENTFIELD_REGISTERED: set[str] = set()
+# LiteLLM callback names whose logger reads the LangFuse-native metadata
+# aliases (trace_id, session_id, trace_name, generation_name, tags).
+_LANGFUSE_CALLBACKS = frozenset({"langfuse", "langfuse_otel"})
 
 
 def resolve_callbacks(
@@ -61,15 +64,24 @@ def register_callbacks(
                 log_debug(
                     f"LiteLLM callback '{name}' is not in LiteLLM's known callback list; registering it anyway"
                 )
+            # Only record a name that one of the branches below actually
+            # installed: reporting success for a callback that was never
+            # registered would also flip the vendor-alias gate in
+            # build_execution_metadata() on for it.
+            added = False
             add_callback = getattr(manager, "add_litellm_callback", None)
             if callable(add_callback):
                 add_callback(name)
+                added = True
             else:
                 callbacks = getattr(litellm_module, "callbacks", None)
-                if isinstance(callbacks, list) and name not in callbacks:
-                    callbacks.append(name)
-            _AGENTFIELD_REGISTERED.add(name)
-            registered.append(name)
+                if isinstance(callbacks, list):
+                    if name not in callbacks:
+                        callbacks.append(name)
+                    added = True
+            if added:
+                _AGENTFIELD_REGISTERED.add(name)
+                registered.append(name)
     except Exception as exc:
         log_warn(f"Could not register LiteLLM observability callback: {exc}")
     return registered
@@ -118,7 +130,12 @@ def build_execution_metadata(
         key: str(value) for key, value in values.items() if value not in (None, "")
     }
 
-    if agentfield_registered_callbacks():
+    # The aliases below are LangFuse-native keys, so they are stamped only when
+    # AgentField itself registered a LangFuse-family callback. Gating on "any
+    # AgentField-registered callback" would still re-key, rename and re-tag the
+    # generations of an application that registered `langfuse` itself while the
+    # operator set AGENTFIELD_LITELLM_CALLBACKS to some other vendor.
+    if agentfield_registered_callbacks() & _LANGFUSE_CALLBACKS:
         aliases = {
             "trace_id": run_id,
             "session_id": getattr(context, "session_id", None),
@@ -141,8 +158,11 @@ def build_execution_metadata(
             tags.append(f"agentfield-reasoner:{reasoner}")
         metadata["tags"] = tags
 
-    metadata.pop("user_id", None)
-    metadata.pop("requester_metadata", None)
+    # NOTE: never add a "user_id" or "requester_metadata" key to this dict.
+    # LiteLLM's anthropic transform copies metadata["user_id"] into the
+    # provider request body, and its vertex transform turns
+    # metadata["requester_metadata"] into request labels — either would leak
+    # AgentField identifiers past the LiteLLM boundary.
     return metadata
 
 
@@ -164,7 +184,17 @@ def apply_execution_metadata(
             return
         merged = dict(existing or {})
         for key, value in stamp.items():
-            merged.setdefault(key, value)
+            if key in merged:
+                # A caller-supplied value — or one an earlier stamp left on the
+                # params this call was shallow-copied from — always wins.
+                value = merged[key]
+            # Give a stamped list value its own object. The tool-calling loop
+            # passes `{**litellm_params}` per turn, so without this every turn
+            # would share one metadata["tags"] list, and LangFuse-style
+            # integrations append to it.
+            if isinstance(value, list):
+                value = list(value)
+            merged[key] = value
         params["metadata"] = merged
     except Exception as exc:
         log_debug(f"Could not apply AgentField LiteLLM metadata: {exc}")

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -61,6 +61,12 @@ exclude = ["tests*", "examples*"]
 agentfield = ["py.typed"]
 
 [project.optional-dependencies]
+langfuse = [
+    # LiteLLM's standard `langfuse` callback uses the Langfuse v2 client API.
+    # Keep this aligned with LiteLLM's own proxy-runtime compatibility range;
+    # installing an unbounded Langfuse v3/v4 package silently disables traces.
+    "langfuse>=2.59.7,<3",
+]
 harness-claude = [
     "claude-agent-sdk>=0.1",
 ]
@@ -82,6 +88,8 @@ harness = [
 ]
 dev = [
     "tomli>=2.0; python_version < '3.11'",
+    # Exercise the real optional callback in SDK CI and the LiteLLM canary.
+    "langfuse>=2.59.7,<3",
     "pytest>=9.0.3,<10",
     "pytest-asyncio>=1.3,<2",
     "pytest-cov>=4.1,<5",

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -108,7 +108,7 @@ markers = [
     "harness_live: live tests that invoke real coding agents (claude, codex, opencode) — costs real money",
     "httpx_mock: pytest-httpx marker for configuring mock behavior"
 ]
-addopts = "-ra -q -m \"not harness_live and not functional\" --strict-markers --strict-config --cov=agentfield.client --cov=agentfield.agent_field_handler --cov=agentfield.execution_context --cov=agentfield.execution_state --cov=agentfield.memory --cov=agentfield.rate_limiter --cov=agentfield.result_cache --cov-report=term-missing:skip-covered"
+addopts = "-ra -q -m \"not harness_live and not functional\" --strict-markers --strict-config --cov=agentfield.client --cov=agentfield.litellm_observability --cov=agentfield.agent_field_handler --cov=agentfield.execution_context --cov=agentfield.execution_state --cov=agentfield.memory --cov=agentfield.rate_limiter --cov=agentfield.result_cache --cov-report=term-missing:skip-covered"
 asyncio_mode = "auto"
 
 [tool.coverage.run]

--- a/sdk/python/tests/test_litellm_observability.py
+++ b/sdk/python/tests/test_litellm_observability.py
@@ -1,0 +1,464 @@
+import copy
+import json
+import sys
+import threading
+import types
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from types import SimpleNamespace
+
+import pytest
+
+from agentfield.agent import Agent
+from agentfield.agent_ai import AgentAI
+from agentfield.execution_context import (
+    ExecutionContext,
+    reset_execution_context,
+    set_execution_context,
+)
+from agentfield.litellm_observability import (
+    _AGENTFIELD_REGISTERED,
+    apply_execution_metadata,
+    build_execution_metadata,
+    register_callbacks,
+    resolve_callbacks,
+)
+from agentfield.types import AIConfig
+from tests.helpers import StubAgent
+
+
+@pytest.fixture(autouse=True)
+def restore_observability_globals():
+    saved = set(_AGENTFIELD_REGISTERED)
+    yield
+    _AGENTFIELD_REGISTERED.clear()
+    _AGENTFIELD_REGISTERED.update(saved)
+
+
+@pytest.fixture
+def real_litellm_state():
+    import litellm
+
+    attributes = ("callbacks", "success_callback", "failure_callback")
+    saved = {name: copy.copy(getattr(litellm, name)) for name in attributes}
+    yield litellm
+    for name, value in saved.items():
+        current = getattr(litellm, name)
+        if isinstance(current, list):
+            current[:] = value
+        else:
+            setattr(litellm, name, value)
+
+
+class CallbackManager:
+    def __init__(self, callbacks):
+        self.callbacks = callbacks
+
+    def add_litellm_callback(self, name):
+        if name not in self.callbacks:
+            self.callbacks.append(name)
+
+
+def callback_module(*, known=("langfuse", "logfire")):
+    module = types.ModuleType("litellm_stub")
+    module.callbacks = []
+    module.success_callback = []
+    module.failure_callback = []
+    module._known_custom_logger_compatible_callbacks = list(known)
+    module.logging_callback_manager = CallbackManager(module.callbacks)
+    return module
+
+
+def execution_context(**overrides):
+    values = {
+        "run_id": "run-1",
+        "execution_id": "exec-1",
+        "agent_instance": SimpleNamespace(node_id="node-1"),
+        "reasoner_name": "answer",
+        "agent_node_id": "node-1",
+        "session_id": "session-1",
+        "parent_execution_id": "parent-1",
+    }
+    values.update(overrides)
+    return ExecutionContext(**values)
+
+
+class DummyAIConfig:
+    def __init__(self):
+        self.model = "openai/gpt-4o-mini"
+        self.temperature = 0.1
+        self.max_tokens = 100
+        self.top_p = 1.0
+        self.stream = False
+        self.response_format = "auto"
+        self.fallback_models = []
+        self.final_fallback_model = None
+        self.enable_rate_limit_retry = False
+        self.model_limits_cache = {
+            self.model: {"context_length": 1000, "max_output_tokens": 100}
+        }
+
+    def copy(self, deep=False):
+        return copy.deepcopy(self)
+
+    async def get_model_limits(self, model=None):
+        return self.model_limits_cache[self.model]
+
+    def get_litellm_params(self, **overrides):
+        params = {"model": self.model, "stream": False}
+        params.update(overrides)
+        return params
+
+
+def ai_stub(monkeypatch, responses):
+    module = types.ModuleType("litellm")
+    captured = []
+
+    async def acompletion(**kwargs):
+        captured.append(kwargs)
+        return responses[min(len(captured) - 1, len(responses) - 1)]
+
+    module.acompletion = acompletion
+    module.utils = SimpleNamespace(
+        token_counter=lambda **kwargs: 10,
+        trim_messages=lambda messages, model, max_tokens: messages,
+    )
+    monkeypatch.setitem(sys.modules, "litellm", module)
+    monkeypatch.setattr("agentfield.agent_ai.litellm", module)
+    return captured
+
+
+def chat_response(content="ok"):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content, audio=None))]
+    )
+
+
+def make_agent_ai():
+    agent = StubAgent()
+    agent.ai_config = DummyAIConfig()
+    agent.memory = SimpleNamespace()
+    return AgentAI(agent)
+
+
+def test_resolve_callbacks_parses_env_list():
+    assert resolve_callbacks(
+        [" LOGFIRE "], {"AGENTFIELD_LITELLM_CALLBACKS": "langfuse, LOGFIRE ,,,langfuse"}
+    ) == ["logfire", "langfuse"]
+    # Env-only form, exactly as stated in the behaviour contract.
+    assert resolve_callbacks(
+        env={"AGENTFIELD_LITELLM_CALLBACKS": "langfuse, LOGFIRE ,,"}
+    ) == ["langfuse", "logfire"]
+
+
+def test_resolve_callbacks_passes_unknown_names_through(monkeypatch):
+    module = callback_module(known=())
+    messages = []
+    monkeypatch.setattr("agentfield.litellm_observability.log_debug", messages.append)
+    assert register_callbacks(["helicone"], env={}, litellm_module=module) == [
+        "helicone"
+    ]
+    assert module.callbacks == ["helicone"]
+    assert "helicone" in messages[0]
+
+
+def test_register_callbacks_is_idempotent():
+    module = callback_module()
+    register_callbacks(["langfuse"], env={}, litellm_module=module)
+    register_callbacks(["langfuse"], env={}, litellm_module=module)
+    assert module.callbacks == ["langfuse"]
+
+
+def test_register_callbacks_never_raises():
+    module = callback_module()
+    module.logging_callback_manager.add_litellm_callback = lambda name: (
+        _ for _ in ()
+    ).throw(RuntimeError("boom"))
+    assert register_callbacks(["langfuse"], env={}, litellm_module=module) == []
+
+
+def test_register_callbacks_without_manager_falls_back():
+    module = types.SimpleNamespace(callbacks=[])
+    register_callbacks(["helicone"], env={}, litellm_module=module)
+    register_callbacks(["helicone"], env={}, litellm_module=module)
+    assert module.callbacks == ["helicone"]
+
+
+def test_no_env_no_callbacks_registered():
+    module = callback_module()
+    before = (
+        list(module.callbacks),
+        list(module.success_callback),
+        list(module.failure_callback),
+    )
+    assert register_callbacks(env={}, litellm_module=module) == []
+    assert before == (
+        module.callbacks,
+        module.success_callback,
+        module.failure_callback,
+    )
+
+
+def test_agent_construction_does_not_touch_litellm_callbacks(
+    monkeypatch, real_litellm_state
+):
+    monkeypatch.delenv("AGENTFIELD_LITELLM_CALLBACKS", raising=False)
+    before = tuple(
+        copy.copy(getattr(real_litellm_state, name))
+        for name in ("callbacks", "success_callback", "failure_callback")
+    )
+    Agent(node_id="observability-test", auto_register=False, enable_did=False)
+    after = tuple(
+        copy.copy(getattr(real_litellm_state, name))
+        for name in ("callbacks", "success_callback", "failure_callback")
+    )
+    assert after == before
+
+
+async def test_agent_construction_survives_registration_failure(monkeypatch):
+    monkeypatch.setattr(
+        "agentfield.agent.register_callbacks",
+        lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    assert Agent(node_id="observability-test", auto_register=False, enable_did=False)
+    # ... and the completion that follows still returns the model's answer.
+    ai_stub(monkeypatch, [chat_response()])
+    assert (await make_agent_ai().ai(user="hello")).text == "ok"
+
+
+async def test_registered_callback_appears_once_across_agents_and_calls(
+    monkeypatch, real_litellm_state
+):
+    monkeypatch.setenv("AGENTFIELD_LITELLM_CALLBACKS", "langfuse")
+    Agent(node_id="observability-n1", auto_register=False, enable_did=False)
+    Agent(node_id="observability-n2", auto_register=False, enable_did=False)
+    # Stub the completion path only after the real module has been registered
+    # against, so the two calls below exercise app.ai without network.
+    ai_stub(monkeypatch, [chat_response(), chat_response()])
+    agent_ai = make_agent_ai()
+    await agent_ai.ai(user="one")
+    await agent_ai.ai(user="two")
+    assert real_litellm_state.callbacks.count("langfuse") == 1
+
+
+def test_metadata_keys_from_execution_context():
+    register_callbacks(["langfuse"], env={}, litellm_module=callback_module())
+    metadata = build_execution_metadata(execution_context())
+    assert set(metadata) == {
+        "agentfield_execution_id",
+        "agentfield_run_id",
+        "agentfield_agent_node_id",
+        "agentfield_reasoner",
+        "agentfield_session_id",
+        "agentfield_parent_execution_id",
+        "trace_id",
+        "session_id",
+        "trace_name",
+        "generation_name",
+        "tags",
+    }
+    assert all(
+        isinstance(value, str) for key, value in metadata.items() if key != "tags"
+    )
+    assert all(isinstance(value, str) for value in metadata["tags"])
+
+
+def test_metadata_omits_absent_optional_fields():
+    metadata = build_execution_metadata(
+        execution_context(session_id=None, parent_execution_id=None)
+    )
+    assert "agentfield_session_id" not in metadata
+    assert "agentfield_parent_execution_id" not in metadata
+    assert "" not in metadata.values()
+
+
+def test_vendor_aliases_only_when_agentfield_registered():
+    context = execution_context()
+    aliases = {"trace_id", "session_id", "trace_name", "generation_name", "tags"}
+    user_module = callback_module()
+    user_module.callbacks.append("langfuse")
+    assert aliases.isdisjoint(build_execution_metadata(context))
+    register_callbacks(["langfuse"], env={}, litellm_module=user_module)
+    metadata = build_execution_metadata(context)
+    assert aliases <= metadata.keys()
+    assert isinstance(metadata["tags"], list)
+
+
+def test_metadata_never_contains_user_id_or_requester_metadata():
+    metadata = build_execution_metadata(execution_context())
+    assert "user_id" not in metadata
+    assert "requester_metadata" not in metadata
+
+
+def test_stamp_never_overrides_caller_metadata():
+    params = {"metadata": {"trace_id": "mine", "x": 1}}
+    apply_execution_metadata(params, context=execution_context())
+    assert params["metadata"]["trace_id"] == "mine"
+    assert params["metadata"]["x"] == 1
+    assert params["metadata"]["agentfield_run_id"] == "run-1"
+
+
+def test_stamp_ignores_non_dict_metadata():
+    params = {"metadata": "nope"}
+    apply_execution_metadata(params, context=execution_context())
+    assert params["metadata"] == "nope"
+
+
+def test_stamp_without_context_is_noop_safe():
+    params = {}
+    apply_execution_metadata(params)
+    assert params == {}
+
+
+def test_build_execution_metadata_honours_opt_out_when_called_directly():
+    assert (
+        build_execution_metadata(
+            execution_context(), env={"AGENTFIELD_LITELLM_METADATA": " OFF "}
+        )
+        == {}
+    )
+
+
+def test_apply_execution_metadata_never_raises(monkeypatch):
+    class Hostile(dict):
+        def get(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+    params = Hostile()
+    apply_execution_metadata(params, context=execution_context())
+    assert params == {}
+
+
+@pytest.mark.parametrize(
+    "value,enabled",
+    [
+        ("false", False),
+        ("0", False),
+        ("No", False),
+        (" OFF ", False),
+        (None, True),
+        ("true", True),
+        ("unexpected", True),
+    ],
+)
+def test_metadata_opt_out_env(value, enabled):
+    env = {} if value is None else {"AGENTFIELD_LITELLM_METADATA": value}
+    params = {}
+    apply_execution_metadata(params, context=execution_context(), env=env)
+    assert ("metadata" in params) is enabled
+
+
+async def test_agent_ai_passes_metadata_to_acompletion(monkeypatch):
+    captured = ai_stub(monkeypatch, [chat_response()])
+    token = set_execution_context(execution_context())
+    try:
+        assert (await make_agent_ai().ai(user="hello")).text == "ok"
+    finally:
+        reset_execution_context(token)
+    assert captured[0]["metadata"]["agentfield_run_id"] == "run-1"
+
+
+async def test_agent_ai_without_context_emits_no_agentfield_keys(monkeypatch):
+    captured = ai_stub(monkeypatch, [chat_response()])
+    assert (await make_agent_ai().ai(user="hello")).text == "ok"
+    assert not any(
+        key.startswith("agentfield_") for key in captured[0].get("metadata", {})
+    )
+
+
+async def test_tool_loop_inherits_metadata(monkeypatch):
+    captured = ai_stub(monkeypatch, [chat_response()])
+
+    async def fake_loop(*, litellm_params, make_completion, **kwargs):
+        first = await make_completion({**litellm_params})
+        await make_completion({**litellm_params})
+        return first, []
+
+    monkeypatch.setattr("agentfield.tool_calling.execute_tool_call_loop", fake_loop)
+    monkeypatch.setattr(
+        "agentfield.tool_calling._build_tool_config",
+        lambda tools, agent: (
+            [],
+            SimpleNamespace(max_turns=2, max_tool_calls=2),
+            False,
+        ),
+    )
+    token = set_execution_context(execution_context())
+    try:
+        await make_agent_ai().ai(user="hello", tools=[])
+    finally:
+        reset_execution_context(token)
+    assert [call["metadata"]["agentfield_run_id"] for call in captured] == [
+        "run-1",
+        "run-1",
+    ]
+    assert id(captured[0]["metadata"]) != id(captured[1]["metadata"])
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["openai/gpt-4o-mini", "litellm_proxy/gpt-4o-mini", "openrouter/gpt-4o-mini"],
+)
+async def test_metadata_never_reaches_the_wire(model, real_litellm_state):
+    captured = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            captured.append(json.loads(self.rfile.read(length)))
+            body = json.dumps(
+                {
+                    "id": "chatcmpl-1",
+                    "object": "chat.completion",
+                    "created": 1,
+                    "model": "gpt-4o-mini",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "finish_reason": "stop",
+                            "message": {"role": "assistant", "content": "ok"},
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                }
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        import litellm
+
+        await litellm.acompletion(
+            model=model,
+            messages=[{"role": "user", "content": "hello"}],
+            metadata={
+                "agentfield_run_id": "run_x",
+                "agentfield_execution_id": "exec_x",
+            },
+            api_base=f"http://127.0.0.1:{server.server_port}",
+            api_key="sk-test",
+            timeout=10,
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=10)
+        server.server_close()
+    assert captured
+    assert "metadata" not in captured[0]
+    assert not any(key.startswith("agentfield_") for key in captured[0])
+
+
+def test_tts_paths_are_not_stamped():
+    assert "metadata" not in AIConfig(model="openai/gpt-4o-mini").get_litellm_params()

--- a/sdk/python/tests/test_litellm_observability.py
+++ b/sdk/python/tests/test_litellm_observability.py
@@ -1,4 +1,5 @@
 import copy
+import importlib.metadata
 import json
 import sys
 import threading
@@ -7,6 +8,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from types import SimpleNamespace
 
 import pytest
+from packaging.version import Version
 
 from agentfield.agent import Agent
 from agentfield.agent_ai import AgentAI
@@ -26,9 +28,37 @@ from agentfield.types import AIConfig
 from tests.helpers import StubAgent
 
 
+_LITELLM_VERSION = Version(importlib.metadata.version("litellm"))
+
+# LiteLLM below 1.98 routes an `openrouter/` model that carries a custom
+# api_base through the OpenAI SDK while still applying
+# OpenrouterConfig.transform_request, which unconditionally injects a top-level
+# `usage` key that AsyncCompletions.create() rejects. That is LiteLLM's own
+# request shaping and has nothing to do with the metadata under test; real
+# AgentField OpenRouter traffic carries no custom api_base and is unaffected.
+# pyproject.toml caps LiteLLM at <1.98.0 on Python 3.10, so this route is only
+# exercisable on the newer legs of the CI matrix.
+_openrouter_route = pytest.param(
+    "openrouter/gpt-4o-mini",
+    marks=pytest.mark.skipif(
+        _LITELLM_VERSION < Version("1.98.0"),
+        reason=(
+            "litellm <1.98 sends OpenrouterConfig's top-level `usage` through "
+            "the OpenAI SDK, which rejects it; unrelated to metadata"
+        ),
+    ),
+)
+
+
 @pytest.fixture(autouse=True)
 def restore_observability_globals():
     saved = set(_AGENTFIELD_REGISTERED)
+    # Start from empty. Several tests below assert that the vendor-alias keys
+    # are absent, which only holds if this process-global set is empty on
+    # entry. Today no other module registers a callback, so restoring on the
+    # way out would be enough — clearing on the way in keeps that from becoming
+    # an order-dependent failure the first time one does.
+    _AGENTFIELD_REGISTERED.clear()
     yield
     _AGENTFIELD_REGISTERED.clear()
     _AGENTFIELD_REGISTERED.update(saved)
@@ -283,8 +313,42 @@ def test_vendor_aliases_only_when_agentfield_registered():
     assert isinstance(metadata["tags"], list)
 
 
-def test_metadata_never_contains_user_id_or_requester_metadata():
+def test_vendor_aliases_not_stamped_for_a_non_langfuse_callback():
+    # An application registered `langfuse` itself; the operator asked AgentField
+    # for a different vendor. Stamping the LangFuse-native aliases here would
+    # re-key, rename and re-tag that application's own generations.
+    module = callback_module(known=())
+    module.callbacks.append("langfuse")
+    assert register_callbacks(["helicone"], env={}, litellm_module=module) == [
+        "helicone"
+    ]
     metadata = build_execution_metadata(execution_context())
+    assert {
+        "trace_id",
+        "session_id",
+        "trace_name",
+        "generation_name",
+        "tags",
+    }.isdisjoint(metadata)
+    assert metadata["agentfield_run_id"] == "run-1"
+
+
+def test_register_callbacks_reports_nothing_when_no_branch_registers():
+    # Neither an add_litellm_callback manager nor a `callbacks` list: there is
+    # nowhere to install the callback, so it must not be reported as registered
+    # and must not flip the vendor-alias gate.
+    module = types.SimpleNamespace()
+    assert register_callbacks(["langfuse"], env={}, litellm_module=module) == []
+    assert _AGENTFIELD_REGISTERED == set()
+    assert "trace_id" not in build_execution_metadata(execution_context())
+
+
+def test_metadata_never_contains_user_id_or_requester_metadata():
+    # Register a LangFuse callback so the alias branch — the one place a future
+    # `user_id` / `requester_metadata` alias would plausibly be added — is live.
+    register_callbacks(["langfuse"], env={}, litellm_module=callback_module())
+    metadata = build_execution_metadata(execution_context())
+    assert "tags" in metadata
     assert "user_id" not in metadata
     assert "requester_metadata" not in metadata
 
@@ -367,6 +431,9 @@ async def test_agent_ai_without_context_emits_no_agentfield_keys(monkeypatch):
 
 async def test_tool_loop_inherits_metadata(monkeypatch):
     captured = ai_stub(monkeypatch, [chat_response()])
+    # Registered so the stamp carries the `tags` list, whose per-turn identity
+    # is asserted below.
+    register_callbacks(["langfuse"], env={}, litellm_module=callback_module())
 
     async def fake_loop(*, litellm_params, make_completion, **kwargs):
         first = await make_completion({**litellm_params})
@@ -392,11 +459,16 @@ async def test_tool_loop_inherits_metadata(monkeypatch):
         "run-1",
     ]
     assert id(captured[0]["metadata"]) != id(captured[1]["metadata"])
+    # ... and the container values are not shared by reference either, so a
+    # LangFuse-style integration appending to one turn's tags cannot leak into
+    # the next turn.
+    assert captured[0]["metadata"]["tags"] == captured[1]["metadata"]["tags"]
+    assert id(captured[0]["metadata"]["tags"]) != id(captured[1]["metadata"]["tags"])
 
 
 @pytest.mark.parametrize(
     "model",
-    ["openai/gpt-4o-mini", "litellm_proxy/gpt-4o-mini", "openrouter/gpt-4o-mini"],
+    ["openai/gpt-4o-mini", "litellm_proxy/gpt-4o-mini", _openrouter_route],
 )
 async def test_metadata_never_reaches_the_wire(model, real_litellm_state):
     captured = []
@@ -461,4 +533,14 @@ async def test_metadata_never_reaches_the_wire(model, real_litellm_state):
 
 
 def test_tts_paths_are_not_stamped():
-    assert "metadata" not in AIConfig(model="openai/gpt-4o-mini").get_litellm_params()
+    # Must run with a live ExecutionContext: the regression this guards is the
+    # stamp migrating into AIConfig.get_litellm_params, whose dict the two TTS
+    # call sites read config["api_key"] out of — one of them builds a raw OpenAI
+    # SDK client whose create() has no metadata kwarg, and the resulting
+    # TypeError is swallowed into a silent degrade to a text-only response.
+    token = set_execution_context(execution_context())
+    try:
+        params = AIConfig(model="openai/gpt-4o-mini").get_litellm_params()
+    finally:
+        reset_execution_context(token)
+    assert "metadata" not in params

--- a/sdk/python/tests/test_litellm_observability.py
+++ b/sdk/python/tests/test_litellm_observability.py
@@ -1,10 +1,16 @@
 import copy
+import hashlib
 import importlib.metadata
+import importlib.util
 import json
+import os
+import subprocess
 import sys
+import textwrap
 import threading
 import types
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -19,6 +25,8 @@ from agentfield.execution_context import (
 )
 from agentfield.litellm_observability import (
     _AGENTFIELD_REGISTERED,
+    _AGENTFIELD_REGISTRATION_MODULES,
+    agentfield_registered_callbacks,
     apply_execution_metadata,
     build_execution_metadata,
     register_callbacks,
@@ -51,17 +59,26 @@ _openrouter_route = pytest.param(
 
 
 @pytest.fixture(autouse=True)
-def restore_observability_globals():
+def restore_observability_globals(monkeypatch):
     saved = set(_AGENTFIELD_REGISTERED)
+    saved_modules = dict(_AGENTFIELD_REGISTRATION_MODULES)
     # Start from empty. Several tests below assert that the vendor-alias keys
     # are absent, which only holds if this process-global set is empty on
     # entry. Today no other module registers a callback, so restoring on the
     # way out would be enough — clearing on the way in keeps that from becoming
     # an order-dependent failure the first time one does.
     _AGENTFIELD_REGISTERED.clear()
+    _AGENTFIELD_REGISTRATION_MODULES.clear()
+    # Most historical tests exercise the contents of the stamp. Explicitly opt
+    # those tests in while the dedicated contract tests below pass isolated
+    # env mappings to cover the new default-off behavior.
+    monkeypatch.setenv("AGENTFIELD_LITELLM_METADATA", "true")
+    monkeypatch.delenv("AGENTFIELD_LITELLM_CALLBACKS", raising=False)
     yield
     _AGENTFIELD_REGISTERED.clear()
     _AGENTFIELD_REGISTERED.update(saved)
+    _AGENTFIELD_REGISTRATION_MODULES.clear()
+    _AGENTFIELD_REGISTRATION_MODULES.update(saved_modules)
 
 
 @pytest.fixture
@@ -206,6 +223,21 @@ def test_register_callbacks_never_raises():
     assert register_callbacks(["langfuse"], env={}, litellm_module=module) == []
 
 
+def test_incompatible_langfuse_runtime_is_refused(monkeypatch):
+    module = callback_module()
+    module.__name__ = "litellm"
+    messages = []
+    monkeypatch.setattr(
+        "agentfield.litellm_observability.importlib.metadata.version",
+        lambda distribution: "3.15.0",
+    )
+    monkeypatch.setattr("agentfield.litellm_observability.log_warn", messages.append)
+
+    assert register_callbacks(["langfuse"], env={}, litellm_module=module) == []
+    assert module.callbacks == []
+    assert any("incompatible" in message for message in messages)
+
+
 def test_register_callbacks_without_manager_falls_back():
     module = types.SimpleNamespace(callbacks=[])
     register_callbacks(["helicone"], env={}, litellm_module=module)
@@ -281,15 +313,19 @@ def test_metadata_keys_from_execution_context():
         "agentfield_session_id",
         "agentfield_parent_execution_id",
         "trace_id",
+        "trace_metadata",
         "session_id",
         "trace_name",
         "generation_name",
         "tags",
     }
     assert all(
-        isinstance(value, str) for key, value in metadata.items() if key != "tags"
+        isinstance(value, str)
+        for key, value in metadata.items()
+        if key not in {"tags", "trace_metadata"}
     )
     assert all(isinstance(value, str) for value in metadata["tags"])
+    assert metadata["trace_metadata"]["agentfield_run_id"] == "run-1"
 
 
 def test_metadata_omits_absent_optional_fields():
@@ -303,14 +339,36 @@ def test_metadata_omits_absent_optional_fields():
 
 def test_vendor_aliases_only_when_agentfield_registered():
     context = execution_context()
-    aliases = {"trace_id", "session_id", "trace_name", "generation_name", "tags"}
+    aliases = {
+        "trace_id",
+        "trace_metadata",
+        "session_id",
+        "trace_name",
+        "generation_name",
+        "tags",
+    }
     user_module = callback_module()
     user_module.callbacks.append("langfuse")
     assert aliases.isdisjoint(build_execution_metadata(context))
-    register_callbacks(["langfuse"], env={}, litellm_module=user_module)
+    # An application-owned callback must not be silently claimed.
+    assert register_callbacks(["langfuse"], env={}, litellm_module=user_module) == []
+    assert aliases.isdisjoint(build_execution_metadata(context))
+
+    agentfield_module = callback_module()
+    register_callbacks(["langfuse"], env={}, litellm_module=agentfield_module)
     metadata = build_execution_metadata(context)
     assert aliases <= metadata.keys()
     assert isinstance(metadata["tags"], list)
+
+
+def test_langfuse_trace_id_is_stable_w3c_compatible():
+    register_callbacks(["langfuse"], env={}, litellm_module=callback_module())
+    metadata = build_execution_metadata(execution_context(run_id="run/not-w3c"))
+    assert metadata["trace_id"] == hashlib.sha256(b"run/not-w3c").hexdigest()[:32]
+    assert len(metadata["trace_id"]) == 32
+    assert all(character in "0123456789abcdef" for character in metadata["trace_id"])
+    assert metadata["agentfield_run_id"] == "run/not-w3c"
+    assert metadata["trace_metadata"]["agentfield_run_id"] == "run/not-w3c"
 
 
 def test_vendor_aliases_not_stamped_for_a_non_langfuse_callback():
@@ -325,6 +383,7 @@ def test_vendor_aliases_not_stamped_for_a_non_langfuse_callback():
     metadata = build_execution_metadata(execution_context())
     assert {
         "trace_id",
+        "trace_metadata",
         "session_id",
         "trace_name",
         "generation_name",
@@ -340,6 +399,29 @@ def test_register_callbacks_reports_nothing_when_no_branch_registers():
     module = types.SimpleNamespace()
     assert register_callbacks(["langfuse"], env={}, litellm_module=module) == []
     assert _AGENTFIELD_REGISTERED == set()
+    assert "trace_id" not in build_execution_metadata(execution_context())
+
+
+def test_register_callbacks_does_not_claim_a_refused_callback():
+    module = callback_module()
+    module.logging_callback_manager.add_litellm_callback = lambda name: None
+
+    assert register_callbacks(["langfuse"], env={}, litellm_module=module) == []
+    assert module.callbacks == []
+    assert agentfield_registered_callbacks() == frozenset()
+    assert "trace_id" not in build_execution_metadata(execution_context())
+
+
+def test_removed_callback_reconciles_ownership_and_alias_gate():
+    module = callback_module()
+    assert register_callbacks(["langfuse"], env={}, litellm_module=module) == [
+        "langfuse"
+    ]
+    assert "trace_id" in build_execution_metadata(execution_context())
+
+    module.callbacks.remove("langfuse")
+    assert agentfield_registered_callbacks() == frozenset()
+    assert _AGENTFIELD_REGISTRATION_MODULES == {}
     assert "trace_id" not in build_execution_metadata(execution_context())
 
 
@@ -399,16 +481,43 @@ def test_apply_execution_metadata_never_raises(monkeypatch):
         ("0", False),
         ("No", False),
         (" OFF ", False),
-        (None, True),
+        (None, False),
+        ("", False),
         ("true", True),
-        ("unexpected", True),
+        (" 1 ", True),
+        ("YES", True),
+        ("on", True),
+        ("unexpected", False),
     ],
 )
-def test_metadata_opt_out_env(value, enabled):
+def test_metadata_opt_in_env(value, enabled):
     env = {} if value is None else {"AGENTFIELD_LITELLM_METADATA": value}
     params = {}
     apply_execution_metadata(params, context=execution_context(), env=env)
     assert ("metadata" in params) is enabled
+
+
+def test_callback_configuration_opts_into_metadata():
+    params = {}
+    apply_execution_metadata(
+        params,
+        context=execution_context(),
+        env={"AGENTFIELD_LITELLM_CALLBACKS": "logfire"},
+    )
+    assert params["metadata"]["agentfield_run_id"] == "run-1"
+
+
+def test_explicit_metadata_false_overrides_callback_configuration():
+    params = {}
+    apply_execution_metadata(
+        params,
+        context=execution_context(),
+        env={
+            "AGENTFIELD_LITELLM_CALLBACKS": "langfuse",
+            "AGENTFIELD_LITELLM_METADATA": "false",
+        },
+    )
+    assert params == {}
 
 
 async def test_agent_ai_passes_metadata_to_acompletion(monkeypatch):
@@ -530,6 +639,188 @@ async def test_metadata_never_reaches_the_wire(model, real_litellm_state):
     assert captured
     assert "metadata" not in captured[0]
     assert not any(key.startswith("agentfield_") for key in captured[0])
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("langfuse") is None,
+    reason="install the langfuse extra to exercise the real LiteLLM callback",
+)
+def test_langfuse_callback_sends_correlated_local_ingestion():
+    """Catch compatible-install failures that LiteLLM logs but does not raise.
+
+    A subprocess keeps LiteLLM's global callback state isolated. Both the fake
+    OpenAI provider and fake LangFuse ingestion endpoint are local, so this
+    canary needs neither an LLM key nor LangFuse credentials.
+    """
+    assert Version(importlib.metadata.version("langfuse")) < Version("3")
+    requests = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self._respond({"data": []})
+
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            raw_body = self.rfile.read(length)
+            try:
+                body = json.loads(raw_body)
+            except json.JSONDecodeError:
+                body = raw_body.decode(errors="replace")
+            requests.append((self.path, body))
+            if self.path.startswith("/chat/completions"):
+                self._respond(
+                    {
+                        "id": "chatcmpl-langfuse-canary",
+                        "object": "chat.completion",
+                        "created": 1,
+                        "model": "gpt-4o-mini",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "finish_reason": "stop",
+                                "message": {
+                                    "role": "assistant",
+                                    "content": "local-canary-ok",
+                                },
+                            }
+                        ],
+                        "usage": {
+                            "prompt_tokens": 2,
+                            "completion_tokens": 3,
+                            "total_tokens": 5,
+                        },
+                    }
+                )
+            else:
+                self._respond({})
+
+        def _respond(self, payload):
+            body = json.dumps(payload).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base_url = f"http://127.0.0.1:{server.server_port}"
+    run_id = "run_langfuse_local_canary"
+    expected_trace_id = hashlib.sha256(run_id.encode()).hexdigest()[:32]
+    script = textwrap.dedent(
+        f"""
+        import asyncio
+
+        from agentfield.agent import Agent
+        from agentfield.execution_context import (
+            ExecutionContext,
+            reset_execution_context,
+            set_execution_context,
+        )
+        from agentfield.types import AIConfig
+
+        async def main():
+            config = AIConfig(
+                model="openai/gpt-4o-mini",
+                api_base={base_url!r},
+                api_key="sk-local-only",
+                retry_attempts=0,
+                enable_rate_limit_retry=False,
+                model_limits_cache={{
+                    "openai/gpt-4o-mini": {{
+                        "context_length": 1000,
+                        "max_output_tokens": 100,
+                    }}
+                }},
+            )
+            app = Agent(
+                node_id="langfuse-canary-node",
+                ai_config=config,
+                auto_register=False,
+                enable_did=False,
+            )
+            context = ExecutionContext(
+                run_id={run_id!r},
+                execution_id="exec_langfuse_local_canary",
+                agent_instance=app,
+                agent_node_id=app.node_id,
+                reasoner_name="local_ingestion_canary",
+            )
+            token = set_execution_context(context)
+            try:
+                response = await app.ai(user="hello from local canary")
+            finally:
+                reset_execution_context(token)
+
+            # LiteLLM dispatches async success callbacks after the completion.
+            # Keep this loop alive long enough for LangFuse's one-second flush.
+            await asyncio.sleep(3)
+            from litellm.litellm_core_utils.litellm_logging import (
+                _in_memory_loggers,
+            )
+            for logger in list(_in_memory_loggers):
+                client = getattr(logger, "Langfuse", None)
+                if client is None:
+                    continue
+                flush = getattr(client, "flush", None)
+                if callable(flush):
+                    await asyncio.to_thread(flush)
+                shutdown = getattr(client, "shutdown", None)
+                if callable(shutdown):
+                    await asyncio.to_thread(shutdown)
+            print("LANGFUSE_CANARY_RESPONSE=" + str(response.text))
+
+        asyncio.run(main())
+        """
+    )
+    env = os.environ.copy()
+    env.pop("AGENTFIELD_LITELLM_METADATA", None)
+    env.update(
+        {
+            "AGENTFIELD_LITELLM_CALLBACKS": "langfuse",
+            "LANGFUSE_PUBLIC_KEY": "pk-local-only",
+            "LANGFUSE_SECRET_KEY": "sk-local-only",
+            "LANGFUSE_HOST": base_url,
+            "LANGFUSE_FLUSH_INTERVAL": "1",
+        }
+    )
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=Path(__file__).resolve().parents[1],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=10)
+        server.server_close()
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "LANGFUSE_CANARY_RESPONSE=local-canary-ok" in result.stdout
+    provider_requests = [
+        body for path, body in requests if path.startswith("/chat/completions")
+    ]
+    ingestion_requests = [
+        body for path, body in requests if path.startswith("/api/public/ingestion")
+    ]
+    assert provider_requests
+    assert "metadata" not in provider_requests[0]
+    assert not any(key.startswith("agentfield_") for key in provider_requests[0])
+    assert ingestion_requests, result.stdout + result.stderr
+    serialized_ingestion = json.dumps(ingestion_requests)
+    assert expected_trace_id in serialized_ingestion
+    assert run_id in serialized_ingestion
+    assert "agentfield_run_id" in serialized_ingestion
+    assert "hello from local canary" in serialized_ingestion
+    assert "local-canary-ok" in serialized_ingestion
 
 
 def test_tts_paths_are_not_stamped():

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -29,6 +29,7 @@ dependencies = [
 dev = [
     { name = "freezegun" },
     { name = "hypothesis" },
+    { name = "langfuse" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -58,6 +59,9 @@ harness-codex = [
 harness-opencode = [
     { name = "opencode-ai" },
 ]
+langfuse = [
+    { name = "langfuse" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -71,6 +75,8 @@ requires-dist = [
     { name = "freezegun", marker = "extra == 'dev'", specifier = ">=1.2,<2" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.88,<7" },
     { name = "joserfc", specifier = ">=1.0" },
+    { name = "langfuse", marker = "extra == 'dev'", specifier = ">=2.59.7,<3" },
+    { name = "langfuse", marker = "extra == 'langfuse'", specifier = ">=2.59.7,<3" },
     { name = "litellm", marker = "python_full_version < '3.11'", specifier = "!=1.97.0,<1.98.0" },
     { name = "litellm", marker = "python_full_version >= '3.11'" },
     { name = "openai-codex", marker = "extra == 'harness-all'", specifier = ">=0.1.0b3" },
@@ -95,7 +101,7 @@ requires-dist = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-provides-extras = ["harness-claude", "harness-codex", "harness-opencode", "harness-all", "harness", "dev"]
+provides-extras = ["langfuse", "harness-claude", "harness-codex", "harness-opencode", "harness-all", "harness", "dev"]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -263,6 +269,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
 ]
 
 [[package]]
@@ -1071,6 +1086,25 @@ wheels = [
 ]
 
 [[package]]
+name = "langfuse"
+version = "2.60.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "backoff" },
+    { name = "httpx" },
+    { name = "idna" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/45/77fdf53c9e9f49bb78f72eba3f992f2f3d8343e05976aabfe1fca276a640/langfuse-2.60.10.tar.gz", hash = "sha256:a26d0d927a28ee01b2d12bb5b862590b643cc4e60a28de6e2b0c2cfff5dbfc6a", size = 152648, upload-time = "2025-09-16T15:08:12.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/69/08584fbd69e14398d3932a77d0c8d7e20389da3e6470210d6719afba2801/langfuse-2.60.10-py3-none-any.whl", hash = "sha256:815c6369194aa5b2a24f88eb9952f7c3fc863272c41e90642a71f3bc76f4a11f", size = 275568, upload-time = "2025-09-16T15:08:10.166Z" },
+]
+
+[[package]]
 name = "litellm"
 version = "1.87.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1421,11 +1455,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.1"
+version = "24.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950, upload-time = "2024-11-08T09:47:47.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451, upload-time = "2024-11-08T09:47:44.722Z" },
 ]
 
 [[package]]
@@ -2418,6 +2452,55 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.17.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/23/bb82321b86411eb51e5a5db3fb8f8032fd30bd7c2d74bfe936136b2fa1d6/wrapt-1.17.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:88bbae4d40d5a46142e70d58bf664a89b6b4befaea7b2ecc14e03cedb8e06c04", size = 53482, upload-time = "2025-08-12T05:51:44.467Z" },
+    { url = "https://files.pythonhosted.org/packages/45/69/f3c47642b79485a30a59c63f6d739ed779fb4cc8323205d047d741d55220/wrapt-1.17.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6b13af258d6a9ad602d57d889f83b9d5543acd471eee12eb51f5b01f8eb1bc2", size = 38676, upload-time = "2025-08-12T05:51:32.636Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/71/e7e7f5670c1eafd9e990438e69d8fb46fa91a50785332e06b560c869454f/wrapt-1.17.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd341868a4b6714a5962c1af0bd44f7c404ef78720c7de4892901e540417111c", size = 38957, upload-time = "2025-08-12T05:51:54.655Z" },
+    { url = "https://files.pythonhosted.org/packages/de/17/9f8f86755c191d6779d7ddead1a53c7a8aa18bccb7cea8e7e72dfa6a8a09/wrapt-1.17.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f9b2601381be482f70e5d1051a5965c25fb3625455a2bf520b5a077b22afb775", size = 81975, upload-time = "2025-08-12T05:52:30.109Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/15/dd576273491f9f43dd09fce517f6c2ce6eb4fe21681726068db0d0467096/wrapt-1.17.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:343e44b2a8e60e06a7e0d29c1671a0d9951f59174f3709962b5143f60a2a98bd", size = 83149, upload-time = "2025-08-12T05:52:09.316Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c4/5eb4ce0d4814521fee7aa806264bf7a114e748ad05110441cd5b8a5c744b/wrapt-1.17.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:33486899acd2d7d3066156b03465b949da3fd41a5da6e394ec49d271baefcf05", size = 82209, upload-time = "2025-08-12T05:52:10.331Z" },
+    { url = "https://files.pythonhosted.org/packages/31/4b/819e9e0eb5c8dc86f60dfc42aa4e2c0d6c3db8732bce93cc752e604bb5f5/wrapt-1.17.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e6f40a8aa5a92f150bdb3e1c44b7e98fb7113955b2e5394122fa5532fec4b418", size = 81551, upload-time = "2025-08-12T05:52:31.137Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/83/ed6baf89ba3a56694700139698cf703aac9f0f9eb03dab92f57551bd5385/wrapt-1.17.3-cp310-cp310-win32.whl", hash = "sha256:a36692b8491d30a8c75f1dfee65bef119d6f39ea84ee04d9f9311f83c5ad9390", size = 36464, upload-time = "2025-08-12T05:53:01.204Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/90/ee61d36862340ad7e9d15a02529df6b948676b9a5829fd5e16640156627d/wrapt-1.17.3-cp310-cp310-win_amd64.whl", hash = "sha256:afd964fd43b10c12213574db492cb8f73b2f0826c8df07a68288f8f19af2ebe6", size = 38748, upload-time = "2025-08-12T05:53:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c3/cefe0bd330d389c9983ced15d326f45373f4073c9f4a8c2f99b50bfea329/wrapt-1.17.3-cp310-cp310-win_arm64.whl", hash = "sha256:af338aa93554be859173c39c85243970dc6a289fa907402289eeae7543e1ae18", size = 36810, upload-time = "2025-08-12T05:52:51.906Z" },
+    { url = "https://files.pythonhosted.org/packages/52/db/00e2a219213856074a213503fdac0511203dceefff26e1daa15250cc01a0/wrapt-1.17.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:273a736c4645e63ac582c60a56b0acb529ef07f78e08dc6bfadf6a46b19c0da7", size = 53482, upload-time = "2025-08-12T05:51:45.79Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/30/ca3c4a5eba478408572096fe9ce36e6e915994dd26a4e9e98b4f729c06d9/wrapt-1.17.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5531d911795e3f935a9c23eb1c8c03c211661a5060aab167065896bbf62a5f85", size = 38674, upload-time = "2025-08-12T05:51:34.629Z" },
+    { url = "https://files.pythonhosted.org/packages/31/25/3e8cc2c46b5329c5957cec959cb76a10718e1a513309c31399a4dad07eb3/wrapt-1.17.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0610b46293c59a3adbae3dee552b648b984176f8562ee0dba099a56cfbe4df1f", size = 38959, upload-time = "2025-08-12T05:51:56.074Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/8f/a32a99fc03e4b37e31b57cb9cefc65050ea08147a8ce12f288616b05ef54/wrapt-1.17.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b32888aad8b6e68f83a8fdccbf3165f5469702a7544472bdf41f582970ed3311", size = 82376, upload-time = "2025-08-12T05:52:32.134Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/4930cb8d9d70d59c27ee1332a318c20291749b4fba31f113c2f8ac49a72e/wrapt-1.17.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cccf4f81371f257440c88faed6b74f1053eef90807b77e31ca057b2db74edb1", size = 83604, upload-time = "2025-08-12T05:52:11.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f3/1afd48de81d63dd66e01b263a6fbb86e1b5053b419b9b33d13e1f6d0f7d0/wrapt-1.17.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8a210b158a34164de8bb68b0e7780041a903d7b00c87e906fb69928bf7890d5", size = 82782, upload-time = "2025-08-12T05:52:12.626Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d7/4ad5327612173b144998232f98a85bb24b60c352afb73bc48e3e0d2bdc4e/wrapt-1.17.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:79573c24a46ce11aab457b472efd8d125e5a51da2d1d24387666cd85f54c05b2", size = 82076, upload-time = "2025-08-12T05:52:33.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/59/e0adfc831674a65694f18ea6dc821f9fcb9ec82c2ce7e3d73a88ba2e8718/wrapt-1.17.3-cp311-cp311-win32.whl", hash = "sha256:c31eebe420a9a5d2887b13000b043ff6ca27c452a9a22fa71f35f118e8d4bf89", size = 36457, upload-time = "2025-08-12T05:53:03.936Z" },
+    { url = "https://files.pythonhosted.org/packages/83/88/16b7231ba49861b6f75fc309b11012ede4d6b0a9c90969d9e0db8d991aeb/wrapt-1.17.3-cp311-cp311-win_amd64.whl", hash = "sha256:0b1831115c97f0663cb77aa27d381237e73ad4f721391a9bfb2fe8bc25fa6e77", size = 38745, upload-time = "2025-08-12T05:53:02.885Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1e/c4d4f3398ec073012c51d1c8d87f715f56765444e1a4b11e5180577b7e6e/wrapt-1.17.3-cp311-cp311-win_arm64.whl", hash = "sha256:5a7b3c1ee8265eb4c8f1b7d29943f195c00673f5ab60c192eba2d4a7eae5f46a", size = 36806, upload-time = "2025-08-12T05:52:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/41/cad1aba93e752f1f9268c77270da3c469883d56e2798e7df6240dcb2287b/wrapt-1.17.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab232e7fdb44cdfbf55fc3afa31bcdb0d8980b9b95c38b6405df2acb672af0e0", size = 53998, upload-time = "2025-08-12T05:51:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f8/096a7cc13097a1869fe44efe68dace40d2a16ecb853141394047f0780b96/wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9baa544e6acc91130e926e8c802a17f3b16fbea0fd441b5a60f5cf2cc5c3deba", size = 39020, upload-time = "2025-08-12T05:51:35.906Z" },
+    { url = "https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b538e31eca1a7ea4605e44f81a48aa24c4632a277431a6ed3f328835901f4fd", size = 39098, upload-time = "2025-08-12T05:51:57.474Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828", size = 88036, upload-time = "2025-08-12T05:52:34.784Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/38/2e1785df03b3d72d34fc6252d91d9d12dc27a5c89caef3335a1bbb8908ca/wrapt-1.17.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3af60380ba0b7b5aeb329bc4e402acd25bd877e98b3727b0135cb5c2efdaefe9", size = 88156, upload-time = "2025-08-12T05:52:13.599Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8b/48cdb60fe0603e34e05cffda0b2a4adab81fd43718e11111a4b0100fd7c1/wrapt-1.17.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b02e424deef65c9f7326d8c19220a2c9040c51dc165cddb732f16198c168396", size = 87102, upload-time = "2025-08-12T05:52:14.56Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/51/d81abca783b58f40a154f1b2c56db1d2d9e0d04fa2d4224e357529f57a57/wrapt-1.17.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:74afa28374a3c3a11b3b5e5fca0ae03bef8450d6aa3ab3a1e2c30e3a75d023dc", size = 87732, upload-time = "2025-08-12T05:52:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b1/43b286ca1392a006d5336412d41663eeef1ad57485f3e52c767376ba7e5a/wrapt-1.17.3-cp312-cp312-win32.whl", hash = "sha256:4da9f45279fff3543c371d5ababc57a0384f70be244de7759c85a7f989cb4ebe", size = 36705, upload-time = "2025-08-12T05:53:07.123Z" },
+    { url = "https://files.pythonhosted.org/packages/28/de/49493f962bd3c586ab4b88066e967aa2e0703d6ef2c43aa28cb83bf7b507/wrapt-1.17.3-cp312-cp312-win_amd64.whl", hash = "sha256:e71d5c6ebac14875668a1e90baf2ea0ef5b7ac7918355850c0908ae82bcb297c", size = 38877, upload-time = "2025-08-12T05:53:05.436Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/48/0f7102fe9cb1e8a5a77f80d4f0956d62d97034bbe88d33e94699f99d181d/wrapt-1.17.3-cp312-cp312-win_arm64.whl", hash = "sha256:604d076c55e2fdd4c1c03d06dc1a31b95130010517b5019db15365ec4a405fc6", size = 36885, upload-time = "2025-08-12T05:52:54.367Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
+    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
+    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Opt-in observability for every LLM call made through `app.ai`. `AGENTFIELD_LITELLM_CALLBACKS=langfuse` (comma-separated; `logfire`, `langsmith`, or any litellm-supported callback name works the same way) registers the callbacks once, idempotently, at Agent init — and every completion is stamped with AgentField correlation metadata (`agentfield_execution_id`, `run_id`, `session_id`, `parent_execution_id`, `agent_node_id`, `reasoner`), so traces group by run instead of arriving as anonymous calls. LangFuse trace/session aliases are stamped only when a langfuse-family callback was registered *by AgentField* (never re-keying an existing LangFuse setup), caller-supplied metadata always wins, and a broken callback can never fail a reasoner. Everything is off by default; `AGENTFIELD_LITELLM_METADATA=false` disables stamping independently.

## Why
Refs #990, #997 (the Logfire/observability half — `logfire` is a supported callback name and the metadata rides on its spans; the Pydantic AI durable-execution adapter is tracked separately on #997).

## Changes
- feat(sdk-python): opt-in litellm callbacks and execution metadata
- test(sdk-python): cover litellm observability callbacks and metadata
- docs: document litellm observability callbacks and execution metadata
- fix(sdk-python): narrow litellm alias gate and callback bookkeeping (review round)
- test(sdk-python): fix the py3.10 leg and guard the alias narrowing (review round)
- docs: scope litellm alias stamping to the langfuse family (review round)
- chore(sdk-python): include litellm_observability in the coverage module list

## Validation contract
- C1 - env unset: litellm.callbacks / success_callback / failure_callback unchanged after Agent construction + reasoner run → `test_no_env_no_callbacks_registered`, `test_agent_construction_does_not_touch_litellm_callbacks`
- C2 - AGENTFIELD_LITELLM_CALLBACKS='langfuse': appears exactly once after N agents / M calls → `test_register_callbacks_is_idempotent`, `test_registered_callback_appears_once_across_agents_and_calls`
- C3 - 'langfuse, LOGFIRE ,,' resolves to ['langfuse','logfire'] → `test_resolve_callbacks_parses_env_list`
- C4 - unrecognised name passed through to add_litellm_callback, logged at debug, not dropped → `test_resolve_callbacks_passes_unknown_names_through`
- C5 - registration failure: Agent still constructs and the subsequent app.ai returns the model's answer → `test_register_callbacks_never_raises`, `test_agent_construction_survives_registration_failure`
- C6 - every app.ai text completion carries agentfield_execution_id / run_id / agent_node_id / reasoner; vision.py + harness schema repair explicitly out of scope → `test_metadata_keys_from_execution_context`, `test_agent_ai_passes_metadata_to_acompletion`, `docs/llm-observability.md:42 (out-of-scope statement)`
- C7 - agentfield_session_id / agentfield_parent_execution_id only when present, never empty strings → `test_metadata_omits_absent_optional_fields`
- C8 - LangFuse-native aliases stamped ONLY when AgentField itself registered the callback → `test_vendor_aliases_only_when_agentfield_registered`
- C9 - every metadata value is str except tags which is list[str] → `test_metadata_keys_from_execution_context`, `test_vendor_aliases_only_when_agentfield_registered`
- C10 - caller-supplied metadata key survives verbatim (setdefault per key); non-dict metadata left untouched and raises nothing → `test_stamp_never_overrides_caller_metadata`, `test_stamp_ignores_non_dict_metadata`
- C11 - outside any reasoner the call still succeeds and emits no agentfield_execution_id → `test_stamp_without_context_is_noop_safe`, `test_agent_ai_without_context_emits_no_agentfield_keys`
- C12 - tool loop: same agentfield_run_id every turn AND a fresh metadata dict per call → `test_tool_loop_inherits_metadata`
- C13 - no agentfield_* key ever in the provider request body, proven by live capture not by all_litellm_params membership → `test_metadata_never_reaches_the_wire[openai/gpt-4o-mini]`, `test_metadata_never_reaches_the_wire[litellm_proxy/gpt-4o-mini]`, `test_metadata_never_reaches_the_wire[openrouter/gpt-4o-mini]`
- C14 - user_id and requester_metadata never emitted inside metadata → `test_metadata_never_contains_user_id_or_requester_metadata`
- C15 - AGENTFIELD_LITELLM_METADATA=false opt-out mirrors the AGENTFIELD_OPENROUTER_ATTRIBUTION convention → `test_metadata_opt_out_env (7 cases: false/0/No/' OFF '/unset/true/unexpected)`, `test_build_execution_metadata_honours_opt_out_when_called_directly`
- C16 - TTS paths not stamped by splatting get_litellm_params → `test_tts_paths_are_not_stamped (sdk/python/agentfield/types.py left untouched; stamp lives in AgentAI.ai)`
- C17 - no hard dependency on private litellm attributes (getattr + graceful fallback) → `test_register_callbacks_without_manager_falls_back`
- C18 - docs state the three pitfalls (process-global callback state / langfuse+logfire not deps and degrade to a logged no-op / otel callback yields a second disconnected trace tree) → `docs/llm-observability.md:44-46 - each claim verified: the langfuse-missing degradation reproduced live against litellm 1.98.0 ('[Non-Blocking Error] Error initializing custom logger', completion still returned 'ok'); 'traceparent' appears nowhere in the repo (git grep -il traceparent returns nothing)`
- C19 - doc page lives outside docs/integrations/ → `docs/llm-observability.md is at the docs root; docs/integrations/ untouched`

Adversarial re-review after the fix round confirmed all 8 first-round findings resolved (the 8th — the new module missing from the `--cov` list — is fixed in the last commit). Verified against a patched `acompletion` that metadata never reaches the provider request body on `openai/`, `litellm_proxy/` and `openrouter/` routes.

## How it was tested
CI-literal gates in the worktree: `ruff check .`, `./scripts/run_pytest.sh` (full sdk-python suite), `./scripts/coverage-surface.sh sdk-python`, `./scripts/patch-coverage-gate.sh` — ALL-PASS with the new module included in coverage.

## Notes / follow-ups
litellm callback state is process-global by design upstream; the docs page spells out that pitfall, the optional-dependency behaviour, and that the control plane cannot observe agent-internal litellm calls (they never transit it) — CP OTLP spans and these traces share the run id instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
