### PR TITLE
fix(storage): rebind postgres tx prepares and guard stale retries

### DIFF
--- a/control-plane/internal/storage/coverage_misc_helpers_test.go
+++ b/control-plane/internal/storage/coverage_misc_helpers_test.go
@@ -3,8 +3,10 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"errors"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
@@ -17,9 +19,121 @@ type testRollbacker struct {
 	rollbacks int
 }
 
+type prepareCaptureState struct {
+	mu      sync.Mutex
+	queries []string
+}
+
+type prepareCaptureConnector struct {
+	state *prepareCaptureState
+}
+
+type prepareCaptureDriver struct{}
+
+type prepareCaptureConn struct {
+	state *prepareCaptureState
+}
+
+type prepareCaptureTx struct{}
+
+type prepareCaptureStmt struct{}
+
+func (prepareCaptureConnector) Driver() driver.Driver {
+	return prepareCaptureDriver{}
+}
+
+func (c prepareCaptureConnector) Connect(context.Context) (driver.Conn, error) {
+	return &prepareCaptureConn{state: c.state}, nil
+}
+
+func (prepareCaptureDriver) Open(string) (driver.Conn, error) {
+	return nil, errors.New("prepare capture driver requires a connector")
+}
+
+func (c *prepareCaptureConn) recordPrepare(query string) driver.Stmt {
+	c.state.mu.Lock()
+	c.state.queries = append(c.state.queries, query)
+	c.state.mu.Unlock()
+	return prepareCaptureStmt{}
+}
+
+func (c *prepareCaptureConn) Prepare(query string) (driver.Stmt, error) {
+	return c.recordPrepare(query), nil
+}
+
+func (c *prepareCaptureConn) PrepareContext(_ context.Context, query string) (driver.Stmt, error) {
+	return c.recordPrepare(query), nil
+}
+
+func (*prepareCaptureConn) Close() error { return nil }
+
+func (*prepareCaptureConn) Begin() (driver.Tx, error) {
+	return prepareCaptureTx{}, nil
+}
+
+func (prepareCaptureTx) Commit() error   { return nil }
+func (prepareCaptureTx) Rollback() error { return nil }
+
+func (prepareCaptureStmt) Close() error  { return nil }
+func (prepareCaptureStmt) NumInput() int { return -1 }
+func (prepareCaptureStmt) Exec([]driver.Value) (driver.Result, error) {
+	return driver.RowsAffected(0), nil
+}
+func (prepareCaptureStmt) Query([]driver.Value) (driver.Rows, error) {
+	return nil, errors.New("prepare capture query not supported")
+}
+
+func (s *prepareCaptureState) preparedQueries() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.queries...)
+}
+
 func (r *testRollbacker) Rollback() error {
 	r.rollbacks++
 	return r.err
+}
+
+func TestSQLTxPrepareRebindsByMode(t *testing.T) {
+	tests := []struct {
+		name string
+		mode string
+		want []string
+	}{
+		{
+			name: "postgres",
+			mode: "postgres",
+			want: []string{"SELECT $1", "UPDATE items SET name = $1"},
+		},
+		{
+			name: "sqlite",
+			mode: "local",
+			want: []string{"SELECT ?", "UPDATE items SET name = ?"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state := &prepareCaptureState{}
+			rawDB := sql.OpenDB(prepareCaptureConnector{state: state})
+			t.Cleanup(func() { _ = rawDB.Close() })
+
+			rawTx, err := rawDB.Begin()
+			require.NoError(t, err)
+			tx := newSQLTx(rawTx, test.mode)
+
+			stmt, err := tx.PrepareContext(context.Background(), "SELECT ?")
+			require.NoError(t, err)
+			require.NoError(t, stmt.Close())
+
+			stmt, err = tx.Prepare("UPDATE items SET name = ?")
+			require.NoError(t, err)
+			require.NoError(t, stmt.Close())
+			require.NoError(t, tx.Rollback())
+
+			require.Equal(t, test.want, state.preparedQueries())
+		})
+	}
 }
 
 func TestStorageHelperCoverage(t *testing.T) {

--- a/control-plane/internal/storage/execution_records.go
+++ b/control-plane/internal/storage/execution_records.go
@@ -1573,8 +1573,13 @@ func (ls *LocalStorage) markAgentExecutionsOrphaned(ctx context.Context, agentNo
 
 // RetryStaleWorkflowExecutions finds stale workflow executions that haven't exceeded
 // maxRetries and resets both workflow_executions and executions back to "pending"
-// so the paired records stay in sync for the retry path.
+// so the paired records stay in sync for the retry path. The candidate predicates
+// are repeated in the conditional update so activity after selection prevents a retry.
 func (ls *LocalStorage) RetryStaleWorkflowExecutions(ctx context.Context, staleAfter time.Duration, maxRetries int, limit int) ([]string, error) {
+	return ls.retryStaleWorkflowExecutions(ctx, staleAfter, maxRetries, limit, nil)
+}
+
+func (ls *LocalStorage) retryStaleWorkflowExecutions(ctx context.Context, staleAfter time.Duration, maxRetries int, limit int, afterCandidateSelection func()) ([]string, error) {
 	if limit <= 0 || maxRetries <= 0 {
 		return nil, nil
 	}
@@ -1584,17 +1589,22 @@ func (ls *LocalStorage) RetryStaleWorkflowExecutions(ctx context.Context, staleA
 
 	cutoff := time.Now().UTC().Add(-staleAfter)
 	db := ls.requireSQLDB()
-	tsExpr := ls.staleTimestampExpr("COALESCE(updated_at, created_at, started_at)")
+	workflowTSExpr := ls.staleTimestampExpr("COALESCE(w.updated_at, w.created_at, w.started_at)")
+	executionTSExpr := ls.staleTimestampExpr("COALESCE(e.updated_at, e.created_at, e.started_at)")
 	cutoffExpr := ls.staleTimestampExpr("?")
 
 	rows, err := db.QueryContext(ctx, `
-		SELECT execution_id
-		FROM workflow_executions
-		WHERE status IN ('running', 'pending', 'queued')
-		  AND retry_count < ?
-		  AND `+tsExpr+` <= `+cutoffExpr+`
-		ORDER BY `+tsExpr+` ASC
-		LIMIT ?`, maxRetries, cutoff, limit)
+		SELECT w.execution_id
+		FROM workflow_executions w
+		LEFT JOIN executions e
+		  ON e.execution_id = w.execution_id
+		 AND e.status IN ('running', 'pending', 'queued', 'waiting')
+		WHERE w.status IN ('running', 'pending', 'queued')
+		  AND w.retry_count < ?
+		  AND `+workflowTSExpr+` <= `+cutoffExpr+`
+		  AND (e.execution_id IS NULL OR `+executionTSExpr+` <= `+cutoffExpr+`)
+		ORDER BY `+workflowTSExpr+` ASC
+		LIMIT ?`, maxRetries, cutoff, cutoff, limit)
 	if err != nil {
 		return nil, fmt.Errorf("query retriable workflow executions: %w", err)
 	}
@@ -1616,6 +1626,12 @@ func (ls *LocalStorage) RetryStaleWorkflowExecutions(ctx context.Context, staleA
 		return nil, nil
 	}
 
+	// Package tests use this seam to make the candidate-selection-to-update
+	// interleaving deterministic; production callers leave it nil.
+	if afterCandidateSelection != nil {
+		afterCandidateSelection()
+	}
+
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("begin retry transaction: %w", err)
@@ -1626,13 +1642,29 @@ func (ls *LocalStorage) RetryStaleWorkflowExecutions(ctx context.Context, staleA
 	retryReason := "auto-retry after stale timeout"
 
 	workflowStmt, err := tx.PrepareContext(ctx, `
-		UPDATE workflow_executions
+		UPDATE workflow_executions AS w
 		SET status = 'pending',
 		    retry_count = retry_count + 1,
 		    error_message = ?,
 		    completed_at = NULL,
 		    updated_at = ?
-		WHERE execution_id = ? AND status IN ('running', 'pending', 'queued')`)
+		WHERE w.execution_id = ?
+		  AND w.status IN ('running', 'pending', 'queued')
+		  AND w.retry_count < ?
+		  AND `+workflowTSExpr+` <= `+cutoffExpr+`
+		  AND (
+		      NOT EXISTS (
+		          SELECT 1 FROM executions e
+		          WHERE e.execution_id = w.execution_id
+		            AND e.status IN ('running', 'pending', 'queued', 'waiting')
+		      )
+		      OR EXISTS (
+		          SELECT 1 FROM executions e
+		          WHERE e.execution_id = w.execution_id
+		            AND e.status IN ('running', 'pending', 'queued', 'waiting')
+		            AND `+executionTSExpr+` <= `+cutoffExpr+`
+		      )
+		  )`)
 	if err != nil {
 		return nil, fmt.Errorf("prepare retry statement: %w", err)
 	}
@@ -1653,7 +1685,7 @@ func (ls *LocalStorage) RetryStaleWorkflowExecutions(ctx context.Context, staleA
 
 	var retried []string
 	for _, id := range ids {
-		result, err := workflowStmt.ExecContext(ctx, retryReason, now, id)
+		result, err := workflowStmt.ExecContext(ctx, retryReason, now, id, maxRetries, cutoff, cutoff)
 		if err != nil {
 			return retried, fmt.Errorf("retry workflow execution %s: %w", id, err)
 		}

--- a/control-plane/internal/storage/execution_records.go
+++ b/control-plane/internal/storage/execution_records.go
@@ -1574,7 +1574,8 @@ func (ls *LocalStorage) markAgentExecutionsOrphaned(ctx context.Context, agentNo
 // RetryStaleWorkflowExecutions finds stale workflow executions that haven't exceeded
 // maxRetries and resets both workflow_executions and executions back to "pending"
 // so the paired records stay in sync for the retry path. The candidate predicates
-// are repeated in the conditional update so activity after selection prevents a retry.
+// are repeated in both conditional updates, so activity after selection — including
+// a heartbeat landing between the workflow and execution statements — prevents a retry.
 func (ls *LocalStorage) RetryStaleWorkflowExecutions(ctx context.Context, staleAfter time.Duration, maxRetries int, limit int) ([]string, error) {
 	return ls.retryStaleWorkflowExecutions(ctx, staleAfter, maxRetries, limit, nil)
 }
@@ -1670,14 +1671,19 @@ func (ls *LocalStorage) retryStaleWorkflowExecutions(ctx context.Context, staleA
 	}
 	defer workflowStmt.Close()
 
+	// The execution update repeats the staleness predicate: a heartbeat can
+	// land between the workflow guard above and this statement, and the fresh
+	// execution must not be dragged back to pending.
 	executionStmt, err := tx.PrepareContext(ctx, `
-		UPDATE executions
+		UPDATE executions AS e
 		SET status = 'pending',
 		    error_message = ?,
 		    completed_at = NULL,
 		    duration_ms = NULL,
 		    updated_at = ?
-		WHERE execution_id = ? AND status IN ('running', 'pending', 'queued')`)
+		WHERE e.execution_id = ?
+		  AND e.status IN ('running', 'pending', 'queued')
+		  AND `+executionTSExpr+` <= `+cutoffExpr)
 	if err != nil {
 		return nil, fmt.Errorf("prepare execution retry statement: %w", err)
 	}
@@ -1697,7 +1703,7 @@ func (ls *LocalStorage) retryStaleWorkflowExecutions(ctx context.Context, staleA
 			continue
 		}
 
-		if _, err := executionStmt.ExecContext(ctx, retryReason, now, id); err != nil {
+		if _, err := executionStmt.ExecContext(ctx, retryReason, now, id, cutoff); err != nil {
 			return retried, fmt.Errorf("retry execution %s: %w", id, err)
 		}
 		retried = append(retried, id)

--- a/control-plane/internal/storage/postgres_stale_reaper_live_test.go
+++ b/control-plane/internal/storage/postgres_stale_reaper_live_test.go
@@ -1,0 +1,438 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Agent-Field/agentfield/control-plane/pkg/types"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise the stale reapers against a real PostgreSQL server.
+// They are gated on POSTGRES_TEST_URL, the same variable the rest of the
+// storage suite uses, and connect only to a loopback host. Each test creates
+// its own throwaway database so rows never leak between tests.
+
+// livePostgresConnConfig reads POSTGRES_TEST_URL and refuses anything that is
+// not a loopback server, so a stray staging DSN can never be touched.
+func livePostgresConnConfig(t *testing.T) *pgx.ConnConfig {
+	t.Helper()
+
+	dsn := strings.TrimSpace(os.Getenv("POSTGRES_TEST_URL"))
+	if dsn == "" {
+		t.Skip("POSTGRES_TEST_URL not set, skipping live postgres tests")
+	}
+
+	cfg, err := pgx.ParseConfig(dsn)
+	require.NoError(t, err, "parse POSTGRES_TEST_URL")
+
+	host := cfg.Host
+	if host == "" {
+		host = "localhost"
+	}
+	ip := net.ParseIP(host)
+	require.Truef(t,
+		strings.EqualFold(host, "localhost") || (ip != nil && ip.IsLoopback()),
+		"live postgres tests refuse non-loopback host %q", host)
+	return cfg
+}
+
+// livePostgresStorage spins up an isolated database on the live server and
+// returns a Postgres-backed LocalStorage pointed at it.
+func livePostgresStorage(t *testing.T) (*LocalStorage, context.Context) {
+	t.Helper()
+
+	cfg := livePostgresConnConfig(t)
+	ctx := context.Background()
+
+	dbName := fmt.Sprintf("af_reaper_live_%d_%d", time.Now().UnixNano(), os.Getpid())
+
+	admin, err := sql.Open("pgx", cfg.ConnString())
+	require.NoError(t, err)
+	_, err = admin.ExecContext(ctx, "CREATE DATABASE "+dbName)
+	_ = admin.Close()
+	require.NoError(t, err, "create throwaway database %s", dbName)
+
+	t.Cleanup(func() {
+		drop, dropErr := sql.Open("pgx", cfg.ConnString())
+		if dropErr != nil {
+			return
+		}
+		defer drop.Close()
+		_, _ = drop.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+dbName+" WITH (FORCE)")
+	})
+
+	storageCfg := StorageConfig{
+		Mode: "postgres",
+		Postgres: PostgresStorageConfig{
+			Host:     cfg.Host,
+			Port:     int(cfg.Port),
+			User:     cfg.User,
+			Password: cfg.Password,
+			Database: dbName,
+			SSLMode:  "disable",
+		},
+	}
+	ls := NewPostgresStorage(PostgresStorageConfig{})
+	require.NoError(t, ls.Initialize(ctx, storageCfg), "initialize postgres storage")
+	t.Cleanup(func() { _ = ls.Close(context.Background()) })
+
+	return ls, ctx
+}
+
+// preparedSQLRecorder wraps a real PostgreSQL connector and records every SQL
+// string handed to the driver's prepare path. That string is the post-rebind
+// text, so it is the exact statement PostgreSQL would parse.
+type preparedSQLRecorder struct {
+	inner driver.Connector
+	mu    sync.Mutex
+	sql   []string
+}
+
+func (r *preparedSQLRecorder) record(query string) {
+	r.mu.Lock()
+	r.sql = append(r.sql, query)
+	r.mu.Unlock()
+}
+
+func (r *preparedSQLRecorder) prepared() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.sql...)
+}
+
+func (r *preparedSQLRecorder) Connect(ctx context.Context) (driver.Conn, error) {
+	conn, err := r.inner.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &recordingConn{Conn: conn, recorder: r}, nil
+}
+
+func (r *preparedSQLRecorder) Driver() driver.Driver { return recordingDriver{recorder: r} }
+
+type recordingDriver struct{ recorder *preparedSQLRecorder }
+
+func (d recordingDriver) Open(string) (driver.Conn, error) {
+	return d.recorder.Connect(context.Background())
+}
+
+type recordingConn struct {
+	driver.Conn
+	recorder *preparedSQLRecorder
+}
+
+func (c *recordingConn) Prepare(query string) (driver.Stmt, error) {
+	c.recorder.record(query)
+	return c.Conn.Prepare(query)
+}
+
+func (c *recordingConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	c.recorder.record(query)
+	if pc, ok := c.Conn.(driver.ConnPrepareContext); ok {
+		return pc.PrepareContext(ctx, query)
+	}
+	return c.Conn.Prepare(query)
+}
+
+func (c *recordingConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	if b, ok := c.Conn.(driver.ConnBeginTx); ok {
+		return b.BeginTx(ctx, opts)
+	}
+	return c.Conn.Begin()
+}
+
+// livePreparedRecorder opens a recorder-backed *sql.DB for the same throwaway
+// database as ls and swaps it in, returning a restore func.
+func livePreparedRecorder(t *testing.T, cfg *pgx.ConnConfig) (*preparedSQLRecorder, *sql.DB) {
+	t.Helper()
+	connector := stdlib.GetConnector(*cfg)
+	recorder := &preparedSQLRecorder{inner: connector}
+	db := sql.OpenDB(recorder)
+	return recorder, db
+}
+
+func liveConfigForDatabase(t *testing.T, dbName string) *pgx.ConnConfig {
+	t.Helper()
+	cfg := livePostgresConnConfig(t)
+	cfg.Database = dbName
+	return cfg
+}
+
+// livePostgresStorageWithRecorder returns the storage, its database name, and a
+// recorder swapped in as the storage SQL handle so prepared statements are
+// captured while the reapers run. The original handle is restored on cleanup.
+func livePostgresStorageWithRecorder(t *testing.T) (*LocalStorage, context.Context, *preparedSQLRecorder) {
+	t.Helper()
+
+	ls, ctx := livePostgresStorage(t)
+	dbName := ls.postgresConfig.Database
+	require.NotEmpty(t, dbName)
+
+	recorder, recDB := livePreparedRecorder(t, liveConfigForDatabase(t, dbName))
+	original := ls.db
+	ls.db = newSQLDatabase(recDB, "postgres")
+	t.Cleanup(func() {
+		ls.db = original
+		_ = recDB.Close()
+	})
+	return ls, ctx, recorder
+}
+
+func staleLiveWorkflow(id string, updatedAt time.Time) *types.WorkflowExecution {
+	return &types.WorkflowExecution{
+		WorkflowID:          "wf-" + id,
+		ExecutionID:         id,
+		AgentFieldRequestID: "req-" + id,
+		AgentNodeID:         "agent-live",
+		ReasonerID:          "reasoner-live",
+		Status:              "running",
+		StartedAt:           updatedAt,
+		InputData:           json.RawMessage(`{}`),
+		OutputData:          json.RawMessage(`{}`),
+		RetryCount:          0,
+		CreatedAt:           updatedAt,
+		UpdatedAt:           updatedAt,
+	}
+}
+
+func liveExecution(id string, startedAt time.Time) *types.Execution {
+	return &types.Execution{
+		ExecutionID:  id,
+		RunID:        "run-" + id,
+		AgentNodeID:  "agent-live",
+		ReasonerID:   "reasoner-live",
+		NodeID:       "agent-live",
+		Status:       "running",
+		StartedAt:    startedAt,
+		CreatedAt:    startedAt,
+		UpdatedAt:    startedAt,
+		InputPayload: json.RawMessage(`{}`),
+	}
+}
+
+// TestPostgresStaleReaperRawPlaceholdersFailToPrepare reproduces the original
+// defect at the SQL level: the pre-fix code sent `?` placeholders straight to
+// PostgreSQL, which rejects them with SQLSTATE 42601.
+func TestPostgresStaleReaperRawPlaceholdersFailToPrepare(t *testing.T) {
+	cfg := livePostgresConnConfig(t)
+
+	db, err := sql.Open("pgx", cfg.ConnString())
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+
+	raw := `UPDATE executions AS e
+		SET status = ?, error_message = ?, completed_at = ?, duration_ms = ?, updated_at = ?
+		WHERE e.execution_id = ?
+		  AND e.status IN ('running', 'pending', 'queued')
+		  AND COALESCE(e.updated_at, e.created_at, e.started_at) <= ?`
+
+	stmt, err := tx.PrepareContext(ctx, raw)
+	if err == nil {
+		_, err = stmt.ExecContext(ctx, "timeout", "timed out", time.Now(), 1, time.Now(), "id", time.Now())
+		_ = stmt.Close()
+	}
+	require.Error(t, err, "unrebound ? placeholders must not prepare on PostgreSQL")
+
+	var pgErr *pgconn.PgError
+	require.ErrorAs(t, err, &pgErr)
+	require.Equal(t, "42601", pgErr.Code)
+	t.Logf("pre-fix reproduction: PostgreSQL rejected ? placeholders: SQLSTATE %s: %s", pgErr.Code, pgErr.Message)
+}
+
+// TestPostgresStaleReaperPreparedStatementsAreRebound captures the SQL text the
+// reapers hand to the driver and asserts every placeholder was rewritten to $n
+// before it reached PostgreSQL.
+func TestPostgresStaleReaperPreparedStatementsAreRebound(t *testing.T) {
+	ls, ctx, recorder := livePostgresStorageWithRecorder(t)
+	now := time.Now().UTC()
+	suffix := time.Now().UnixNano()
+
+	staleID := fmt.Sprintf("exec-live-prepare-%d", suffix)
+	require.NoError(t, ls.StoreWorkflowExecution(ctx, staleLiveWorkflow(staleID, now.Add(-2*time.Hour))))
+	require.NoError(t, ls.CreateExecutionRecord(ctx, liveExecution(staleID, now.Add(-2*time.Hour))))
+	backdateExecutionUpdatedAt(t, ls, "executions", staleID, now.Add(-2*time.Hour))
+
+	_, err := ls.MarkStaleWorkflowExecutions(ctx, time.Hour, 100)
+	require.NoError(t, err)
+	_, err = ls.MarkStaleExecutions(ctx, time.Hour, 100)
+	require.NoError(t, err)
+	_, err = ls.RetryStaleWorkflowExecutions(ctx, time.Hour, 3, 100)
+	require.NoError(t, err)
+
+	prepared := recorder.prepared()
+	require.NotEmpty(t, prepared, "expected the reapers to prepare statements")
+
+	var updateStmts []string
+	for _, query := range prepared {
+		normalized := strings.ToLower(strings.TrimSpace(query))
+		if strings.HasPrefix(normalized, "update") {
+			updateStmts = append(updateStmts, query)
+			require.NotContains(t, query, "?", "prepared update still contains ? placeholder")
+			require.Contains(t, query, "$1", "prepared update is missing $1 placeholder")
+		}
+	}
+	require.NotEmpty(t, updateStmts, "expected prepared UPDATE statements")
+
+	for _, query := range updateStmts {
+		t.Logf("PostgreSQL prepared update:\n%s", strings.Join(strings.Fields(query), " "))
+	}
+}
+
+// TestPostgresMarkStaleWorkflowExecutionsReapsStaleAndSparesFreshExecution drives
+// the workflow reaper end to end: a workflow stale on both clocks is reaped,
+// while a stale workflow whose paired execution is still fresh survives.
+func TestPostgresMarkStaleWorkflowExecutionsReapsStaleAndSparesFreshExecution(t *testing.T) {
+	ls, ctx := livePostgresStorage(t)
+	now := time.Now().UTC()
+	suffix := time.Now().UnixNano()
+
+	staleID := fmt.Sprintf("exec-live-reap-stale-%d", suffix)
+	freshID := fmt.Sprintf("exec-live-reap-fresh-%d", suffix)
+
+	// Stale on both clocks: workflow and paired execution both 2h old.
+	require.NoError(t, ls.StoreWorkflowExecution(ctx, staleLiveWorkflow(staleID, now.Add(-2*time.Hour))))
+	require.NoError(t, ls.CreateExecutionRecord(ctx, liveExecution(staleID, now.Add(-2*time.Hour))))
+	backdateExecutionUpdatedAt(t, ls, "executions", staleID, now.Add(-2*time.Hour))
+
+	// Stale workflow, fresh paired execution: the execution heartbeat must protect it.
+	require.NoError(t, ls.StoreWorkflowExecution(ctx, staleLiveWorkflow(freshID, now.Add(-2*time.Hour))))
+	require.NoError(t, ls.CreateExecutionRecord(ctx, liveExecution(freshID, now.Add(-2*time.Hour))))
+	// CreateExecutionRecord leaves executions.updated_at at "now" (fresh).
+
+	reaped, err := ls.MarkStaleWorkflowExecutions(ctx, time.Hour, 100)
+	require.NoError(t, err)
+	require.Equal(t, 1, reaped, "only the workflow stale on both clocks should be reaped")
+
+	staleWorkflow, err := ls.GetWorkflowExecution(ctx, staleID)
+	require.NoError(t, err)
+	require.Equal(t, "timeout", staleWorkflow.Status)
+	t.Logf("reaped (stale on both clocks): %s status=%s", staleID, staleWorkflow.Status)
+
+	staleExecution, err := ls.GetExecutionRecord(ctx, staleID)
+	require.NoError(t, err)
+	require.Equal(t, "timeout", staleExecution.Status)
+
+	freshWorkflow, err := ls.GetWorkflowExecution(ctx, freshID)
+	require.NoError(t, err)
+	require.Equal(t, "running", freshWorkflow.Status)
+	require.Equal(t, 0, freshWorkflow.RetryCount)
+	t.Logf("survived (fresh paired execution): %s status=%s", freshID, freshWorkflow.Status)
+
+	freshExecution, err := ls.GetExecutionRecord(ctx, freshID)
+	require.NoError(t, err)
+	require.Equal(t, "running", freshExecution.Status)
+}
+
+// TestPostgresMarkStaleWorkflowExecutionsReapsWhenPairedExecutionIsTerminal
+// covers the new guard's status filter: a fresh but terminal paired execution
+// does not shield a stale workflow from being reaped.
+func TestPostgresMarkStaleWorkflowExecutionsReapsWhenPairedExecutionIsTerminal(t *testing.T) {
+	ls, ctx := livePostgresStorage(t)
+	now := time.Now().UTC()
+	id := fmt.Sprintf("exec-live-terminal-%d", time.Now().UnixNano())
+
+	require.NoError(t, ls.StoreWorkflowExecution(ctx, staleLiveWorkflow(id, now.Add(-2*time.Hour))))
+	exec := liveExecution(id, now.Add(-2*time.Hour))
+	exec.Status = "succeeded"
+	require.NoError(t, ls.CreateExecutionRecord(ctx, exec))
+
+	reaped, err := ls.MarkStaleWorkflowExecutions(ctx, time.Hour, 100)
+	require.NoError(t, err)
+	require.Equal(t, 1, reaped, "a terminal paired execution must not shield a stale workflow")
+
+	workflow, err := ls.GetWorkflowExecution(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "timeout", workflow.Status)
+	t.Logf("reaped (terminal paired execution): %s status=%s", id, workflow.Status)
+}
+
+// TestPostgresMarkStaleExecutionsReapsStaleAndSparesFreshExecution covers the
+// legacy reaper on live PostgreSQL so both prepare call sites are proven.
+func TestPostgresMarkStaleExecutionsReapsStaleAndSparesFreshExecution(t *testing.T) {
+	ls, ctx := livePostgresStorage(t)
+	now := time.Now().UTC()
+	suffix := time.Now().UnixNano()
+
+	staleID := fmt.Sprintf("exec-live-legacy-stale-%d", suffix)
+	freshID := fmt.Sprintf("exec-live-legacy-fresh-%d", suffix)
+
+	require.NoError(t, ls.CreateExecutionRecord(ctx, liveExecution(staleID, now.Add(-2*time.Hour))))
+	backdateExecutionUpdatedAt(t, ls, "executions", staleID, now.Add(-2*time.Hour))
+	require.NoError(t, ls.CreateExecutionRecord(ctx, liveExecution(freshID, now.Add(-2*time.Hour))))
+
+	reaped, err := ls.MarkStaleExecutions(ctx, time.Hour, 100)
+	require.NoError(t, err)
+	require.Equal(t, 1, reaped)
+
+	staleExecution, err := ls.GetExecutionRecord(ctx, staleID)
+	require.NoError(t, err)
+	require.Equal(t, "timeout", staleExecution.Status)
+	t.Logf("reaped (stale on both clocks): %s status=%s", staleID, staleExecution.Status)
+
+	freshExecution, err := ls.GetExecutionRecord(ctx, freshID)
+	require.NoError(t, err)
+	require.Equal(t, "running", freshExecution.Status)
+	t.Logf("survived (fresh activity): %s status=%s", freshID, freshExecution.Status)
+}
+
+// TestPostgresRetryStaleWorkflowExecutionsRepassesStaleAndSparesFreshExecution
+// drives the retry reaper end to end. The paired-execution guard is the part of
+// the fix that stops a fresh execution from being re-dispatched.
+func TestPostgresRetryStaleWorkflowExecutionsRepassesStaleAndSparesFreshExecution(t *testing.T) {
+	ls, ctx := livePostgresStorage(t)
+	now := time.Now().UTC()
+	suffix := time.Now().UnixNano()
+
+	staleID := fmt.Sprintf("exec-live-retry-stale-%d", suffix)
+	freshID := fmt.Sprintf("exec-live-retry-fresh-%d", suffix)
+
+	require.NoError(t, ls.StoreWorkflowExecution(ctx, staleLiveWorkflow(staleID, now.Add(-2*time.Hour))))
+	require.NoError(t, ls.CreateExecutionRecord(ctx, liveExecution(staleID, now.Add(-2*time.Hour))))
+	backdateExecutionUpdatedAt(t, ls, "executions", staleID, now.Add(-2*time.Hour))
+
+	require.NoError(t, ls.StoreWorkflowExecution(ctx, staleLiveWorkflow(freshID, now.Add(-2*time.Hour))))
+	require.NoError(t, ls.CreateExecutionRecord(ctx, liveExecution(freshID, now.Add(-2*time.Hour))))
+
+	retried, err := ls.RetryStaleWorkflowExecutions(ctx, time.Hour, 3, 100)
+	require.NoError(t, err)
+	require.Equal(t, []string{staleID}, retried, "only the workflow stale on both clocks should be retried")
+
+	staleWorkflow, err := ls.GetWorkflowExecution(ctx, staleID)
+	require.NoError(t, err)
+	require.Equal(t, "pending", staleWorkflow.Status)
+	require.Equal(t, 1, staleWorkflow.RetryCount)
+	require.Nil(t, staleWorkflow.CompletedAt)
+	t.Logf("retried (stale on both clocks): %s status=%s retry_count=%d", staleID, staleWorkflow.Status, staleWorkflow.RetryCount)
+
+	staleExecution, err := ls.GetExecutionRecord(ctx, staleID)
+	require.NoError(t, err)
+	require.Equal(t, "pending", staleExecution.Status)
+
+	freshWorkflow, err := ls.GetWorkflowExecution(ctx, freshID)
+	require.NoError(t, err)
+	require.Equal(t, "running", freshWorkflow.Status)
+	require.Equal(t, 0, freshWorkflow.RetryCount)
+	t.Logf("survived (fresh paired execution): %s status=%s retry_count=%d", freshID, freshWorkflow.Status, freshWorkflow.RetryCount)
+
+	freshExecution, err := ls.GetExecutionRecord(ctx, freshID)
+	require.NoError(t, err)
+	require.Equal(t, "running", freshExecution.Status)
+}

--- a/control-plane/internal/storage/postgres_stale_reaper_live_test.go
+++ b/control-plane/internal/storage/postgres_stale_reaper_live_test.go
@@ -436,3 +436,104 @@ func TestPostgresRetryStaleWorkflowExecutionsRepassesStaleAndSparesFreshExecutio
 	require.NoError(t, err)
 	require.Equal(t, "running", freshExecution.Status)
 }
+
+// TestPostgresRetryStaleWorkflowExecutionsHeartbeatBetweenStatementsSparesExecution
+// pins down the between-statements heartbeat race on the real engine. A second
+// session holds the paired execution's row lock; the retry transaction runs its
+// workflow UPDATE and then parks on the execution UPDATE. While it is parked,
+// the heartbeat commits, so the execution UPDATE must re-check the staleness
+// predicate and leave the freshly heartbeated execution alone.
+func TestPostgresRetryStaleWorkflowExecutionsHeartbeatBetweenStatementsSparesExecution(t *testing.T) {
+	ls, ctx := livePostgresStorage(t)
+	now := time.Now().UTC()
+	id := fmt.Sprintf("exec-live-retry-between-%d", time.Now().UnixNano())
+
+	require.NoError(t, ls.StoreWorkflowExecution(ctx, staleLiveWorkflow(id, now.Add(-2*time.Hour))))
+	require.NoError(t, ls.CreateExecutionRecord(ctx, liveExecution(id, now.Add(-2*time.Hour))))
+	backdateExecutionUpdatedAt(t, ls, "executions", id, now.Add(-2*time.Hour))
+
+	// A second session takes the execution row lock first, so the retry
+	// transaction reaches its second UPDATE and blocks there.
+	gateCfg := liveConfigForDatabase(t, ls.postgresConfig.Database)
+	// ConnConfig.ConnString() keeps the original database, so build the handle
+	// from the connector like livePreparedRecorder does.
+	gate := sql.OpenDB(stdlib.GetConnector(*gateCfg))
+	defer gate.Close()
+
+	gateTx, err := gate.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer func() { _ = gateTx.Rollback() }()
+
+	var lockedID string
+	require.NoError(t, gateTx.QueryRowContext(ctx,
+		"SELECT execution_id FROM executions WHERE execution_id = $1 FOR UPDATE", id).Scan(&lockedID))
+
+	type retryOutcome struct {
+		retried []string
+		err     error
+	}
+	outcomeCh := make(chan retryOutcome, 1)
+	go func() {
+		retried, err := ls.RetryStaleWorkflowExecutions(ctx, time.Hour, 3, 100)
+		outcomeCh <- retryOutcome{retried: retried, err: err}
+	}()
+
+	// Wait until the retry transaction has run its workflow UPDATE (it holds
+	// the table's ROW EXCLUSIVE lock) and is on or about to reach the paired
+	// execution UPDATE.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		var workflowUpdated bool
+		require.NoError(t, gateTx.QueryRowContext(ctx, `
+			SELECT EXISTS (
+			    SELECT 1
+			    FROM pg_locks
+			    WHERE relation = to_regclass('public.workflow_executions')
+			      AND mode = 'RowExclusiveLock'
+			      AND granted
+			)`).Scan(&workflowUpdated))
+		if workflowUpdated {
+			break
+		}
+		select {
+		case outcome := <-outcomeCh:
+			t.Fatalf("retry finished before the heartbeat could interleave: retried=%v err=%v", outcome.retried, outcome.err)
+		case <-time.After(10 * time.Millisecond):
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("retry transaction never reached the workflow UPDATE")
+		}
+	}
+
+	// The heartbeat commits while the retry sits between its two statements.
+	heartbeatAt := time.Now().UTC()
+	_, err = gateTx.ExecContext(ctx, `
+		UPDATE executions
+		SET updated_at = $1, status_reason = 'heartbeat-between-statements'
+		WHERE execution_id = $2`, heartbeatAt, id)
+	require.NoError(t, err)
+	require.NoError(t, gateTx.Commit())
+
+	select {
+	case outcome := <-outcomeCh:
+		require.NoError(t, outcome.err)
+		require.Equal(t, []string{id}, outcome.retried)
+	case <-time.After(15 * time.Second):
+		t.Fatal("retry transaction did not finish after the heartbeat committed")
+	}
+
+	execution, err := ls.GetExecutionRecord(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "running", execution.Status,
+		"a heartbeat between the retry statements must not be dragged back to pending")
+	require.NotNil(t, execution.StatusReason)
+	require.Equal(t, "heartbeat-between-statements", *execution.StatusReason)
+	require.True(t, execution.UpdatedAt.After(now.Add(-time.Minute)),
+		"the heartbeat timestamp must be the surviving one")
+
+	workflow, err := ls.GetWorkflowExecution(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "pending", workflow.Status,
+		"the workflow decision was made before the heartbeat landed")
+	require.Equal(t, 1, workflow.RetryCount)
+}

--- a/control-plane/internal/storage/retry_stale_test.go
+++ b/control-plane/internal/storage/retry_stale_test.go
@@ -239,6 +239,82 @@ func TestRetryStaleWorkflowExecutions_ActivityAfterSelectionSkipsUpdate(t *testi
 	require.Len(t, executionRecord.Notes, 1)
 }
 
+// TestRetryStaleWorkflowExecutions_HeartbeatBetweenStatementsSparesExecution
+// covers the window between the workflow UPDATE and the paired execution
+// UPDATE. An AFTER UPDATE trigger on workflow_executions simulates a heartbeat
+// that commits after the workflow guard has been evaluated: the execution's
+// activity clock moves while the retry is between its two statements. The
+// execution UPDATE must repeat the staleness predicate, so the fresh execution
+// survives instead of being dragged back to pending.
+func TestRetryStaleWorkflowExecutions_HeartbeatBetweenStatementsSparesExecution(t *testing.T) {
+	ls, ctx := setupRetryTestStorage(t)
+	now := time.Now().UTC()
+
+	workflow := &types.WorkflowExecution{
+		WorkflowID:          "wf-retry-between-statements",
+		ExecutionID:         "exec-retry-between-statements",
+		AgentFieldRequestID: "req-retry-between-statements",
+		AgentNodeID:         "agent-1",
+		ReasonerID:          "reason-1",
+		Status:              "running",
+		StartedAt:           now.Add(-2 * time.Hour),
+		CreatedAt:           now.Add(-2 * time.Hour),
+		UpdatedAt:           now.Add(-2 * time.Hour),
+		InputData:           json.RawMessage(`{}`),
+		OutputData:          json.RawMessage(`{}`),
+		RetryCount:          0,
+	}
+	require.NoError(t, ls.StoreWorkflowExecution(ctx, workflow))
+
+	require.NoError(t, ls.CreateExecutionRecord(ctx, &types.Execution{
+		ExecutionID:  workflow.ExecutionID,
+		RunID:        "run-retry-between-statements",
+		AgentNodeID:  "agent-1",
+		ReasonerID:   "reason-1",
+		NodeID:       "agent-1",
+		Status:       "running",
+		StartedAt:    now.Add(-2 * time.Hour),
+		InputPayload: json.RawMessage(`{}`),
+	}))
+	backdateExecutionUpdatedAt(t, ls, "executions", workflow.ExecutionID, now.Add(-2*time.Hour))
+
+	// The trigger stamps a heartbeat on the paired execution as soon as the
+	// retry's workflow UPDATE has matched, i.e. between the retry's two
+	// statements.
+	db := ls.requireSQLDB()
+	_, err := db.Exec(`
+		CREATE TRIGGER retry_heartbeat_between_statements
+		AFTER UPDATE ON workflow_executions
+		FOR EACH ROW
+		BEGIN
+			UPDATE executions
+			SET updated_at = CURRENT_TIMESTAMP,
+			    status_reason = 'heartbeat-between-statements'
+			WHERE execution_id = NEW.execution_id;
+		END`)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = db.Exec("DROP TRIGGER IF EXISTS retry_heartbeat_between_statements")
+	})
+
+	retried, err := ls.RetryStaleWorkflowExecutions(ctx, 30*time.Minute, 3, 100)
+	require.NoError(t, err)
+	require.Equal(t, []string{workflow.ExecutionID}, retried)
+
+	executionRecord, err := ls.GetExecutionRecord(ctx, workflow.ExecutionID)
+	require.NoError(t, err)
+	require.Equal(t, "running", executionRecord.Status,
+		"a heartbeat between the retry statements must not be dragged back to pending")
+	require.NotNil(t, executionRecord.StatusReason)
+	require.Equal(t, "heartbeat-between-statements", *executionRecord.StatusReason,
+		"the between-statements heartbeat must be the surviving write")
+
+	workflowRecord, err := ls.GetWorkflowExecution(ctx, workflow.ExecutionID)
+	require.NoError(t, err)
+	require.Equal(t, "pending", workflowRecord.Status)
+	require.Equal(t, 1, workflowRecord.RetryCount)
+}
+
 func TestRetryStaleWorkflowExecutions_DisabledWithZeroMaxRetries(t *testing.T) {
 	ls, ctx := setupRetryTestStorage(t)
 

--- a/control-plane/internal/storage/retry_stale_test.go
+++ b/control-plane/internal/storage/retry_stale_test.go
@@ -68,6 +68,9 @@ func TestRetryStaleWorkflowExecutions(t *testing.T) {
 		UpdatedAt:    now.Add(-2 * time.Hour),
 		InputPayload: json.RawMessage(`{}`),
 	}))
+	// CreateExecutionRecord initializes activity timestamps to the current time;
+	// backdate the paired row so both clocks are stale for this retry case.
+	backdateExecutionUpdatedAt(t, ls, "executions", "exec-retry-1", now.Add(-2*time.Hour))
 
 	// Create a stale execution that already exhausted retries
 	exhaustedExec := &types.WorkflowExecution{
@@ -136,6 +139,104 @@ func TestRetryStaleWorkflowExecutions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "running", fresh.Status)
 	assert.Equal(t, 0, fresh.RetryCount)
+}
+
+func TestRetryStaleWorkflowExecutions_ExecutionActivityProtectsWorkflow(t *testing.T) {
+	ls, ctx := setupRetryTestStorage(t)
+	now := time.Now().UTC()
+
+	workflow := &types.WorkflowExecution{
+		WorkflowID:          "wf-retry-heartbeat",
+		ExecutionID:         "exec-retry-heartbeat",
+		AgentFieldRequestID: "req-retry-heartbeat",
+		AgentNodeID:         "agent-1",
+		ReasonerID:          "reason-1",
+		Status:              "running",
+		StartedAt:           now.Add(-2 * time.Hour),
+		CreatedAt:           now.Add(-2 * time.Hour),
+		UpdatedAt:           now.Add(-1 * time.Hour),
+		InputData:           json.RawMessage(`{}`),
+		OutputData:          json.RawMessage(`{}`),
+		RetryCount:          0,
+	}
+	require.NoError(t, ls.StoreWorkflowExecution(ctx, workflow))
+
+	// The execution is fresh even though its paired workflow row is stale.
+	require.NoError(t, ls.CreateExecutionRecord(ctx, &types.Execution{
+		ExecutionID: "exec-retry-heartbeat",
+		RunID:       "run-retry-heartbeat",
+		AgentNodeID: "agent-1",
+		ReasonerID:  "reason-1",
+		NodeID:      "agent-1",
+		Status:      "running",
+		StartedAt:   now.Add(-2 * time.Hour),
+	}))
+
+	retried, err := ls.RetryStaleWorkflowExecutions(ctx, 30*time.Minute, 3, 100)
+	require.NoError(t, err)
+	require.Empty(t, retried, "fresh paired execution activity must protect a stale workflow")
+
+	workflowRecord, err := ls.GetWorkflowExecution(ctx, workflow.ExecutionID)
+	require.NoError(t, err)
+	require.Equal(t, "running", workflowRecord.Status)
+	require.Equal(t, 0, workflowRecord.RetryCount)
+}
+
+func TestRetryStaleWorkflowExecutions_ActivityAfterSelectionSkipsUpdate(t *testing.T) {
+	ls, ctx := setupRetryTestStorage(t)
+	now := time.Now().UTC()
+
+	workflow := &types.WorkflowExecution{
+		WorkflowID:          "wf-retry-selection-race",
+		ExecutionID:         "exec-retry-selection-race",
+		AgentFieldRequestID: "req-retry-selection-race",
+		AgentNodeID:         "agent-1",
+		ReasonerID:          "reason-1",
+		Status:              "running",
+		StartedAt:           now.Add(-2 * time.Hour),
+		CreatedAt:           now.Add(-2 * time.Hour),
+		UpdatedAt:           now.Add(-1 * time.Hour),
+		InputData:           json.RawMessage(`{}`),
+		OutputData:          json.RawMessage(`{}`),
+		RetryCount:          0,
+	}
+	require.NoError(t, ls.StoreWorkflowExecution(ctx, workflow))
+
+	execution := &types.Execution{
+		ExecutionID: "exec-retry-selection-race",
+		RunID:       "run-retry-selection-race",
+		AgentNodeID: "agent-1",
+		ReasonerID:  "reason-1",
+		NodeID:      "agent-1",
+		Status:      "running",
+		StartedAt:   now.Add(-2 * time.Hour),
+	}
+	require.NoError(t, ls.CreateExecutionRecord(ctx, execution))
+	backdateExecutionUpdatedAt(t, ls, "executions", execution.ExecutionID, now.Add(-1*time.Hour))
+
+	var heartbeatErr error
+	retried, err := ls.retryStaleWorkflowExecutions(ctx, 30*time.Minute, 3, 100, func() {
+		_, heartbeatErr = ls.UpdateExecutionRecord(ctx, execution.ExecutionID, func(current *types.Execution) (*types.Execution, error) {
+			current.Notes = append(current.Notes, types.ExecutionNote{
+				Message:   "heartbeat",
+				Timestamp: now,
+			})
+			return current, nil
+		})
+	})
+	require.NoError(t, heartbeatErr)
+	require.NoError(t, err)
+	require.Empty(t, retried, "activity after selection must prevent the retry update")
+
+	workflowRecord, err := ls.GetWorkflowExecution(ctx, workflow.ExecutionID)
+	require.NoError(t, err)
+	require.Equal(t, "running", workflowRecord.Status)
+	require.Equal(t, 0, workflowRecord.RetryCount)
+
+	executionRecord, err := ls.GetExecutionRecord(ctx, execution.ExecutionID)
+	require.NoError(t, err)
+	require.Equal(t, "running", executionRecord.Status)
+	require.Len(t, executionRecord.Notes, 1)
 }
 
 func TestRetryStaleWorkflowExecutions_DisabledWithZeroMaxRetries(t *testing.T) {

--- a/control-plane/internal/storage/sql_helpers.go
+++ b/control-plane/internal/storage/sql_helpers.go
@@ -150,3 +150,14 @@ func (tx *sqlTx) QueryRowContext(ctx context.Context, query string, args ...inte
 func (tx *sqlTx) QueryRow(query string, args ...interface{}) *sql.Row {
 	return tx.Tx.QueryRow(tx.rebind(query), args...)
 }
+
+// Both preparation methods must rebind here: callers can use either the
+// context-aware or deprecated API, and the embedded *sql.Tx methods would
+// otherwise send ? placeholders directly to PostgreSQL.
+func (tx *sqlTx) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	return tx.Tx.PrepareContext(ctx, tx.rebind(query))
+}
+
+func (tx *sqlTx) Prepare(query string) (*sql.Stmt, error) {
+	return tx.Tx.Prepare(tx.rebind(query))
+}


### PR DESCRIPTION
## Problem

On the PostgreSQL backend the stale cleanup path does nothing. Both reapers return `n=0` with:

```
prepare stale execution update: ERROR: syntax error at or near "," (SQLSTATE 42601)
```

`sqlTx` embeds `*sql.Tx` and overrides `Exec`, `Query`, and `QueryRow` so `?` placeholders are rebound to `$n`, but it never overrode `PrepareContext` or `Prepare`. A prepared statement created inside a transaction therefore went to the driver with `?` placeholders intact and failed to prepare on PostgreSQL, which is why `MarkStaleExecutions` and `MarkStaleWorkflowExecutions` never reaped anything in cloud mode.

`RetryStaleWorkflowExecutions` has a related gap. It selects on the workflow clock alone and runs before the reaper, so once the path works it would start re-dispatching workflows whose paired execution is still active.

## Change

- Adds `sqlTx.PrepareContext` and the deprecated `sqlTx.Prepare`, both rebinding the query before delegating to `*sql.Tx`, matching what `sqlDatabase` already did.
- Makes `RetryStaleWorkflowExecutions` consult the paired `executions` activity clock, the same way `MarkStaleWorkflowExecutions` does.
- Repeats the status, retry-count, workflow-clock, and paired-execution-clock predicates in the conditional retry update, so activity arriving between selection and update leaves the workflow untouched. `RowsAffected > 0` gating and retry-count semantics are unchanged.

## Verification

Focused validation passes:

```sh
cd control-plane
go test ./internal/storage ./internal/handlers -count=1
go vet ./...
gofmt -d internal/storage/sql_helpers.go internal/storage/execution_records.go internal/storage/coverage_misc_helpers_test.go internal/storage/retry_stale_test.go
git diff --check
```

The full control-plane suite was also run. Storage and handlers pass; unrelated pre-existing failures remain in `internal/core/services` and `internal/packages` (environment and path expectations). No unrelated package was changed.

### Live PostgreSQL

Run against a throwaway PostgreSQL 16 container, loopback only on a dynamically allocated port, per-test throwaway database, container and volume removed afterwards.

The storage suite reads `POSTGRES_TEST_URL`. With it set, `go test ./internal/storage/ -run TestPostgres -v -count=1` gives **18 passed, 0 failed, 1 skipped** (the skip is the pre-existing unconditional `TestPostgresStorage_DatabaseCreation`). The whole storage package also passes with a live database configured.

Evidence that this pins the fix rather than merely passing next to it:

- Pre-fix reproduction: sending the reaper's `?` placeholders straight to PostgreSQL fails with `SQLSTATE 42601`, the error reported above.
- Post-fix, the text handed to the driver is rebound, with `$1..$8` for the workflow and retry UPDATEs and `$1..$6` for the execution sync UPDATE.
- End to end on the live database: a workflow stale on both clocks is reaped (`status=timeout`), a workflow whose paired execution has fresh activity survives (`status=running`), the retry guard re-dispatches a genuinely stale workflow (`status=pending retry_count=1`) and leaves a freshly heartbeating one alone, and the terminal-paired-execution branch still reaps.
- Removing the two `sqlTx.Prepare*` overrides on this branch makes the three new live tests fail with the original error.

Known harness gaps left untouched: `coverage_postgres_test.go` sits behind the `integration` build tag with a hardcoded DSN, and `locks_test.go`'s `setupPostgresTestStorage` returns nil unconditionally, so both skip regardless of `POSTGRES_TEST_URL`. `go test -race` for this package also aborts in the `boltdb/bolt` v1.3.1 dependency during SQLite initialization, independent of this change.

One deployment note: the workflow-side reaper only started consulting the execution clock in #1046, so this fix changes behaviour only on a control plane that includes that change.
