### PR TITLE
test(harness): cover raw result text and failure type serialization

### DIFF
--- a/sdk/go/harness/result_test.go
+++ b/sdk/go/harness/result_test.go
@@ -1,0 +1,63 @@
+package harness
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResultTextReturnsRawResult(t *testing.T) {
+	tests := []struct {
+		name   string
+		result Result
+		want   string
+	}{
+		{name: "zero value", result: Result{}, want: ""},
+		{name: "plain text", result: Result{Result: "hello"}, want: "hello"},
+		{name: "whitespace and unicode", result: Result{Result: " \t你好\nworld\r\n "}, want: " \t你好\nworld\r\n "},
+		{
+			name: "raw JSON rather than parsed value",
+			result: Result{
+				Result: ` { "message": "hello" } `,
+				Parsed: map[string]any{"message": "hello"},
+			},
+			want: ` { "message": "hello" } `,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.result.Text())
+		})
+	}
+}
+
+func TestFailureTypeJSONSerialization(t *testing.T) {
+	tests := []struct {
+		name  string
+		value FailureType
+		want  string
+	}{
+		{name: "zero value", value: "", want: `""`},
+		{name: "none", value: FailureNone, want: `"none"`},
+		{name: "crash", value: FailureCrash, want: `"crash"`},
+		{name: "timeout", value: FailureTimeout, want: `"timeout"`},
+		{name: "API error", value: FailureAPIError, want: `"api_error"`},
+		{name: "no output", value: FailureNoOutput, want: `"no_output"`},
+		{name: "schema", value: FailureSchema, want: `"schema"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.value)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(data))
+
+			var decoded FailureType
+			require.NoError(t, json.Unmarshal(data, &decoded))
+			assert.Equal(t, tt.value, decoded)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds table-driven tests for `Result.Text()` raw text preservation and JSON serialization/round trips for all six `FailureType` constants and the zero value.

This PR covers only the claimed `sdk/go/harness/result_test.go` subtask of #404. No production code changes.

## Type of change

- [x] Tests only

## Test plan

Commands run from `sdk/go`:

- [x] `gofmt -w harness/result_test.go`
- [x] `go test ./harness -run '^(TestResultTextReturnsRawResult|TestFailureTypeJSONSerialization)$' -count=1 -v` — all 11 cases passed.
- [x] `TMPDIR=/private/tmp go test ./harness/... -count=1 -cover` — passed; 92.3% package coverage.
- [x] `golangci-lint run --new-from-rev=HEAD~1 ./harness/...` — passed.

Additional validation:
- Python SDK: 2364 passed, 4 skipped.
- TypeScript SDK: 970 passed.
- Web UI: 700 passed; build passed.
- Python lint passed.

Full-repository checks were not entirely green on macOS:
- `./scripts/test-all.sh` stopped at an existing control-plane test requiring Linux `/proc` process-environment access. Remaining component suites were run separately.
- `make lint` reported existing Go issues outside this change.
- An existing harness cancellation test failed during a concurrent run; the full harness suite passed on a separate rerun.
- `TMPDIR=/private/tmp` avoids an existing macOS `/var` versus `/private/var` path comparison failure.

## Test coverage

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR (no bare additions). This PR adds tests only.
- [ ] The coverage gate check is green in CI before requesting review.

No production code was removed, and `coverage-baseline.json` was not changed. The 92.3% result is local harness package coverage; the repository-wide coverage gate still needs to run in CI.

## Checklist

- [ ] I have read CONTRIBUTING.md (if present) and docs/DEVELOPMENT.md.
- [ ] Commits are signed and follow conventional-commits style.
- [x] I have linked any related issues.

Read `CLAUDE.md`, `AGENTS.md`, and `docs/CONTRIBUTING.md`. The commit follows conventional-commits style but is not cryptographically signed.

AI-assisted implementation, reviewed and tested locally.

## Related issues / PRs

Refs #404 — only the `sdk/go/harness/result_test.go` subtask.