### PR TITLE
fix(control-plane): compare execution timestamps by instant on SQLite (#1040)

### DIFF
--- a/control-plane/internal/handlers/execution_notes.go
+++ b/control-plane/internal/handlers/execution_notes.go
@@ -135,7 +135,9 @@ func AddExecutionNoteHandler(storageProvider ExecutionNoteStorage, ownershipEnfo
 
 			// Add the new note
 			execution.Notes = append(execution.Notes, note)
-			execution.UpdatedAt = time.Now()
+			// Persist in UTC so the stored text carries no local zone offset,
+			// which would break the stale-execution reaper on SQLite (#1040).
+			execution.UpdatedAt = time.Now().UTC()
 
 			return execution, nil
 		})

--- a/control-plane/internal/storage/execution_records.go
+++ b/control-plane/internal/storage/execution_records.go
@@ -12,6 +12,25 @@ import (
 	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
 )
 
+// staleTimestampExpr returns the SQL expression used to compare an execution's
+// most recent activity timestamp against the stale cutoff.
+//
+// SQLite stores timestamps as text and compares them lexically. When a host
+// runs in a non-UTC timezone, time.Now() persists values carrying a local zone
+// offset (e.g. "...-05:00"), and a fresh local value can sort BEFORE a UTC
+// cutoff even though its instant is newer, wrongly reaping active executions
+// (#1040). Wrapping the value in julianday() forces an instant-aware numeric
+// comparison that is offset-correct.
+//
+// Postgres columns are timestamptz and already compare by instant, and
+// julianday() does not exist there, so Postgres keeps the plain expression.
+func (ls *LocalStorage) staleTimestampExpr(col string) string {
+	if ls.requireSQLDB().Mode() == "postgres" {
+		return col
+	}
+	return "julianday(" + col + ")"
+}
+
 // maxNodesForDepthCalc caps the number of executions for which we compute DAG depth to avoid heavy queries.
 const maxNodesForDepthCalc = 1000
 
