### PR TITLE
feat(control-plane,k8s): shutdown min delay, drain-aware readiness, chart defaults and a coherent tuning recipe

### DIFF
--- a/control-plane/.env.example
+++ b/control-plane/.env.example
@@ -114,6 +114,9 @@ AGENTFIELD_STORAGE_MODE=local
 # Leave unset (true) in anything but local debugging (YAML: logging.redact_payloads).
 # AGENTFIELD_LOG_REDACT_PAYLOADS=true
 
+# Keep serving briefly after SIGTERM so shutdown-aware readiness can propagate.
+# AGENTFIELD_SHUTDOWN_MIN_DELAY=5s
+
 # OpenTelemetry tracing (control plane)
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 # Per-signal endpoint takes precedence and normally includes /v1/traces.

--- a/control-plane/cmd/af/main.go
+++ b/control-plane/cmd/af/main.go
@@ -243,7 +243,7 @@ func runServer(cmd *cobra.Command, args []string) {
 	fmt.Printf("Press Ctrl+C to exit.\n")
 
 	shutdownCtx, stopSignals := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	if err := drainOnShutdown(shutdownCtx, stopSignals, agentfieldServer.Stop); err != nil {
+	if err := drainOnShutdown(shutdownCtx, stopSignals, agentfieldServer.BeginDrain, cfg.AgentField.ShutdownMinDelay, agentfieldServer.Stop); err != nil {
 		log.Printf("Error during shutdown: %v", err)
 		os.Exit(1)
 	}
@@ -251,13 +251,22 @@ func runServer(cmd *cobra.Command, args []string) {
 
 // drainOnShutdown blocks until ctx is cancelled by a shutdown signal, restores
 // the default signal behavior (so a second signal forces an immediate exit),
-// and then runs the server's bounded shutdown sequence.
-func drainOnShutdown(ctx context.Context, stopSignals func(), stop func() error) error {
+// flips the server to draining so readiness probes start failing, waits out
+// minDelay while the listener keeps serving, and then runs the server's
+// bounded shutdown sequence. minDelay of 0 skips the wait entirely.
+func drainOnShutdown(ctx context.Context, stopSignals func(), beginDrain func(), minDelay time.Duration, stop func() error) error {
 	waitForShutdown(ctx)
 	if stopSignals != nil {
 		stopSignals()
 	}
+	if beginDrain != nil {
+		beginDrain()
+	}
 	fmt.Println("\nShutdown signal received, draining connections...")
+	if minDelay > 0 {
+		log.Printf("Waiting %s before closing the listener", minDelay)
+		time.Sleep(minDelay)
+	}
 	if err := stop(); err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			log.Printf("Warning: shutdown drain timed out; forced close completed: %v", err)

--- a/control-plane/cmd/af/main_test.go
+++ b/control-plane/cmd/af/main_test.go
@@ -124,7 +124,7 @@ func TestDrainOnShutdownRunsStopAfterSignalAndRestoresSignals(t *testing.T) {
 	stops := 0
 	done := make(chan error, 1)
 	go func() {
-		done <- drainOnShutdown(ctx, func() { restored = true }, func() error { stops++; return nil })
+		done <- drainOnShutdown(ctx, func() { restored = true }, nil, 0, func() error { stops++; return nil })
 	}()
 	select {
 	case err := <-done:
@@ -152,7 +152,7 @@ func TestDrainOnShutdownPropagatesStopError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	want := errors.New("drain failed")
-	if err := drainOnShutdown(ctx, nil, func() error { return want }); !errors.Is(err, want) {
+	if err := drainOnShutdown(ctx, nil, nil, 0, func() error { return want }); !errors.Is(err, want) {
 		t.Fatalf("got %v, want %v", err, want)
 	}
 }
@@ -160,7 +160,31 @@ func TestDrainOnShutdownPropagatesStopError(t *testing.T) {
 func TestDrainOnShutdownTreatsTimeoutAsSuccessfulExit(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	require.NoError(t, drainOnShutdown(ctx, nil, func() error {
+	require.NoError(t, drainOnShutdown(ctx, nil, nil, 0, func() error {
 		return context.DeadlineExceeded
 	}))
+}
+
+func TestDrainOnShutdownBeginsDrainBeforeMinimumDelayAndStop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	started := time.Now()
+	drained := false
+	signalsRestored := false
+	require.NoError(t, drainOnShutdown(ctx, func() { signalsRestored = true }, func() {
+		require.True(t, signalsRestored, "signal disposition must be restored before draining")
+		drained = true
+	}, 50*time.Millisecond, func() error {
+		require.True(t, drained)
+		require.GreaterOrEqual(t, time.Since(started), 50*time.Millisecond)
+		return nil
+	}))
+}
+
+func TestDrainOnShutdownZeroDelayStopsImmediately(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	started := time.Now()
+	require.NoError(t, drainOnShutdown(ctx, nil, func() {}, 0, func() error { return nil }))
+	require.Less(t, time.Since(started), 40*time.Millisecond)
 }

--- a/control-plane/cmd/agentfield-server/main.go
+++ b/control-plane/cmd/agentfield-server/main.go
@@ -261,14 +261,27 @@ func runServer(cmd *cobra.Command, args []string) {
 
 	// Graceful shutdown
 	fmt.Println("\nShutdown signal received, draining connections...")
-	if err := finishShutdown(agentfieldServer.Stop); err != nil {
+	if err := finishShutdown(agentfieldServer.BeginDrain, cfg.AgentField.ShutdownMinDelay, agentfieldServer.Stop); err != nil {
 		log.Printf("Error during shutdown: %v", err)
 		os.Exit(1)
 	}
 	fmt.Println("Server stopped gracefully.")
 }
 
-func finishShutdown(stop func() error) error {
+// finishShutdown flips the server to draining so readiness probes start
+// failing, waits out minDelay while the listener keeps serving, and then runs
+// the server's bounded shutdown sequence. minDelay of 0 skips the wait. It is
+// deliberately called after waitForShutdownFunc has returned: that helper
+// restores the default signal disposition on return, so a second signal
+// received during the wait terminates the process immediately.
+func finishShutdown(beginDrain func(), minDelay time.Duration, stop func() error) error {
+	if beginDrain != nil {
+		beginDrain()
+	}
+	if minDelay > 0 {
+		log.Printf("Waiting %s before closing the listener", minDelay)
+		time.Sleep(minDelay)
+	}
 	err := stop()
 	if errors.Is(err, context.DeadlineExceeded) {
 		log.Printf("Warning: shutdown drain timed out; forced close completed: %v", err)

--- a/control-plane/cmd/agentfield-server/main_test.go
+++ b/control-plane/cmd/agentfield-server/main_test.go
@@ -20,15 +20,41 @@ import (
 )
 
 func TestFinishShutdownTreatsTimeoutAsSuccessfulExit(t *testing.T) {
-	if err := finishShutdown(func() error { return context.DeadlineExceeded }); err != nil {
+	if err := finishShutdown(nil, 0, func() error { return context.DeadlineExceeded }); err != nil {
 		t.Fatalf("timeout should be a successful shutdown exit: %v", err)
 	}
 }
 
 func TestFinishShutdownPropagatesGenuineFailure(t *testing.T) {
 	want := errors.New("close failed")
-	if err := finishShutdown(func() error { return want }); !errors.Is(err, want) {
+	if err := finishShutdown(nil, 0, func() error { return want }); !errors.Is(err, want) {
 		t.Fatalf("got %v, want %v", err, want)
+	}
+}
+
+func TestFinishShutdownBeginsDrainBeforeMinimumDelayAndStop(t *testing.T) {
+	started := time.Now()
+	drained := false
+	if err := finishShutdown(func() { drained = true }, 50*time.Millisecond, func() error {
+		if !drained {
+			t.Fatal("stop called before beginDrain")
+		}
+		if elapsed := time.Since(started); elapsed < 50*time.Millisecond {
+			t.Fatalf("stop called after %s, want at least 50ms", elapsed)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFinishShutdownZeroDelayStopsImmediately(t *testing.T) {
+	started := time.Now()
+	if err := finishShutdown(func() {}, 0, func() error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(started); elapsed >= 40*time.Millisecond {
+		t.Fatalf("zero delay took %s", elapsed)
 	}
 }
 

--- a/control-plane/internal/config/config.go
+++ b/control-plane/internal/config/config.go
@@ -75,6 +75,7 @@ type UIConfig struct {
 type AgentFieldConfig struct {
 	Port             int                    `yaml:"port"`
 	ShutdownTimeout  time.Duration          `yaml:"shutdown_timeout" mapstructure:"shutdown_timeout"`
+	ShutdownMinDelay time.Duration          `yaml:"shutdown_min_delay" mapstructure:"shutdown_min_delay"`
 	ARD              ARDConfig              `yaml:"ard" mapstructure:"ard"`
 	Registration     RegistrationConfig     `yaml:"registration" mapstructure:"registration"`
 	NodeHealth       NodeHealthConfig       `yaml:"node_health" mapstructure:"node_health"`
@@ -737,6 +738,13 @@ func ApplyEnvOverrides(cfg *Config) {
 			fmt.Fprintf(os.Stderr, "Warning: invalid AGENTFIELD_SHUTDOWN_TIMEOUT=%q; keeping %s\n", val, cfg.AgentField.ShutdownTimeout)
 		}
 	}
+	if val := os.Getenv("AGENTFIELD_SHUTDOWN_MIN_DELAY"); val != "" {
+		if d, ok := parseNonNegativeDuration(val); ok {
+			cfg.AgentField.ShutdownMinDelay = d
+		} else {
+			fmt.Fprintf(os.Stderr, "Warning: invalid AGENTFIELD_SHUTDOWN_MIN_DELAY=%q; keeping %s\n", val, cfg.AgentField.ShutdownMinDelay)
+		}
+	}
 
 	// Node health monitoring overrides
 	if val := os.Getenv("AGENTFIELD_HEALTH_CHECK_INTERVAL"); val != "" {
@@ -1078,6 +1086,22 @@ func parseShutdownTimeout(val string) (time.Duration, bool) {
 	if secs, err := strconv.ParseFloat(val, 64); err == nil {
 		d := time.Duration(secs * float64(time.Second))
 		return d, d > 0
+	}
+	return 0, false
+}
+
+// parseNonNegativeDuration parses a duration given as a Go duration string or
+// as bare seconds. Unlike parseShutdownTimeout, zero is a valid value: it is
+// the default for AGENTFIELD_SHUTDOWN_MIN_DELAY and means "do not wait".
+// Negative values are rejected.
+func parseNonNegativeDuration(val string) (time.Duration, bool) {
+	val = strings.TrimSpace(val)
+	if d, err := time.ParseDuration(val); err == nil {
+		return d, d >= 0
+	}
+	if secs, err := strconv.ParseFloat(val, 64); err == nil {
+		d := time.Duration(secs * float64(time.Second))
+		return d, d >= 0
 	}
 	return 0, false
 }

--- a/control-plane/internal/config/config_additional_test.go
+++ b/control-plane/internal/config/config_additional_test.go
@@ -678,3 +678,48 @@ func TestShutdownTimeoutEnvAcceptsBareSecondsLikeTheSDKs(t *testing.T) {
 		t.Fatalf("expected the 30s default to survive an invalid value, got %v", cfg.AgentField.ShutdownTimeout)
 	}
 }
+
+func TestShutdownMinDelayEnvParsing(t *testing.T) {
+	tests := []struct {
+		name       string
+		value      string
+		configured time.Duration
+		want       time.Duration
+	}{
+		{name: "bare seconds", value: "5", want: 5 * time.Second},
+		{name: "duration", value: "5s", want: 5 * time.Second},
+		{name: "subsecond duration", value: "500ms", want: 500 * time.Millisecond},
+		{name: "zero", value: "0", configured: time.Second, want: 0},
+		{name: "unset", value: "", configured: time.Second, want: time.Second},
+		{name: "unparseable", value: "abc", configured: time.Second, want: time.Second},
+		{name: "negative", value: "-1s", configured: time.Second, want: time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("AGENTFIELD_SHUTDOWN_MIN_DELAY", tt.value)
+			cfg := Config{AgentField: AgentFieldConfig{ShutdownMinDelay: tt.configured}}
+			ApplyEnvOverrides(&cfg)
+			if cfg.AgentField.ShutdownMinDelay != tt.want {
+				t.Fatalf("got %s, want %s", cfg.AgentField.ShutdownMinDelay, tt.want)
+			}
+		})
+	}
+}
+
+func TestShutdownTimeoutZeroStillKeepsCurrentValue(t *testing.T) {
+	t.Setenv("AGENTFIELD_SHUTDOWN_TIMEOUT", "0")
+	cfg := Config{AgentField: AgentFieldConfig{ShutdownTimeout: 15 * time.Second}}
+	ApplyEnvOverrides(&cfg)
+	if cfg.AgentField.ShutdownTimeout != 15*time.Second {
+		t.Fatalf("zero changed shutdown timeout to %s", cfg.AgentField.ShutdownTimeout)
+	}
+}
+
+func TestShutdownMinDelayDefaultsToZero(t *testing.T) {
+	t.Setenv("AGENTFIELD_SHUTDOWN_MIN_DELAY", "")
+	cfg := Config{}
+	ApplyDefaults(&cfg)
+	if cfg.AgentField.ShutdownMinDelay != 0 {
+		t.Fatalf("got %s, want zero", cfg.AgentField.ShutdownMinDelay)
+	}
+}

--- a/control-plane/internal/server/apicatalog/catalog_entries.go
+++ b/control-plane/internal/server/apicatalog/catalog_entries.go
@@ -7,6 +7,8 @@ func DefaultEntries() []EndpointEntry {
 		// --- Health ---
 		{Method: "GET", Path: "/health", Group: "health", Summary: "Server health check", AuthLevel: "public", Tags: []string{"health", "monitoring"}},
 		{Method: "GET", Path: "/api/v1/health", Group: "health", Summary: "API health check", AuthLevel: "public", Tags: []string{"health", "monitoring"}},
+		{Method: "GET", Path: "/readyz", Group: "health", Summary: "Shutdown-aware readiness probe", AuthLevel: "public", Tags: []string{"health", "monitoring"}},
+		{Method: "GET", Path: "/api/v1/health/ready", Group: "health", Summary: "Shutdown-aware API readiness probe", AuthLevel: "public", Tags: []string{"health", "monitoring"}},
 		{Method: "GET", Path: "/metrics", Group: "health", Summary: "Prometheus metrics", AuthLevel: "public", Tags: []string{"metrics", "monitoring", "prometheus"}},
 
 		// --- Discovery ---

--- a/control-plane/internal/server/manifest_readiness_defaults_test.go
+++ b/control-plane/internal/server/manifest_readiness_defaults_test.go
@@ -1,9 +1,13 @@
 package server
 
 import (
+	"bytes"
+	"io"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -25,7 +29,9 @@ func TestManifestReadinessDefaultsRemainBackwardCompatible(t *testing.T) {
 	var helm struct {
 		ControlPlane struct {
 			ReadinessProbe struct {
-				Path string `yaml:"path"`
+				Path             string `yaml:"path"`
+				PeriodSeconds    int    `yaml:"periodSeconds"`
+				FailureThreshold int    `yaml:"failureThreshold"`
 			} `yaml:"readinessProbe"`
 			ShutdownMinDelay              string `yaml:"shutdownMinDelay"`
 			TerminationGracePeriodSeconds int    `yaml:"terminationGracePeriodSeconds"`
@@ -49,6 +55,8 @@ func TestManifestReadinessDefaultsRemainBackwardCompatible(t *testing.T) {
 		want      any
 	}{
 		{name: "readiness probe path", reference: ".Values.controlPlane.readinessProbe.path", got: helm.ControlPlane.ReadinessProbe.Path, want: "/api/v1/health"},
+		{name: "readiness probe period", reference: ".Values.controlPlane.readinessProbe.periodSeconds", got: helm.ControlPlane.ReadinessProbe.PeriodSeconds, want: 2},
+		{name: "readiness probe failure threshold", reference: ".Values.controlPlane.readinessProbe.failureThreshold", got: helm.ControlPlane.ReadinessProbe.FailureThreshold, want: 1},
 		{name: "shutdown min delay", reference: ".Values.controlPlane.shutdownMinDelay", got: helm.ControlPlane.ShutdownMinDelay, want: "5s"},
 		{name: "termination grace period", reference: ".Values.controlPlane.terminationGracePeriodSeconds", got: helm.ControlPlane.TerminationGracePeriodSeconds, want: 60},
 	} {
@@ -61,6 +69,14 @@ func TestManifestReadinessDefaultsRemainBackwardCompatible(t *testing.T) {
 			}
 		})
 	}
+	delay, err := time.ParseDuration(helm.ControlPlane.ShutdownMinDelay)
+	if err != nil {
+		t.Fatalf("parse Helm shutdown minimum delay: %v", err)
+	}
+	readinessFailureWindow := time.Duration(helm.ControlPlane.ReadinessProbe.PeriodSeconds*helm.ControlPlane.ReadinessProbe.FailureThreshold) * time.Second
+	if readinessFailureWindow >= delay {
+		t.Fatalf("readiness failure window %s must be shorter than shutdown minimum delay %s", readinessFailureWindow, delay)
+	}
 
 	var base struct {
 		Spec struct {
@@ -71,6 +87,8 @@ func TestManifestReadinessDefaultsRemainBackwardCompatible(t *testing.T) {
 							HTTPGet struct {
 								Path string `yaml:"path"`
 							} `yaml:"httpGet"`
+							PeriodSeconds    int `yaml:"periodSeconds"`
+							FailureThreshold int `yaml:"failureThreshold"`
 						} `yaml:"readinessProbe"`
 					} `yaml:"containers"`
 				} `yaml:"spec"`
@@ -84,7 +102,137 @@ func TestManifestReadinessDefaultsRemainBackwardCompatible(t *testing.T) {
 	if err := yaml.Unmarshal(data, &base); err != nil {
 		t.Fatal(err)
 	}
-	if len(base.Spec.Template.Spec.Containers) == 0 || base.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Path != "/api/v1/health" {
+	if len(base.Spec.Template.Spec.Containers) == 0 {
+		t.Fatal("base manifest has no containers")
+	}
+	baseReadiness := base.Spec.Template.Spec.Containers[0].ReadinessProbe
+	if baseReadiness.HTTPGet.Path != "/api/v1/health" {
 		t.Fatalf("base manifest readiness path changed")
 	}
+	if baseReadiness.PeriodSeconds != 2 || baseReadiness.FailureThreshold != 1 {
+		t.Fatalf("base readiness timing = period %ds, threshold %d; want period 2s, threshold 1", baseReadiness.PeriodSeconds, baseReadiness.FailureThreshold)
+	}
+}
+
+type renderedControlPlane struct {
+	TerminationGracePeriodSeconds int
+	Container                     renderedControlPlaneContainer
+}
+
+type renderedControlPlaneContainer struct {
+	Name string `yaml:"name"`
+	Env  []struct {
+		Name  string `yaml:"name"`
+		Value string `yaml:"value"`
+	} `yaml:"env"`
+	ReadinessProbe struct {
+		HTTPGet struct {
+			Path string `yaml:"path"`
+		} `yaml:"httpGet"`
+		PeriodSeconds    int `yaml:"periodSeconds"`
+		FailureThreshold int `yaml:"failureThreshold"`
+	} `yaml:"readinessProbe"`
+}
+
+func TestHelmControlPlaneShutdownContractRenders(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skipf("helm unavailable: %v", err)
+	}
+	if _, err := os.Stat("../../../deployments/helm/agentfield/Chart.yaml"); err != nil {
+		t.Skipf("Helm chart unavailable in this build context: %v", err)
+	}
+
+	tests := []struct {
+		name              string
+		extraArgs         []string
+		wantReadinessPath string
+		wantMinDelayValue string
+		wantMinDelayCount int
+	}{
+		{name: "defaults", wantReadinessPath: "/api/v1/health", wantMinDelayValue: "5s", wantMinDelayCount: 1},
+		{name: "drain aware readiness opt in", extraArgs: []string{"--set-string", "controlPlane.readinessProbe.path=/api/v1/health/ready"}, wantReadinessPath: "/api/v1/health/ready", wantMinDelayValue: "5s", wantMinDelayCount: 1},
+		{name: "env map overrides generated value", extraArgs: []string{"--set-string", "controlPlane.env.AGENTFIELD_SHUTDOWN_MIN_DELAY=17s"}, wantReadinessPath: "/api/v1/health", wantMinDelayValue: "17s", wantMinDelayCount: 1},
+		{name: "extra env overrides generated value", extraArgs: []string{"--set-string", "controlPlane.extraEnv[0].name=AGENTFIELD_SHUTDOWN_MIN_DELAY", "--set-string", "controlPlane.extraEnv[0].value=23s"}, wantReadinessPath: "/api/v1/health", wantMinDelayValue: "23s", wantMinDelayCount: 1},
+		{name: "zero disables generated value", extraArgs: []string{"--set", "controlPlane.shutdownMinDelay=0"}, wantReadinessPath: "/api/v1/health", wantMinDelayCount: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rendered := renderHelmControlPlane(t, tt.extraArgs...)
+			probe := rendered.Container.ReadinessProbe
+			if probe.HTTPGet.Path != tt.wantReadinessPath {
+				t.Fatalf("readiness path = %q, want %q", probe.HTTPGet.Path, tt.wantReadinessPath)
+			}
+			if probe.PeriodSeconds != 2 || probe.FailureThreshold != 1 {
+				t.Fatalf("readiness timing = period %ds, threshold %d; want period 2s, threshold 1", probe.PeriodSeconds, probe.FailureThreshold)
+			}
+			if rendered.TerminationGracePeriodSeconds != 60 {
+				t.Fatalf("termination grace = %d, want 60", rendered.TerminationGracePeriodSeconds)
+			}
+
+			count, value := shutdownMinDelayEnv(rendered.Container)
+			if count != tt.wantMinDelayCount {
+				t.Fatalf("rendered %d AGENTFIELD_SHUTDOWN_MIN_DELAY entries, want %d", count, tt.wantMinDelayCount)
+			}
+			if count > 0 && value != tt.wantMinDelayValue {
+				t.Fatalf("AGENTFIELD_SHUTDOWN_MIN_DELAY = %q, want %q", value, tt.wantMinDelayValue)
+			}
+		})
+	}
+}
+
+func renderHelmControlPlane(t *testing.T, extraArgs ...string) renderedControlPlane {
+	t.Helper()
+	chartPath := "../../../deployments/helm/agentfield"
+	args := append([]string{"template", "shutdown-contract", chartPath}, extraArgs...)
+	out, err := exec.Command("helm", args...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("helm template failed: %v\n%s", err, out)
+	}
+
+	decoder := yaml.NewDecoder(bytes.NewReader(out))
+	for {
+		var manifest struct {
+			Kind string `yaml:"kind"`
+			Spec struct {
+				Template struct {
+					Spec struct {
+						TerminationGracePeriodSeconds int                             `yaml:"terminationGracePeriodSeconds"`
+						Containers                    []renderedControlPlaneContainer `yaml:"containers"`
+					} `yaml:"spec"`
+				} `yaml:"template"`
+			} `yaml:"spec"`
+		}
+		if err := decoder.Decode(&manifest); err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatalf("decode helm output: %v", err)
+		}
+		if manifest.Kind != "Deployment" {
+			continue
+		}
+		for _, container := range manifest.Spec.Template.Spec.Containers {
+			if container.Name == "control-plane" {
+				return renderedControlPlane{
+					TerminationGracePeriodSeconds: manifest.Spec.Template.Spec.TerminationGracePeriodSeconds,
+					Container:                     container,
+				}
+			}
+		}
+	}
+	t.Fatal("rendered chart has no control-plane Deployment container")
+	return renderedControlPlane{}
+}
+
+func shutdownMinDelayEnv(container renderedControlPlaneContainer) (int, string) {
+	count := 0
+	value := ""
+	for _, env := range container.Env {
+		if env.Name == "AGENTFIELD_SHUTDOWN_MIN_DELAY" {
+			count++
+			value = env.Value
+		}
+	}
+	return count, value
 }

--- a/control-plane/internal/server/manifest_readiness_defaults_test.go
+++ b/control-plane/internal/server/manifest_readiness_defaults_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -9,6 +10,7 @@ import (
 
 func TestManifestReadinessDefaultsRemainBackwardCompatible(t *testing.T) {
 	helmPath := "../../../deployments/helm/agentfield/values.yaml"
+	helmTemplatePath := "../../../deployments/helm/agentfield/templates/control-plane-deployment.yaml"
 	basePath := "../../../deployments/kubernetes/base/control-plane-deployment.yaml"
 	if _, err := os.Stat(helmPath); err != nil {
 		t.Skipf("Helm values unavailable in this build context: %v", err)
@@ -16,12 +18,17 @@ func TestManifestReadinessDefaultsRemainBackwardCompatible(t *testing.T) {
 	if _, err := os.Stat(basePath); err != nil {
 		t.Skipf("base manifest unavailable in this build context: %v", err)
 	}
+	if _, err := os.Stat(helmTemplatePath); err != nil {
+		t.Skipf("Helm template unavailable in this build context: %v", err)
+	}
 
 	var helm struct {
 		ControlPlane struct {
 			ReadinessProbe struct {
 				Path string `yaml:"path"`
 			} `yaml:"readinessProbe"`
+			ShutdownMinDelay              string `yaml:"shutdownMinDelay"`
+			TerminationGracePeriodSeconds int    `yaml:"terminationGracePeriodSeconds"`
 		} `yaml:"controlPlane"`
 	}
 	data, err := os.ReadFile(helmPath)
@@ -31,8 +38,28 @@ func TestManifestReadinessDefaultsRemainBackwardCompatible(t *testing.T) {
 	if err := yaml.Unmarshal(data, &helm); err != nil {
 		t.Fatal(err)
 	}
-	if helm.ControlPlane.ReadinessProbe.Path != "/api/v1/health" {
-		t.Fatalf("Helm readiness path = %q", helm.ControlPlane.ReadinessProbe.Path)
+	templateData, err := os.ReadFile(helmTemplatePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name      string
+		reference string
+		got       any
+		want      any
+	}{
+		{name: "readiness probe path", reference: ".Values.controlPlane.readinessProbe.path", got: helm.ControlPlane.ReadinessProbe.Path, want: "/api/v1/health"},
+		{name: "shutdown min delay", reference: ".Values.controlPlane.shutdownMinDelay", got: helm.ControlPlane.ShutdownMinDelay, want: "5s"},
+		{name: "termination grace period", reference: ".Values.controlPlane.terminationGracePeriodSeconds", got: helm.ControlPlane.TerminationGracePeriodSeconds, want: 60},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if test.got != test.want {
+				t.Fatalf("Helm default = %v, want %v", test.got, test.want)
+			}
+			if !strings.Contains(string(templateData), test.reference) {
+				t.Fatalf("Helm control-plane deployment template does not reference %q", test.reference)
+			}
+		})
 	}
 
 	var base struct {

--- a/control-plane/internal/server/manifest_readiness_defaults_test.go
+++ b/control-plane/internal/server/manifest_readiness_defaults_test.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestManifestReadinessDefaultsRemainBackwardCompatible(t *testing.T) {
+	helmPath := "../../../deployments/helm/agentfield/values.yaml"
+	basePath := "../../../deployments/kubernetes/base/control-plane-deployment.yaml"
+	if _, err := os.Stat(helmPath); err != nil {
+		t.Skipf("Helm values unavailable in this build context: %v", err)
+	}
+	if _, err := os.Stat(basePath); err != nil {
+		t.Skipf("base manifest unavailable in this build context: %v", err)
+	}
+
+	var helm struct {
+		ControlPlane struct {
+			ReadinessProbe struct {
+				Path string `yaml:"path"`
+			} `yaml:"readinessProbe"`
+		} `yaml:"controlPlane"`
+	}
+	data, err := os.ReadFile(helmPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := yaml.Unmarshal(data, &helm); err != nil {
+		t.Fatal(err)
+	}
+	if helm.ControlPlane.ReadinessProbe.Path != "/api/v1/health" {
+		t.Fatalf("Helm readiness path = %q", helm.ControlPlane.ReadinessProbe.Path)
+	}
+
+	var base struct {
+		Spec struct {
+			Template struct {
+				Spec struct {
+					Containers []struct {
+						ReadinessProbe struct {
+							HTTPGet struct {
+								Path string `yaml:"path"`
+							} `yaml:"httpGet"`
+						} `yaml:"readinessProbe"`
+					} `yaml:"containers"`
+				} `yaml:"spec"`
+			} `yaml:"template"`
+		} `yaml:"spec"`
+	}
+	data, err = os.ReadFile(basePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := yaml.Unmarshal(data, &base); err != nil {
+		t.Fatal(err)
+	}
+	if len(base.Spec.Template.Spec.Containers) == 0 || base.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Path != "/api/v1/health" {
+		t.Fatalf("base manifest readiness path changed")
+	}
+}

--- a/control-plane/internal/server/routes_core.go
+++ b/control-plane/internal/server/routes_core.go
@@ -22,6 +22,7 @@ import (
 func (s *AgentFieldServer) registerPublicRoutes() {
 	s.Router.GET("/metrics", gin.WrapH(promhttp.Handler()))
 	s.Router.GET("/health", s.healthCheckHandler)
+	s.Router.GET("/readyz", s.readinessHandler)
 }
 
 // registerCoreRoutes installs the core agent-facing REST surface under
@@ -29,6 +30,7 @@ func (s *AgentFieldServer) registerPublicRoutes() {
 func (s *AgentFieldServer) registerCoreRoutes(agentAPI *gin.RouterGroup) {
 	// Health check endpoint for container orchestration
 	agentAPI.GET("/health", s.healthCheckHandler)
+	agentAPI.GET("/health/ready", s.readinessHandler)
 	agentAPI.GET("/version", s.versionHandler)
 
 	// Apply global rate limiting if enabled
@@ -273,6 +275,23 @@ func (s *AgentFieldServer) healthCheckHandler(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, healthStatus)
+}
+
+// readinessHandler answers Kubernetes readiness probes. It reports the same
+// dependency checks as healthCheckHandler, except that once BeginDrain has
+// run it answers 503 unconditionally so kube-proxy removes this pod from the
+// Service endpoints while the listener is still accepting and completing
+// requests.
+func (s *AgentFieldServer) readinessHandler(c *gin.Context) {
+	if s.IsDraining() {
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"status":    "draining",
+			"timestamp": time.Now().UTC().Format(time.RFC3339),
+			"version":   buildVersion,
+		})
+		return
+	}
+	s.healthCheckHandler(c)
 }
 
 type hostingInfo struct {

--- a/control-plane/internal/server/routes_middleware.go
+++ b/control-plane/internal/server/routes_middleware.go
@@ -58,7 +58,7 @@ func (s *AgentFieldServer) applyGlobalMiddleware() {
 	// because EventSource and WebSocket clients cannot set custom headers.
 	// Note: The approval webhook callback is authenticated via HMAC signature,
 	// not the global API key. Always bypass API-key auth on that endpoint.
-	skipPaths := append(append([]string{}, s.config.API.Auth.SkipPaths...), "/api/v1/webhooks/approval-response")
+	skipPaths := append(append([]string{}, s.config.API.Auth.SkipPaths...), "/api/v1/webhooks/approval-response", "/readyz", "/api/v1/health/ready")
 	skipPrefixes := []string{}
 	if s.config.AgentField.ARD.Enabled && s.config.AgentField.ARD.Publish.Enabled {
 		skipPaths = append(skipPaths, "/.well-known/ai-catalog.json")
@@ -89,6 +89,8 @@ func (s *AgentFieldServer) applyGlobalMiddleware() {
 				"/health",
 				"/metrics",
 				"/api/v1/health",
+				"/readyz",
+				"/api/v1/health/ready",
 			},
 		}
 		s.Router.Use(middleware.DIDAuthMiddleware(s.didWebService, didAuthConfig))

--- a/control-plane/internal/server/server.go
+++ b/control-plane/internal/server/server.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Agent-Field/agentfield/control-plane/internal/config"
@@ -116,6 +117,7 @@ type AgentFieldServer struct {
 	httpServerMu      sync.RWMutex
 	httpServer        *http.Server
 	stopping          bool
+	draining          atomic.Bool
 	streamCtx         context.Context
 	cancelStreams     context.CancelFunc
 	cancelStreamsOnce sync.Once
@@ -911,6 +913,7 @@ func (s *AgentFieldServer) ListReasoners(ctx context.Context, _ *adminpb.ListRea
 
 // Stop gracefully shuts down the AgentFieldServer.
 func (s *AgentFieldServer) Stop() error {
+	s.BeginDrain()
 	s.httpServerMu.Lock()
 	s.stopping = true
 	s.httpServerMu.Unlock()
@@ -1031,6 +1034,20 @@ func (s *AgentFieldServer) Stop() error {
 
 	// TODO: Implement graceful shutdown for WebSocket
 	return httpShutdownErr
+}
+
+// BeginDrain marks the control plane as shutting down so readiness probes
+// start failing while the HTTP listener is still open and still serving. It
+// is safe to call more than once and never blocks. Liveness (/health,
+// /api/v1/health) is deliberately untouched: the process is alive and must
+// not be killed by the kubelet mid-drain.
+func (s *AgentFieldServer) BeginDrain() {
+	s.draining.Store(true)
+}
+
+// IsDraining reports whether shutdown draining has begun.
+func (s *AgentFieldServer) IsDraining() bool {
+	return s.draining.Load()
 }
 
 func (s *AgentFieldServer) streamHandler(handler gin.HandlerFunc) gin.HandlerFunc {

--- a/control-plane/internal/server/server_routes_test.go
+++ b/control-plane/internal/server/server_routes_test.go
@@ -657,6 +657,52 @@ func TestSetupRoutesRegistersHealthEndpoint(t *testing.T) {
 	})
 }
 
+func TestReadinessTurnsUnavailableDuringDrainWhileLivenessStaysHealthy(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	srv := &AgentFieldServer{
+		Router:            gin.New(),
+		storage:           newStubStorage(),
+		payloadStore:      &stubPayloadStore{},
+		webhookDispatcher: &stubWebhookDispatcher{},
+		config: &config.Config{
+			UI:  config.UIConfig{Enabled: false},
+			API: config.APIConfig{Auth: config.AuthConfig{APIKey: "super-secret-key"}},
+		},
+		storageHealthOverride: func(context.Context) gin.H { return gin.H{"status": "healthy"} },
+	}
+	srv.setupRoutes()
+
+	assertStatuses := func(wantReady int) {
+		t.Helper()
+		for _, path := range []string{"/readyz", "/api/v1/health/ready"} {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			w := httptest.NewRecorder()
+			srv.Router.ServeHTTP(w, req)
+			require.Equal(t, wantReady, w.Code, path)
+		}
+		for _, path := range []string{"/health", "/api/v1/health"} {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			w := httptest.NewRecorder()
+			srv.Router.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code, path)
+		}
+	}
+
+	assertStatuses(http.StatusOK)
+	srv.BeginDrain()
+	require.True(t, srv.IsDraining())
+	assertStatuses(http.StatusServiceUnavailable)
+
+	// Draining only changes readiness: ordinary authenticated traffic is still
+	// accepted and answered for the whole minimum-delay window, because the
+	// listener is not closed until Stop() runs.
+	served := httptest.NewRequest(http.MethodGet, "/api/v1/version", nil)
+	served.Header.Set("X-API-Key", "super-secret-key")
+	servedRecorder := httptest.NewRecorder()
+	srv.Router.ServeHTTP(servedRecorder, served)
+	require.Equal(t, http.StatusOK, servedRecorder.Code, "requests must keep being served while draining")
+}
+
 func TestSetupRoutesRegistersAuthenticatedVersionEndpoint(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/deployments/helm/agentfield/templates/control-plane-deployment.yaml
+++ b/deployments/helm/agentfield/templates/control-plane-deployment.yaml
@@ -1,3 +1,9 @@
+{{- $shutdownMinDelayInExtraEnv := false -}}
+{{- range .Values.controlPlane.extraEnv -}}
+{{- if eq (default "" .name) "AGENTFIELD_SHUTDOWN_MIN_DELAY" -}}
+{{- $shutdownMinDelayInExtraEnv = true -}}
+{{- end -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,7 +52,7 @@ spec:
               value: {{ .Values.controlPlane.service.port | quote }}
             - name: AGENTFIELD_STORAGE_MODE
               value: {{ .Values.controlPlane.storage.mode | quote }}
-            {{- if and .Values.controlPlane.shutdownMinDelay (not (hasKey .Values.controlPlane.env "AGENTFIELD_SHUTDOWN_MIN_DELAY")) }}
+            {{- if and .Values.controlPlane.shutdownMinDelay (not (hasKey .Values.controlPlane.env "AGENTFIELD_SHUTDOWN_MIN_DELAY")) (not $shutdownMinDelayInExtraEnv) }}
             - name: AGENTFIELD_SHUTDOWN_MIN_DELAY
               value: {{ .Values.controlPlane.shutdownMinDelay | quote }}
             {{- end }}
@@ -111,9 +117,9 @@ spec:
               path: {{ .Values.controlPlane.readinessProbe.path | default "/api/v1/health" }}
               port: http
             initialDelaySeconds: 5
-            periodSeconds: 5
+            periodSeconds: {{ .Values.controlPlane.readinessProbe.periodSeconds | default 2 }}
             timeoutSeconds: 5
-            failureThreshold: 6
+            failureThreshold: {{ .Values.controlPlane.readinessProbe.failureThreshold | default 1 }}
           {{- with .Values.controlPlane.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/deployments/helm/agentfield/templates/control-plane-deployment.yaml
+++ b/deployments/helm/agentfield/templates/control-plane-deployment.yaml
@@ -46,6 +46,10 @@ spec:
               value: {{ .Values.controlPlane.service.port | quote }}
             - name: AGENTFIELD_STORAGE_MODE
               value: {{ .Values.controlPlane.storage.mode | quote }}
+            {{- if and .Values.controlPlane.shutdownMinDelay (not (hasKey .Values.controlPlane.env "AGENTFIELD_SHUTDOWN_MIN_DELAY")) }}
+            - name: AGENTFIELD_SHUTDOWN_MIN_DELAY
+              value: {{ .Values.controlPlane.shutdownMinDelay | quote }}
+            {{- end }}
             {{- if eq .Values.controlPlane.storage.mode "postgres" }}
             {{- if .Values.postgres.enabled }}
             - name: AGENTFIELD_STORAGE_POSTGRES_HOST
@@ -104,7 +108,7 @@ spec:
             failureThreshold: 6
           readinessProbe:
             httpGet:
-              path: /api/v1/health
+              path: {{ .Values.controlPlane.readinessProbe.path | default "/api/v1/health" }}
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5

--- a/deployments/helm/agentfield/values.yaml
+++ b/deployments/helm/agentfield/values.yaml
@@ -1,6 +1,21 @@
 controlPlane:
   replicaCount: 1
-  terminationGracePeriodSeconds: 45
+  # Control-plane pod grace. Sized for shutdownMinDelay (5s) + the 30s
+  # AGENTFIELD_SHUTDOWN_TIMEOUT drain + roughly 20s of shutdown tail.
+  terminationGracePeriodSeconds: 60
+  # Seconds the control plane keeps serving after SIGTERM before it starts
+  # closing the listener, so kube-proxy can remove this pod from the Service
+  # endpoints first. Accepts bare seconds or a Go duration. "0" (or "")
+  # reproduces the previous shutdown timing exactly.
+  shutdownMinDelay: 5s
+  readinessProbe:
+    # Default stays /api/v1/health so a chart upgrade against an older cached
+    # image cannot 404 the probe and leave a single-replica Service with zero
+    # endpoints. Switch to /api/v1/health/ready (or /readyz) once every node
+    # runs a control-plane image newer than v0.1.137: that path also reports
+    # 503 during the shutdown min-delay window, which /api/v1/health
+    # deliberately does not.
+    path: /api/v1/health
 
   image:
     repository: agentfield/control-plane

--- a/deployments/helm/agentfield/values.yaml
+++ b/deployments/helm/agentfield/values.yaml
@@ -16,6 +16,12 @@ controlPlane:
     # 503 during the shutdown min-delay window, which /api/v1/health
     # deliberately does not.
     path: /api/v1/health
+    # A draining pod must fail readiness before shutdownMinDelay closes the
+    # listener. With one required failure and a two-second period, the next
+    # probe marks it Unready within 2s and leaves about 3s for endpoint
+    # propagation under the shipped 5s delay.
+    periodSeconds: 2
+    failureThreshold: 1
 
   image:
     repository: agentfield/control-plane
@@ -48,6 +54,9 @@ controlPlane:
     AGENTFIELD_CONFIG_FILE: /dev/null
 
   extraEnv: []
+  # AGENTFIELD_SHUTDOWN_MIN_DELAY may be set here instead of
+  # controlPlane.shutdownMinDelay; the template suppresses its generated entry
+  # so the rendered Pod never contains two variables with the same name.
   # - name: AGENTFIELD_AGENT_DRAIN_GRACE
   #   value: "60s"
 

--- a/deployments/kubernetes/base/control-plane-deployment.yaml
+++ b/deployments/kubernetes/base/control-plane-deployment.yaml
@@ -50,8 +50,12 @@ spec:
               path: /api/v1/health
               port: http
             initialDelaySeconds: 5
-            periodSeconds: 5
+            # Once the path is switched to /api/v1/health/ready, one failed
+            # probe marks the pod Unready within 2s of BeginDrain. That leaves
+            # about 3s of the 5s minimum delay for endpoint propagation.
+            periodSeconds: 2
             timeoutSeconds: 5
+            failureThreshold: 1
       volumes:
         - name: data
           persistentVolumeClaim:

--- a/deployments/kubernetes/base/control-plane-deployment.yaml
+++ b/deployments/kubernetes/base/control-plane-deployment.yaml
@@ -12,7 +12,7 @@ spec:
       labels:
         app.kubernetes.io/component: control-plane
     spec:
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 60
       containers:
         - name: control-plane
           image: agentfield/control-plane:latest
@@ -31,6 +31,8 @@ spec:
               value: "/dev/null"
             - name: AGENTFIELD_STORAGE_MODE
               value: "local"
+            - name: AGENTFIELD_SHUTDOWN_MIN_DELAY
+              value: "5s"
           volumeMounts:
             - name: data
               mountPath: /data
@@ -41,6 +43,8 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 5
+          # Keep the image-compatible default; opt in to shutdown-aware
+          # readiness with /api/v1/health/ready after upgrading every image.
           readinessProbe:
             httpGet:
               path: /api/v1/health

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -116,9 +116,10 @@ The telemetry payload does not include prompts, inputs, outputs, logs, secrets, 
 - `AGENTFIELD_EXEC_ASYNC_QUEUE_CAPACITY` (default: `1024`): Maximum number of asynchronous executions waiting for a worker; non-positive values use the default. Requests arriving once the queue is saturated are rejected with `503`, a `Retry-After` header and a `retry_after` field, and no execution row is persisted for them.
 - `AGENTFIELD_MAX_EXECUTE_BODY_BYTES` (default: `33554432`, 32 MiB): Maximum request body size, in bytes, for POST routes under `/api/v1/execute`. Oversize requests are rejected with `413` before any execution is persisted; other routes are not capped by this setting.
 - `AGENTFIELD_MAX_REGISTER_BODY_BYTES` (default: `8388608`, 8 MiB): Maximum request body size, in bytes, for node registration POST routes (`/api/v1/nodes`, `/api/v1/nodes/register`, and `/api/v1/nodes/register-serverless`). Oversize requests are rejected with `413` before registration handling begins.
-- `AGENTFIELD_SHUTDOWN_TIMEOUT` (default: `30s`): Grace period for draining the control plane HTTP server during shutdown.
+- `AGENTFIELD_SHUTDOWN_TIMEOUT` (default: `30s`): Grace period for draining the control-plane HTTP server. Accepts bare seconds (`30`) and Go duration strings (`30s`, `5m`). The same budget is shared with `StopAsyncWorkerPool`, which is guaranteed a fresh budget of at least 5s, so total shutdown can exceed this value. See the [Kubernetes shutdown and drain recipe](deploying-on-kubernetes.md).
+- `AGENTFIELD_SHUTDOWN_MIN_DELAY` (default: `0`): Control-plane-only delay between SIGTERM/SIGINT and closing the listener; zero preserves existing timing. Accepts bare seconds or a Go duration; invalid or negative values warn and keep the current value. This name is reserved for the control plane so future SDKs do not acquire another dual-meaning shutdown variable. Equivalent YAML: `agentfield.shutdown_min_delay`. It also affects `af server`, the code path the desktop app launches, so a value in `~/.agentfield/agentfield.yaml` slows local Ctrl+C too. See the [Kubernetes shutdown and drain recipe](deploying-on-kubernetes.md).
 - `AGENTFIELD_AGENT_RESTART_GRACE` (default: `15s`): How long an execution waits for an agent process to return during a coordinated restart; a negative duration disables the wait.
-- `AGENTFIELD_AGENT_DRAIN_GRACE` (default: `60s`): How long instance-scoped non-terminal work may keep completing after a replacement agent instance registers, before it is marked `agent_restart_orphaned`. The deferred in-memory timer is lost on a control-plane restart; the stale-execution sweep configured by `AGENTFIELD_EXECUTION_STALE_TIMEOUT` is the backstop. Equivalent YAML: `agentfield.node_health.agent_drain_grace`.
+- `AGENTFIELD_AGENT_DRAIN_GRACE` (default: `60s`): How long instance-scoped non-terminal work may keep completing after a replacement agent instance registers, before it is marked `agent_restart_orphaned`. The deferred in-memory timer is lost on a control-plane restart; the stale-execution sweep configured by `AGENTFIELD_EXECUTION_STALE_TIMEOUT` is the backstop. Equivalent YAML: `agentfield.node_health.agent_drain_grace`. See the [Kubernetes shutdown and drain recipe](deploying-on-kubernetes.md).
 
 For Kubernetes, set `terminationGracePeriodSeconds` above the SDK drain window so the departing pod can return accepted work. Keep the agent `version` stable across rolling updates: changing it creates a separate versioned registration, so its work is recovered only by the stale sweep rather than this re-registration drain timer.
 
@@ -218,7 +219,7 @@ Note that this is the **agent-node** meaning of the variable. The control plane 
 
 The Python SDK's equivalent setting is documented under "Python SDK agents" below.
 
-In Kubernetes, set the agent pod's `terminationGracePeriodSeconds` at least 10 seconds higher than `AGENTFIELD_SHUTDOWN_TIMEOUT` to leave room for post-cancel settlement and the control-plane notification before the container is killed.
+In Kubernetes, set the agent pod's `terminationGracePeriodSeconds` at least 15 seconds higher than `AGENTFIELD_SHUTDOWN_TIMEOUT` to cover five seconds of post-cancel settlement and ten seconds of callback/process-exit headroom.
 
 ### Go SDK agents (example: `examples/go_agent_nodes`)
 
@@ -249,7 +250,7 @@ On SIGTERM or a graceful `POST /shutdown`, the node immediately stops heartbeats
 
 `af stop` waits **at least** the node's shutdown budget, not exactly that duration: its total wait also includes the initial HTTP request and, when needed, the signal fallback after the budget expires.
 
-For Kubernetes, set `terminationGracePeriodSeconds` to a value greater than the shutdown budget. This leaves time for the terminal callback and normal process teardown after the reasoner drain. The older `Agent.setup_signal_handlers()` API is retained for compatibility, but `app.serve()` owns the production uvicorn-aware signal lifecycle.
+For Kubernetes, set `terminationGracePeriodSeconds` to a value greater than the shutdown budget. This leaves time for the terminal callback and normal process teardown after the reasoner drain. `app.serve()` owns the production uvicorn-aware signal lifecycle.
 
 ### MiniMax video generation
 

--- a/docs/deploying-on-kubernetes.md
+++ b/docs/deploying-on-kubernetes.md
@@ -2,33 +2,111 @@
 
 AgentField's control plane must be able to reach every agent at its registered callback URL. In Kubernetes, expose each agent with a `Service` and register its service DNS name. Mount `AGENTFIELD_HOME` on persistent storage when using the `local` storage mode.
 
-## Rolling deployments
+## Control-plane shutdown
 
-Agent registration is keyed by agent node ID and agent `version`. Keep `version` stable during an ordinary rollout: changing it creates a distinct registered version and bypasses the replacement-instance drain behavior.
+`AGENTFIELD_SHUTDOWN_MIN_DELAY` is a control-plane-only delay between the shutdown signal and the start of listener shutdown. Its default is `0`, which reproduces the previous timing exactly. It accepts bare seconds (`5`) or Go durations (`5s`, `500ms`); an unparseable or negative value logs one warning and keeps the current value. Equivalent YAML: `agentfield.shutdown_min_delay`.
 
-When a replacement instance registers with the same node ID and version, the control plane stops routing new work to the departing instance and gives its in-flight executions `AGENTFIELD_AGENT_DRAIN_GRACE` (default `60s`) to finish. This grace is implemented by an in-memory timer, so a control-plane restart loses the timer; the stale sweep controlled by `AGENTFIELD_EXECUTION_STALE_TIMEOUT` (default `30m`) remains the backstop. Executions are scoped by `instance_id`, so only work belonging to the departing instance is reaped.
+During the delay the process keeps serving normally — new requests are accepted and completed, and no execution is failed because of the delay. What changes is readiness:
 
-Dispatch to a node whose last heartbeat falls within the drain window is held for `AGENTFIELD_AGENT_RESTART_GRACE` (default `15s`) while a replacement can register. If none does, the request returns HTTP 503.
+| Route | During the min-delay window | Purpose |
+| --- | --- | --- |
+| `GET /readyz` | `503` | readiness |
+| `GET /api/v1/health/ready` | `503` | readiness |
+| `GET /health` | `200` while storage is healthy | liveness |
+| `GET /api/v1/health` | `200` while storage is healthy | liveness |
 
-Python, Go, and TypeScript agents handle SIGTERM by draining in-flight work for `AGENTFIELD_SHUTDOWN_TIMEOUT` (default `30s`). The value accepts bare seconds (`30`) or a duration (`30s`, `5m`). At the deadline, remaining work is cancelled, allowed up to five more seconds to settle, and reported with terminal status `cancelled`. Python and Go also expose `POST /shutdown`; TypeScript uses the process signal. Kubernetes should use SIGTERM directly: do not add an HTTP `preStop` hook, because Kubernetes `httpGet` hooks issue GET while `/shutdown` requires POST.
+That split is the point of the knob: the readiness routes fail first so kube-proxy removes the pod from the `Service` endpoints while the listener is still open, and liveness keeps passing so the kubelet does not kill a pod that is deliberately draining. All four routes are unauthenticated. Once the delay elapses and shutdown starts, the listener closes and probes get a connection refusal, which the kubelet also treats as a failure — do not expect `503` right up to process exit.
 
-Use this baseline for every control-plane and agent pod:
+A second SIGTERM or SIGINT during the window terminates the process immediately.
+
+The chart ships `controlPlane.readinessProbe.path: /api/v1/health` on purpose. `controlPlane.image.tag` defaults to `latest` with `pullPolicy: IfNotPresent` and `replicaCount: 1`, so a chart upgrade can land on a node that still has an older cached image; pointing the probe at a path that image does not serve would 404 every probe and leave the `Service` with zero endpoints. Switch to the shutdown-aware path only once every control-plane pod runs an image newer than v0.1.137:
+
+```yaml
+controlPlane:
+  readinessProbe:
+    path: /api/v1/health/ready
+```
+
+Leave the liveness probe on `/api/v1/health`.
+
+The chart already sets `controlPlane.shutdownMinDelay: 5s` and `controlPlane.terminationGracePeriodSeconds: 60`. A `preStop` hook is a useful complement, because it delays SIGTERM itself while endpoint removal propagates. Use an `exec` sleep — a Kubernetes `httpGet` hook can only issue GET, and the control plane exposes no GET shutdown route:
 
 ```yaml
 spec:
   template:
     spec:
-      terminationGracePeriodSeconds: 45
+      containers:
+        - name: control-plane
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 5"]
 ```
 
-The 45-second pod grace accommodates the default 30-second agent drain, five-second settlement, and process-exit headroom. If you increase `AGENTFIELD_SHUTDOWN_TIMEOUT`, increase the pod grace too. A practical rollout configuration is:
+Size the control-plane pod grace as `AGENTFIELD_SHUTDOWN_MIN_DELAY` + `AGENTFIELD_SHUTDOWN_TIMEOUT` + roughly 20 seconds of shutdown tail. The tail is a fresh asynchronous-pool drain budget of at least 5s, plus 5s each for package maintenance, the observability forwarder and the OpenTelemetry tracer, plus an unbounded `adminGRPCServer.GracefulStop()`. With the shipped `5s` minimum delay and the default 30-second `AGENTFIELD_SHUTDOWN_TIMEOUT` that is 55 seconds, hence the chart's `60`. Add the `preStop` sleep on top if you use one.
 
-- control plane: `AGENTFIELD_AGENT_DRAIN_GRACE=60s` and `AGENTFIELD_AGENT_RESTART_GRACE=15s`;
-- each agent: `AGENTFIELD_SHUTDOWN_TIMEOUT=30s`;
-- each pod: `terminationGracePeriodSeconds: 45`;
-- agent manifest: keep `version` unchanged across replica replacements.
+The control plane uses `AGENTFIELD_SHUTDOWN_TIMEOUT` (default `30s`) to drain its own HTTP server and its asynchronous execution pool. During shutdown it rejects new queued work, drains active work, and marks work still queued as `failed` with status reason `control_plane_shutdown`.
 
-The control plane independently uses `AGENTFIELD_SHUTDOWN_TIMEOUT` (default `30s`) to drain its asynchronous execution pool. During shutdown it rejects new queued work, drains active work, and marks work still queued as `failed` with reason `control_plane_shutdown`.
+`AGENTFIELD_SHUTDOWN_MIN_DELAY` is deliberately control-plane-only, and the name is reserved for the control plane so a future SDK does not adopt it and repeat the dual meaning `AGENTFIELD_SHUTDOWN_TIMEOUT` already carries. Note that it applies to `af server` too — the same binary and code path the desktop app launches — so `agentfield.shutdown_min_delay` in `~/.agentfield/agentfield.yaml` also slows a local Ctrl+C.
+
+## Agent shutdown
+
+Python, Go, and TypeScript agents handle SIGTERM by draining in-flight work for `AGENTFIELD_SHUTDOWN_TIMEOUT` (default `30s`). The value accepts bare seconds (`30`) or a duration (`30s`, `5m`). At the deadline, remaining work is cancelled, allowed up to five more seconds to settle, and reported with terminal status `cancelled`. Python and Go also expose `POST /shutdown`; TypeScript uses the process signal. Kubernetes should use SIGTERM directly: do not add an HTTP `preStop` hook, because Kubernetes `httpGet` hooks issue GET while `/shutdown` requires POST.
+
+Set an agent pod's `terminationGracePeriodSeconds` at least 15 seconds above its `AGENTFIELD_SHUTDOWN_TIMEOUT` — five seconds of post-cancel settlement plus headroom for the terminal callback and process exit. The 45 seconds used by the shipped agent manifests is the 30-second default drain plus that 15.
+
+## Rolling deployments and long reasoners
+
+Agent registration is keyed by agent node ID and agent `version`. Keep `version` stable during an ordinary rollout: changing it creates a distinct registered version and bypasses the replacement-instance drain behavior described below.
+
+Agent Deployments must run `replicas: 1` today. Executions are stamped with the node row's current `InstanceID` — the last registrant — and the callback URL is a single field per node ID and version. The replacement path is triggered by *any* re-registration carrying a non-empty `instance_id` that differs from the stored one, not by rollouts specifically, so horizontal replicas of one node ID are indistinguishable from a replacement. The reap additionally sweeps non-terminal rows whose `instance_id` is empty (rows written by SDKs that predate instance stamping). Every shipped agent manifest already sets `replicas: 1`.
+
+When a replacement instance registers with the same node ID and version, the control plane stops routing new work to the departing instance and gives its in-flight executions `AGENTFIELD_AGENT_DRAIN_GRACE` (default `60s`) to finish. This grace is implemented by an in-memory timer, so a control-plane restart loses the timer; the stale sweep controlled by `AGENTFIELD_EXECUTION_STALE_TIMEOUT` (default `30m`) remains the backstop. Executions are scoped by `instance_id`, so only work belonging to the departing instance is reaped.
+
+Dispatch to a node whose last heartbeat falls within the drain window is held for `AGENTFIELD_AGENT_RESTART_GRACE` (default `15s`) while a replacement can register. If none does, the request returns HTTP `503` with `Retry-After: 1`.
+
+### Sizing the drain grace
+
+The deferred reap fires `AGENTFIELD_AGENT_DRAIN_GRACE` after the **replacement registers**, regardless of how much drain budget the departing pod still has. Under a default rolling update the replacement becomes Ready and registers *before* Kubernetes signals the old pod, so that lag counts against the grace:
+
+```text
+AGENTFIELD_AGENT_DRAIN_GRACE >=
+    (replacement registration -> old-pod SIGTERM lag)
+  + AGENTFIELD_SHUTDOWN_TIMEOUT
+  + 5s post-cancel settlement
+  + terminal-callback latency
+  + explicit headroom
+```
+
+Set `strategy.rollingUpdate.maxSurge: 0` to make the lag term zero, or measure it and budget for it. Size `AGENTFIELD_AGENT_DRAIN_GRACE` at or above the longest reasoner you are willing to protect.
+
+For an agent whose longest reasoner runs about 10 minutes:
+
+- `strategy.rollingUpdate.maxSurge: 0` on the agent Deployment, so the old pod is signalled before the replacement registers;
+- agent env `AGENTFIELD_SHUTDOWN_TIMEOUT: "11m"` — the drain budget must outlast the reasoner;
+- agent pod `terminationGracePeriodSeconds: 690` — `11m` plus the 15-second floor above;
+- control-plane env `AGENTFIELD_AGENT_DRAIN_GRACE: "12m"` — `11m` drain + 5s settlement + callback latency + headroom;
+- control-plane env `AGENTFIELD_AGENT_RESTART_GRACE: "15s"` — leave it at the default; see the warning below.
+
+Write these with unit suffixes. `AGENTFIELD_AGENT_DRAIN_GRACE` is parsed with plain Go duration syntax and has no bare-seconds fallback and no warning on failure, so a bare `660` is silently ignored and the `60s` default survives — unlike `AGENTFIELD_SHUTDOWN_TIMEOUT`, which does accept bare seconds and at least warns. `AGENTFIELD_AGENT_DRAIN_GRACE=0s` does **not** disable the reap: a zero value keeps the `60s` default. A negative duration makes the reap fire immediately. There is no opt-out.
+
+### What raising the drain grace costs
+
+`AGENTFIELD_AGENT_DRAIN_GRACE` is a single **global** control-plane setting, not a per-agent one, and the same window also decides whether an offline node counts as draining. Raising it to `12m` therefore means every crashed agent's in-flight rows sit in `running` for 12 minutes, and a dispatch to any dead node is held for `AGENTFIELD_AGENT_RESTART_GRACE` and then answered `503` for as long as 12 minutes after that node's last heartbeat. Keep `AGENTFIELD_AGENT_RESTART_GRACE` small so those dispatches fail fast rather than blocking a caller.
+
+`AGENTFIELD_EXECUTION_STALE_TIMEOUT` (default `30m`) is the second ceiling: it reaps any non-terminal **leaf** execution regardless of how the drain knobs are set. A leaf that runs longer than 30 minutes cannot be protected by tuning the drain grace alone.
+
+### Why the stock defaults are safe
+
+With the defaults, the agent's 30-second shutdown timeout is well inside the control plane's 60-second drain grace, so a cancelled reasoner reports its terminal `cancelled` status long before the reap could fire. The dangerous configuration is created by raising `AGENTFIELD_SHUTDOWN_TIMEOUT` on its own — increase `AGENTFIELD_AGENT_DRAIN_GRACE` with it, not just `terminationGracePeriodSeconds`.
+
+If the reap does win the race, the row is marked `failed` and its `status_reason` is the string to grep for:
+
+```text
+agent_restart_orphaned: previous instance <instance-id> is gone and the execution did not complete within the drain window
+```
+
+A late callback against that row behaves as follows: a `succeeded` callback arriving after the reap is rejected with `409` (a terminal status may not be replaced by a different terminal status); a re-delivery of the *same* terminal status is an idempotent `200` no-op; a late **non-terminal** write currently surfaces as `500` rather than a `409` — that is a rough edge to be fixed, not intended behaviour.
 
 ## Cleanup and retention
 

--- a/docs/deploying-on-kubernetes.md
+++ b/docs/deploying-on-kubernetes.md
@@ -84,7 +84,7 @@ For an agent whose longest reasoner runs about 10 minutes:
 
 - `strategy.rollingUpdate.maxSurge: 0` on the agent Deployment, so the old pod is signalled before the replacement registers;
 - agent env `AGENTFIELD_SHUTDOWN_TIMEOUT: "11m"` — the drain budget must outlast the reasoner;
-- agent pod `terminationGracePeriodSeconds: 690` — `11m` plus the 15-second floor above;
+- agent pod `terminationGracePeriodSeconds: 675` — `11m` plus the 15-second floor above;
 - control-plane env `AGENTFIELD_AGENT_DRAIN_GRACE: "12m"` — `11m` drain + 5s settlement + callback latency + headroom;
 - control-plane env `AGENTFIELD_AGENT_RESTART_GRACE: "15s"` — leave it at the default; see the warning below.
 

--- a/docs/deploying-on-kubernetes.md
+++ b/docs/deploying-on-kubernetes.md
@@ -29,7 +29,9 @@ controlPlane:
 
 Leave the liveness probe on `/api/v1/health`.
 
-The chart already sets `controlPlane.shutdownMinDelay: 5s` and `controlPlane.terminationGracePeriodSeconds: 60`. A `preStop` hook is a useful complement, because it delays SIGTERM itself while endpoint removal propagates. Use an `exec` sleep — a Kubernetes `httpGet` hook can only issue GET, and the control plane exposes no GET shutdown route:
+The chart's readiness probe uses `periodSeconds: 2` and `failureThreshold: 1`. Once the path is switched, the first probe after `BeginDrain` therefore marks the pod Unready within two seconds, leaving about three seconds of the shipped five-second minimum delay for the EndpointSlice change to propagate before the listener closes. If you customize the probe, keep `periodSeconds * failureThreshold` below `AGENTFIELD_SHUTDOWN_MIN_DELAY`; otherwise the listener can close while Kubernetes still considers the pod Ready.
+
+The chart already sets `controlPlane.shutdownMinDelay: 5s` and `controlPlane.terminationGracePeriodSeconds: 60`. A `preStop` hook is a useful complement, because it delays SIGTERM itself while endpoint removal propagates. The shipped control-plane image is distroless and has no `sh` or `sleep` executable, so use Kubernetes' native `sleep` lifecycle action rather than an `exec` hook:
 
 ```yaml
 spec:
@@ -39,11 +41,13 @@ spec:
         - name: control-plane
           lifecycle:
             preStop:
-              exec:
-                command: ["sh", "-c", "sleep 5"]
+              sleep:
+                seconds: 5
 ```
 
-Size the control-plane pod grace as `AGENTFIELD_SHUTDOWN_MIN_DELAY` + `AGENTFIELD_SHUTDOWN_TIMEOUT` + roughly 20 seconds of shutdown tail. The tail is a fresh asynchronous-pool drain budget of at least 5s, plus 5s each for package maintenance, the observability forwarder and the OpenTelemetry tracer, plus an unbounded `adminGRPCServer.GracefulStop()`. With the shipped `5s` minimum delay and the default 30-second `AGENTFIELD_SHUTDOWN_TIMEOUT` that is 55 seconds, hence the chart's `60`. Add the `preStop` sleep on top if you use one.
+The native sleep action was introduced behind the `PodLifecycleSleepAction` feature gate in Kubernetes 1.29, is enabled by default from 1.30, and is GA from 1.34. On 1.29 the cluster administrator must enable that feature gate. On older clusters, or clusters that explicitly disable it, the distroless image cannot run an exec-based sleep; rely on `AGENTFIELD_SHUTDOWN_MIN_DELAY` alone or build a derived image containing a sleep executable and point an `exec` hook directly at that executable.
+
+Size the control-plane pod grace as the `preStop` sleep (if any) + `AGENTFIELD_SHUTDOWN_MIN_DELAY` + `AGENTFIELD_SHUTDOWN_TIMEOUT` + roughly 20 seconds of shutdown tail. The tail is a fresh asynchronous-pool drain budget of at least 5s, plus 5s each for package maintenance, the observability forwarder and the OpenTelemetry tracer, plus an unbounded `adminGRPCServer.GracefulStop()`. Without `preStop`, the shipped `5s` minimum delay and default 30-second shutdown timeout total about 55 seconds, so the chart's `60` leaves about five seconds of headroom. A five-second `preStop` raises the bounded sum to 60 seconds; set `terminationGracePeriodSeconds: 65` to retain that headroom.
 
 The control plane uses `AGENTFIELD_SHUTDOWN_TIMEOUT` (default `30s`) to drain its own HTTP server and its asynchronous execution pool. During shutdown it rejects new queued work, drains active work, and marks work still queued as `failed` with status reason `control_plane_shutdown`.
 


### PR DESCRIPTION
## Summary
The Kubernetes "min delay" half of graceful shutdown, plus one coherent tuning recipe. `AGENTFIELD_SHUTDOWN_MIN_DELAY` (default `0` = exactly today's timing; accepts `5`, `5s`, `1m`) keeps the control plane serving for that long after SIGTERM while a shutdown-aware readiness surface flips to 503 immediately and liveness stays green — the standard fix for endpoint-propagation lag, so kube-proxy stops routing before the listener closes. The Helm chart opts the control plane into `shutdownMinDelay: 5s` and raises its `terminationGracePeriodSeconds` to 60; agent templates are untouched. The shipped readiness probe **path is unchanged by default** — the new path is behind a values key defaulting to the current one, so a cached older image can never brick readiness. `docs/deploying-on-kubernetes.md` is rewritten into a derivable recipe (drain budget, settlement, grace windows, preStop, worked examples), linked from the docs index, and every path/env/default in it resolves to code in this branch.

## Why
Refs #989 (the `minSigtermDelay` ask; the max side shipped in v0.1.137) and #987 (the drain-grace sizing invariant for long orchestrators, and the replicas=1 caveat, are now stated plainly).

Deliberately not done, with reasons in the linked issues: no SDK-side min delay (equivalent to `preStop.sleep`, and the control plane already holds dispatch once an agent announces shutdown) and no GET handler on `/shutdown` (a process-killing side effect behind an unauthenticated GET; `preStop: {sleep: ...}` covers the k8s-native ask).

## Changes
- feat(control-plane): add AGENTFIELD_SHUTDOWN_MIN_DELAY and shutdown-aware readiness
- test(control-plane): cover the min delay, the drain readiness flip and the shipped probe path
- feat(deployments): ship a 5s control-plane shutdown delay and a gated readiness path
- docs(k8s): make the drain and shutdown recipe derivable without reading code
- docs(k8s): fix the worked terminationGracePeriodSeconds arithmetic (review round)
- test(control-plane): assert the helm templates consume the new values keys (review round)

## Validation contract
- `AGENTFIELD_SHUTDOWN_MIN_DELAY` unset/`0` reproduces v0.1.137 shutdown timing exactly → `TestDrainOnShutdownZeroDelayStopsImmediately`, `TestFinishShutdownZeroDelayStopsImmediately`, `TestShutdownMinDelayDefaultsToZero`
- Readiness turns 503 for the whole delay window, before the listener closes → `TestReadinessTurnsUnavailableDuringDrainWhileLivenessStaysHealthy`, `TestDrainOnShutdownBeginsDrainBeforeMinimumDelayAndStop`, `TestFinishShutdownBeginsDrainBeforeMinimumDelayAndStop`
- Liveness stays 200 during drain → `TestReadinessTurnsUnavailableDuringDrainWhileLivenessStaysHealthy`
- Parser accepts bare seconds and Go durations, ignores invalid values → `TestShutdownMinDelayEnvParsing`; `AGENTFIELD_SHUTDOWN_TIMEOUT` parsing unchanged → `TestShutdownTimeoutZeroStillKeepsCurrentValue`, `TestShutdownTimeoutEnvOverrideIgnoresInvalidValue`, `TestShutdownTimeoutEnvAcceptsBareSecondsLikeTheSDKs`
- Readiness aliases bypass API-key/DID auth (a probe never needs credentials) → `TestReadinessTurnsUnavailableDuringDrainWhileLivenessStaysHealthy`
- Shipped probe path stays backward compatible; every new Helm value is consumed by the templates → `TestManifestReadinessDefaultsRemainBackwardCompatible` (values defaults + template-reference assertions)
- Chart renders → `helm lint` + `helm template` in the gate run

## How it was tested
CI-literal gates in the worktree: `go build`, `gofmt -l`, `go vet`, full control-plane suite (`-tags sqlite_fts5`, minus `internal/packages`), `./scripts/coverage-surface.sh control-plane`, `./scripts/patch-coverage-gate.sh` (≥80 % on touched lines), `helm lint` + `helm template`, YAML parse of all manifests — ALL-PASS. Rebased onto current `main`; the full control-plane suite was re-run post-rebase.

## Notes / follow-ups
An adversarial review ran between the first four commits and the last two; both findings it raised (a wrong worked-example sum; helm values wiring untested) are fixed in the review-round commits. The k8s doc states the two operational caveats explicitly: the deferred reap fires `AGENTFIELD_AGENT_DRAIN_GRACE` after the *replacement* registers regardless of the departing pod's budget, and agent Deployments should run `replicas: 1` today (a sibling replica is indistinguishable from a replacement; the escape hatch ships separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
