### PR TITLE
fix(go-sdk): make harness schema path tests OS-portable

### DIFF
--- a/sdk/go/harness/schema_test.go
+++ b/sdk/go/harness/schema_test.go
@@ -11,12 +11,12 @@ import (
 )
 
 func TestOutputPath(t *testing.T) {
-	assert.Equal(t, "/tmp/.agentfield_output.json", OutputPath("/tmp"))
-	assert.Equal(t, "foo/.agentfield_output.json", OutputPath("foo"))
+	assert.Equal(t, filepath.Join("/tmp", outputFilename), OutputPath("/tmp"))
+	assert.Equal(t, filepath.Join("foo", outputFilename), OutputPath("foo"))
 }
 
 func TestSchemaPath(t *testing.T) {
-	assert.Equal(t, "/tmp/.agentfield_schema.json", SchemaPath("/tmp"))
+	assert.Equal(t, filepath.Join("/tmp", schemaFilename), SchemaPath("/tmp"))
 }
 
 func TestBuildPromptSuffix_SmallSchema(t *testing.T) {


### PR DESCRIPTION
## Summary

`TestOutputPath` and `TestSchemaPath` in `sdk/go/harness/schema_test.go` asserted hardcoded Unix path separators (`/tmp/.agentfield_output.json`), so they failed on Windows where `filepath.Join` produces backslash separators. This makes the assertions compute the expected value with `filepath.Join` and the existing filename constants, matching how the production code (`OutputPath`/`SchemaPath`) builds the path.

The production code was already correct; only the tests were non-portable. Go SDK CI runs on `ubuntu-latest` only, so this surfaced only in local Windows development. The change is a no-op on Linux (`filepath.Join` yields the identical string) and a fix on Windows.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] Tests only
- [ ] CI / tooling
- [ ] Breaking change

## Test plan

- [x] `cd sdk/go && go test ./harness/ -run 'TestOutputPath|TestSchemaPath' -count=1` (fails on Windows before, passes after)
- [x] `cd sdk/go && go build ./...`
- [x] `cd sdk/go && go vet ./harness/`

Before (Windows):
```
--- FAIL: TestOutputPath (0.00s)
    expected: "/tmp/.agentfield_output.json"
    actual  : "\tmp\.agentfield_output.json"
--- FAIL: TestSchemaPath (0.00s)
```
After: both pass on Windows, unchanged on Linux.

## Test coverage

- [x] I ran tests for the surface(s) I changed locally.
- [x] New code paths are covered by tests in this PR (no bare additions).
- [x] No production code changed; this is a test-only assertion fix, so coverage is unaffected.
- [ ] The coverage gate check is green in CI before requesting review.

## Checklist

- [x] I have read CONTRIBUTING.md (if present) and docs/DEVELOPMENT.md.
- [ ] Commits are signed and follow conventional-commits style. (conventional-commits: yes; commit signing not configured in my environment)
- [x] I have linked any related issues.

## Related issues / PRs

Surfaced while reviewing #404 (Go SDK `harness/` test coverage). Not a scoped item of that issue; filing as an independent portability fix.
