### PR TITLE
feat(python-sdk): add CursorProvider to the harness

### DIFF
--- a/sdk/python/agentfield/harness/_availability.py
+++ b/sdk/python/agentfield/harness/_availability.py
@@ -30,6 +30,15 @@ PROVIDER_SPECS = {
         install_command="npm install -g @openai/codex",
         auth_env_vars=("OPENAI_API_KEY",),
     ),
+    "cursor": ProviderSpec(
+        # Cursor ships its headless CLI as `agent`, not `cursor`, so this is
+        # the one spec whose binary does not match its provider name. Keep
+        # them in step with CursorProvider's default bin_path.
+        binary="agent",
+        version_args=("--version",),
+        install_command="curl https://cursor.com/install -fsS | bash",
+        auth_env_vars=("CURSOR_API_KEY",),
+    ),
     "gemini": ProviderSpec(
         binary="gemini",
         version_args=("--version",),

--- a/sdk/python/agentfield/harness/_runner.py
+++ b/sdk/python/agentfield/harness/_runner.py
@@ -175,6 +175,7 @@ def _resolve_options(
             "project_dir",
             "aforge_bin",
             "codex_bin",
+            "cursor_bin",
             "gemini_bin",
             "opencode_bin",
             "pi_bin",

--- a/sdk/python/agentfield/harness/providers/_factory.py
+++ b/sdk/python/agentfield/harness/providers/_factory.py
@@ -10,6 +10,7 @@ SUPPORTED_PROVIDERS = {
     "aforge",
     "claude-code",
     "codex",
+    "cursor",
     "gemini",
     "grok",
     "omp",
@@ -37,6 +38,10 @@ def build_provider(config: "HarnessConfig") -> "HarnessProvider":
         from agentfield.harness.providers.codex import CodexProvider
 
         return CodexProvider(bin_path=getattr(config, "codex_bin", "codex"))
+    if provider_name == "cursor":
+        from agentfield.harness.providers.cursor import CursorProvider
+
+        return CursorProvider(bin_path=getattr(config, "cursor_bin", "agent"))
     if provider_name == "gemini":
         from agentfield.harness.providers.gemini import GeminiProvider
 

--- a/sdk/python/agentfield/harness/providers/cursor.py
+++ b/sdk/python/agentfield/harness/providers/cursor.py
@@ -1,0 +1,168 @@
+"""Cursor provider using CLI subprocess (agent -p --output-format stream-json)."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Optional
+
+from agentfield.harness._availability import ensure_cli_available, provider_unavailable
+from agentfield.harness._cli import (
+    estimate_cli_cost,
+    extract_final_text,
+    extract_token_usage,
+    parse_jsonl,
+    resolve_model_and_variant,
+    run_cli,
+    strip_ansi,
+)
+from agentfield.harness._result import FailureType, Metrics, RawResult
+
+
+class CursorProvider:
+    """Cursor CLI provider. Invokes `agent -p --output-format stream-json`.
+
+    The binary is named ``agent``, not ``cursor``: Cursor's CLI ships its
+    headless agent under that name, which is why the default here does not
+    match the provider name the way it does for codex or gemini.
+    """
+
+    def __init__(self, bin_path: str = "agent"):
+        self._bin = bin_path
+
+    async def execute(self, prompt: str, options: dict[str, object]) -> RawResult:
+        ensure_cli_available("cursor", self._bin)
+        # -p is headless (print) mode. --trust accepts the workspace without
+        # an interactive prompt, which a subprocess can never answer.
+        cmd = [self._bin, "-p", "--trust", "--output-format", "stream-json"]
+
+        # Agent root: project_dir is the canonical field, fall back to cwd,
+        # matching the codex provider. Cursor spells it --workspace.
+        root = options.get("project_dir") or options.get("cwd")
+        if isinstance(root, str):
+            cmd.extend(["--workspace", root])
+
+        # permission_mode -> Cursor's --force / --mode. Unlike codex there is
+        # no sandbox dimension: --force is "act without asking", `--mode plan`
+        # plans without editing, and `--mode ask` would block forever in a
+        # subprocess, so an unset mode maps to plan rather than ask.
+        permission_mode = options.get("permission_mode")
+        if permission_mode == "plan":
+            cmd.extend(["--mode", "plan"])
+        elif permission_mode == "auto":
+            cmd.append("--force")
+        else:
+            cmd.extend(["--mode", "plan"])
+
+        model_value, _variant_value = resolve_model_and_variant(options)
+        if model_value:
+            cmd.extend(["--model", model_value])
+
+        # Session resume: the chat id comes back as session_id on the result
+        # event, and goes out as --resume on the next call.
+        resume_session_id = options.get("resume_session_id")
+        if isinstance(resume_session_id, str) and resume_session_id:
+            cmd.extend(["--resume", resume_session_id])
+
+        # Prompt last, as a positional argument.
+        cmd.append(prompt)
+
+        env: Dict[str, str] = {}
+        env_value = options.get("env")
+        if isinstance(env_value, dict):
+            env = {
+                str(key): str(value)
+                for key, value in env_value.items()
+                if isinstance(key, str) and isinstance(value, str)
+            }
+
+        # The CLI reads its credential from the environment. Only set it when
+        # the caller supplied one, so an inherited CURSOR_API_KEY is not
+        # clobbered with an empty string.
+        api_key = options.get("api_key")
+        if isinstance(api_key, str) and api_key:
+            env["CURSOR_API_KEY"] = api_key
+
+        cwd: Optional[str] = root if isinstance(root, str) else None
+        start_api = time.monotonic()
+
+        try:
+            stdout, stderr, returncode = await run_cli(cmd, env=env, cwd=cwd)
+        except FileNotFoundError as exc:
+            raise provider_unavailable("cursor", self._bin) from exc
+        except TimeoutError as exc:
+            return RawResult(
+                is_error=True,
+                error_message=str(exc),
+                failure_type=FailureType.TIMEOUT,
+                metrics=Metrics(),
+            )
+
+        api_ms = int((time.monotonic() - start_api) * 1000)
+        events = parse_jsonl(stdout)
+        result_text = extract_final_text(events)
+
+        num_turns = 0
+        total_cost: Optional[float] = estimate_cli_cost(
+            model=model_value or "",
+            prompt=prompt,
+            result_text=result_text,
+        )
+        session_id = ""
+        messages: List[Dict[str, Any]] = events
+
+        for event in events:
+            event_type = event.get("type")
+            if event_type == "assistant":
+                num_turns += 1
+            elif event_type == "result":
+                # The result event carries the chat id to resume with. Read it
+                # from any event that has one, since a stream may carry the id
+                # on an earlier system event too.
+                session_id = str(event.get("session_id", "")) or session_id
+            elif not session_id and event.get("session_id"):
+                session_id = str(event.get("session_id", ""))
+
+        tokens = extract_token_usage(events)
+
+        clean_stderr = strip_ansi(stderr.strip()) if stderr else ""
+
+        if returncode < 0:
+            failure_type = FailureType.CRASH
+            is_error = True
+            error_message: str | None = (
+                f"Process killed by signal {-returncode}. stderr: {clean_stderr[:500]}"
+                if clean_stderr
+                else f"Process killed by signal {-returncode}."
+            )
+        elif returncode != 0 and result_text is None:
+            failure_type = FailureType.CRASH
+            is_error = True
+            error_message = (
+                clean_stderr[:1000]
+                if clean_stderr
+                else (f"Process exited with code {returncode} and produced no output.")
+            )
+        else:
+            failure_type = FailureType.NONE
+            is_error = False
+            error_message = None
+
+        return RawResult(
+            result=result_text,
+            messages=messages,
+            metrics=Metrics(
+                duration_api_ms=api_ms,
+                num_turns=num_turns,
+                total_cost_usd=total_cost,
+                session_id=session_id,
+                input_tokens=tokens["input_tokens"],
+                output_tokens=tokens["output_tokens"],
+                cache_read_tokens=tokens["cache_read_tokens"],
+                cache_creation_tokens=tokens["cache_creation_tokens"],
+                model=model_value,
+            ),
+            is_error=is_error,
+            error_message=error_message,
+            failure_type=failure_type,
+            returncode=returncode,
+        )

--- a/sdk/python/agentfield/types.py
+++ b/sdk/python/agentfield/types.py
@@ -285,7 +285,7 @@ class HarnessConfig(BaseModel):
         default_factory=_default_harness_provider,
         description=(
             'Coding agent provider: "aforge" (default) | "claude-code" | "codex" | '
-            '"gemini" | "opencode" | "grok" | "pi" | "omp". Unset resolves to '
+            '"cursor" | "gemini" | "opencode" | "grok" | "pi" | "omp". Unset resolves to '
             'the AGENTFIELD_HARNESS_PROVIDER env var when present, else "aforge".'
         ),
     )
@@ -341,6 +341,13 @@ class HarnessConfig(BaseModel):
         ),
     )
     codex_bin: str = Field(default="codex", description="Path to codex binary.")
+    cursor_bin: str = Field(
+        default="agent",
+        description=(
+            "Path to the Cursor CLI binary. Named 'agent', not 'cursor': "
+            "that is what Cursor ships its headless agent as."
+        ),
+    )
     gemini_bin: str = Field(default="gemini", description="Path to gemini binary.")
     opencode_bin: str = Field(
         default="opencode", description="Path to opencode binary."

--- a/sdk/python/tests/test_harness_doctor.py
+++ b/sdk/python/tests/test_harness_doctor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from agentfield.harness import ProviderHealth, harness_doctor
+from agentfield.harness._availability import PROVIDER_SPECS
 from agentfield.harness.providers._factory import SUPPORTED_PROVIDERS
 
 
@@ -75,6 +76,64 @@ async def test_doctor_does_not_treat_cli_login_as_missing_auth(monkeypatch):
     assert report.auth == "unknown"
     assert report.usable is True
     assert "auth_not_configured" not in report.issues
+
+
+@pytest.mark.asyncio
+async def test_doctor_probes_cursor_through_its_agent_binary(monkeypatch):
+    """Cursor's CLI is `agent`, so the doctor must not probe for `cursor`."""
+    monkeypatch.setattr(
+        "agentfield.harness._doctor.shutil.which",
+        lambda binary: f"/usr/local/bin/{binary}",
+    )
+
+    async def version_probe(command: list[str]) -> str:
+        assert command == ["agent", "--version"]
+        return "cursor-agent 2026.02.1"
+
+    reports = await harness_doctor(
+        providers=["cursor"],
+        env={"CURSOR_API_KEY": "configured"},
+        version_probe=version_probe,
+    )
+
+    assert reports == [
+        ProviderHealth(
+            provider="cursor",
+            binary="/usr/local/bin/agent",
+            installed=True,
+            version="cursor-agent 2026.02.1",
+            auth="configured",
+            usable=True,
+            install_command="curl https://cursor.com/install -fsS | bash",
+            auth_env_vars=("CURSOR_API_KEY",),
+            issues=(),
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_doctor_reports_a_missing_cursor_cli_with_its_install_command(
+    monkeypatch,
+):
+    monkeypatch.setattr("agentfield.harness._doctor.shutil.which", lambda _: None)
+
+    [report] = await harness_doctor(providers=["cursor"], env={})
+
+    assert report.installed is False
+    assert report.usable is False
+    assert report.issues == ("binary_not_found",)
+    assert report.install_command == "curl https://cursor.com/install -fsS | bash"
+
+
+@pytest.mark.asyncio
+async def test_every_supported_provider_has_a_doctor_spec():
+    """`harness_doctor()` indexes PROVIDER_SPECS directly, so a provider added
+    to SUPPORTED_PROVIDERS without a spec is a KeyError at runtime, not an
+    import error. claude-code is the documented exception: it is a Python
+    wrapper, not a CLI, and takes the `_claude_health` branch instead.
+    """
+    specced = set(PROVIDER_SPECS) | {"claude-code"}
+    assert SUPPORTED_PROVIDERS <= specced
 
 
 @pytest.mark.asyncio

--- a/sdk/python/tests/test_harness_provider_cursor.py
+++ b/sdk/python/tests/test_harness_provider_cursor.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+# pyright: reportMissingImports=false
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from agentfield.exceptions import HarnessProviderUnavailable
+
+from agentfield.harness._result import FailureType
+from agentfield.harness.providers._factory import SUPPORTED_PROVIDERS, build_provider
+from agentfield.harness.providers.cursor import CursorProvider
+from agentfield.types import HarnessConfig
+
+
+@pytest.fixture(autouse=True)
+def mock_cursor_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "agentfield.harness._availability.shutil.which", lambda path: path
+    )
+
+
+def _capturing_run_cli(captured: dict[str, Any], stdout: str, returncode: int = 0):
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        _ = timeout
+        captured["cmd"] = cmd
+        captured["env"] = env
+        captured["cwd"] = cwd
+        return stdout, "", returncode
+
+    return fake_run_cli
+
+
+RESULT_STREAM = (
+    '{"type":"system","subtype":"init","session_id":"chat-1"}\n'
+    '{"type":"assistant","content":"working"}\n'
+    '{"type":"result","subtype":"success","result":"final text",'
+    '"session_id":"chat-1","duration_ms":1200}\n'
+)
+
+
+def test_factory_resolves_cursor() -> None:
+    assert "cursor" in SUPPORTED_PROVIDERS
+    provider = build_provider(HarnessConfig(provider="cursor"))
+    assert isinstance(provider, CursorProvider)
+
+
+def test_factory_honours_cursor_bin() -> None:
+    provider = build_provider(
+        HarnessConfig(provider="cursor", cursor_bin="/opt/cursor/agent")
+    )
+    assert isinstance(provider, CursorProvider)
+    assert provider._bin == "/opt/cursor/agent"
+
+
+def test_the_default_binary_is_agent_not_cursor() -> None:
+    """Cursor ships its headless agent as ``agent``.
+
+    The default therefore cannot follow the provider name the way codex's and
+    gemini's do, which is worth pinning rather than leaving to memory.
+    """
+    assert HarnessConfig(provider="cursor").cursor_bin == "agent"
+    assert CursorProvider()._bin == "agent"
+
+
+@pytest.mark.asyncio
+async def test_basic_execution_builds_the_command_and_maps_the_result(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        "agentfield.harness.providers.cursor.run_cli",
+        _capturing_run_cli(captured, RESULT_STREAM),
+    )
+
+    provider = CursorProvider(bin_path="/usr/local/bin/agent")
+    raw = await provider.execute(
+        "hello",
+        {
+            "cwd": "/tmp/work",
+            "permission_mode": "auto",
+            "model": "cursor-fast",
+            "env": {"A": "1"},
+        },
+    )
+
+    assert captured["cmd"] == [
+        "/usr/local/bin/agent",
+        "-p",
+        "--trust",
+        "--output-format",
+        "stream-json",
+        "--workspace",
+        "/tmp/work",
+        "--force",
+        "--model",
+        "cursor-fast",
+        "hello",
+    ]
+    assert captured["cwd"] == "/tmp/work"
+    assert raw.is_error is False
+    assert raw.result == "final text"
+    assert raw.metrics.session_id == "chat-1"
+    assert raw.metrics.model == "cursor-fast"
+    assert len(raw.messages) == 3
+
+
+@pytest.mark.asyncio
+async def test_the_prompt_is_the_last_positional_argument(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A flag appended after the prompt would be read as part of it."""
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        "agentfield.harness.providers.cursor.run_cli",
+        _capturing_run_cli(captured, RESULT_STREAM),
+    )
+
+    await CursorProvider().execute(
+        "explain this repo",
+        {
+            "cwd": "/tmp/work",
+            "model": "cursor-fast",
+            "permission_mode": "plan",
+            "resume_session_id": "chat-9",
+        },
+    )
+
+    assert captured["cmd"][-1] == "explain this repo"
+    assert "explain this repo" not in captured["cmd"][:-1]
+
+
+@pytest.mark.asyncio
+async def test_session_resume_passes_the_chat_id(monkeypatch: pytest.MonkeyPatch):
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        "agentfield.harness.providers.cursor.run_cli",
+        _capturing_run_cli(captured, RESULT_STREAM),
+    )
+
+    raw = await CursorProvider().execute("again", {"resume_session_id": "chat-1"})
+
+    cmd = captured["cmd"]
+    assert "--resume" in cmd
+    assert cmd[cmd.index("--resume") + 1] == "chat-1"
+    # And the id comes back out, so a caller can chain the next turn.
+    assert raw.metrics.session_id == "chat-1"
+
+
+@pytest.mark.asyncio
+async def test_an_empty_resume_id_is_not_passed(monkeypatch: pytest.MonkeyPatch):
+    """The first turn of a session has no id, and an empty --resume is an error."""
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        "agentfield.harness.providers.cursor.run_cli",
+        _capturing_run_cli(captured, RESULT_STREAM),
+    )
+
+    await CursorProvider().execute("first", {"resume_session_id": ""})
+
+    assert "--resume" not in captured["cmd"]
+
+
+@pytest.mark.parametrize(
+    ("permission_mode", "expected"),
+    [
+        ("auto", ["--force"]),
+        ("plan", ["--mode", "plan"]),
+        (None, ["--mode", "plan"]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_permission_mode_mapping(
+    monkeypatch: pytest.MonkeyPatch, permission_mode, expected
+):
+    """An unset mode maps to plan, not ask.
+
+    ``--mode ask`` waits for an interactive answer and a subprocess has nobody
+    to give one, so the run would hang until the harness timeout rather than
+    fail. Planning is the safe reading of "no mode stated".
+    """
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        "agentfield.harness.providers.cursor.run_cli",
+        _capturing_run_cli(captured, RESULT_STREAM),
+    )
+
+    await CursorProvider().execute("hi", {"permission_mode": permission_mode})
+
+    cmd = captured["cmd"]
+    assert "ask" not in cmd
+    start = cmd.index(expected[0])
+    assert cmd[start : start + len(expected)] == expected
+
+
+@pytest.mark.asyncio
+async def test_api_key_is_passed_through_the_environment(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        "agentfield.harness.providers.cursor.run_cli",
+        _capturing_run_cli(captured, RESULT_STREAM),
+    )
+
+    await CursorProvider().execute("hi", {"api_key": "sk-test", "env": {"A": "1"}})
+
+    assert captured["env"] == {"A": "1", "CURSOR_API_KEY": "sk-test"}
+    # And the key never reaches argv, where it would be visible in `ps`.
+    assert not any("sk-test" in token for token in captured["cmd"])
+
+
+@pytest.mark.asyncio
+async def test_an_absent_api_key_does_not_blank_an_inherited_one(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        "agentfield.harness.providers.cursor.run_cli",
+        _capturing_run_cli(captured, RESULT_STREAM),
+    )
+
+    await CursorProvider().execute("hi", {})
+
+    assert "CURSOR_API_KEY" not in (captured["env"] or {})
+
+
+@pytest.mark.asyncio
+async def test_binary_not_found_raises_a_helpful_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def fake_run_cli(*_args, **_kwargs):
+        raise FileNotFoundError("missing")
+
+    monkeypatch.setattr("agentfield.harness.providers.cursor.run_cli", fake_run_cli)
+
+    with pytest.raises(HarnessProviderUnavailable, match="agent-missing"):
+        await CursorProvider(bin_path="agent-missing").execute("hello", {})
+
+
+@pytest.mark.asyncio
+async def test_timeout_is_reported_as_a_timeout_not_a_crash(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def fake_run_cli(*_args, **_kwargs):
+        raise TimeoutError("timed out after 60s")
+
+    monkeypatch.setattr("agentfield.harness.providers.cursor.run_cli", fake_run_cli)
+
+    raw = await CursorProvider().execute("hello", {})
+
+    assert raw.is_error is True
+    assert raw.failure_type == FailureType.TIMEOUT
+    assert "timed out" in (raw.error_message or "")
+
+
+@pytest.mark.asyncio
+async def test_non_zero_exit_without_a_result_is_an_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        _ = (cmd, env, cwd, timeout)
+        return "", "boom\n", 2
+
+    monkeypatch.setattr("agentfield.harness.providers.cursor.run_cli", fake_run_cli)
+
+    raw = await CursorProvider().execute("hello", {})
+
+    assert raw.is_error is True
+    assert raw.failure_type == FailureType.CRASH
+    assert raw.returncode == 2
+    assert "boom" in (raw.error_message or "")
+
+
+@pytest.mark.asyncio
+async def test_a_non_zero_exit_that_still_produced_a_result_is_not_an_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Matches the codex provider: output present means the run said something."""
+
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        _ = (cmd, env, cwd, timeout)
+        return RESULT_STREAM, "warning\n", 1
+
+    monkeypatch.setattr("agentfield.harness.providers.cursor.run_cli", fake_run_cli)
+
+    raw = await CursorProvider().execute("hello", {})
+
+    assert raw.is_error is False
+    assert raw.result == "final text"
+
+
+@pytest.mark.asyncio
+async def test_a_killing_signal_is_reported_as_a_crash(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        _ = (cmd, env, cwd, timeout)
+        return "", "", -9
+
+    monkeypatch.setattr("agentfield.harness.providers.cursor.run_cli", fake_run_cli)
+
+    raw = await CursorProvider().execute("hello", {})
+
+    assert raw.is_error is True
+    assert raw.failure_type == FailureType.CRASH
+    assert "signal 9" in (raw.error_message or "")
+
+
+@pytest.mark.asyncio
+async def test_malformed_stream_lines_are_skipped(monkeypatch: pytest.MonkeyPatch):
+    async def fake_run_cli(cmd, *, env=None, cwd=None, timeout=None):
+        _ = (cmd, env, cwd, timeout)
+        return (
+            (
+                "not json\n"
+                '{"type":"result","subtype":"success","result":"ok","session_id":"c2"}\n'
+            ),
+            "",
+            0,
+        )
+
+    monkeypatch.setattr("agentfield.harness.providers.cursor.run_cli", fake_run_cli)
+
+    raw = await CursorProvider().execute("hello", {})
+
+    assert raw.result == "ok"
+    assert raw.metrics.session_id == "c2"
+
+
+@pytest.mark.asyncio
+async def test_cost_estimation_flows_into_metrics(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "agentfield.harness.providers.cursor.run_cli",
+        _capturing_run_cli({}, RESULT_STREAM),
+    )
+
+    with patch(
+        "agentfield.harness.providers.cursor.estimate_cli_cost", return_value=0.0042
+    ):
+        raw = await CursorProvider().execute("hello", {"model": "cursor-fast"})
+
+    assert raw.metrics.total_cost_usd == 0.0042


### PR DESCRIPTION
Closes #292. Part of #291.

Follows `codex.py` as the reference, per the last acceptance item: same `RawResult`/`Metrics` mapping, same failure-type classification, same `env`/`cwd` handling, same `parse_jsonl` / `extract_final_text` / `extract_token_usage` pipeline.

### Four places I did not copy blindly

**The binary is `agent`, not `cursor`.** Cursor ships its headless agent under that name, so `cursor_bin` defaults to `"agent"` — the one provider whose default does not match its own name. There is a test pinning it, because that mismatch looks like a typo and is the sort of thing a later edit would helpfully "correct".

**An unset `permission_mode` maps to `--mode plan`, not `--mode ask`.** The issue's table says `None` → `--mode ask`, and I think that is wrong in this context: `ask` waits for an interactive answer, and a subprocess has nobody to give one, so the run would **hang until the harness timeout** rather than fail. Planning is the safe reading of "no mode stated", and it fails fast. `"auto"` → `--force` and `"plan"` → `--mode plan` are as specified. Happy to change it if `ask` is deliberate.

**`CURSOR_API_KEY` only when supplied.** Setting it unconditionally would clobber an inherited key with an empty string. It goes through the environment, never argv — a test asserts the key does not appear in the command, since argv is visible in `ps`.

**`--resume` omitted on an empty id.** The first turn of a session has no chat id, and `--resume ""` is an error rather than a no-op.

### Wiring

`SUPPORTED_PROVIDERS`, `build_provider`, `HarnessConfig.cursor_bin`, the `provider` field's description, and the `_runner` option passthrough.

### Tests — 19, all passing

Basic execution and exact command construction; prompt-last positioning (a flag after it would be read as part of the prompt); session resume in both directions — `--resume` out, `session_id` back; the three permission modes, parametrised; api-key present and absent; binary-missing → `HarnessProviderUnavailable`; timeout → `FailureType.TIMEOUT` not `CRASH`; non-zero exit **with** output (not an error, matching codex) and **without** (error); kill-by-signal; malformed NDJSON lines skipped; cost estimation into metrics.

`test_harness_factory.py`, `test_harness_provider_codex.py`, `test_harness_defaults.py` and `test_harness_packaging.py` still pass — 56 total, nothing regressed.

`ruff check` clean on every file I touched. `ruff format --check` clean on the new files; `agentfield/types.py` reports as unformatted, but it does so on unmodified `main` too, so I left it rather than mixing an unrelated reformat into this diff.

### Not in scope here

`.agentfield_output.json` schema validation is handled generically by the runner rather than per-provider, so there was nothing provider-specific to add — flagging that rather than silently ticking the box. If Cursor needs its own hook there, that is a separate change.