@@ -1177,17 +1196,19 @@ func (ls *LocalStorage) MarkStaleExecutions(ctx context.Context, staleAfter time
 	cutoff := time.Now().UTC().Add(-staleAfter)
 
 	db := ls.requireSQLDB()
+	tsExpr := ls.staleTimestampExpr("COALESCE(updated_at, created_at, started_at)")
+	cutoffExpr := ls.staleTimestampExpr("?")
 	rows, err := db.QueryContext(ctx, `
 		SELECT execution_id, started_at
 		FROM executions e
 		WHERE status IN ('running', 'pending', 'queued')
-		  AND COALESCE(updated_at, created_at, started_at) <= ?
+		  AND `+tsExpr+` <= `+cutoffExpr+`
 		  AND NOT EXISTS (
 		      SELECT 1 FROM executions c
 		      WHERE c.parent_execution_id = e.execution_id
 		        AND c.status IN ('running', 'pending', 'queued')
 		  )
-		ORDER BY COALESCE(updated_at, created_at, started_at) ASC
+		ORDER BY `+tsExpr+` ASC
 		LIMIT ?`, cutoff, limit)
 	if err != nil {
 		return 0, fmt.Errorf("query stale executions: %w", err)
@@ -1290,18 +1311,20 @@ func (ls *LocalStorage) MarkStaleWorkflowExecutions(ctx context.Context, staleAf
 	cutoff := time.Now().UTC().Add(-staleAfter)
 
 	db := ls.requireSQLDB()
+	tsExpr := ls.staleTimestampExpr("COALESCE(updated_at, created_at, started_at)")
+	cutoffExpr := ls.staleTimestampExpr("?")
 	rows, err := db.QueryContext(ctx, `
 		SELECT execution_id, started_at
 		FROM workflow_executions w
 		WHERE status IN ('running', 'pending', 'queued', 'waiting')
-		  AND COALESCE(updated_at, created_at, started_at) <= ?
+		  AND `+tsExpr+` <= `+cutoffExpr+`
 		  AND COALESCE(approval_status, '') != 'pending'
 		  AND NOT EXISTS (
 		      SELECT 1 FROM workflow_executions c
 		      WHERE c.parent_execution_id = w.execution_id
 		        AND c.status IN ('running', 'pending', 'queued', 'waiting')
 		  )
-		ORDER BY COALESCE(updated_at, created_at, started_at) ASC
+		ORDER BY `+tsExpr+` ASC
 		LIMIT ?`, cutoff, limit)
 	if err != nil {
 		return 0, fmt.Errorf("query stale workflow executions: %w", err)
@@ -1497,14 +1520,16 @@ func (ls *LocalStorage) RetryStaleWorkflowExecutions(ctx context.Context, staleA
 
 	cutoff := time.Now().UTC().Add(-staleAfter)
 	db := ls.requireSQLDB()
+	tsExpr := ls.staleTimestampExpr("COALESCE(updated_at, created_at, started_at)")
+	cutoffExpr := ls.staleTimestampExpr("?")
 
 	rows, err := db.QueryContext(ctx, `
 		SELECT execution_id
 		FROM workflow_executions
 		WHERE status IN ('running', 'pending', 'queued')
 		  AND retry_count < ?
-		  AND COALESCE(updated_at, created_at, started_at) <= ?
-		ORDER BY COALESCE(updated_at, created_at, started_at) ASC
+		  AND `+tsExpr+` <= `+cutoffExpr+`
+		ORDER BY `+tsExpr+` ASC
 		LIMIT ?`, maxRetries, cutoff, limit)
 	if err != nil {
 		return nil, fmt.Errorf("query retriable workflow executions: %w", err)

--- a/control-plane/internal/storage/local.go
+++ b/control-plane/internal/storage/local.go
@@ -1923,7 +1923,7 @@ func (ls *LocalStorage) executeWorkflowInsert(ctx context.Context, q DBTX, execu
 			execution.ApprovalRequestID, execution.ApprovalRequestURL, execution.ApprovalStatus,
 			execution.ApprovalResponse, execution.ApprovalRequestedAt, execution.ApprovalRespondedAt,
 			execution.ApprovalCallbackURL, execution.ApprovalExpiresAt,
-			notesJSON, time.Now(), execution.ExecutionID)
+			notesJSON, time.Now().UTC(), execution.ExecutionID)
 
 		if err != nil {
 			return fmt.Errorf("failed to update workflow execution: %w", err)
@@ -1947,12 +1947,14 @@ func (ls *LocalStorage) executeWorkflowInsert(ctx context.Context, q DBTX, execu
 		return fmt.Errorf("failed to marshal notes: %w", err)
 	}
 
-	// Set default timestamps if not provided
+	// Set default timestamps if not provided. Persist in UTC so the stored
+	// text carries no local zone offset: a non-UTC offset breaks the reaper's
+	// timestamp comparison on SQLite (#1040).
 	if execution.CreatedAt.IsZero() {
-		execution.CreatedAt = time.Now()
+		execution.CreatedAt = time.Now().UTC()
 	}
 	if execution.UpdatedAt.IsZero() {
-		execution.UpdatedAt = time.Now()
+		execution.UpdatedAt = time.Now().UTC()
 	}
 
 	// Execute INSERT query using the DBTX interface
@@ -2107,12 +2109,13 @@ func (ls *LocalStorage) executeWorkflowInsertWithTx(ctx context.Context, tx DBTX
 			total_duration_ms = excluded.total_duration_ms,
 			updated_at = excluded.updated_at`
 
-	// Set default timestamps if not provided
+	// Set default timestamps if not provided. Persist in UTC so the stored
+	// text carries no local zone offset (see #1040).
 	if workflow.CreatedAt.IsZero() {
-		workflow.CreatedAt = time.Now()
+		workflow.CreatedAt = time.Now().UTC()
 	}
 	if workflow.UpdatedAt.IsZero() {
-		workflow.UpdatedAt = time.Now()
+		workflow.UpdatedAt = time.Now().UTC()
 	}
 
 	// Marshal workflow tags

--- a/control-plane/internal/storage/stale_execution_tz_test.go
+++ b/control-plane/internal/storage/stale_execution_tz_test.go
@@ -1,0 +1,146 @@
+package storage
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+// setExecutionTimestampsWithOffset overwrites created_at/updated_at/started_at
+// for a row with a value carrying a fixed non-UTC zone offset. On a non-UTC
+// host, time.Now() produces exactly this kind of value, so this reproduces
+// what real deployments persist (#1040).
+func setExecutionTimestampsWithOffset(t *testing.T, ls *LocalStorage, table, executionID string, ts time.Time) {
+	t.Helper()
+	db := ls.requireSQLDB()
+	_, err := db.Exec(
+		"UPDATE "+table+" SET created_at = ?, updated_at = ?, started_at = ? WHERE execution_id = ?",
+		ts, ts, ts, executionID,
+	)
+	require.NoError(t, err)
+}
+
+// TestMarkStaleExecutions_FreshNonUTCTimestampNotReaped reproduces #1040: a
+// fresh execution whose timestamps were persisted with a non-UTC offset must
+// not be reaped, because its instant is well within the stale window. Before
+// the fix SQLite compared timestamps lexically as text, so a "-05:00" fresh
+// value sorted before a UTC cutoff and got wrongly timed out.
+func TestMarkStaleExecutions_FreshNonUTCTimestampNotReaped(t *testing.T) {
+	ls, ctx := setupTestLocalStorage(t)
+
+	loc := time.FixedZone("CDT", -5*60*60)
+	freshLocal := time.Now().In(loc) // fresh instant, but stored with -05:00 offset
+
+	fresh := &types.Execution{
+		ExecutionID: "exec-fresh-nonutc",
+		RunID:       "run-1",
+		AgentNodeID: "agent-1",
+		ReasonerID:  "reasoner-1",
+		NodeID:      "node-1",
+		Status:      "running",
+		StartedAt:   freshLocal,
+	}
+	require.NoError(t, ls.CreateExecutionRecord(ctx, fresh))
+	setExecutionTimestampsWithOffset(t, ls, "executions", "exec-fresh-nonutc", freshLocal)
+
+	reaped, err := ls.MarkStaleExecutions(ctx, 30*time.Minute, 100)
+	require.NoError(t, err)
+	require.Equal(t, 0, reaped, "fresh execution stored with non-UTC offset must not be reaped")
+
+	rec, err := ls.GetExecutionRecord(ctx, "exec-fresh-nonutc")
+	require.NoError(t, err)
+	require.Equal(t, "running", rec.Status, "fresh execution must stay running")
+}
+
+// TestMarkStaleExecutions_StaleNonUTCTimestampReaped is the inverse guard: a
+// genuinely stale execution stored with a non-UTC offset must still be reaped.
+func TestMarkStaleExecutions_StaleNonUTCTimestampReaped(t *testing.T) {
+	ls, ctx := setupTestLocalStorage(t)
+
+	loc := time.FixedZone("CDT", -5*60*60)
+	staleLocal := time.Now().In(loc).Add(-1 * time.Hour) // 1h old, past the 30m window
+
+	stale := &types.Execution{
+		ExecutionID: "exec-stale-nonutc",
+		RunID:       "run-1",
+		AgentNodeID: "agent-1",
+		ReasonerID:  "reasoner-1",
+		NodeID:      "node-1",
+		Status:      "running",
+		StartedAt:   staleLocal,
+	}
+	require.NoError(t, ls.CreateExecutionRecord(ctx, stale))
+	setExecutionTimestampsWithOffset(t, ls, "executions", "exec-stale-nonutc", staleLocal)
+
+	reaped, err := ls.MarkStaleExecutions(ctx, 30*time.Minute, 100)
+	require.NoError(t, err)
+	require.Equal(t, 1, reaped, "genuinely stale non-UTC execution must be reaped")
+
+	rec, err := ls.GetExecutionRecord(ctx, "exec-stale-nonutc")
+	require.NoError(t, err)
+	require.Equal(t, "timeout", rec.Status)
+}
+
+// TestMarkStaleWorkflowExecutions_FreshNonUTCTimestampNotReaped mirrors the
+// reproduction for the workflow_executions selection path.
+func TestMarkStaleWorkflowExecutions_FreshNonUTCTimestampNotReaped(t *testing.T) {
+	ls, ctx := setupTestLocalStorage(t)
+
+	loc := time.FixedZone("CDT", -5*60*60)
+	freshLocal := time.Now().In(loc)
+
+	fresh := &types.WorkflowExecution{
+		WorkflowID:          "wf-fresh",
+		ExecutionID:         "wf-fresh-nonutc",
+		AgentFieldRequestID: "req-fresh",
+		AgentNodeID:         "agent-1",
+		ReasonerID:          "reasoner-1",
+		Status:              "running",
+		StartedAt:           freshLocal,
+		CreatedAt:           freshLocal,
+		UpdatedAt:           freshLocal,
+		WorkflowTags:        []string{},
+		InputData:           json.RawMessage("{}"),
+		OutputData:          json.RawMessage("{}"),
+	}
+	require.NoError(t, ls.StoreWorkflowExecution(ctx, fresh))
+	setExecutionTimestampsWithOffset(t, ls, "workflow_executions", "wf-fresh-nonutc", freshLocal)
+
+	reaped, err := ls.MarkStaleWorkflowExecutions(ctx, 30*time.Minute, 100)
+	require.NoError(t, err)
+	require.Equal(t, 0, reaped, "fresh workflow execution stored with non-UTC offset must not be reaped")
+}
+
+// TestRetryStaleWorkflowExecutions_FreshNonUTCTimestampNotRetried mirrors the
+// reproduction for the retry-selection path.
+func TestRetryStaleWorkflowExecutions_FreshNonUTCTimestampNotRetried(t *testing.T) {
+	ls, ctx := setupTestLocalStorage(t)
+
+	loc := time.FixedZone("CDT", -5*60*60)
+	freshLocal := time.Now().In(loc)
+
+	fresh := &types.WorkflowExecution{
+		WorkflowID:          "wf-retry-fresh",
+		ExecutionID:         "wf-retry-fresh-nonutc",
+		AgentFieldRequestID: "req-retry-fresh",
+		AgentNodeID:         "agent-1",
+		ReasonerID:          "reasoner-1",
+		Status:              "running",
+		StartedAt:           freshLocal,
+		CreatedAt:           freshLocal,
+		UpdatedAt:           freshLocal,
+		WorkflowTags:        []string{},
+		InputData:           json.RawMessage("{}"),
+		OutputData:          json.RawMessage("{}"),
+	}
+	require.NoError(t, ls.StoreWorkflowExecution(ctx, fresh))
+	setExecutionTimestampsWithOffset(t, ls, "workflow_executions", "wf-retry-fresh-nonutc", freshLocal)
+
+	retried, err := ls.RetryStaleWorkflowExecutions(ctx, 30*time.Minute, 3, 100)
+	require.NoError(t, err)
+	require.Empty(t, retried, "fresh workflow execution stored with non-UTC offset must not be retried")
+}


### PR DESCRIPTION
## Summary

On a non-UTC host using local SQLite storage, the stale-execution reaper could mark a fresh, active execution as timed out within seconds of starting (the issue reports ~108s against a 30-minute timeout). Later successful status callbacks were then rejected with HTTP 409 because the row had already become terminal. This PR compares execution timestamps by instant instead of by text, and persists execution/workflow timestamps in UTC so the offset is never stored.

Fixes #1040.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] Tests only
- [ ] CI / tooling
- [ ] Breaking change

Root cause: SQLite compares timestamp columns as text. Write paths persisted timestamps with `time.Now()`, so on a non-UTC host they carried a local zone offset (e.g. `...-05:00`). A fresh local value sorts lexically before a UTC cutoff even though its instant is newer, so the reaper's `COALESCE(updated_at, created_at, started_at) <= cutoff` test matched rows that were not actually stale.

Fix has two layers:

1. Read path: wrap the timestamp comparison and `ORDER BY` in `julianday()` for SQLite so the comparison is instant-aware and offset-correct. Postgres uses `timestamptz` (already instant-aware) and has no `julianday()`, so the Postgres query path is left unchanged via a dialect-aware helper. This also corrects rows already persisted with an offset.
2. Write path: normalize execution and workflow `created_at`/`updated_at` to `time.Now().UTC()` so newly stored rows never carry a local offset.

Applies to `MarkStaleExecutions`, `MarkStaleWorkflowExecutions`, and `RetryStaleWorkflowExecutions`.

Behavior that does NOT change: the set of rows reaped/retried for correctly-stored UTC timestamps, all status transitions, the executions-table sync, the retry logic, and the parent-child skip guards. Only the timestamp comparison semantics change (text -> instant).

## Test plan

- `cd control-plane && go test ./internal/storage/ -run 'Stale|Retry|NonUTC' -count=1`
- `cd control-plane && go test ./internal/storage/ ./internal/handlers/ -count=1`

New regression tests in `internal/storage/stale_execution_tz_test.go`:
- Fresh execution stored with a `-05:00` offset must NOT be reaped (fails before the fix, passes after).
- Genuinely stale execution stored with a `-05:00` offset must still be reaped.
- Same fresh-not-reaped guard for `MarkStaleWorkflowExecutions` and `RetryStaleWorkflowExecutions`.

I confirmed the two fresh-timestamp tests fail on the unpatched code and pass after the fix, and that all existing stale/retry and NULL-fallback reaper tests still pass.

## Test coverage

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR (no bare additions).
- [x] I did not remove code, so no baseline changes are needed.
- [ ] The coverage gate check is green in CI before requesting review.

## Checklist

- [x] I have read the development docs.
- [x] Commits follow conventional-commits style.
- [x] I have linked the related issue (Fixes #1040).

## Related issues / PRs

Fixes #1040
