### PR TITLE
ci(python-sdk): enforce mypy with module-by-module allowlist ratchet (#971)

### DIFF
--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -56,6 +56,11 @@ jobs:
         run: |
           ruff check .
 
+      - name: Type check (mypy)
+        working-directory: sdk/python
+        run: |
+          mypy --config-file mypy.ini agentfield/
+
       - name: Format (auto-fix)
         working-directory: sdk/python
         run: |

--- a/sdk/python/mypy.ini
+++ b/sdk/python/mypy.ini
@@ -12,3 +12,113 @@ ignore_missing_imports = True
 
 [mypy-tests.*]
 disallow_untyped_defs = False
+
+# --- mypy ratchet allowlist (issue #971) ---
+# These modules are not yet type-clean. The CI gate runs mypy on the whole
+# package with these modules' errors suppressed, so the gate can be enforced
+# now and the allowlist shrunk module by module. To clean a module: fix its
+# type errors, then delete its section below. Do NOT add "# type: ignore"
+# sprinkles to reach green. New non-allowlisted modules must stay clean.
+
+[mypy-agentfield.agent]
+ignore_errors = True
+
+[mypy-agentfield.agent_ai]
+ignore_errors = True
+
+[mypy-agentfield.agent_discovery]
+ignore_errors = True
+
+[mypy-agentfield.agent_server]
+ignore_errors = True
+
+[mypy-agentfield.agent_serverless]
+ignore_errors = True
+
+[mypy-agentfield.agent_utils]
+ignore_errors = True
+
+[mypy-agentfield.agent_vc]
+ignore_errors = True
+
+[mypy-agentfield.agent_workflow]
+ignore_errors = True
+
+[mypy-agentfield.async_execution_manager]
+ignore_errors = True
+
+[mypy-agentfield.cancel]
+ignore_errors = True
+
+[mypy-agentfield.client]
+ignore_errors = True
+
+[mypy-agentfield.connection_manager]
+ignore_errors = True
+
+[mypy-agentfield.crypto]
+ignore_errors = True
+
+[mypy-agentfield.decorators]
+ignore_errors = True
+
+[mypy-agentfield.did_auth]
+ignore_errors = True
+
+[mypy-agentfield.did_manager]
+ignore_errors = True
+
+[mypy-agentfield.harness._cli]
+ignore_errors = True
+
+[mypy-agentfield.harness._runner]
+ignore_errors = True
+
+[mypy-agentfield.harness.providers.aforge]
+ignore_errors = True
+
+[mypy-agentfield.harness.providers.grok]
+ignore_errors = True
+
+[mypy-agentfield.harness.providers.opencode]
+ignore_errors = True
+
+[mypy-agentfield.harness.providers.pi]
+ignore_errors = True
+
+[mypy-agentfield.http_connection_manager]
+ignore_errors = True
+
+[mypy-agentfield.logger]
+ignore_errors = True
+
+[mypy-agentfield.media_providers]
+ignore_errors = True
+
+[mypy-agentfield.memory]
+ignore_errors = True
+
+[mypy-agentfield.memory_events]
+ignore_errors = True
+
+[mypy-agentfield.mesh]
+ignore_errors = True
+
+[mypy-agentfield.multimodal_response]
+ignore_errors = True
+
+[mypy-agentfield.pydantic_utils]
+ignore_errors = True
+
+[mypy-agentfield.rate_limiter]
+ignore_errors = True
+
+[mypy-agentfield.types]
+ignore_errors = True
+
+[mypy-agentfield.vc_generator]
+ignore_errors = True
+
+[mypy-agentfield.vision]
+ignore_errors = True
+

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -100,6 +100,7 @@ dev = [
     "syrupy>=5,<6",
     "hypothesis>=6.88,<7",
     "pytest-socket>=0.6,<0.8",
+    "mypy==1.18.2",
 ]
 
 [tool.pytest.ini_options]

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -30,6 +30,7 @@ dev = [
     { name = "freezegun" },
     { name = "hypothesis" },
     { name = "langfuse" },
+    { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -79,6 +80,7 @@ requires-dist = [
     { name = "langfuse", marker = "extra == 'langfuse'", specifier = ">=2.59.7,<3" },
     { name = "litellm", marker = "python_full_version < '3.11'", specifier = "!=1.97.0,<1.98.0" },
     { name = "litellm", marker = "python_full_version >= '3.11'" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==1.18.2" },
     { name = "openai-codex", marker = "extra == 'harness-all'", specifier = ">=0.1.0b3" },
     { name = "openai-codex", marker = "extra == 'harness-codex'", specifier = ">=0.1.0b3" },
     { name = "openai-codex-cli-bin", marker = "extra == 'harness-all'", specifier = "==0.137.0a4" },
@@ -616,7 +618,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1390,6 +1392,54 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.18.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/77/8f0d0001ffad290cef2f7f216f96c814866248a0b92a722365ed54648e7e/mypy-1.18.2.tar.gz", hash = "sha256:06a398102a5f203d7477b2923dda3634c36727fa5c237d8f859ef90c42a9924b", size = 3448846, upload-time = "2025-09-19T00:11:10.519Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/6f/657961a0743cff32e6c0611b63ff1c1970a0b482ace35b069203bf705187/mypy-1.18.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c1eab0cf6294dafe397c261a75f96dc2c31bffe3b944faa24db5def4e2b0f77c", size = 12807973, upload-time = "2025-09-19T00:10:35.282Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e9/420822d4f661f13ca8900f5fa239b40ee3be8b62b32f3357df9a3045a08b/mypy-1.18.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7a780ca61fc239e4865968ebc5240bb3bf610ef59ac398de9a7421b54e4a207e", size = 11896527, upload-time = "2025-09-19T00:10:55.791Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/73/a05b2bbaa7005f4642fcfe40fb73f2b4fb6bb44229bd585b5878e9a87ef8/mypy-1.18.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448acd386266989ef11662ce3c8011fd2a7b632e0ec7d61a98edd8e27472225b", size = 12507004, upload-time = "2025-09-19T00:11:05.411Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/f6e4b9f0d031c11ccbd6f17da26564f3a0f3c4155af344006434b0a05a9d/mypy-1.18.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f9e171c465ad3901dc652643ee4bffa8e9fef4d7d0eece23b428908c77a76a66", size = 13245947, upload-time = "2025-09-19T00:10:46.923Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/97/19727e7499bfa1ae0773d06afd30ac66a58ed7437d940c70548634b24185/mypy-1.18.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:592ec214750bc00741af1f80cbf96b5013d81486b7bb24cb052382c19e40b428", size = 13499217, upload-time = "2025-09-19T00:09:39.472Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/4f/90dc8c15c1441bf31cf0f9918bb077e452618708199e530f4cbd5cede6ff/mypy-1.18.2-cp310-cp310-win_amd64.whl", hash = "sha256:7fb95f97199ea11769ebe3638c29b550b5221e997c63b14ef93d2e971606ebed", size = 9766753, upload-time = "2025-09-19T00:10:49.161Z" },
+    { url = "https://files.pythonhosted.org/packages/88/87/cafd3ae563f88f94eec33f35ff722d043e09832ea8530ef149ec1efbaf08/mypy-1.18.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:807d9315ab9d464125aa9fcf6d84fde6e1dc67da0b6f80e7405506b8ac72bc7f", size = 12731198, upload-time = "2025-09-19T00:09:44.857Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e0/1e96c3d4266a06d4b0197ace5356d67d937d8358e2ee3ffac71faa843724/mypy-1.18.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:776bb00de1778caf4db739c6e83919c1d85a448f71979b6a0edd774ea8399341", size = 11817879, upload-time = "2025-09-19T00:09:47.131Z" },
+    { url = "https://files.pythonhosted.org/packages/72/ef/0c9ba89eb03453e76bdac5a78b08260a848c7bfc5d6603634774d9cd9525/mypy-1.18.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1379451880512ffce14505493bd9fe469e0697543717298242574882cf8cdb8d", size = 12427292, upload-time = "2025-09-19T00:10:22.472Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/52/ec4a061dd599eb8179d5411d99775bec2a20542505988f40fc2fee781068/mypy-1.18.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1331eb7fd110d60c24999893320967594ff84c38ac6d19e0a76c5fd809a84c86", size = 13163750, upload-time = "2025-09-19T00:09:51.472Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5f/2cf2ceb3b36372d51568f2208c021870fe7834cf3186b653ac6446511839/mypy-1.18.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3ca30b50a51e7ba93b00422e486cbb124f1c56a535e20eff7b2d6ab72b3b2e37", size = 13351827, upload-time = "2025-09-19T00:09:58.311Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/7d/2697b930179e7277529eaaec1513f8de622818696857f689e4a5432e5e27/mypy-1.18.2-cp311-cp311-win_amd64.whl", hash = "sha256:664dc726e67fa54e14536f6e1224bcfce1d9e5ac02426d2326e2bb4e081d1ce8", size = 9757983, upload-time = "2025-09-19T00:10:09.071Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/dfdd2bc60c66611dd8335f463818514733bc763e4760dee289dcc33df709/mypy-1.18.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33eca32dd124b29400c31d7cf784e795b050ace0e1f91b8dc035672725617e34", size = 12908273, upload-time = "2025-09-19T00:10:58.321Z" },
+    { url = "https://files.pythonhosted.org/packages/81/14/6a9de6d13a122d5608e1a04130724caf9170333ac5a924e10f670687d3eb/mypy-1.18.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a3c47adf30d65e89b2dcd2fa32f3aeb5e94ca970d2c15fcb25e297871c8e4764", size = 11920910, upload-time = "2025-09-19T00:10:20.043Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a9/b29de53e42f18e8cc547e38daa9dfa132ffdc64f7250e353f5c8cdd44bee/mypy-1.18.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d6c838e831a062f5f29d11c9057c6009f60cb294fea33a98422688181fe2893", size = 12465585, upload-time = "2025-09-19T00:10:33.005Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ae/6c3d2c7c61ff21f2bee938c917616c92ebf852f015fb55917fd6e2811db2/mypy-1.18.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01199871b6110a2ce984bde85acd481232d17413868c9807e95c1b0739a58914", size = 13348562, upload-time = "2025-09-19T00:10:11.51Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/31/aec68ab3b4aebdf8f36d191b0685d99faa899ab990753ca0fee60fb99511/mypy-1.18.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a2afc0fa0b0e91b4599ddfe0f91e2c26c2b5a5ab263737e998d6817874c5f7c8", size = 13533296, upload-time = "2025-09-19T00:10:06.568Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/83/abcb3ad9478fca3ebeb6a5358bb0b22c95ea42b43b7789c7fb1297ca44f4/mypy-1.18.2-cp312-cp312-win_amd64.whl", hash = "sha256:d8068d0afe682c7c4897c0f7ce84ea77f6de953262b12d07038f4d296d547074", size = 9828828, upload-time = "2025-09-19T00:10:28.203Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/04/7f462e6fbba87a72bc8097b93f6842499c428a6ff0c81dd46948d175afe8/mypy-1.18.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:07b8b0f580ca6d289e69209ec9d3911b4a26e5abfde32228a288eb79df129fcc", size = 12898728, upload-time = "2025-09-19T00:10:01.33Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5b/61ed4efb64f1871b41fd0b82d29a64640f3516078f6c7905b68ab1ad8b13/mypy-1.18.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ed4482847168439651d3feee5833ccedbf6657e964572706a2adb1f7fa4dfe2e", size = 11910758, upload-time = "2025-09-19T00:10:42.607Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/46/d297d4b683cc89a6e4108c4250a6a6b717f5fa96e1a30a7944a6da44da35/mypy-1.18.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3ad2afadd1e9fea5cf99a45a822346971ede8685cc581ed9cd4d42eaf940986", size = 12475342, upload-time = "2025-09-19T00:11:00.371Z" },
+    { url = "https://files.pythonhosted.org/packages/83/45/4798f4d00df13eae3bfdf726c9244bcb495ab5bd588c0eed93a2f2dd67f3/mypy-1.18.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a431a6f1ef14cf8c144c6b14793a23ec4eae3db28277c358136e79d7d062f62d", size = 13338709, upload-time = "2025-09-19T00:11:03.358Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/09/479f7358d9625172521a87a9271ddd2441e1dab16a09708f056e97007207/mypy-1.18.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7ab28cc197f1dd77a67e1c6f35cd1f8e8b73ed2217e4fc005f9e6a504e46e7ba", size = 13529806, upload-time = "2025-09-19T00:10:26.073Z" },
+    { url = "https://files.pythonhosted.org/packages/71/cf/ac0f2c7e9d0ea3c75cd99dff7aec1c9df4a1376537cb90e4c882267ee7e9/mypy-1.18.2-cp313-cp313-win_amd64.whl", hash = "sha256:0e2785a84b34a72ba55fb5daf079a1003a34c05b22238da94fcae2bbe46f3544", size = 9833262, upload-time = "2025-09-19T00:10:40.035Z" },
+    { url = "https://files.pythonhosted.org/packages/87/e3/be76d87158ebafa0309946c4a73831974d4d6ab4f4ef40c3b53a385a66fd/mypy-1.18.2-py3-none-any.whl", hash = "sha256:22a1748707dd62b58d2ae53562ffc4d7f8bcc727e8ac7cbc69c053ddc874d47e", size = 2352367, upload-time = "2025-09-19T00:10:15.489Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.24.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1460,6 +1510,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950, upload-time = "2024-11-08T09:47:47.202Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451, upload-time = "2024-11-08T09:47:44.722Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adopts the mypy half of #620 as phase 1 of #971. The ruff half shipped in #812, but the mypy half was never wired up: `sdk/python/mypy.ini` existed and nothing ran it. This adds a required `mypy` step to the Python SDK CI with a module-by-module allowlist, so the gate can be turned on immediately (zero behavior change) and the allowlist shrunk module by module.

Closes #971 (phase 1). Refs #620.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] Tests only
- [x] CI / tooling
- [ ] Breaking change

## What changed

- Pin `mypy==1.18.2` in the `dev` extras (`pyproject.toml`) and regenerate `uv.lock`.
- Add a per-module `ignore_errors = True` allowlist to `mypy.ini` for the 34 modules that currently have type errors (217 errors total), with a header comment describing the ratchet and how to shrink it.
- Add a `Type check (mypy)` step to `.github/workflows/sdk-python.yml` running `mypy --config-file mypy.ini agentfield/`.

No `# type: ignore` sprinkles were added, and no `agentfield/` source was modified.

## Validation contract (from #971)

- [x] CI fails if a non-allowlisted module gains a new mypy error. Verified: injecting a type error into a clean module (`agent_cli.py`) makes mypy exit 1.
- [x] Removing a module from the allowlist while it still has errors fails CI. Verified: removing `agentfield.types` re-surfaces its errors (exit 1).
- [x] `pip install .[dev]` provides the pinned mypy version used in CI.

## Test plan

- [x] `cd sdk/python && mypy --config-file mypy.ini agentfield/` -> `Success: no issues found in 79 source files` (exit 0)
- [x] `cd sdk/python && ruff check .` -> `All checks passed!`
- [x] `cd sdk/python && uv lock --check` -> clean after regenerating `uv.lock`
- [x] `python -c "import agentfield"` -> imports OK
- [x] Ratchet invariants verified (see Validation contract above)

## Test coverage

- [x] I ran tests for the surface(s) I changed locally.
- [x] No production code changed; this is CI/tooling only, so coverage is unaffected.
- [ ] The coverage gate check is green in CI before requesting review.

## Checklist

- [x] I have read CONTRIBUTING.md (if present) and docs/DEVELOPMENT.md.
- [ ] Commits are signed and follow conventional-commits style. (conventional-commits: yes; commit signing not configured in my environment)
- [x] I have linked any related issues.

## Related issues / PRs

Closes #971 (phase 1). Refs #620, #812.

## Notes for reviewers

- The mypy step runs in the existing `lint-and-test` matrix (Python 3.10-3.13). `mypy.ini` pins `python_version = 3.10`, so results are identical across matrix rows; running it in every row is redundant but harmless. Happy to move it to a single dedicated job if you prefer.
- Phase 2 (cleaning the async-heavy modules first, per the issue's suggested order) is intentionally out of scope for this PR to keep it a pure, reviewable wiring change.
